### PR TITLE
fix(shared): stop update schemas from inventing values

### DIFF
--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -92,18 +92,25 @@ export const labelCreateSchema = z.object({
   teamId: idSchema.nullable().default(null),
 });
 
-export const labelUpdateSchema = labelCreateSchema.partial();
+export const labelUpdateSchema = z
+  .object({
+    name: z.string().trim().min(1).max(48),
+    color: colorSchema,
+    teamId: idSchema.nullable(),
+  })
+  .partial();
+
+export const prioritySchema = z
+  .number()
+  .int()
+  .refine((value): value is (typeof PRIORITIES)[number] => PRIORITIES.includes(value as 0));
 
 export const issueCreateSchema = z.object({
   teamId: idSchema,
   title: titleSchema,
   description: markdownSchema.default(''),
   stateId: idSchema.optional(),
-  priority: z
-    .number()
-    .int()
-    .refine((value): value is (typeof PRIORITIES)[number] => PRIORITIES.includes(value as 0))
-    .default(0),
+  priority: prioritySchema.default(0),
   assigneeId: idSchema.nullable().default(null),
   projectId: idSchema.nullable().default(null),
   milestoneId: idSchema.nullable().default(null),
@@ -114,13 +121,23 @@ export const issueCreateSchema = z.object({
   labelIds: z.array(idSchema).max(50).default([]),
 });
 
-export const issueUpdateSchema = issueCreateSchema
-  .partial()
-  .omit({ teamId: true, labelIds: true })
-  .extend({
-    labelIds: z.array(idSchema).max(50).optional(),
-    sortOrder: z.number().optional(),
-  });
+export const issueUpdateSchema = z
+  .object({
+    title: titleSchema,
+    description: markdownSchema,
+    stateId: idSchema,
+    priority: prioritySchema,
+    assigneeId: idSchema.nullable(),
+    projectId: idSchema.nullable(),
+    milestoneId: idSchema.nullable(),
+    cycleId: idSchema.nullable(),
+    parentId: idSchema.nullable(),
+    estimate: z.number().int().min(0).max(100).nullable(),
+    dueDate: z.coerce.date().nullable(),
+    labelIds: z.array(idSchema).max(50),
+    sortOrder: z.number(),
+  })
+  .partial();
 
 export const issueMoveSchema = z.object({
   stateId: idSchema.optional(),
@@ -182,7 +199,21 @@ export const projectCreateSchema = z.object({
   color: colorSchema.optional(),
 });
 
-export const projectUpdateSchema = projectCreateSchema.partial();
+export const projectUpdateSchema = z
+  .object({
+    name: z.string().trim().min(2).max(120),
+    summary: z.string().max(500),
+    description: markdownSchema,
+    status: z.enum(PROJECT_STATUSES),
+    health: z.enum(PROJECT_HEALTHS),
+    leadId: idSchema.nullable(),
+    startDate: z.coerce.date().nullable(),
+    targetDate: z.coerce.date().nullable(),
+    teamIds: z.array(idSchema).max(50),
+    icon: z.string().max(32),
+    color: colorSchema,
+  })
+  .partial();
 
 export const projectUpdatePostSchema = z.object({
   health: z.enum(PROJECT_HEALTHS),
@@ -196,7 +227,13 @@ export const milestoneCreateSchema = z.object({
   targetDate: z.coerce.date().nullable().default(null),
 });
 
-export const milestoneUpdateSchema = milestoneCreateSchema.partial().omit({ projectId: true });
+export const milestoneUpdateSchema = z
+  .object({
+    name: z.string().trim().min(1).max(120),
+    description: z.string().max(2000),
+    targetDate: z.coerce.date().nullable(),
+  })
+  .partial();
 
 export const cycleCreateSchema = z.object({
   teamId: idSchema,
@@ -205,7 +242,13 @@ export const cycleCreateSchema = z.object({
   endsAt: z.coerce.date(),
 });
 
-export const cycleUpdateSchema = cycleCreateSchema.partial().omit({ teamId: true });
+export const cycleUpdateSchema = z
+  .object({
+    name: z.string().trim().min(1).max(120),
+    startsAt: z.coerce.date(),
+    endsAt: z.coerce.date(),
+  })
+  .partial();
 
 export const docCreateSchema = z.object({
   title: z.string().trim().min(1).max(200),
@@ -215,7 +258,15 @@ export const docCreateSchema = z.object({
   visibility: z.enum(DOC_VISIBILITIES).default('workspace'),
 });
 
-export const docUpdateSchema = docCreateSchema.partial();
+export const docUpdateSchema = z
+  .object({
+    title: z.string().trim().min(1).max(200),
+    content: markdownSchema,
+    projectId: idSchema.nullable(),
+    collectionId: idSchema.nullable(),
+    visibility: z.enum(DOC_VISIBILITIES),
+  })
+  .partial();
 
 export const viewCreateSchema = z.object({
   name: z.string().trim().min(1).max(120),
@@ -225,7 +276,15 @@ export const viewCreateSchema = z.object({
   shared: z.boolean().default(false),
 });
 
-export const viewUpdateSchema = viewCreateSchema.partial();
+export const viewUpdateSchema = z
+  .object({
+    name: z.string().trim().min(1).max(120),
+    filter: issueFilterSchema.partial(),
+    layout: z.enum(['list', 'board', 'table', 'calendar', 'timeline']),
+    groupBy: z.enum(['state', 'assignee', 'priority', 'project', 'label', 'cycle', 'none']),
+    shared: z.boolean(),
+  })
+  .partial();
 
 export const uploadRequestSchema = z.object({
   fileName: z.string().trim().min(1).max(255),

--- a/packages/shared/src/validators/validators.test.ts
+++ b/packages/shared/src/validators/validators.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cycleUpdateSchema,
+  docUpdateSchema,
+  issueCreateSchema,
+  issueUpdateSchema,
+  labelUpdateSchema,
+  milestoneUpdateSchema,
+  organizationUpdateSchema,
+  projectUpdateSchema,
+  teamUpdateSchema,
+  viewUpdateSchema,
+  workflowStateUpdateSchema,
+} from './index.ts';
+
+const updateSchemas = {
+  issue: issueUpdateSchema,
+  label: labelUpdateSchema,
+  project: projectUpdateSchema,
+  milestone: milestoneUpdateSchema,
+  cycle: cycleUpdateSchema,
+  doc: docUpdateSchema,
+  view: viewUpdateSchema,
+  team: teamUpdateSchema,
+  workflowState: workflowStateUpdateSchema,
+  organization: organizationUpdateSchema,
+} as const;
+
+describe('update schemas never invent values', () => {
+  it('returns an empty object for an empty patch', () => {
+    for (const [name, schema] of Object.entries(updateSchemas)) {
+      expect({ name, value: schema.parse({}) }).toEqual({ name, value: {} });
+    }
+  });
+
+  it('returns only the keys the caller supplied', () => {
+    expect(issueUpdateSchema.parse({ stateId: 'state_1' })).toEqual({ stateId: 'state_1' });
+    expect(labelUpdateSchema.parse({ name: 'Bug' })).toEqual({ name: 'Bug' });
+    expect(projectUpdateSchema.parse({ name: 'Alpha' })).toEqual({ name: 'Alpha' });
+    expect(docUpdateSchema.parse({ title: 'Runbook' })).toEqual({ title: 'Runbook' });
+  });
+
+  it('still accepts an explicit null so a field can be cleared', () => {
+    expect(issueUpdateSchema.parse({ assigneeId: null })).toEqual({ assigneeId: null });
+  });
+
+  it('still validates the fields it is given', () => {
+    expect(issueUpdateSchema.safeParse({ priority: 9 }).success).toBe(false);
+    expect(issueUpdateSchema.safeParse({ title: '' }).success).toBe(false);
+    expect(labelUpdateSchema.safeParse({ color: 'red' }).success).toBe(false);
+  });
+});
+
+describe('create schemas still apply their defaults', () => {
+  it('fills defaults the caller omitted', () => {
+    const parsed = issueCreateSchema.parse({ teamId: 'team_1', title: 'Ship it' });
+    expect(parsed.priority).toBe(0);
+    expect(parsed.description).toBe('');
+    expect(parsed.assigneeId).toBeNull();
+    expect(parsed.labelIds).toEqual([]);
+  });
+});


### PR DESCRIPTION
Update schemas derived with .partial() inherited create-schema defaults, so a single-field PATCH would silently reset every unspecified field.