### PR TITLE
fix: validate every test database url by its database name

### DIFF
--- a/apps/realtime/vitest.config.ts
+++ b/apps/realtime/vitest.config.ts
@@ -2,13 +2,27 @@ import { defineConfig } from 'vitest/config';
 
 const LOCAL_TEST_DATABASE_URL = 'postgres://orbit:orbit@localhost:5434/orbit_test_rt';
 
+function databaseNameOf(candidate: string): string {
+  return new URL(candidate).pathname.replace(/^\//, '');
+}
+
+function assertTestDatabase(candidate: string, source: string): string {
+  const name = databaseNameOf(candidate);
+  if (!name.includes('test')) {
+    throw new Error(
+      `Refusing to run tests against "${name}" from ${source}. Point it at a database whose name contains "test".`,
+    );
+  }
+  return candidate;
+}
+
 function resolveTestDatabaseUrl(): string {
   const explicit = process.env['TEST_DATABASE_URL'];
-  if (explicit !== undefined) return explicit;
+  if (explicit !== undefined) return assertTestDatabase(explicit, 'TEST_DATABASE_URL');
   const ambient = process.env['DATABASE_URL'];
   if (ambient === undefined) return LOCAL_TEST_DATABASE_URL;
+  if (databaseNameOf(ambient).includes('test')) return ambient;
   const url = new URL(ambient);
-  if (url.pathname.replace(/^\//, '').includes('test')) return ambient;
   url.pathname = '/orbit_test_rt';
   return url.toString();
 }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -2,13 +2,27 @@ import { defineConfig } from 'vitest/config';
 
 const LOCAL_TEST_DATABASE_URL = 'postgres://orbit:orbit@localhost:5434/orbit_test_core';
 
+function databaseNameOf(candidate: string): string {
+  return new URL(candidate).pathname.replace(/^\//, '');
+}
+
+function assertTestDatabase(candidate: string, source: string): string {
+  const name = databaseNameOf(candidate);
+  if (!name.includes('test')) {
+    throw new Error(
+      `Refusing to run tests against "${name}" from ${source}. Point it at a database whose name contains "test".`,
+    );
+  }
+  return candidate;
+}
+
 function resolveTestDatabaseUrl(): string {
   const explicit = process.env['TEST_DATABASE_URL'];
-  if (explicit !== undefined) return explicit;
+  if (explicit !== undefined) return assertTestDatabase(explicit, 'TEST_DATABASE_URL');
   const ambient = process.env['DATABASE_URL'];
   if (ambient === undefined) return LOCAL_TEST_DATABASE_URL;
+  if (databaseNameOf(ambient).includes('test')) return ambient;
   const url = new URL(ambient);
-  if (url.pathname.replace(/^\//, '').includes('test')) return ambient;
   url.pathname = '/orbit_test_core';
   return url.toString();
 }

--- a/packages/services/src/test-database.ts
+++ b/packages/services/src/test-database.ts
@@ -5,13 +5,27 @@ import { Pool } from 'pg';
 
 const LOCAL_TEST_DATABASE_URL = 'postgres://orbit:orbit@localhost:5434/orbit_test_svc';
 
+function databaseNameOf(candidate: string): string {
+  return new URL(candidate).pathname.replace(/^\//, '');
+}
+
+function assertTestDatabase(candidate: string, source: string): string {
+  const name = databaseNameOf(candidate);
+  if (!name.includes('test')) {
+    throw new Error(
+      `Refusing to run tests against "${name}" from ${source}. Point it at a database whose name contains "test".`,
+    );
+  }
+  return candidate;
+}
+
 function resolveTestDatabaseUrl(): string {
   const explicit = process.env['TEST_DATABASE_URL'];
-  if (explicit !== undefined) return explicit;
+  if (explicit !== undefined) return assertTestDatabase(explicit, 'TEST_DATABASE_URL');
   const ambient = process.env['DATABASE_URL'];
   if (ambient === undefined) return LOCAL_TEST_DATABASE_URL;
+  if (databaseNameOf(ambient).includes('test')) return ambient;
   const url = new URL(ambient);
-  if (url.pathname.replace(/^\//, '').includes('test')) return ambient;
   url.pathname = '/orbit_test_svc';
   return url.toString();
 }


### PR DESCRIPTION
The isolation guard matched `test` anywhere in the connection string and skipped `TEST_DATABASE_URL` entirely; both now parse the url and check only the database name.