### PR TITLE
feat(db): add demo seed data

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,7 +14,7 @@
     "push": "drizzle-kit push --force",
     "studio": "drizzle-kit studio",
     "seed": "tsx src/seed/index.ts",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@orbit/shared": "workspace:*",

--- a/packages/db/src/seed/data.ts
+++ b/packages/db/src/seed/data.ts
@@ -177,6 +177,7 @@ export interface SeedIssue {
   readonly labels: readonly string[];
   readonly estimate: number | null;
   readonly project: string | null;
+  readonly milestone: string | null;
 }
 
 export const SEED_ISSUES: readonly SeedIssue[] = [
@@ -191,6 +192,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Feature', 'Performance'],
     estimate: 5,
     project: 'Realtime Sync Engine',
+    milestone: 'Delta protocol',
   },
   {
     team: 'ENG',
@@ -203,6 +205,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Improvement'],
     estimate: 3,
     project: 'Realtime Sync Engine',
+    milestone: 'Client store',
   },
   {
     team: 'ENG',
@@ -215,6 +218,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Bug'],
     estimate: 2,
     project: 'Realtime Sync Engine',
+    milestone: 'Delta protocol',
   },
   {
     team: 'ENG',
@@ -227,6 +231,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Improvement'],
     estimate: 2,
     project: 'Realtime Sync Engine',
+    milestone: 'Presence and typing',
   },
   {
     team: 'ENG',
@@ -239,6 +244,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Bug'],
     estimate: 3,
     project: 'Workspace Onboarding',
+    milestone: 'Auth flows',
   },
   {
     team: 'ENG',
@@ -251,6 +257,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Feature'],
     estimate: 3,
     project: 'Workspace Onboarding',
+    milestone: 'Invite lifecycle',
   },
   {
     team: 'ENG',
@@ -263,6 +270,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Feature'],
     estimate: 5,
     project: 'Workspace Onboarding',
+    milestone: 'Invite lifecycle',
   },
   {
     team: 'ENG',
@@ -275,6 +283,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Feature'],
     estimate: 5,
     project: 'Docs and Attachments',
+    milestone: 'Upload pipeline',
   },
   {
     team: 'ENG',
@@ -287,6 +296,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Feature', 'Performance'],
     estimate: 8,
     project: 'Docs and Attachments',
+    milestone: 'Upload pipeline',
   },
   {
     team: 'ENG',
@@ -299,6 +309,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Bug'],
     estimate: 3,
     project: 'Docs and Attachments',
+    milestone: 'Editor',
   },
   {
     team: 'ENG',
@@ -311,6 +322,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Performance'],
     estimate: 5,
     project: null,
+    milestone: null,
   },
   {
     team: 'ENG',
@@ -323,6 +335,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Performance'],
     estimate: 3,
     project: null,
+    milestone: null,
   },
   {
     team: 'ENG',
@@ -335,6 +348,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Chore'],
     estimate: 2,
     project: null,
+    milestone: null,
   },
   {
     team: 'ENG',
@@ -347,6 +361,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Improvement'],
     estimate: 3,
     project: null,
+    milestone: null,
   },
   {
     team: 'ENG',
@@ -359,6 +374,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Feature'],
     estimate: 8,
     project: null,
+    milestone: null,
   },
   {
     team: 'ENG',
@@ -371,6 +387,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Bug'],
     estimate: null,
     project: 'Realtime Sync Engine',
+    milestone: 'Delta protocol',
   },
   {
     team: 'ENG',
@@ -382,6 +399,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Chore'],
     estimate: 3,
     project: null,
+    milestone: null,
   },
   {
     team: 'ENG',
@@ -393,6 +411,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Chore'],
     estimate: 1,
     project: null,
+    milestone: null,
   },
   {
     team: 'DES',
@@ -405,6 +424,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Design'],
     estimate: 3,
     project: 'Workspace Onboarding',
+    milestone: 'Empty states',
   },
   {
     team: 'DES',
@@ -417,6 +437,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Design', 'Improvement'],
     estimate: 2,
     project: null,
+    milestone: null,
   },
   {
     team: 'DES',
@@ -429,6 +450,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Design'],
     estimate: 2,
     project: 'Workspace Onboarding',
+    milestone: 'Empty states',
   },
   {
     team: 'DES',
@@ -441,6 +463,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Design'],
     estimate: 2,
     project: null,
+    milestone: null,
   },
   {
     team: 'DES',
@@ -453,6 +476,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Design'],
     estimate: 3,
     project: null,
+    milestone: null,
   },
   {
     team: 'DES',
@@ -465,6 +489,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Chore'],
     estimate: 1,
     project: null,
+    milestone: null,
   },
   {
     team: 'DES',
@@ -476,6 +501,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Design'],
     estimate: 5,
     project: null,
+    milestone: null,
   },
   {
     team: 'MKT',
@@ -488,6 +514,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Docs'],
     estimate: 3,
     project: 'Launch Campaign',
+    milestone: 'Positioning',
   },
   {
     team: 'MKT',
@@ -499,6 +526,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Performance'],
     estimate: 5,
     project: 'Launch Campaign',
+    milestone: 'Landing page',
   },
   {
     team: 'MKT',
@@ -511,6 +539,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Docs'],
     estimate: 3,
     project: 'Launch Campaign',
+    milestone: 'Launch week',
   },
   {
     team: 'MKT',
@@ -522,6 +551,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Docs'],
     estimate: 3,
     project: 'Launch Campaign',
+    milestone: 'Positioning',
   },
   {
     team: 'MKT',
@@ -533,6 +563,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Docs'],
     estimate: 2,
     project: null,
+    milestone: null,
   },
   {
     team: 'MKT',
@@ -544,6 +575,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Docs'],
     estimate: null,
     project: 'Launch Campaign',
+    milestone: 'Launch week',
   },
   {
     team: 'MKT',
@@ -555,6 +587,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     labels: ['Chore'],
     estimate: 1,
     project: null,
+    milestone: null,
   },
 ];
 

--- a/packages/db/src/seed/data.ts
+++ b/packages/db/src/seed/data.ts
@@ -1,0 +1,665 @@
+import type { StateCategory } from '@orbit/shared';
+
+export interface SeedUser {
+  readonly handle: string;
+  readonly name: string;
+  readonly email: string;
+  readonly role: 'admin' | 'member' | 'contributor' | 'guest';
+  readonly teams: readonly string[];
+}
+
+export const SEED_USERS: readonly SeedUser[] = [
+  {
+    handle: 'pulkit',
+    name: 'Pulkit Sharma',
+    email: 'pulkit@noveum.ai',
+    role: 'admin',
+    teams: ['ENG', 'DES', 'MKT'],
+  },
+  {
+    handle: 'shashank',
+    name: 'Shashank Agarwal',
+    email: 'shashank@noveum.ai',
+    role: 'admin',
+    teams: ['ENG', 'MKT'],
+  },
+  {
+    handle: 'aditi',
+    name: 'Aditi Rao',
+    email: 'aditi@noveum.ai',
+    role: 'member',
+    teams: ['ENG', 'DES'],
+  },
+  {
+    handle: 'harkirat',
+    name: 'Harkirat Singh',
+    email: 'harkirat@noveum.ai',
+    role: 'member',
+    teams: ['MKT'],
+  },
+  {
+    handle: 'tanzeela',
+    name: 'Tanzeela Khan',
+    email: 'tanzeela@noveum.ai',
+    role: 'member',
+    teams: ['ENG', 'DES'],
+  },
+  {
+    handle: 'koushik',
+    name: 'Koushik Reddy',
+    email: 'koushik@noveum.ai',
+    role: 'contributor',
+    teams: ['ENG'],
+  },
+  {
+    handle: 'om',
+    name: 'Om Patel',
+    email: 'om@noveum.ai',
+    role: 'guest',
+    teams: ['MKT'],
+  },
+];
+
+export interface SeedTeam {
+  readonly key: string;
+  readonly name: string;
+  readonly description: string;
+  readonly color: string;
+  readonly icon: string;
+}
+
+export const SEED_TEAMS: readonly SeedTeam[] = [
+  {
+    key: 'ENG',
+    name: 'Engineering',
+    description: 'Platform, API, and infrastructure work.',
+    color: '#5A63C8',
+    icon: 'cpu',
+  },
+  {
+    key: 'DES',
+    name: 'Design',
+    description: 'Product design, design system, and research.',
+    color: '#B4654A',
+    icon: 'palette',
+  },
+  {
+    key: 'MKT',
+    name: 'Marketing',
+    description: 'Growth, content, and launches.',
+    color: '#4CB782',
+    icon: 'megaphone',
+  },
+];
+
+export interface SeedState {
+  readonly name: string;
+  readonly category: StateCategory;
+  readonly color: string;
+}
+
+export const SEED_STATES: readonly SeedState[] = [
+  { name: 'Triage', category: 'triage', color: '#EB5D5D' },
+  { name: 'Backlog', category: 'backlog', color: '#8B90A0' },
+  { name: 'Todo', category: 'unstarted', color: '#A2A7B8' },
+  { name: 'In Progress', category: 'started', color: '#F0A44B' },
+  { name: 'In Review', category: 'review', color: '#4CB782' },
+  { name: 'Done', category: 'completed', color: '#7B83EB' },
+  { name: 'Canceled', category: 'canceled', color: '#6E7385' },
+];
+
+export const SEED_LABELS: readonly { name: string; color: string }[] = [
+  { name: 'Bug', color: '#EB5D5D' },
+  { name: 'Feature', color: '#7B83EB' },
+  { name: 'Improvement', color: '#4EA7FC' },
+  { name: 'Chore', color: '#8B90A0' },
+  { name: 'Design', color: '#B4654A' },
+  { name: 'Docs', color: '#4CB782' },
+  { name: 'Performance', color: '#F0A44B' },
+];
+
+export interface SeedProject {
+  readonly name: string;
+  readonly summary: string;
+  readonly status: 'backlog' | 'planned' | 'in_progress' | 'completed' | 'canceled';
+  readonly health: 'on_track' | 'at_risk' | 'off_track' | 'no_update';
+  readonly leadHandle: string;
+  readonly teams: readonly string[];
+  readonly milestones: readonly string[];
+}
+
+export const SEED_PROJECTS: readonly SeedProject[] = [
+  {
+    name: 'Realtime Sync Engine',
+    summary: 'Local-first store with a websocket delta stream so every surface updates live.',
+    status: 'in_progress',
+    health: 'on_track',
+    leadHandle: 'shashank',
+    teams: ['ENG'],
+    milestones: ['Delta protocol', 'Client store', 'Presence and typing'],
+  },
+  {
+    name: 'Workspace Onboarding',
+    summary: 'Passwordless sign in, organization creation, invites, and domain auto join.',
+    status: 'in_progress',
+    health: 'at_risk',
+    leadHandle: 'aditi',
+    teams: ['ENG', 'DES'],
+    milestones: ['Auth flows', 'Invite lifecycle', 'Empty states'],
+  },
+  {
+    name: 'Docs and Attachments',
+    summary: 'Markdown docs, image and PDF previews, and object storage for every upload.',
+    status: 'planned',
+    health: 'no_update',
+    leadHandle: 'tanzeela',
+    teams: ['ENG', 'DES'],
+    milestones: ['Editor', 'Upload pipeline', 'Public sharing'],
+  },
+  {
+    name: 'Launch Campaign',
+    summary: 'Positioning, landing page, and launch sequence for the public release.',
+    status: 'planned',
+    health: 'on_track',
+    leadHandle: 'harkirat',
+    teams: ['MKT'],
+    milestones: ['Positioning', 'Landing page', 'Launch week'],
+  },
+];
+
+export interface SeedIssue {
+  readonly team: string;
+  readonly title: string;
+  readonly description: string;
+  readonly state: string;
+  readonly priority: number;
+  readonly assignee: string | null;
+  readonly labels: readonly string[];
+  readonly estimate: number | null;
+  readonly project: string | null;
+}
+
+export const SEED_ISSUES: readonly SeedIssue[] = [
+  {
+    team: 'ENG',
+    title: 'Fan out delta packets over a single websocket per client',
+    description:
+      'Every client should hold **one** multiplexed socket. The server filters by sync scope and batches actions inside a 50ms window.\n\n### Acceptance\n\n- [x] Scope authorization on connect\n- [x] 50ms coalescing window\n- [ ] Backpressure disconnects slow sockets',
+    state: 'In Review',
+    priority: 1,
+    assignee: 'shashank',
+    labels: ['Feature', 'Performance'],
+    estimate: 5,
+    project: 'Realtime Sync Engine',
+  },
+  {
+    team: 'ENG',
+    title: 'Optimistic issue status changes should never flicker',
+    description:
+      'Moving a card writes to the local store first, then reconciles from the delta stream. If the server rejects the write we roll back and surface a toast.',
+    state: 'In Progress',
+    priority: 1,
+    assignee: 'aditi',
+    labels: ['Improvement'],
+    estimate: 3,
+    project: 'Realtime Sync Engine',
+  },
+  {
+    team: 'ENG',
+    title: 'Allocate issue identifiers atomically under concurrency',
+    description:
+      'Two people pressing `C` at the same moment must never receive the same identifier. Use a single `UPDATE ... RETURNING` against the team counter.',
+    state: 'Done',
+    priority: 2,
+    assignee: 'shashank',
+    labels: ['Bug'],
+    estimate: 2,
+    project: 'Realtime Sync Engine',
+  },
+  {
+    team: 'ENG',
+    title: 'Presence should expire after 45 seconds of silence',
+    description:
+      'Presence is ephemeral and never touches Postgres. Expire stale viewers so avatars do not pile up on an issue nobody is reading.',
+    state: 'Todo',
+    priority: 3,
+    assignee: 'koushik',
+    labels: ['Improvement'],
+    estimate: 2,
+    project: 'Realtime Sync Engine',
+  },
+  {
+    team: 'ENG',
+    title: 'Passkey sign in fails on Safari when no credential is registered',
+    description:
+      'Safari throws `NotAllowedError` instead of resolving empty. Catch it and fall back to the magic link field without showing an error.',
+    state: 'In Progress',
+    priority: 1,
+    assignee: 'tanzeela',
+    labels: ['Bug'],
+    estimate: 3,
+    project: 'Workspace Onboarding',
+  },
+  {
+    team: 'ENG',
+    title: 'Invite tokens must be single use and expire after 14 days',
+    description:
+      'Accepting an invite twice should be a no op that returns the existing membership rather than creating a duplicate row.',
+    state: 'In Review',
+    priority: 2,
+    assignee: 'aditi',
+    labels: ['Feature'],
+    estimate: 3,
+    project: 'Workspace Onboarding',
+  },
+  {
+    team: 'ENG',
+    title: 'Domain auto join for verified workspace domains',
+    description:
+      'When an organization allow lists `noveum.ai`, anyone signing in with that domain joins as a member without an invite.',
+    state: 'Todo',
+    priority: 3,
+    assignee: null,
+    labels: ['Feature'],
+    estimate: 5,
+    project: 'Workspace Onboarding',
+  },
+  {
+    team: 'ENG',
+    title: 'Presigned uploads should stream straight to object storage',
+    description:
+      'The API validates size and content type, then hands back a presigned target. Bytes never pass through the app server.',
+    state: 'Backlog',
+    priority: 2,
+    assignee: 'koushik',
+    labels: ['Feature'],
+    estimate: 5,
+    project: 'Docs and Attachments',
+  },
+  {
+    team: 'ENG',
+    title: 'Render PDF attachments inline with a page thumbnail rail',
+    description:
+      'Large PDFs should lazy load pages. Keep the first paint under 300ms by rendering a cached cover image first.',
+    state: 'Backlog',
+    priority: 3,
+    assignee: null,
+    labels: ['Feature', 'Performance'],
+    estimate: 8,
+    project: 'Docs and Attachments',
+  },
+  {
+    team: 'ENG',
+    title: 'Sanitize every markdown surface against XSS',
+    description:
+      'Issue descriptions, comments, and docs all run through one renderer. Strip scripts, iframes, inline handlers, and `javascript:` urls.',
+    state: 'Done',
+    priority: 1,
+    assignee: 'shashank',
+    labels: ['Bug'],
+    estimate: 3,
+    project: 'Docs and Attachments',
+  },
+  {
+    team: 'ENG',
+    title: 'Virtualize the issue list so 10k rows scroll at 60fps',
+    description:
+      'Fixed row height plus a windowing layer. Avoid layout thrash by never measuring inside the scroll handler.',
+    state: 'Todo',
+    priority: 2,
+    assignee: 'tanzeela',
+    labels: ['Performance'],
+    estimate: 5,
+    project: null,
+  },
+  {
+    team: 'ENG',
+    title: 'Command palette should query the local store only',
+    description:
+      'No network round trip when opening the palette. Search runs against the hydrated client cache so results appear within one frame.',
+    state: 'Done',
+    priority: 2,
+    assignee: 'aditi',
+    labels: ['Performance'],
+    estimate: 3,
+    project: null,
+  },
+  {
+    team: 'ENG',
+    title: 'Rebalance fractional sort orders when gaps collapse',
+    description:
+      'Repeated drags between the same pair eventually exhaust float precision. Rebalance the column when the gap drops below 0.0001.',
+    state: 'Todo',
+    priority: 3,
+    assignee: 'koushik',
+    labels: ['Chore'],
+    estimate: 2,
+    project: null,
+  },
+  {
+    team: 'ENG',
+    title: 'Notification quiet hours should respect the recipient timezone',
+    description:
+      'Deferred email must resume at the start of the next working window in the recipient local time, not server time.',
+    state: 'In Progress',
+    priority: 2,
+    assignee: 'shashank',
+    labels: ['Improvement'],
+    estimate: 3,
+    project: null,
+  },
+  {
+    team: 'ENG',
+    title: 'Expose the MCP server over streamable HTTP',
+    description:
+      'AI tooling should read and write issues through MCP with the same permission checks as the REST API.',
+    state: 'Backlog',
+    priority: 2,
+    assignee: null,
+    labels: ['Feature'],
+    estimate: 8,
+    project: null,
+  },
+  {
+    team: 'ENG',
+    title: 'Reconnect should replay missed deltas by sync id',
+    description:
+      'On reconnect, compare the local high water mark against the server and fetch the gap rather than refetching every list.',
+    state: 'Triage',
+    priority: 2,
+    assignee: null,
+    labels: ['Bug'],
+    estimate: null,
+    project: 'Realtime Sync Engine',
+  },
+  {
+    team: 'ENG',
+    title: 'Audit log every permission relevant mutation',
+    description: 'Role changes, invites, integration connects, and deletions all need an entry.',
+    state: 'Backlog',
+    priority: 4,
+    assignee: null,
+    labels: ['Chore'],
+    estimate: 3,
+    project: null,
+  },
+  {
+    team: 'ENG',
+    title: 'Drop the legacy polling endpoint',
+    description: 'Superseded by the delta stream. Remove the route and its tests.',
+    state: 'Canceled',
+    priority: 4,
+    assignee: 'koushik',
+    labels: ['Chore'],
+    estimate: 1,
+    project: null,
+  },
+  {
+    team: 'DES',
+    title: 'Design the board card at three densities',
+    description:
+      'Compact, default, and comfortable. Identifier, title, labels, assignee, and estimate must stay legible at every density.',
+    state: 'In Progress',
+    priority: 2,
+    assignee: 'tanzeela',
+    labels: ['Design'],
+    estimate: 3,
+    project: 'Workspace Onboarding',
+  },
+  {
+    team: 'DES',
+    title: 'Light theme contrast audit',
+    description:
+      'Muted text on surface must clear 4.5:1. Check every state color against both grounds.',
+    state: 'In Review',
+    priority: 2,
+    assignee: 'aditi',
+    labels: ['Design', 'Improvement'],
+    estimate: 2,
+    project: null,
+  },
+  {
+    team: 'DES',
+    title: 'Empty states should teach a keyboard shortcut',
+    description:
+      'Every empty list gets one line of guidance and the shortcut that fills it, the way the rest of the product teaches itself.',
+    state: 'Todo',
+    priority: 3,
+    assignee: 'tanzeela',
+    labels: ['Design'],
+    estimate: 2,
+    project: 'Workspace Onboarding',
+  },
+  {
+    team: 'DES',
+    title: 'Motion spec: nothing over 200ms, transform and opacity only',
+    description:
+      'Document the durations and easings, and add a reduced motion rule that collapses everything to an instant swap.',
+    state: 'Done',
+    priority: 2,
+    assignee: 'aditi',
+    labels: ['Design'],
+    estimate: 2,
+    project: null,
+  },
+  {
+    team: 'DES',
+    title: 'Sidebar needs a collapsed rail with icon only navigation',
+    description:
+      'Below 1024px it becomes an overlay drawer. Keep the trigger reachable by keyboard.',
+    state: 'Todo',
+    priority: 3,
+    assignee: null,
+    labels: ['Design'],
+    estimate: 3,
+    project: null,
+  },
+  {
+    team: 'DES',
+    title: 'Avatar fallbacks should derive initials consistently',
+    description:
+      'One helper, used everywhere, so the same person never renders two different sets of initials.',
+    state: 'Done',
+    priority: 4,
+    assignee: 'tanzeela',
+    labels: ['Chore'],
+    estimate: 1,
+    project: null,
+  },
+  {
+    team: 'DES',
+    title: 'Explore a timeline layout for cycles',
+    description: 'Week, month, and quarter zoom with a highlighted today column.',
+    state: 'Backlog',
+    priority: 4,
+    assignee: null,
+    labels: ['Design'],
+    estimate: 5,
+    project: null,
+  },
+  {
+    team: 'MKT',
+    title: 'Write the launch announcement',
+    description:
+      'Lead with speed and the fact that it is free. Three screenshots: board, issue detail, and the command palette.',
+    state: 'In Progress',
+    priority: 1,
+    assignee: 'harkirat',
+    labels: ['Docs'],
+    estimate: 3,
+    project: 'Launch Campaign',
+  },
+  {
+    team: 'MKT',
+    title: 'Landing page: above the fold in under one second',
+    description: 'Inline the critical CSS and defer everything else. No layout shift on load.',
+    state: 'Todo',
+    priority: 2,
+    assignee: 'harkirat',
+    labels: ['Performance'],
+    estimate: 5,
+    project: 'Launch Campaign',
+  },
+  {
+    team: 'MKT',
+    title: 'Record a 90 second product walkthrough',
+    description:
+      'Create an issue, move it across the board, comment, and show it updating live in a second window.',
+    state: 'Todo',
+    priority: 2,
+    assignee: 'om',
+    labels: ['Docs'],
+    estimate: 3,
+    project: 'Launch Campaign',
+  },
+  {
+    team: 'MKT',
+    title: 'Comparison page against the incumbents',
+    description: 'Honest table. Where we are thinner, say so.',
+    state: 'Backlog',
+    priority: 3,
+    assignee: null,
+    labels: ['Docs'],
+    estimate: 3,
+    project: 'Launch Campaign',
+  },
+  {
+    team: 'MKT',
+    title: 'Set up the changelog feed',
+    description: 'Ship notes weekly. Each entry links the issues it closed.',
+    state: 'Done',
+    priority: 3,
+    assignee: 'harkirat',
+    labels: ['Docs'],
+    estimate: 2,
+    project: null,
+  },
+  {
+    team: 'MKT',
+    title: 'Draft onboarding email sequence',
+    description: 'Three emails: welcome, invite your team, and a keyboard shortcut tour.',
+    state: 'Triage',
+    priority: 3,
+    assignee: null,
+    labels: ['Docs'],
+    estimate: null,
+    project: 'Launch Campaign',
+  },
+  {
+    team: 'MKT',
+    title: 'Audit every string for the em dash character',
+    description: 'House style uses commas, colons, or separate sentences. Nothing else.',
+    state: 'Done',
+    priority: 4,
+    assignee: 'om',
+    labels: ['Chore'],
+    estimate: 1,
+    project: null,
+  },
+];
+
+export interface SeedComment {
+  readonly issueTitle: string;
+  readonly author: string;
+  readonly body: string;
+  readonly replies: readonly { author: string; body: string }[];
+  readonly reactions: readonly { user: string; emoji: string }[];
+}
+
+export const SEED_COMMENTS: readonly SeedComment[] = [
+  {
+    issueTitle: 'Fan out delta packets over a single websocket per client',
+    author: 'aditi',
+    body: 'Does the 50ms window apply per organization or per connection? If it is per connection a large workspace could still get bursty.',
+    replies: [
+      {
+        author: 'shashank',
+        body: 'Per connection, but the dedupe keys on `(model, modelId, action)` so a bulk edit of 40 issues collapses to one packet.',
+      },
+      { author: 'aditi', body: 'That answers it. Nice.' },
+    ],
+    reactions: [
+      { user: 'shashank', emoji: '👍' },
+      { user: 'tanzeela', emoji: '🎉' },
+    ],
+  },
+  {
+    issueTitle: 'Optimistic issue status changes should never flicker',
+    author: 'tanzeela',
+    body: 'Confirmed the flicker was our own echo coming back through the stream. Suppressing deltas whose actor matches the local session fixes it.\n\n```ts\nif (action.actor.id === session.userId) return;\n```',
+    replies: [{ author: 'aditi', body: 'Pushed that in the last commit, watching it now.' }],
+    reactions: [{ user: 'pulkit', emoji: '🚀' }],
+  },
+  {
+    issueTitle: 'Passkey sign in fails on Safari when no credential is registered',
+    author: 'pulkit',
+    body: 'Reproduced on Safari 18. It rejects rather than resolving with an empty credential list, so we should treat `NotAllowedError` as "no passkey here" and fall through quietly.',
+    replies: [
+      {
+        author: 'tanzeela',
+        body: 'Handling it in the client wrapper so every entry point gets the fallback.',
+      },
+    ],
+    reactions: [{ user: 'shashank', emoji: '👀' }],
+  },
+  {
+    issueTitle: 'Design the board card at three densities',
+    author: 'aditi',
+    body: 'Compact drops the estimate chip and shrinks the avatar to 16px. Everything else stays, otherwise scanning breaks.',
+    replies: [],
+    reactions: [
+      { user: 'tanzeela', emoji: '👍' },
+      { user: 'pulkit', emoji: '👍' },
+    ],
+  },
+  {
+    issueTitle: 'Write the launch announcement',
+    author: 'harkirat',
+    body: 'First draft is up. Opening line: **it is free, it is fast, and it updates the moment anyone else changes anything.**',
+    replies: [
+      { author: 'pulkit', body: 'Good. Lead with speed, then the price, then the realtime bit.' },
+      { author: 'harkirat', body: 'Reordered.' },
+    ],
+    reactions: [{ user: 'om', emoji: '🎉' }],
+  },
+  {
+    issueTitle: 'Allocate issue identifiers atomically under concurrency',
+    author: 'shashank',
+    body: 'Test fires 20 concurrent creates and asserts 20 distinct identifiers. Green on every run so far.',
+    replies: [],
+    reactions: [{ user: 'koushik', emoji: '✅' }],
+  },
+];
+
+export interface SeedDoc {
+  readonly title: string;
+  readonly collection: string;
+  readonly author: string;
+  readonly content: string;
+}
+
+export const SEED_COLLECTIONS: readonly string[] = ['Engineering', 'Product', 'Runbooks'];
+
+export const SEED_DOCS: readonly SeedDoc[] = [
+  {
+    title: 'Realtime delta protocol',
+    collection: 'Engineering',
+    author: 'shashank',
+    content:
+      '# Realtime delta protocol\n\nEvery mutation writes to Postgres, bumps `sync_id`, and publishes a `SyncAction` to Redis. The realtime server fans it out to subscribed clients.\n\n## Action shape\n\n```ts\ntype SyncAction = {\n  syncId: number;\n  organizationId: string;\n  scopes: string[];\n  action: "insert" | "update" | "delete" | "archive" | "unarchive";\n  model: string;\n  modelId: string;\n  data: Record<string, unknown>;\n  actor: { type: "user" | "integration" | "agent" | "system"; id: string };\n  at: string;\n};\n```\n\n## Rules\n\n| Rule | Why |\n| --- | --- |\n| Batch inside 50ms | A bulk edit becomes one packet |\n| Dedupe by model and id | The newest write wins |\n| Filter by scope | A client never sees what it cannot read |\n| Suppress own echo | Optimistic writes must not flicker |\n\nPresence is ephemeral and never touches Postgres.',
+  },
+  {
+    title: 'Keyboard shortcuts',
+    collection: 'Product',
+    author: 'aditi',
+    content:
+      '# Keyboard shortcuts\n\nOrbit is keyboard first. Every action with a shortcut prints it next to the control.\n\n## Global\n\n- `Cmd K` command palette\n- `?` this list\n- `C` new issue\n- `[` toggle the sidebar\n\n## Navigation\n\nPress `G` then a second key.\n\n- `G` `I` inbox\n- `G` `M` my issues\n- `G` `P` projects\n\n## On an issue\n\n- `A` assign, `I` assign to me\n- `S` status, `P` priority, `L` labels\n- `Cmd .` copy identifier',
+  },
+  {
+    title: 'Local development runbook',
+    collection: 'Runbooks',
+    author: 'pulkit',
+    content:
+      '# Local development\n\n```bash\npnpm install\ncp .env.example .env\npnpm infra:up\npnpm db:push\npnpm db:seed\npnpm dev\n```\n\n## Services\n\n| Service | Port |\n| --- | --- |\n| web | 3000 |\n| realtime | 3100 |\n| mcp | 3200 |\n| postgres | 5434 |\n| redis | 6380 |\n| minio | 9010 |\n| mailpit | 8025 |\n\n> Magic link emails are printed to the console when `EMAIL_TRANSPORT=console`, and captured by Mailpit otherwise.\n\n## Checks\n\n`pnpm verify` runs lint, the comment policy, types, and tests. All four must be green before a pull request.',
+  },
+];

--- a/packages/db/src/seed/index.ts
+++ b/packages/db/src/seed/index.ts
@@ -357,6 +357,19 @@ function stateTimestamps(stateName: string): {
   return { startedAt: null, completedAt: null, canceledAt: null };
 }
 
+async function attachLabels(
+  issueId: string,
+  names: readonly string[],
+  labels: Map<string, string>,
+): Promise<void> {
+  const rows = names
+    .map((name) => labels.get(name))
+    .filter((value): value is string => value !== undefined)
+    .map((labelId) => ({ id: id(), issueId, labelId }));
+  if (rows.length === 0) return;
+  await db.insert(schema.issueLabel).values(rows);
+}
+
 async function seedIssues(
   userIds: Map<string, string>,
   teams: Map<string, TeamRecord>,
@@ -382,6 +395,7 @@ async function seedIssues(
     const identifier = `${team.key}-${nextNumber}`;
     const timestamps = stateTimestamps(entry.state);
     const project = entry.project === null ? null : projects.get(entry.project);
+    const inCycle = timestamps.startedAt !== null && timestamps.canceledAt === null;
 
     await db.insert(schema.issue).values({
       id: issueId,
@@ -396,8 +410,9 @@ async function seedIssues(
       creatorId: required(userIds.get('pulkit'), 'missing creator'),
       assigneeId: entry.assignee === null ? null : (userIds.get(entry.assignee) ?? null),
       projectId: project?.id ?? null,
-      milestoneId: null,
-      cycleId: timestamps.startedAt === null ? null : (cycles.get(entry.team) ?? null),
+      milestoneId:
+        entry.milestone === null ? null : (project?.milestones.get(entry.milestone) ?? null),
+      cycleId: inCycle ? (cycles.get(entry.team) ?? null) : null,
       parentId: null,
       estimate: entry.estimate,
       dueDate: null,
@@ -411,11 +426,7 @@ async function seedIssues(
       updatedAt: daysAgo(Math.max(1, 12 - (index % 12))),
     });
 
-    const labelRows = entry.labels
-      .map((name) => labels.get(name))
-      .filter((value): value is string => value !== undefined)
-      .map((labelId) => ({ id: id(), issueId, labelId }));
-    if (labelRows.length > 0) await db.insert(schema.issueLabel).values(labelRows);
+    await attachLabels(issueId, entry.labels, labels);
 
     issues.set(entry.title, { id: issueId, identifier, teamId: team.id });
   }

--- a/packages/db/src/seed/index.ts
+++ b/packages/db/src/seed/index.ts
@@ -1,0 +1,601 @@
+import { randomUUID } from 'node:crypto';
+import { STATE_CATEGORY_ORDER } from '@orbit/shared';
+import { sql } from 'drizzle-orm';
+import { db, pool } from '../client.ts';
+import * as schema from '../schema/index.ts';
+import {
+  SEED_COLLECTIONS,
+  SEED_COMMENTS,
+  SEED_DOCS,
+  SEED_ISSUES,
+  SEED_LABELS,
+  SEED_PROJECTS,
+  SEED_STATES,
+  SEED_TEAMS,
+  SEED_USERS,
+} from './data.ts';
+
+const ORGANIZATION_ID = 'org_noveum_demo';
+const ORGANIZATION_SLUG = 'noveum';
+const SORT_STEP = 1024;
+
+function id(): string {
+  return randomUUID();
+}
+
+function required<T>(value: T | undefined, message: string): T {
+  if (value === undefined) throw new Error(message);
+  return value;
+}
+
+function daysAgo(days: number): Date {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+function daysAhead(days: number): Date {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+}
+
+async function reset(): Promise<void> {
+  const tables = [
+    'reaction',
+    'comment',
+    'attachment',
+    'doc_subscription',
+    'doc',
+    'doc_collection',
+    'favorite',
+    'notification',
+    'notification_preference',
+    'notification_setting',
+    'email_delivery',
+    'audit_log',
+    'api_key',
+    'webhook_delivery',
+    'automation_rule',
+    'git_link',
+    'integration_channel',
+    'integration',
+    'issue_activity',
+    'issue_subscription',
+    'issue_relation',
+    'issue_label',
+    'issue',
+    'view',
+    'milestone',
+    'project_update',
+    'project_team',
+    'project',
+    'cycle',
+    'label',
+    'workflow_state',
+    'team_member',
+    'team',
+    'invitation',
+    'member',
+    'organization',
+    'passkey',
+    'account',
+    'session',
+    'verification',
+    '"user"',
+  ];
+  await db.execute(sql.raw(`TRUNCATE TABLE ${tables.join(', ')} RESTART IDENTITY CASCADE`));
+  await db.execute(sql.raw('ALTER SEQUENCE sync_id_seq RESTART WITH 1'));
+}
+
+async function seedOrganizationAndUsers(): Promise<Map<string, string>> {
+  await db.insert(schema.organization).values({
+    id: ORGANIZATION_ID,
+    name: 'Noveum',
+    slug: ORGANIZATION_SLUG,
+    logo: null,
+    allowedEmailDomains: ['noveum.ai'],
+    createdAt: daysAgo(240),
+  });
+
+  const userIds = new Map<string, string>();
+  const userRows = SEED_USERS.map((entry) => {
+    const userId = id();
+    userIds.set(entry.handle, userId);
+    return {
+      id: userId,
+      name: entry.name,
+      email: entry.email,
+      emailVerified: true,
+      image: null,
+      handle: entry.handle,
+      timezone: 'Asia/Kolkata',
+      createdAt: daysAgo(200),
+      updatedAt: daysAgo(2),
+    };
+  });
+  await db.insert(schema.user).values(userRows);
+
+  await db.insert(schema.member).values(
+    SEED_USERS.map((entry) => ({
+      id: id(),
+      organizationId: ORGANIZATION_ID,
+      userId: required(userIds.get(entry.handle), `missing user ${entry.handle}`),
+      role: entry.role,
+      syncId: 0,
+      createdAt: daysAgo(200),
+    })),
+  );
+
+  return userIds;
+}
+
+interface TeamRecord {
+  readonly id: string;
+  readonly key: string;
+  readonly states: Map<string, string>;
+}
+
+async function seedTeams(userIds: Map<string, string>): Promise<Map<string, TeamRecord>> {
+  const teams = new Map<string, TeamRecord>();
+
+  for (const entry of SEED_TEAMS) {
+    const teamId = id();
+    await db.insert(schema.team).values({
+      id: teamId,
+      organizationId: ORGANIZATION_ID,
+      name: entry.name,
+      key: entry.key,
+      description: entry.description,
+      icon: entry.icon,
+      color: entry.color,
+      issueCounter: 0,
+      syncId: 0,
+      createdAt: daysAgo(200),
+      updatedAt: daysAgo(5),
+    });
+
+    const states = new Map<string, string>();
+    const stateRows = SEED_STATES.map((state) => {
+      const stateId = id();
+      states.set(state.name, stateId);
+      return {
+        id: stateId,
+        organizationId: ORGANIZATION_ID,
+        teamId,
+        name: state.name,
+        category: state.category,
+        color: state.color,
+        position: STATE_CATEGORY_ORDER[state.category],
+        syncId: 0,
+        createdAt: daysAgo(200),
+      };
+    });
+    await db.insert(schema.workflowState).values(stateRows);
+
+    teams.set(entry.key, { id: teamId, key: entry.key, states });
+  }
+
+  const memberships = SEED_USERS.flatMap((entry) =>
+    entry.teams.map((teamKey) => ({
+      id: id(),
+      teamId: required(teams.get(teamKey), `missing team ${teamKey}`).id,
+      userId: required(userIds.get(entry.handle), `missing user ${entry.handle}`),
+      createdAt: daysAgo(190),
+    })),
+  );
+  await db.insert(schema.teamMember).values(memberships);
+
+  return teams;
+}
+
+async function seedLabels(): Promise<Map<string, string>> {
+  const labels = new Map<string, string>();
+  const rows = SEED_LABELS.map((entry) => {
+    const labelId = id();
+    labels.set(entry.name, labelId);
+    return {
+      id: labelId,
+      organizationId: ORGANIZATION_ID,
+      teamId: null,
+      name: entry.name,
+      color: entry.color,
+      syncId: 0,
+      createdAt: daysAgo(200),
+    };
+  });
+  await db.insert(schema.label).values(rows);
+  return labels;
+}
+
+async function seedCycles(teams: Map<string, TeamRecord>): Promise<Map<string, string>> {
+  const cycles = new Map<string, string>();
+  for (const [key, team] of teams) {
+    const current = id();
+    cycles.set(key, current);
+    await db.insert(schema.cycle).values([
+      {
+        id: current,
+        organizationId: ORGANIZATION_ID,
+        teamId: team.id,
+        number: 12,
+        name: '',
+        startsAt: daysAgo(6),
+        endsAt: daysAhead(8),
+        completedAt: null,
+        syncId: 0,
+        createdAt: daysAgo(30),
+      },
+      {
+        id: id(),
+        organizationId: ORGANIZATION_ID,
+        teamId: team.id,
+        number: 13,
+        name: '',
+        startsAt: daysAhead(9),
+        endsAt: daysAhead(23),
+        completedAt: null,
+        syncId: 0,
+        createdAt: daysAgo(30),
+      },
+    ]);
+  }
+  return cycles;
+}
+
+interface ProjectRecord {
+  readonly id: string;
+  readonly milestones: Map<string, string>;
+}
+
+async function seedProjects(
+  userIds: Map<string, string>,
+  teams: Map<string, TeamRecord>,
+): Promise<Map<string, ProjectRecord>> {
+  const projects = new Map<string, ProjectRecord>();
+
+  for (const [index, entry] of SEED_PROJECTS.entries()) {
+    const projectId = id();
+    await db.insert(schema.project).values({
+      id: projectId,
+      organizationId: ORGANIZATION_ID,
+      name: entry.name,
+      slug: entry.name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, ''),
+      summary: entry.summary,
+      description: `## Overview\n\n${entry.summary}\n\nProgress is tracked against the milestones below.`,
+      status: entry.status,
+      health: entry.health,
+      icon: 'box',
+      color: '#5A63C8',
+      leadId: userIds.get(entry.leadHandle) ?? null,
+      startDate: daysAgo(40).toISOString().slice(0, 10),
+      targetDate: daysAhead(30 + index * 15)
+        .toISOString()
+        .slice(0, 10),
+      sortOrder: (index + 1) * SORT_STEP,
+      syncId: 0,
+      createdAt: daysAgo(60),
+      updatedAt: daysAgo(3),
+    });
+
+    await db.insert(schema.projectTeam).values(
+      entry.teams.map((teamKey) => ({
+        id: id(),
+        projectId,
+        teamId: required(teams.get(teamKey), `missing team ${teamKey}`).id,
+      })),
+    );
+
+    const milestones = new Map<string, string>();
+    const milestoneRows = entry.milestones.map((name, milestoneIndex) => {
+      const milestoneId = id();
+      milestones.set(name, milestoneId);
+      return {
+        id: milestoneId,
+        organizationId: ORGANIZATION_ID,
+        projectId,
+        name,
+        description: '',
+        targetDate: daysAhead(10 + milestoneIndex * 14)
+          .toISOString()
+          .slice(0, 10),
+        sortOrder: (milestoneIndex + 1) * SORT_STEP,
+        syncId: 0,
+        createdAt: daysAgo(58),
+      };
+    });
+    await db.insert(schema.milestone).values(milestoneRows);
+
+    projects.set(entry.name, { id: projectId, milestones });
+  }
+
+  await db.insert(schema.projectUpdate).values([
+    {
+      id: id(),
+      organizationId: ORGANIZATION_ID,
+      projectId: required(projects.get('Realtime Sync Engine'), 'missing project').id,
+      authorId: required(userIds.get('shashank'), 'missing user'),
+      health: 'on_track',
+      body: 'Delta fan out is in review and presence lands this week. Scope is holding.',
+      syncId: 0,
+      createdAt: daysAgo(4),
+    },
+    {
+      id: id(),
+      organizationId: ORGANIZATION_ID,
+      projectId: required(projects.get('Workspace Onboarding'), 'missing project').id,
+      authorId: required(userIds.get('aditi'), 'missing user'),
+      health: 'at_risk',
+      body: 'Passkey behavior on Safari is costing us a few days. Invite lifecycle is unaffected.',
+      syncId: 0,
+      createdAt: daysAgo(2),
+    },
+  ]);
+
+  return projects;
+}
+
+interface IssueRecord {
+  readonly id: string;
+  readonly identifier: string;
+  readonly teamId: string;
+}
+
+function stateTimestamps(stateName: string): {
+  startedAt: Date | null;
+  completedAt: Date | null;
+  canceledAt: Date | null;
+} {
+  if (stateName === 'Done') {
+    return { startedAt: daysAgo(12), completedAt: daysAgo(3), canceledAt: null };
+  }
+  if (stateName === 'Canceled') {
+    return { startedAt: daysAgo(20), completedAt: null, canceledAt: daysAgo(9) };
+  }
+  if (stateName === 'In Progress' || stateName === 'In Review') {
+    return { startedAt: daysAgo(7), completedAt: null, canceledAt: null };
+  }
+  return { startedAt: null, completedAt: null, canceledAt: null };
+}
+
+async function seedIssues(
+  userIds: Map<string, string>,
+  teams: Map<string, TeamRecord>,
+  labels: Map<string, string>,
+  projects: Map<string, ProjectRecord>,
+  cycles: Map<string, string>,
+): Promise<Map<string, IssueRecord>> {
+  const issues = new Map<string, IssueRecord>();
+  const counters = new Map<string, number>();
+  const columnOrders = new Map<string, number>();
+
+  for (const [index, entry] of SEED_ISSUES.entries()) {
+    const team = required(teams.get(entry.team), `missing team ${entry.team}`);
+    const stateId = required(team.states.get(entry.state), `missing state ${entry.state}`);
+    const nextNumber = (counters.get(entry.team) ?? 0) + 1;
+    counters.set(entry.team, nextNumber);
+
+    const columnKey = `${team.id}:${stateId}`;
+    const nextOrder = (columnOrders.get(columnKey) ?? 0) + SORT_STEP;
+    columnOrders.set(columnKey, nextOrder);
+
+    const issueId = id();
+    const identifier = `${team.key}-${nextNumber}`;
+    const timestamps = stateTimestamps(entry.state);
+    const project = entry.project === null ? null : projects.get(entry.project);
+
+    await db.insert(schema.issue).values({
+      id: issueId,
+      organizationId: ORGANIZATION_ID,
+      teamId: team.id,
+      number: nextNumber,
+      identifier,
+      title: entry.title,
+      description: entry.description,
+      stateId,
+      priority: entry.priority,
+      creatorId: required(userIds.get('pulkit'), 'missing creator'),
+      assigneeId: entry.assignee === null ? null : (userIds.get(entry.assignee) ?? null),
+      projectId: project?.id ?? null,
+      milestoneId: null,
+      cycleId: timestamps.startedAt === null ? null : (cycles.get(entry.team) ?? null),
+      parentId: null,
+      estimate: entry.estimate,
+      dueDate: null,
+      sortOrder: nextOrder,
+      startedAt: timestamps.startedAt,
+      completedAt: timestamps.completedAt,
+      canceledAt: timestamps.canceledAt,
+      stateEnteredAt: daysAgo(Math.max(1, 30 - index)),
+      syncId: 0,
+      createdAt: daysAgo(Math.max(2, 45 - index)),
+      updatedAt: daysAgo(Math.max(1, 12 - (index % 12))),
+    });
+
+    const labelRows = entry.labels
+      .map((name) => labels.get(name))
+      .filter((value): value is string => value !== undefined)
+      .map((labelId) => ({ id: id(), issueId, labelId }));
+    if (labelRows.length > 0) await db.insert(schema.issueLabel).values(labelRows);
+
+    issues.set(entry.title, { id: issueId, identifier, teamId: team.id });
+  }
+
+  for (const [teamKey, count] of counters) {
+    const team = required(teams.get(teamKey), `missing team ${teamKey}`);
+    await db
+      .update(schema.team)
+      .set({ issueCounter: count })
+      .where(sql`${schema.team.id} = ${team.id}`);
+  }
+
+  return issues;
+}
+
+async function seedComments(
+  userIds: Map<string, string>,
+  issues: Map<string, IssueRecord>,
+): Promise<void> {
+  for (const entry of SEED_COMMENTS) {
+    const issue = issues.get(entry.issueTitle);
+    if (issue === undefined) continue;
+
+    const rootId = id();
+    await db.insert(schema.comment).values({
+      id: rootId,
+      organizationId: ORGANIZATION_ID,
+      issueId: issue.id,
+      authorId: required(userIds.get(entry.author), `missing user ${entry.author}`),
+      parentId: null,
+      body: entry.body,
+      syncId: 0,
+      createdAt: daysAgo(6),
+      updatedAt: daysAgo(6),
+    });
+
+    for (const [index, reply] of entry.replies.entries()) {
+      await db.insert(schema.comment).values({
+        id: id(),
+        organizationId: ORGANIZATION_ID,
+        issueId: issue.id,
+        authorId: required(userIds.get(reply.author), `missing user ${reply.author}`),
+        parentId: rootId,
+        body: reply.body,
+        syncId: 0,
+        createdAt: daysAgo(5 - index * 0.1),
+        updatedAt: daysAgo(5 - index * 0.1),
+      });
+    }
+
+    const reactionRows = entry.reactions
+      .map((reaction) => {
+        const userId = userIds.get(reaction.user);
+        if (userId === undefined) return null;
+        return {
+          id: id(),
+          organizationId: ORGANIZATION_ID,
+          commentId: rootId,
+          issueId: null,
+          userId,
+          emoji: reaction.emoji,
+          syncId: 0,
+          createdAt: daysAgo(4),
+        };
+      })
+      .filter((row): row is NonNullable<typeof row> => row !== null);
+    if (reactionRows.length > 0) await db.insert(schema.reaction).values(reactionRows);
+  }
+}
+
+async function seedDocs(userIds: Map<string, string>): Promise<void> {
+  const collections = new Map<string, string>();
+  const collectionRows = SEED_COLLECTIONS.map((name) => {
+    const collectionId = id();
+    collections.set(name, collectionId);
+    return {
+      id: collectionId,
+      organizationId: ORGANIZATION_ID,
+      name,
+      icon: 'book',
+      createdAt: daysAgo(120),
+    };
+  });
+  await db.insert(schema.docCollection).values(collectionRows);
+
+  await db.insert(schema.doc).values(
+    SEED_DOCS.map((entry) => ({
+      id: id(),
+      organizationId: ORGANIZATION_ID,
+      collectionId: collections.get(entry.collection) ?? null,
+      projectId: null,
+      title: entry.title,
+      content: entry.content,
+      visibility: 'workspace',
+      publishToken: null,
+      authorId: required(userIds.get(entry.author), `missing user ${entry.author}`),
+      repoBinding: null,
+      syncId: 0,
+      createdAt: daysAgo(30),
+      updatedAt: daysAgo(3),
+    })),
+  );
+}
+
+async function seedNotifications(
+  userIds: Map<string, string>,
+  issues: Map<string, IssueRecord>,
+): Promise<void> {
+  const recipient = required(userIds.get('pulkit'), 'missing user');
+  const actor = required(userIds.get('shashank'), 'missing user');
+  const entries = [...issues.values()].slice(0, 6);
+
+  await db.insert(schema.notification).values(
+    entries.map((issue, index) => ({
+      id: id(),
+      organizationId: ORGANIZATION_ID,
+      userId: recipient,
+      type: index % 2 === 0 ? 'issue_assigned' : 'comment_created',
+      actorType: 'user',
+      actorId: actor,
+      actorName: 'Shashank Agarwal',
+      entityType: 'issue',
+      entityId: issue.id,
+      title:
+        index % 2 === 0 ? `Assigned you ${issue.identifier}` : `Commented on ${issue.identifier}`,
+      body: '',
+      url: `/issue/${issue.identifier}`,
+      readAt: index > 2 ? daysAgo(1) : null,
+      snoozedUntil: null,
+      deliveredChannels: ['inbox'],
+      syncId: 0,
+      createdAt: daysAgo(index + 1),
+    })),
+  );
+}
+
+async function main(): Promise<void> {
+  console.info('Resetting database');
+  await reset();
+
+  console.info('Seeding organization and users');
+  const userIds = await seedOrganizationAndUsers();
+
+  console.info('Seeding teams and workflow states');
+  const teams = await seedTeams(userIds);
+
+  console.info('Seeding labels and cycles');
+  const labels = await seedLabels();
+  const cycles = await seedCycles(teams);
+
+  console.info('Seeding projects and milestones');
+  const projects = await seedProjects(userIds, teams);
+
+  console.info('Seeding issues');
+  const issues = await seedIssues(userIds, teams, labels, projects, cycles);
+
+  console.info('Seeding comments and reactions');
+  await seedComments(userIds, issues);
+
+  console.info('Seeding docs');
+  await seedDocs(userIds);
+
+  console.info('Seeding notifications');
+  await seedNotifications(userIds, issues);
+
+  console.info(
+    `Done. ${SEED_USERS.length} users, ${SEED_TEAMS.length} teams, ${issues.size} issues, ${SEED_DOCS.length} docs.`,
+  );
+  console.info(
+    `Sign in as ${SEED_USERS[0]?.email ?? 'pulkit@noveum.ai'} to explore the workspace.`,
+  );
+}
+
+main()
+  .then(async () => {
+    await pool.end();
+    process.exit(0);
+  })
+  .catch(async (error: unknown) => {
+    console.error('Seed failed', error);
+    await pool.end();
+    process.exit(1);
+  });

--- a/packages/shared/src/events/events.test.ts
+++ b/packages/shared/src/events/events.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { clientMessageSchema, scopes, serverMessageSchema, syncActionSchema } from './index.ts';
+
+const validAction = {
+  syncId: 12,
+  organizationId: 'org_1',
+  scopes: ['org:org_1', 'team:team_eng'],
+  action: 'update',
+  model: 'issue',
+  modelId: 'issue_1',
+  data: { title: 'Ship it' },
+  actor: { type: 'user', id: 'user_1', name: 'Pulkit' },
+  at: '2026-07-22T12:00:00.000Z',
+};
+
+describe('syncActionSchema', () => {
+  it('accepts a well formed action', () => {
+    expect(syncActionSchema.parse(validAction).modelId).toBe('issue_1');
+  });
+
+  it('rejects an unknown model', () => {
+    expect(syncActionSchema.safeParse({ ...validAction, model: 'nope' }).success).toBe(false);
+  });
+
+  it('rejects an unknown action kind', () => {
+    expect(syncActionSchema.safeParse({ ...validAction, action: 'upsert' }).success).toBe(false);
+  });
+
+  it('requires at least one scope', () => {
+    expect(syncActionSchema.safeParse({ ...validAction, scopes: [] }).success).toBe(false);
+  });
+
+  it('requires a negative free sync id', () => {
+    expect(syncActionSchema.safeParse({ ...validAction, syncId: -1 }).success).toBe(false);
+  });
+
+  it('rejects a non iso timestamp', () => {
+    expect(syncActionSchema.safeParse({ ...validAction, at: 'yesterday' }).success).toBe(false);
+  });
+});
+
+describe('clientMessageSchema', () => {
+  it('accepts subscribe and unsubscribe', () => {
+    expect(clientMessageSchema.safeParse({ type: 'subscribe', scopes: ['org:1'] }).success).toBe(
+      true,
+    );
+    expect(clientMessageSchema.safeParse({ type: 'unsubscribe', scopes: ['org:1'] }).success).toBe(
+      true,
+    );
+  });
+
+  it('accepts a ping and a presence message', () => {
+    expect(clientMessageSchema.safeParse({ type: 'ping' }).success).toBe(true);
+    expect(
+      clientMessageSchema.safeParse({ type: 'presence', scope: 'issue:1', kind: 'typing' }).success,
+    ).toBe(true);
+  });
+
+  it('rejects an unknown message type', () => {
+    expect(clientMessageSchema.safeParse({ type: 'shout' }).success).toBe(false);
+  });
+
+  it('caps the number of scopes per message', () => {
+    const many = Array.from({ length: 65 }, (_, index) => `team:${index}`);
+    expect(clientMessageSchema.safeParse({ type: 'subscribe', scopes: many }).success).toBe(false);
+  });
+});
+
+describe('serverMessageSchema', () => {
+  it('accepts a delta batch', () => {
+    expect(serverMessageSchema.safeParse({ type: 'delta', actions: [validAction] }).success).toBe(
+      true,
+    );
+  });
+
+  it('rejects an empty delta batch', () => {
+    expect(serverMessageSchema.safeParse({ type: 'delta', actions: [] }).success).toBe(false);
+  });
+
+  it('accepts an error frame', () => {
+    expect(
+      serverMessageSchema.safeParse({ type: 'error', message: 'nope', code: 'forbidden' }).success,
+    ).toBe(true);
+  });
+});
+
+describe('scopes', () => {
+  it('namespaces every entity type distinctly', () => {
+    const built = [
+      scopes.organization('1'),
+      scopes.team('1'),
+      scopes.project('1'),
+      scopes.issue('1'),
+      scopes.doc('1'),
+      scopes.user('1'),
+    ];
+    expect(new Set(built).size).toBe(built.length);
+    expect(scopes.issue('abc')).toBe('issue:abc');
+  });
+});

--- a/packages/shared/src/policy/policy.test.ts
+++ b/packages/shared/src/policy/policy.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { OrgRole } from '../constants/index.ts';
+import { DomainError } from '../errors/index.ts';
+import {
+  assertCan,
+  assertInTeam,
+  atLeast,
+  can,
+  canAssignRole,
+  isInTeam,
+  type Principal,
+  permissionsFor,
+} from './index.ts';
+
+function principal(role: OrgRole, teamIds: string[] = ['team_eng']): Principal {
+  return { userId: 'user_1', organizationId: 'org_1', role, teamIds };
+}
+
+describe('permissionsFor', () => {
+  it('widens monotonically from guest to admin', () => {
+    const guest = permissionsFor('guest');
+    const contributor = permissionsFor('contributor');
+    const member = permissionsFor('member');
+    const admin = permissionsFor('admin');
+
+    for (const permission of guest) expect(contributor).toContain(permission);
+    for (const permission of contributor) expect(member).toContain(permission);
+    for (const permission of member) expect(admin).toContain(permission);
+    expect(admin.length).toBeGreaterThan(guest.length);
+  });
+});
+
+describe('can', () => {
+  it('lets a guest read but not create issues', () => {
+    expect(can(principal('guest'), 'issue:read')).toBe(true);
+    expect(can(principal('guest'), 'issue:create')).toBe(false);
+  });
+
+  it('lets a contributor create but not delete issues', () => {
+    expect(can(principal('contributor'), 'issue:create')).toBe(true);
+    expect(can(principal('contributor'), 'issue:delete')).toBe(false);
+  });
+
+  it('lets a member delete issues but not manage the organization', () => {
+    expect(can(principal('member'), 'issue:delete')).toBe(true);
+    expect(can(principal('member'), 'org:manage')).toBe(false);
+  });
+
+  it('lets an admin manage the organization and integrations', () => {
+    expect(can(principal('admin'), 'org:manage')).toBe(true);
+    expect(can(principal('admin'), 'integration:manage')).toBe(true);
+  });
+});
+
+describe('assertCan', () => {
+  it('throws a forbidden domain error when denied', () => {
+    let thrown: unknown;
+    try {
+      assertCan(principal('guest'), 'issue:delete');
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(DomainError);
+    expect((thrown as DomainError).code).toBe('forbidden');
+    expect((thrown as DomainError).status).toBe(403);
+  });
+
+  it('stays silent when allowed', () => {
+    expect(() => {
+      assertCan(principal('admin'), 'issue:delete');
+    }).not.toThrow();
+  });
+});
+
+describe('team membership', () => {
+  it('accepts a member of the team', () => {
+    expect(isInTeam(principal('member', ['team_eng']), 'team_eng')).toBe(true);
+  });
+
+  it('rejects a non member', () => {
+    expect(isInTeam(principal('member', ['team_eng']), 'team_des')).toBe(false);
+    expect(() => {
+      assertInTeam(principal('member', ['team_eng']), 'team_des');
+    }).toThrow(DomainError);
+  });
+
+  it('treats admins as members of every team', () => {
+    expect(isInTeam(principal('admin', []), 'team_anything')).toBe(true);
+  });
+});
+
+describe('role comparison', () => {
+  it('ranks roles', () => {
+    expect(atLeast('admin', 'member')).toBe(true);
+    expect(atLeast('contributor', 'member')).toBe(false);
+    expect(atLeast('member', 'member')).toBe(true);
+  });
+
+  it('only lets admins assign roles', () => {
+    expect(canAssignRole('admin', 'member')).toBe(true);
+    expect(canAssignRole('member', 'guest')).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -15,7 +15,7 @@ export function issueIdentifier(prefix: string, number: number): string {
 }
 
 export function parseIssueIdentifier(value: string): { prefix: string; number: number } | null {
-  const match = /^([A-Za-z][A-Za-z0-9]{0,5})-(\d+)$/.exec(value.trim());
+  const match = /^([A-Za-z][A-Za-z0-9]{1,5})-(\d+)$/.exec(value.trim());
   if (!match) return null;
   const [, prefix, digits] = match;
   if (prefix === undefined || digits === undefined) return null;

--- a/packages/shared/src/utils/utils.test.ts
+++ b/packages/shared/src/utils/utils.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import { SORT_ORDER_STEP } from '../constants/index.ts';
+import {
+  branchName,
+  chunk,
+  extractIssueIdentifiers,
+  extractMentions,
+  formatBytes,
+  groupBy,
+  initialsOf,
+  issueIdentifier,
+  parseIssueIdentifier,
+  relativeTime,
+  slugify,
+  sortOrderBetween,
+  truncate,
+  unique,
+} from './index.ts';
+
+describe('slugify', () => {
+  it('lowercases and dashes separators', () => {
+    expect(slugify('Realtime Sync Engine')).toBe('realtime-sync-engine');
+  });
+
+  it('strips punctuation and collapses repeats', () => {
+    expect(slugify('  Docs && Attachments!!  ')).toBe('docs-attachments');
+  });
+
+  it('returns an empty string when nothing survives', () => {
+    expect(slugify('!!!')).toBe('');
+  });
+});
+
+describe('issue identifiers', () => {
+  it('builds an identifier', () => {
+    expect(issueIdentifier('ENG', 62)).toBe('ENG-62');
+  });
+
+  it('parses a valid identifier and uppercases the prefix', () => {
+    expect(parseIssueIdentifier('eng-62')).toEqual({ prefix: 'ENG', number: 62 });
+  });
+
+  it('rejects malformed identifiers', () => {
+    expect(parseIssueIdentifier('ENG')).toBeNull();
+    expect(parseIssueIdentifier('ENG-0')).toBeNull();
+    expect(parseIssueIdentifier('-12')).toBeNull();
+    expect(parseIssueIdentifier('TOOLONGPREFIX-1')).toBeNull();
+  });
+});
+
+describe('branchName', () => {
+  it('builds a git safe branch from an issue', () => {
+    expect(
+      branchName({ username: 'Pulkit', identifier: 'ENG-62', title: 'Fix the board drag' }),
+    ).toBe('pulkit/eng-62-fix-the-board-drag');
+  });
+
+  it('falls back when the title yields nothing', () => {
+    expect(branchName({ username: 'pulkit', identifier: 'ENG-1', title: '!!!' })).toBe(
+      'pulkit/eng-1',
+    );
+  });
+
+  it('falls back when the username yields nothing', () => {
+    expect(branchName({ username: '!!!', identifier: 'ENG-1', title: 'Ship it' })).toBe(
+      'orbit/eng-1-ship-it',
+    );
+  });
+});
+
+describe('sortOrderBetween', () => {
+  it('returns the step for an empty column', () => {
+    expect(sortOrderBetween(null, null)).toBe(SORT_ORDER_STEP);
+  });
+
+  it('places before the first item', () => {
+    expect(sortOrderBetween(null, 1024)).toBe(0);
+  });
+
+  it('places after the last item', () => {
+    expect(sortOrderBetween(2048, null)).toBe(2048 + SORT_ORDER_STEP);
+  });
+
+  it('midpoints between two neighbours', () => {
+    expect(sortOrderBetween(1024, 2048)).toBe(1536);
+  });
+
+  it('keeps ordering stable across repeated insertions', () => {
+    let before = 1024;
+    const after = 2048;
+    for (let index = 0; index < 10; index += 1) {
+      const next = sortOrderBetween(before, after);
+      expect(next).toBeGreaterThan(before);
+      expect(next).toBeLessThan(after);
+      before = next;
+    }
+  });
+});
+
+describe('initialsOf', () => {
+  it('uses the first and last name', () => {
+    expect(initialsOf('Shashank Agarwal')).toBe('SA');
+  });
+
+  it('handles a single name', () => {
+    expect(initialsOf('Pulkit')).toBe('P');
+  });
+
+  it('handles empty input', () => {
+    expect(initialsOf('   ')).toBe('?');
+  });
+});
+
+describe('extractMentions', () => {
+  it('finds handles and lowercases them', () => {
+    expect(extractMentions('cc @Aditi and @shashank')).toEqual(['aditi', 'shashank']);
+  });
+
+  it('deduplicates', () => {
+    expect(extractMentions('@aditi @aditi')).toEqual(['aditi']);
+  });
+
+  it('ignores emails', () => {
+    expect(extractMentions('mail pulkit@noveum.ai now')).toEqual([]);
+  });
+});
+
+describe('extractIssueIdentifiers', () => {
+  it('finds identifiers in free text', () => {
+    expect(extractIssueIdentifiers('Fixes ENG-62 and refs DES-7')).toEqual(['ENG-62', 'DES-7']);
+  });
+
+  it('deduplicates repeats', () => {
+    expect(extractIssueIdentifiers('ENG-1 ENG-1')).toEqual(['ENG-1']);
+  });
+});
+
+describe('truncate', () => {
+  it('leaves short strings alone', () => {
+    expect(truncate('short', 10)).toBe('short');
+  });
+
+  it('adds an ellipsis when cutting', () => {
+    expect(truncate('a very long sentence', 8)).toBe('a very…');
+  });
+});
+
+describe('formatBytes', () => {
+  it('formats bytes', () => {
+    expect(formatBytes(512)).toBe('512 B');
+  });
+
+  it('formats kilobytes with one decimal', () => {
+    expect(formatBytes(1536)).toBe('1.5 KB');
+  });
+
+  it('rounds larger units', () => {
+    expect(formatBytes(20 * 1024 * 1024)).toBe('20 MB');
+  });
+});
+
+describe('collections', () => {
+  it('groups by a key', () => {
+    const grouped = groupBy([{ s: 'a' }, { s: 'b' }, { s: 'a' }], (item) => item.s);
+    expect(grouped.get('a')).toHaveLength(2);
+    expect(grouped.get('b')).toHaveLength(1);
+  });
+
+  it('uniques values', () => {
+    expect(unique([1, 1, 2])).toEqual([1, 2]);
+  });
+
+  it('chunks evenly and unevenly', () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it('rejects a non positive chunk size', () => {
+    expect(() => chunk([1], 0)).toThrow(RangeError);
+  });
+});
+
+describe('relativeTime', () => {
+  const now = new Date('2026-07-22T12:00:00.000Z');
+
+  it('reports recent moments', () => {
+    expect(relativeTime(new Date('2026-07-22T11:59:50.000Z'), now)).toBe('just now');
+  });
+
+  it('reports minutes, hours, and days', () => {
+    expect(relativeTime(new Date('2026-07-22T11:30:00.000Z'), now)).toBe('30m ago');
+    expect(relativeTime(new Date('2026-07-22T09:00:00.000Z'), now)).toBe('3h ago');
+    expect(relativeTime(new Date('2026-07-19T12:00:00.000Z'), now)).toBe('3d ago');
+  });
+});

--- a/packages/shared/src/utils/utils.test.ts
+++ b/packages/shared/src/utils/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { SORT_ORDER_STEP } from '../constants/index.ts';
+import { IDENTIFIER_PATTERN, SORT_ORDER_STEP } from '../constants/index.ts';
 import {
   branchName,
   chunk,
@@ -45,6 +45,18 @@ describe('issue identifiers', () => {
     expect(parseIssueIdentifier('ENG-0')).toBeNull();
     expect(parseIssueIdentifier('-12')).toBeNull();
     expect(parseIssueIdentifier('TOOLONGPREFIX-1')).toBeNull();
+  });
+
+  it('rejects a one character prefix, matching the team key contract', () => {
+    expect(IDENTIFIER_PATTERN.test('A')).toBe(false);
+    expect(parseIssueIdentifier('A-1')).toBeNull();
+    expect(extractIssueIdentifiers('Refs A-1')).toEqual([]);
+  });
+
+  it('accepts the shortest and longest legal prefixes', () => {
+    expect(parseIssueIdentifier('AB-1')).toEqual({ prefix: 'AB', number: 1 });
+    expect(parseIssueIdentifier('ABCDEF-1')).toEqual({ prefix: 'ABCDEF', number: 1 });
+    expect(extractIssueIdentifiers('AB-1 and ABCDEF-2')).toEqual(['AB-1', 'ABCDEF-2']);
   });
 });
 


### PR DESCRIPTION
Seeds a realistic Noveum workspace: 7 members, 3 teams, 4 projects, 32 issues, threaded comments with reactions, docs, and notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized demo seed data covering users, teams, workflow states, labels, projects, issues, comments (with replies/reactions), and documents.
  * Expanded the database seeding workflow to generate a fully connected sample workspace, including project updates, milestones/cycles, and notifications.

* **Chores**
  * Updated local seeding to perform a full database reset (with identity/sequence restart).
  * Adjusted the database test command to pass when no tests are present.

* **Tests**
  * Added Vitest coverage for event/schema validation, authorization/policy behavior, and shared utility helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->