### PR TITLE
feat(mcp): add the Orbit MCP server over streamable HTTP

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -1,0 +1,105 @@
+# @orbit/mcp
+
+Orbit's MCP server. It speaks the Model Context Protocol over streamable HTTP so an agent can read
+and change work in Orbit through the same domain services and the same permission policy the web app
+uses.
+
+- Endpoint: `POST http://localhost:3200/mcp`
+- Health: `GET http://localhost:3200/health`
+- Auth: `Authorization: Bearer orb_...`
+
+Every call is resolved to the Orbit user who owns the API key. A tool can never do more than that
+person could do in the UI: a guest gets `forbidden` from `create_issue`, and nobody can touch a team
+they are not on.
+
+## Run it
+
+```
+pnpm infra:up
+pnpm db:push
+pnpm db:seed
+pnpm --filter @orbit/mcp dev
+```
+
+`MCP_PORT` sets the port and defaults to `3200`.
+
+## Mint an API key
+
+```
+pnpm --filter @orbit/mcp create-key -- --email pulkit@noveum.ai --name "Local agent"
+```
+
+Flags: `--email` (required), `--name`, `--org <slug>` when the user belongs to several workspaces,
+and `--expiresInDays`. The key is printed once. Only a SHA-256 hash of it is stored, so it cannot be
+shown again. Set `revoked_at` on the row in `api_key` to turn a key off.
+
+## Connect a client
+
+```
+claude mcp add --transport http orbit http://localhost:3200/mcp
+```
+
+Add the key as a bearer token in your client configuration, for example:
+
+```json
+{
+  "mcpServers": {
+    "orbit": {
+      "type": "http",
+      "url": "http://localhost:3200/mcp",
+      "headers": { "Authorization": "Bearer orb_your_key_here" }
+    }
+  }
+}
+```
+
+## Tools
+
+Identifiers are human friendly everywhere. A team is `ENG`, a team name, or an id. An issue is
+`ENG-42` or an id. A user is a name, handle, email, id, or `me`. A cycle is a name, a number, an id,
+or `active`.
+
+| Tool | Arguments |
+| --- | --- |
+| `get_me` | none |
+| `list_teams` | `includeArchived?` |
+| `list_users` | none |
+| `list_states` | `team` |
+| `list_labels` | `team?` |
+| `create_issue` | `team`, `title`, `description?`, `state?`, `priority?`, `assignee?`, `project?`, `cycle?`, `parent?`, `labels?`, `estimate?`, `dueDate?` |
+| `update_issue` | `issue`, `title?`, `description?`, `state?`, `priority?`, `assignee?`, `project?`, `cycle?`, `labels?`, `estimate?`, `dueDate?` |
+| `get_issue` | `issue` |
+| `search_issues` | `query?`, `team?`, `project?`, `cycle?`, `assignee?`, `state?`, `stateCategory?`, `label?`, `parent?`, `includeArchived?`, `includeSubIssues?`, `orderBy?`, `limit?`, `cursor?` |
+| `list_my_issues` | `stateCategory?`, `limit?` |
+| `move_issue` | `issue`, `state?`, `team?`, `beforeIssue?`, `afterIssue?` |
+| `add_comment` | `issue`, `body`, `replyTo?` |
+| `set_relation` | `issue`, `relatedIssue`, `type` |
+| `copy_branch_name` | `issue` |
+| `list_projects` | `includeArchived?` |
+| `create_project` | `name`, `summary?`, `description?`, `status?`, `health?`, `lead?`, `startDate?`, `targetDate?`, `teams?` |
+| `project_progress` | `project` |
+| `list_cycles` | `team` |
+| `active_cycle` | `team` |
+| `cycle_progress` | `team`, `cycle` |
+| `move_to_cycle` | `issue`, `cycle` |
+| `list_members` | none |
+| `invite_member` | `email`, `role?`, `teams?` |
+
+Writes return a `deltas` array describing the `SyncAction`s that were published to Redis, so a caller
+can see exactly what the realtime stream carried.
+
+## Errors
+
+A domain error comes back as a tool result with `isError: true` and a JSON body such as
+`{"error":{"code":"forbidden","message":"Your role cannot issue create."}}`. Stack traces never leave
+the process. A missing or invalid key fails the HTTP request with `401` before any tool runs.
+
+## Tests
+
+```
+pnpm --filter @orbit/mcp test
+```
+
+They run against a real Postgres. Point `TEST_DATABASE_URL` at a database whose name contains `test`,
+or let it default to `postgres://orbit:orbit@localhost:5434/orbit_test_mcp`, and push the schema once
+with `DATABASE_URL=... pnpm --filter @orbit/db push`.

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@orbit/mcp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx watch --env-file-if-exists=../../.env src/index.ts",
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:pg-native --banner:js=\"import{createRequire}from'node:module';const require=createRequire(import.meta.url);\"",
+    "start": "node dist/index.js",
+    "create-key": "tsx --env-file-if-exists=../../.env src/create-key.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "@orbit/core": "workspace:*",
+    "@orbit/db": "workspace:*",
+    "@orbit/shared": "workspace:*",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "esbuild": "0.28.1",
+    "tsx": "4.23.1",
+    "typescript": "5.9.3",
+    "vitest": "4.1.10"
+  }
+}

--- a/apps/mcp/src/auth.test.ts
+++ b/apps/mcp/src/auth.test.ts
@@ -1,0 +1,114 @@
+import { createApiKey, verifyApiKey } from '@orbit/core';
+import { db, eq, schema } from '@orbit/db';
+import { DomainError } from '@orbit/shared/errors';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { HEALTH_PATH, MCP_PATH, type McpHttpServer } from './server.ts';
+import { createWorkspace, resetDatabase, startServer, type TestWorkspace } from './test-helpers.ts';
+
+let workspace: TestWorkspace;
+let server: McpHttpServer;
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  server = await startServer();
+});
+
+afterAll(async () => {
+  await server.close();
+});
+
+function newKey(name: string) {
+  return createApiKey({
+    organizationId: workspace.organizationId,
+    userId: workspace.adminUser.id,
+    name,
+  });
+}
+
+function post(headers: Record<string, string>): Promise<Response> {
+  return fetch(`http://127.0.0.1:${server.port}${MCP_PATH}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'application/json', ...headers },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+  });
+}
+
+describe('api key verification', () => {
+  it('accepts a valid key and resolves the owner principal', async () => {
+    const created = await newKey('valid');
+    expect(created.key.startsWith('orb_')).toBe(true);
+    expect(created.apiKey.hashedKey).not.toContain(created.key);
+
+    const identity = await verifyApiKey(created.key);
+    expect(identity.principal.userId).toBe(workspace.adminUser.id);
+    expect(identity.principal.organizationId).toBe(workspace.organizationId);
+    expect(identity.principal.role).toBe('admin');
+  });
+
+  it('touches lastUsedAt on a successful verification', async () => {
+    const created = await newKey('touched');
+    expect(created.apiKey.lastUsedAt).toBeNull();
+    await verifyApiKey(created.key);
+    const [row] = await db
+      .select()
+      .from(schema.apiKey)
+      .where(eq(schema.apiKey.id, created.apiKey.id));
+    expect(row?.lastUsedAt).toBeInstanceOf(Date);
+  });
+
+  it('rejects a revoked key', async () => {
+    const created = await newKey('revoked');
+    await db
+      .update(schema.apiKey)
+      .set({ revokedAt: new Date() })
+      .where(eq(schema.apiKey.id, created.apiKey.id));
+    await expect(verifyApiKey(created.key)).rejects.toBeInstanceOf(DomainError);
+    await expect(verifyApiKey(created.key)).rejects.toMatchObject({ code: 'unauthorized' });
+  });
+
+  it('rejects an expired key', async () => {
+    const created = await newKey('expired');
+    await db
+      .update(schema.apiKey)
+      .set({ expiresAt: new Date(Date.now() - 1000) })
+      .where(eq(schema.apiKey.id, created.apiKey.id));
+    await expect(verifyApiKey(created.key)).rejects.toMatchObject({ code: 'unauthorized' });
+  });
+
+  it('rejects a tampered key', async () => {
+    const created = await newKey('tampered');
+    const tampered = `${created.key.slice(0, -1)}${created.key.endsWith('a') ? 'b' : 'a'}`;
+    expect(tampered).not.toBe(created.key);
+    await expect(verifyApiKey(tampered)).rejects.toMatchObject({ code: 'unauthorized' });
+  });
+
+  it('rejects a key that does not carry the orbit prefix', async () => {
+    await expect(verifyApiKey('sk_live_nope')).rejects.toMatchObject({ code: 'unauthorized' });
+  });
+});
+
+describe('http transport', () => {
+  it('serves a health check without a key', async () => {
+    const response = await fetch(`http://127.0.0.1:${server.port}${HEALTH_PATH}`);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ status: 'ok', service: 'mcp' });
+  });
+
+  it('rejects an unauthenticated request', async () => {
+    const response = await post({});
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error?: { message?: string } };
+    expect(body.error?.message).toContain('API key');
+  });
+
+  it('rejects a request with an unknown key', async () => {
+    const response = await post({ authorization: 'Bearer orb_notarealkeyatall' });
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects a GET on the mcp endpoint', async () => {
+    const response = await fetch(`http://127.0.0.1:${server.port}${MCP_PATH}`);
+    expect(response.status).toBe(405);
+  });
+});

--- a/apps/mcp/src/comments.ts
+++ b/apps/mcp/src/comments.ts
@@ -1,0 +1,75 @@
+import {
+  appendActivity,
+  buildSyncAction,
+  type IssueRow,
+  issueScopes,
+  newId,
+  nextSyncId,
+  principalActor,
+} from '@orbit/core';
+import { db, schema } from '@orbit/db';
+import { internal } from '@orbit/shared/errors';
+import type { SyncAction } from '@orbit/shared/events';
+import type { Principal } from '@orbit/shared/policy';
+import { assertCan } from '@orbit/shared/policy';
+import { commentCreateSchema } from '@orbit/shared/validators';
+
+export type CommentRow = typeof schema.comment.$inferSelect;
+
+export interface CreatedComment {
+  readonly comment: CommentRow;
+  readonly actions: SyncAction[];
+}
+
+export async function createComment(
+  principal: Principal,
+  issue: IssueRow,
+  input: unknown,
+): Promise<CreatedComment> {
+  assertCan(principal, 'comment:create');
+  const parsed = commentCreateSchema.parse(input);
+
+  return await db.transaction(async (tx) => {
+    const syncId = await nextSyncId(tx);
+    const actor = await principalActor(tx, principal);
+    const [created] = await tx
+      .insert(schema.comment)
+      .values({
+        id: newId(),
+        organizationId: principal.organizationId,
+        issueId: issue.id,
+        authorId: principal.userId,
+        parentId: parsed.parentId,
+        body: parsed.body,
+        syncId,
+      })
+      .returning();
+    if (created === undefined) throw internal('The comment could not be created.');
+
+    await appendActivity(tx, {
+      organizationId: principal.organizationId,
+      issueId: issue.id,
+      actor,
+      field: 'comment',
+      from: null,
+      to: created.id,
+      syncId,
+    });
+
+    return {
+      comment: created,
+      actions: [
+        buildSyncAction({
+          syncId,
+          organizationId: principal.organizationId,
+          scopes: issueScopes(issue),
+          action: 'insert',
+          model: 'comment',
+          modelId: created.id,
+          data: created,
+          actor,
+        }),
+      ],
+    };
+  });
+}

--- a/apps/mcp/src/create-key.ts
+++ b/apps/mcp/src/create-key.ts
@@ -1,0 +1,76 @@
+import { parseArgs } from 'node:util';
+import { createApiKey } from '@orbit/core';
+import { db, eq, pool, schema } from '@orbit/db';
+import { z } from 'zod';
+
+const argsSchema = z.object({
+  email: z.string().email(),
+  name: z.string().trim().min(1).max(120).default('MCP key'),
+  org: z.string().min(1).optional(),
+  expiresInDays: z.coerce.number().int().min(1).max(3650).optional(),
+});
+
+const DAY_MS = 86_400_000;
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      email: { type: 'string' },
+      name: { type: 'string' },
+      org: { type: 'string' },
+      expiresInDays: { type: 'string' },
+    },
+  });
+  const parsed = argsSchema.parse(values);
+
+  const [user] = await db
+    .select()
+    .from(schema.user)
+    .where(eq(schema.user.email, parsed.email.toLowerCase()))
+    .limit(1);
+  if (user === undefined) throw new Error(`No user with the email ${parsed.email}.`);
+
+  const memberships = await db
+    .select({ organization: schema.organization })
+    .from(schema.member)
+    .innerJoin(schema.organization, eq(schema.organization.id, schema.member.organizationId))
+    .where(eq(schema.member.userId, user.id));
+
+  const organization =
+    parsed.org === undefined
+      ? memberships[0]?.organization
+      : memberships.find((row) => row.organization.slug === parsed.org)?.organization;
+  if (organization === undefined) {
+    throw new Error(`${parsed.email} is not a member of any matching workspace.`);
+  }
+
+  const created = await createApiKey({
+    organizationId: organization.id,
+    userId: user.id,
+    name: parsed.name,
+    ...(parsed.expiresInDays === undefined
+      ? {}
+      : { expiresAt: new Date(Date.now() + parsed.expiresInDays * DAY_MS) }),
+  });
+
+  console.info(
+    [
+      `workspace: ${organization.name} (${organization.slug})`,
+      `user:      ${user.name} <${user.email}>`,
+      `key name:  ${created.apiKey.name}`,
+      `key id:    ${created.apiKey.id}`,
+      '',
+      'Copy this key now, it is not stored and cannot be shown again:',
+      created.key,
+    ].join('\n'),
+  );
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+} finally {
+  await pool.end();
+}

--- a/apps/mcp/src/create-key.ts
+++ b/apps/mcp/src/create-key.ts
@@ -14,6 +14,7 @@ const DAY_MS = 86_400_000;
 
 async function main(): Promise<void> {
   const { values } = parseArgs({
+    args: process.argv.slice(2).filter((value) => value !== '--'),
     options: {
       email: { type: 'string' },
       name: { type: 'string' },

--- a/apps/mcp/src/env.ts
+++ b/apps/mcp/src/env.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  MCP_PORT: z.coerce.number().int().min(0).max(65535).default(3200),
+});
+
+export const env = envSchema.parse(process.env);

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -1,0 +1,30 @@
+import { closeRealtime } from '@orbit/core';
+import { pool } from '@orbit/db';
+import { env } from './env.ts';
+import { errorFields, logger } from './logger.ts';
+import { createMcpHttpServer, MCP_PATH } from './server.ts';
+
+const server = await createMcpHttpServer({ port: env.MCP_PORT, host: '0.0.0.0' });
+
+logger.info('listening', { port: server.port, path: MCP_PATH });
+
+let shuttingDown = false;
+
+async function shutdown(signal: string): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  logger.info('shutting down', { signal });
+  await server.close();
+  await closeRealtime();
+  await pool.end();
+  process.exit(0);
+}
+
+for (const signal of ['SIGTERM', 'SIGINT'] as const) {
+  process.on(signal, () => {
+    shutdown(signal).catch((error: unknown) => {
+      logger.error('shutdown failed', errorFields(error));
+      process.exit(1);
+    });
+  });
+}

--- a/apps/mcp/src/logger.ts
+++ b/apps/mcp/src/logger.ts
@@ -1,0 +1,28 @@
+type LogFields = Record<string, unknown>;
+
+type LogLevel = 'info' | 'warn' | 'error';
+
+function write(level: LogLevel, message: string, fields: LogFields | undefined): void {
+  const line = JSON.stringify({
+    level,
+    message,
+    at: new Date().toISOString(),
+    service: 'mcp',
+    ...fields,
+  });
+  if (level === 'error') {
+    console.error(line);
+    return;
+  }
+  console.info(line);
+}
+
+export const logger = {
+  info: (message: string, fields?: LogFields): void => write('info', message, fields),
+  warn: (message: string, fields?: LogFields): void => write('warn', message, fields),
+  error: (message: string, fields?: LogFields): void => write('error', message, fields),
+};
+
+export function errorFields(error: unknown): LogFields {
+  return { error: error instanceof Error ? error.message : String(error) };
+}

--- a/apps/mcp/src/resolve.ts
+++ b/apps/mcp/src/resolve.ts
@@ -1,0 +1,97 @@
+import {
+  activeCycle,
+  type CycleRow,
+  listCycles,
+  listLabels,
+  listMembers,
+  listProjects,
+  listTeams,
+  listWorkflowStates,
+  type ProjectRow,
+  type TeamRow,
+} from '@orbit/core';
+import { notFound } from '@orbit/shared/errors';
+import type { Principal } from '@orbit/shared/policy';
+
+function matches(candidates: readonly (string | null | undefined)[], ref: string): boolean {
+  const needle = ref.trim().toLowerCase();
+  return candidates.some(
+    (candidate) => typeof candidate === 'string' && candidate.toLowerCase() === needle,
+  );
+}
+
+function pick<T>(
+  rows: readonly T[],
+  ref: string,
+  candidates: (row: T) => readonly (string | null | undefined)[],
+): T | undefined {
+  return rows.find((row) => matches(candidates(row), ref));
+}
+
+export async function resolveTeam(principal: Principal, ref: string): Promise<TeamRow> {
+  const teams = await listTeams(principal);
+  const found = pick(teams, ref, (team) => [team.id, team.key, team.name]);
+  if (found === undefined) throw notFound(`No team matches "${ref}".`);
+  return found;
+}
+
+export async function resolveUserId(principal: Principal, ref: string): Promise<string> {
+  if (ref.trim().toLowerCase() === 'me') return principal.userId;
+  const members = await listMembers(principal);
+  const found = pick(members, ref, (row) => [
+    row.user.id,
+    row.user.email,
+    row.user.handle,
+    row.user.name,
+  ]);
+  if (found === undefined) throw notFound(`No user matches "${ref}".`);
+  return found.user.id;
+}
+
+export async function resolveStateId(
+  principal: Principal,
+  teamId: string,
+  ref: string,
+): Promise<string> {
+  const states = await listWorkflowStates(principal, teamId);
+  const found = pick(states, ref, (state) => [state.id, state.name]);
+  if (found === undefined) throw notFound(`No workflow state matches "${ref}" on that team.`);
+  return found.id;
+}
+
+export async function resolveLabelIds(
+  principal: Principal,
+  refs: readonly string[],
+  teamId?: string,
+): Promise<string[]> {
+  if (refs.length === 0) return [];
+  const labels = await listLabels(principal, teamId === undefined ? {} : { teamId });
+  return refs.map((ref) => {
+    const found = pick(labels, ref, (label) => [label.id, label.name]);
+    if (found === undefined) throw notFound(`No label matches "${ref}".`);
+    return found.id;
+  });
+}
+
+export async function resolveProject(principal: Principal, ref: string): Promise<ProjectRow> {
+  const projects = await listProjects(principal, { includeArchived: true });
+  const found = pick(projects, ref, (project) => [project.id, project.slug, project.name]);
+  if (found === undefined) throw notFound(`No project matches "${ref}".`);
+  return found;
+}
+
+export async function resolveCycle(
+  principal: Principal,
+  teamId: string,
+  ref: string,
+): Promise<CycleRow> {
+  if (ref.trim().toLowerCase() === 'active') {
+    const current = await activeCycle(principal, teamId);
+    if (current === undefined) throw notFound('That team has no active cycle.');
+    return current;
+  }
+  const cycles = await listCycles(principal, teamId);
+  const found = pick(cycles, ref, (cycle) => [cycle.id, cycle.name, String(cycle.number)]);
+  if (found === undefined) throw notFound(`No cycle matches "${ref}" on that team.`);
+  return found;
+}

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -115,7 +115,8 @@ export async function createMcpHttpServer(
         response.end();
         return;
       }
-      sendRpcError(response, domain.status, domain.message);
+      const safe = domain.status >= 500 ? 'Something went wrong on our side.' : domain.message;
+      sendRpcError(response, domain.status, safe);
     });
   });
 

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -1,0 +1,140 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { verifyApiKey } from '@orbit/core';
+import { toDomainError, unauthorized } from '@orbit/shared/errors';
+import type { Principal } from '@orbit/shared/policy';
+import { errorFields, logger } from './logger.ts';
+import { registerTools } from './tools/index.ts';
+
+export const MCP_PATH = '/mcp';
+export const HEALTH_PATH = '/health';
+
+const SERVER_VERSION = '0.0.0';
+const JSONRPC_SERVER_ERROR = -32000;
+
+const INSTRUCTIONS = [
+  'Orbit is a work tracker. Issues live on teams and carry identifiers such as ENG-42.',
+  'Call get_me first to learn the caller role and teams, then list_teams, list_states and list_labels before writing.',
+  'Every tool acts as the user who owns the API key, so a request can fail with a forbidden error when their role does not allow it.',
+].join(' ');
+
+export function createOrbitMcpServer(principal: Principal): McpServer {
+  const server = new McpServer(
+    { name: 'orbit', version: SERVER_VERSION },
+    { capabilities: { tools: {} }, instructions: INSTRUCTIONS },
+  );
+  registerTools(server, principal);
+  return server;
+}
+
+function bearerToken(request: IncomingMessage): string {
+  const header = request.headers.authorization ?? '';
+  if (!header.toLowerCase().startsWith('bearer ')) {
+    throw unauthorized('Send an Orbit API key as a bearer token.');
+  }
+  return header.slice('bearer '.length).trim();
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  response.writeHead(status, {
+    'content-type': 'application/json',
+    'content-length': Buffer.byteLength(payload),
+  });
+  response.end(payload);
+}
+
+function sendRpcError(response: ServerResponse, status: number, message: string): void {
+  sendJson(response, status, {
+    jsonrpc: '2.0',
+    error: { code: JSONRPC_SERVER_ERROR, message },
+    id: null,
+  });
+}
+
+async function handleMcpRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+  const identity = await verifyApiKey(bearerToken(request));
+  const server = createOrbitMcpServer(identity.principal);
+  const transport = new StreamableHTTPServerTransport({ enableJsonResponse: true });
+  response.on('close', () => {
+    transport.close().catch((error: unknown) => {
+      logger.error('transport close failed', errorFields(error));
+    });
+    server.close().catch((error: unknown) => {
+      logger.error('server close failed', errorFields(error));
+    });
+  });
+  await server.connect(transport as unknown as Transport);
+  await transport.handleRequest(request, response);
+  logger.info('mcp request', {
+    userId: identity.principal.userId,
+    organizationId: identity.principal.organizationId,
+    apiKeyId: identity.apiKey.id,
+  });
+}
+
+function route(request: IncomingMessage, response: ServerResponse): Promise<void> {
+  const url = new URL(request.url ?? '/', 'http://orbit.mcp');
+  if (url.pathname === HEALTH_PATH) {
+    sendJson(response, 200, { status: 'ok', service: 'mcp' });
+    return Promise.resolve();
+  }
+  if (url.pathname !== MCP_PATH) {
+    sendRpcError(response, 404, 'Unknown endpoint.');
+    return Promise.resolve();
+  }
+  if (request.method !== 'POST') {
+    response.setHeader('allow', 'POST');
+    sendRpcError(response, 405, 'This endpoint only accepts POST.');
+    return Promise.resolve();
+  }
+  return handleMcpRequest(request, response);
+}
+
+export interface McpHttpServer {
+  readonly port: number;
+  close(): Promise<void>;
+}
+
+export interface McpHttpServerOptions {
+  readonly port?: number;
+  readonly host?: string;
+}
+
+export async function createMcpHttpServer(
+  options: McpHttpServerOptions = {},
+): Promise<McpHttpServer> {
+  const http = createServer((request, response) => {
+    route(request, response).catch((error: unknown) => {
+      const domain = toDomainError(error);
+      logger.error('request failed', { code: domain.code, ...errorFields(error) });
+      if (response.headersSent) {
+        response.end();
+        return;
+      }
+      sendRpcError(response, domain.status, domain.message);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    http.once('error', reject);
+    http.listen(options.port ?? 0, options.host ?? '127.0.0.1', () => {
+      http.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = http.address() as AddressInfo;
+
+  return {
+    port: address.port,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        http.close((error) => (error === undefined ? resolve() : reject(error)));
+        http.closeAllConnections();
+      }),
+  };
+}

--- a/apps/mcp/src/test-helpers.ts
+++ b/apps/mcp/src/test-helpers.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from 'node:crypto';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { createApiKey, createOrganization, resolvePrincipal } from '@orbit/core';
+import { db, schema, sql } from '@orbit/db';
+import type { OrgRole } from '@orbit/shared/constants';
+import type { Principal } from '@orbit/shared/policy';
+import { createMcpHttpServer, MCP_PATH, type McpHttpServer } from './server.ts';
+
+export async function resetDatabase(): Promise<void> {
+  const [current] = (await db.execute<{ name: string }>(sql`select current_database() as name`))
+    .rows;
+  if (current === undefined || !current.name.includes('test')) {
+    throw new Error(
+      `resetDatabase refuses to truncate "${current?.name ?? 'unknown'}". Point DATABASE_URL at a database whose name contains "test".`,
+    );
+  }
+  const result = await db.execute<{ tablename: string }>(
+    sql`select tablename from pg_tables where schemaname = 'public'`,
+  );
+  const tables = result.rows.map((row) => `"${row.tablename}"`).join(', ');
+  if (tables.length === 0) return;
+  await db.execute(sql.raw(`truncate table ${tables} restart identity cascade`));
+  await db.execute(sql`select setval('sync_id_seq', 1, false)`);
+}
+
+export async function createUser(name: string): Promise<typeof schema.user.$inferSelect> {
+  const id = randomUUID();
+  const handle = `${name.toLowerCase().replace(/[^a-z0-9]/g, '')}-${id.slice(0, 8)}`;
+  const [row] = await db
+    .insert(schema.user)
+    .values({ id, name, email: `${handle}@orbit.test`, handle, emailVerified: true })
+    .returning();
+  if (row === undefined) throw new Error('Could not create the test user.');
+  return row;
+}
+
+export interface TestWorkspace {
+  readonly organizationId: string;
+  readonly teamId: string;
+  readonly teamKey: string;
+  readonly admin: Principal;
+  readonly adminUser: typeof schema.user.$inferSelect;
+}
+
+export async function createWorkspace(name = 'Nova'): Promise<TestWorkspace> {
+  const adminUser = await createUser('Ada Admin');
+  const bootstrap = await createOrganization(adminUser.id, {
+    name,
+    slug: `${name.toLowerCase()}-${randomUUID().slice(0, 8)}`,
+  });
+  const admin = await resolvePrincipal(adminUser.id, bootstrap.organization.id);
+  return {
+    organizationId: bootstrap.organization.id,
+    teamId: bootstrap.team.id,
+    teamKey: bootstrap.team.key,
+    admin,
+    adminUser,
+  };
+}
+
+export async function addMember(
+  workspace: TestWorkspace,
+  role: OrgRole,
+  name = `${role} person`,
+): Promise<{ principal: Principal; user: typeof schema.user.$inferSelect }> {
+  const user = await createUser(name);
+  await db.insert(schema.member).values({
+    id: randomUUID(),
+    organizationId: workspace.organizationId,
+    userId: user.id,
+    role,
+  });
+  await db
+    .insert(schema.teamMember)
+    .values({ id: randomUUID(), teamId: workspace.teamId, userId: user.id });
+  const principal = await resolvePrincipal(user.id, workspace.organizationId);
+  return { principal, user };
+}
+
+export async function mintKey(
+  organizationId: string,
+  userId: string,
+  name = 'test key',
+): Promise<string> {
+  const created = await createApiKey({ organizationId, userId, name });
+  return created.key;
+}
+
+export interface TestClient {
+  readonly client: Client;
+  call(name: string, args?: Record<string, unknown>): Promise<CallToolResult>;
+  result(name: string, args?: Record<string, unknown>): Promise<Record<string, unknown>>;
+  close(): Promise<void>;
+}
+
+function payloadOf(result: CallToolResult): Record<string, unknown> {
+  const [first] = result.content;
+  if (first === undefined || first.type !== 'text') {
+    throw new Error('The tool returned no text content.');
+  }
+  const parsed: unknown = JSON.parse(first.text);
+  if (typeof parsed !== 'object' || parsed === null)
+    throw new Error('The tool returned no object.');
+  return parsed as Record<string, unknown>;
+}
+
+export async function connect(server: McpHttpServer, apiKey: string): Promise<TestClient> {
+  const client = new Client({ name: 'orbit-test', version: '0.0.0' });
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://127.0.0.1:${server.port}${MCP_PATH}`),
+    { requestInit: { headers: { authorization: `Bearer ${apiKey}` } } },
+  );
+  await client.connect(transport as unknown as Transport);
+  return {
+    client,
+    call: (name, args = {}) =>
+      client.callTool({ name, arguments: args }) as Promise<CallToolResult>,
+    async result(name, args = {}) {
+      const called = (await client.callTool({ name, arguments: args })) as CallToolResult;
+      if (called.isError === true) {
+        throw new Error(`tool ${name} failed: ${JSON.stringify(called.content)}`);
+      }
+      return payloadOf(called);
+    },
+    close: () => client.close(),
+  };
+}
+
+export function errorPayload(result: CallToolResult): { code: string; message: string } {
+  const parsed = payloadOf(result);
+  const error = parsed['error'];
+  if (typeof error !== 'object' || error === null) throw new Error('No error payload.');
+  const shape = error as { code?: unknown; message?: unknown };
+  return { code: String(shape.code), message: String(shape.message) };
+}
+
+export function startServer(): Promise<McpHttpServer> {
+  return createMcpHttpServer({ port: 0, host: '127.0.0.1' });
+}

--- a/apps/mcp/src/tools.test.ts
+++ b/apps/mcp/src/tools.test.ts
@@ -1,0 +1,288 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { McpHttpServer } from './server.ts';
+import {
+  addMember,
+  connect,
+  createWorkspace,
+  errorPayload,
+  mintKey,
+  resetDatabase,
+  startServer,
+  type TestClient,
+  type TestWorkspace,
+} from './test-helpers.ts';
+
+let workspace: TestWorkspace;
+let server: McpHttpServer;
+let admin: TestClient;
+let guest: TestClient;
+
+interface IssueShape {
+  readonly id: string;
+  readonly identifier: string;
+  readonly title: string;
+  readonly state: string | null;
+  readonly priority: string;
+  readonly assignee: string | null;
+  readonly cycleId: string | null;
+}
+
+interface DeltaShape {
+  readonly model: string;
+  readonly action: string;
+  readonly id: string;
+}
+
+function issueOf(payload: Record<string, unknown>): IssueShape {
+  return payload['issue'] as IssueShape;
+}
+
+function issuesOf(payload: Record<string, unknown>): IssueShape[] {
+  return payload['issues'] as IssueShape[];
+}
+
+function deltasOf(payload: Record<string, unknown>): DeltaShape[] {
+  return payload['deltas'] as DeltaShape[];
+}
+
+async function newIssue(title: string, extra: Record<string, unknown> = {}): Promise<IssueShape> {
+  const payload = await admin.result('create_issue', {
+    team: workspace.teamKey,
+    title,
+    ...extra,
+  });
+  return issueOf(payload);
+}
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  server = await startServer();
+  admin = await connect(server, await mintKey(workspace.organizationId, workspace.adminUser.id));
+  const guestMember = await addMember(workspace, 'guest', 'Gus Guest');
+  guest = await connect(server, await mintKey(workspace.organizationId, guestMember.user.id));
+});
+
+afterAll(async () => {
+  await admin.close();
+  await guest.close();
+  await server.close();
+});
+
+describe('discovery', () => {
+  it('advertises every tool with a description', async () => {
+    const { tools } = await admin.client.listTools();
+    const names = tools.map((tool) => tool.name);
+    expect(names).toContain('create_issue');
+    expect(names).toContain('search_issues');
+    expect(names).toContain('cycle_progress');
+    expect(names).toHaveLength(23);
+    for (const tool of tools) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.inputSchema).toBeTruthy();
+    }
+  });
+
+  it('reports the caller identity', async () => {
+    const payload = await admin.result('get_me');
+    expect(payload['role']).toBe('admin');
+    const user = payload['user'] as { email: string };
+    expect(user.email).toBe(workspace.adminUser.email);
+  });
+});
+
+describe('permissions', () => {
+  it('lets a guest read an issue but not create one', async () => {
+    const created = await newIssue('Readable by a guest');
+
+    const denied = await guest.call('create_issue', {
+      team: workspace.teamKey,
+      title: 'Guests cannot write',
+    });
+    expect(denied.isError).toBe(true);
+    expect(errorPayload(denied).code).toBe('forbidden');
+
+    const read = await guest.result('get_issue', { issue: created.identifier });
+    expect(issueOf(read).identifier).toBe(created.identifier);
+  });
+
+  it('stops a guest from inviting members', async () => {
+    const denied = await guest.call('invite_member', { email: 'nope@orbit.test' });
+    expect(denied.isError).toBe(true);
+    expect(errorPayload(denied).code).toBe('forbidden');
+  });
+});
+
+describe('issues', () => {
+  it('round trips a created issue by human identifier', async () => {
+    const created = await newIssue('Ship the MCP server', {
+      description: 'Serve tools over streamable HTTP.',
+      priority: 'high',
+      assignee: 'me',
+    });
+    expect(created.identifier).toMatch(new RegExp(`^${workspace.teamKey}-\\d+$`));
+    expect(created.priority).toBe('High');
+    expect(created.assignee).toBe(workspace.adminUser.name);
+
+    const fetched = await admin.result('get_issue', { issue: created.identifier });
+    const issue = issueOf(fetched) as IssueShape & { description: string; labels: string[] };
+    expect(issue.id).toBe(created.id);
+    expect(issue.description).toBe('Serve tools over streamable HTTP.');
+    expect(issue.labels).toEqual([]);
+  });
+
+  it('filters a search by text, assignee and state category', async () => {
+    const bob = await addMember(workspace, 'member', 'Bo Builder');
+    await newIssue('Cache invalidation strategy');
+    await newIssue('Rewrite the search index', { assignee: bob.user.name });
+    const done = await newIssue('Already finished work');
+    await admin.result('move_issue', { issue: done.identifier, state: 'Done' });
+
+    const byText = await admin.result('search_issues', { query: 'search index' });
+    expect(issuesOf(byText).map((issue) => issue.title)).toEqual(['Rewrite the search index']);
+
+    const byAssignee = await admin.result('search_issues', { assignee: bob.user.handle });
+    expect(issuesOf(byAssignee)).toHaveLength(1);
+    expect(issuesOf(byAssignee)[0]?.title).toBe('Rewrite the search index');
+
+    const completed = await admin.result('search_issues', { stateCategory: 'completed' });
+    expect(issuesOf(completed).map((issue) => issue.identifier)).toContain(done.identifier);
+
+    const byTeam = await admin.result('search_issues', { team: workspace.teamKey, limit: 200 });
+    expect(issuesOf(byTeam).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('lists the issues assigned to the caller', async () => {
+    const mine = await newIssue('Mine to finish', { assignee: 'me' });
+    const payload = await admin.result('list_my_issues', { limit: 100 });
+    expect(issuesOf(payload).map((issue) => issue.identifier)).toContain(mine.identifier);
+  });
+
+  it('emits an issue sync action when moving an issue', async () => {
+    const created = await newIssue('Move me across the board');
+    const payload = await admin.result('move_issue', {
+      issue: created.identifier,
+      state: 'In Progress',
+    });
+    expect(issueOf(payload).state).toBe('In Progress');
+    const deltas = deltasOf(payload);
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toMatchObject({ model: 'issue', action: 'update', id: created.id });
+  });
+
+  it('comments on an issue', async () => {
+    const created = await newIssue('Needs a comment');
+    const payload = await admin.result('add_comment', {
+      issue: created.identifier,
+      body: 'Picking this up now.',
+    });
+    const comment = payload['comment'] as { id: string; body: string; issue: string };
+    expect(comment.body).toBe('Picking this up now.');
+    expect(comment.issue).toBe(created.identifier);
+    expect(deltasOf(payload)[0]).toMatchObject({ model: 'comment', action: 'insert' });
+  });
+
+  it('links two issues in both directions', async () => {
+    const first = await newIssue('Blocks the other');
+    const second = await newIssue('Blocked by the first');
+    await admin.result('set_relation', {
+      issue: first.identifier,
+      relatedIssue: second.identifier,
+      type: 'blocks',
+    });
+
+    const fetched = await admin.result('get_issue', { issue: second.identifier });
+    const issue = issueOf(fetched) as IssueShape & {
+      relations: { type: string; identifier: string }[];
+    };
+    expect(issue.relations).toContainEqual({ type: 'blocked_by', identifier: first.identifier });
+  });
+
+  it('builds a git branch name from an issue', async () => {
+    const created = await newIssue('Fix the flaky login redirect');
+    const payload = await admin.result('copy_branch_name', { issue: created.identifier });
+    expect(payload['branch']).toBe(
+      `${workspace.adminUser.handle}/${created.identifier.toLowerCase()}-fix-the-flaky-login-redirect`,
+    );
+  });
+
+  it('reports a clear error for an unknown identifier', async () => {
+    const missing = await admin.call('get_issue', { issue: 'ZZZ-9999' });
+    expect(missing.isError).toBe(true);
+    expect(errorPayload(missing).code).toBe('not_found');
+  });
+
+  it('reports a validation error when the domain rejects an argument', async () => {
+    const bad = await admin.call('create_issue', { team: workspace.teamKey, title: '   ' });
+    expect(bad.isError).toBe(true);
+    expect(errorPayload(bad).code).toBe('validation_failed');
+  });
+
+  it('rejects an argument that does not match the tool schema', async () => {
+    const bad = await admin.call('create_issue', { team: workspace.teamKey, title: '' });
+    expect(bad.isError).toBe(true);
+    expect(JSON.stringify(bad.content)).toContain('title');
+  });
+});
+
+describe('planning', () => {
+  it('creates a project and reports its progress', async () => {
+    const created = await admin.result('create_project', {
+      name: 'Realtime sync',
+      summary: 'Make everything live',
+      teams: [workspace.teamKey],
+    });
+    const project = created['project'] as { id: string; name: string };
+    expect(project.name).toBe('Realtime sync');
+
+    await newIssue('Wire the socket', { project: 'Realtime sync' });
+    const progress = await admin.result('project_progress', { project: 'realtime-sync' });
+    expect(progress['scope']).toBe(1);
+    expect(progress['completed']).toBe(0);
+  });
+
+  it('moves an issue into the active cycle and back out', async () => {
+    const created = await newIssue('Plan into the cycle');
+    const active = await admin.result('active_cycle', { team: workspace.teamKey });
+    const cycle = active['cycle'] as { id: string };
+    expect(cycle).not.toBeNull();
+
+    const moved = await admin.result('move_to_cycle', {
+      issue: created.identifier,
+      cycle: 'active',
+    });
+    expect(issueOf(moved).cycleId).toBe(cycle.id);
+
+    const progress = await admin.result('cycle_progress', {
+      team: workspace.teamKey,
+      cycle: 'active',
+    });
+    expect(progress['scope']).toBeGreaterThanOrEqual(1);
+
+    const removed = await admin.result('move_to_cycle', {
+      issue: created.identifier,
+      cycle: null,
+    });
+    expect(issueOf(removed).cycleId).toBeNull();
+  });
+
+  it('lists cycles for a team', async () => {
+    const payload = await admin.result('list_cycles', { team: workspace.teamKey });
+    expect((payload['cycles'] as unknown[]).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('admin', () => {
+  it('lists members and invites a new one', async () => {
+    const members = await admin.result('list_members');
+    expect((members['members'] as unknown[]).length).toBeGreaterThanOrEqual(2);
+
+    const invited = await admin.result('invite_member', {
+      email: 'newcomer@orbit.test',
+      role: 'member',
+      teams: [workspace.teamKey],
+    });
+    const invitation = invited['invitation'] as { email: string; role: string };
+    expect(invitation).toMatchObject({ email: 'newcomer@orbit.test', role: 'member' });
+  });
+});

--- a/apps/mcp/src/tools/admin.ts
+++ b/apps/mcp/src/tools/admin.ts
@@ -1,0 +1,70 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { createInvite, listMembers } from '@orbit/core';
+import { ORG_ROLES } from '@orbit/shared/constants';
+import type { Principal } from '@orbit/shared/policy';
+import { z } from 'zod';
+import { resolveTeam } from '../resolve.ts';
+import { deltaViews } from '../views.ts';
+import { defineTool, publish } from './support.ts';
+
+export function registerAdminTools(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'list_members',
+      title: 'List workspace members',
+      description:
+        'List workspace membership with each person role, which is what decides what they may do.',
+      readOnly: true,
+      inputSchema: {},
+    },
+    async () => {
+      const members = await listMembers(principal);
+      return {
+        members: members.map((row) => ({
+          memberId: row.member.id,
+          userId: row.user.id,
+          name: row.user.name,
+          handle: row.user.handle,
+          email: row.user.email,
+          role: row.member.role,
+        })),
+      };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'invite_member',
+      title: 'Invite someone to the workspace',
+      description:
+        'Send a workspace invite to an email address. Requires a role that can invite members. Only admins can invite admins.',
+      readOnly: false,
+      inputSchema: {
+        email: z.string().email().describe('Email address to invite.'),
+        role: z.enum(ORG_ROLES).default('member').describe('Role the invitee joins with.'),
+        teams: z.array(z.string().min(1)).max(50).optional().describe('Teams to add them to.'),
+      },
+    },
+    async (args) => {
+      const teamIds: string[] = [];
+      for (const ref of args.teams ?? []) teamIds.push((await resolveTeam(principal, ref)).id);
+      const created = await createInvite(principal, {
+        email: args.email,
+        role: args.role,
+        teamIds,
+      });
+      await publish(created.actions);
+      return {
+        invitation: {
+          id: created.invitation.id,
+          email: created.invitation.email,
+          role: created.invitation.role,
+          expiresAt: created.invitation.expiresAt.toISOString(),
+        },
+        deltas: deltaViews(created.actions),
+      };
+    },
+  );
+}

--- a/apps/mcp/src/tools/identity.ts
+++ b/apps/mcp/src/tools/identity.ts
@@ -1,0 +1,157 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  getOrganization,
+  listLabels,
+  listMembers,
+  listTeams,
+  listWorkflowStates,
+} from '@orbit/core';
+import { db, eq, schema } from '@orbit/db';
+import { notFound } from '@orbit/shared/errors';
+import type { Principal } from '@orbit/shared/policy';
+import { permissionsFor } from '@orbit/shared/policy';
+import { z } from 'zod';
+import { resolveTeam } from '../resolve.ts';
+import { defineTool } from './support.ts';
+
+const teamRef = z.string().min(1).describe('A team key like "ENG", a team name, or a team id.');
+
+export function registerIdentityTools(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'get_me',
+      title: 'Get the current identity',
+      description:
+        'Return the Orbit user, workspace, role and teams that this API key acts as. Call this first to learn which teams you may write to.',
+      readOnly: true,
+      inputSchema: {},
+    },
+    async () => {
+      const [user] = await db
+        .select({
+          id: schema.user.id,
+          name: schema.user.name,
+          email: schema.user.email,
+          handle: schema.user.handle,
+        })
+        .from(schema.user)
+        .where(eq(schema.user.id, principal.userId))
+        .limit(1);
+      if (user === undefined) throw notFound('That user no longer exists.');
+      const organization = await getOrganization(principal.organizationId);
+      const teams = await listTeams(principal);
+      return {
+        user,
+        organization: { id: organization.id, name: organization.name, slug: organization.slug },
+        role: principal.role,
+        permissions: permissionsFor(principal.role),
+        teams: teams.map((team) => ({ id: team.id, key: team.key, name: team.name })),
+      };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'list_teams',
+      title: 'List teams',
+      description:
+        'List the teams in the workspace that the caller can see. Each team has a key such as "ENG" that prefixes its issue identifiers.',
+      readOnly: true,
+      inputSchema: {
+        includeArchived: z
+          .boolean()
+          .default(false)
+          .describe('Include archived teams. Defaults to false.'),
+      },
+    },
+    async (args) => {
+      const teams = await listTeams(principal, { includeArchived: args.includeArchived });
+      return {
+        teams: teams.map((team) => ({
+          id: team.id,
+          key: team.key,
+          name: team.name,
+          archived: team.archivedAt !== null,
+        })),
+      };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'list_users',
+      title: 'List users',
+      description:
+        'List the people in the workspace. Use a name, handle or email from this list wherever a tool asks for a user.',
+      readOnly: true,
+      inputSchema: {},
+    },
+    async () => {
+      const members = await listMembers(principal);
+      return {
+        users: members.map((row) => ({
+          id: row.user.id,
+          name: row.user.name,
+          handle: row.user.handle,
+          email: row.user.email,
+          role: row.member.role,
+        })),
+      };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'list_states',
+      title: 'List workflow states',
+      description:
+        'List the workflow states of one team, in board order. Use a state name from this list when creating or moving an issue.',
+      readOnly: true,
+      inputSchema: { team: teamRef },
+    },
+    async (args) => {
+      const team = await resolveTeam(principal, args.team);
+      const states = await listWorkflowStates(principal, team.id);
+      return {
+        teamId: team.id,
+        states: states.map((state) => ({
+          id: state.id,
+          name: state.name,
+          category: state.category,
+          position: state.position,
+        })),
+      };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'list_labels',
+      title: 'List labels',
+      description:
+        'List the labels available in the workspace, optionally narrowed to the ones a team can use.',
+      readOnly: true,
+      inputSchema: {
+        team: teamRef.optional().describe('Optional team key, name or id to narrow the labels to.'),
+      },
+    },
+    async (args) => {
+      const teamId =
+        args.team === undefined ? undefined : (await resolveTeam(principal, args.team)).id;
+      const labels = await listLabels(principal, teamId === undefined ? {} : { teamId });
+      return {
+        labels: labels.map((label) => ({
+          id: label.id,
+          name: label.name,
+          color: label.color,
+          teamId: label.teamId,
+        })),
+      };
+    },
+  );
+}

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -1,0 +1,13 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Principal } from '@orbit/shared/policy';
+import { registerAdminTools } from './admin.ts';
+import { registerIdentityTools } from './identity.ts';
+import { registerIssueTools } from './issues.ts';
+import { registerPlanningTools } from './planning.ts';
+
+export function registerTools(server: McpServer, principal: Principal): void {
+  registerIdentityTools(server, principal);
+  registerIssueTools(server, principal);
+  registerPlanningTools(server, principal);
+  registerAdminTools(server, principal);
+}

--- a/apps/mcp/src/tools/issues.ts
+++ b/apps/mcp/src/tools/issues.ts
@@ -1,0 +1,533 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  createIssue,
+  getIssue,
+  listIssueLabels,
+  listIssues,
+  listLabels,
+  listRelations,
+  moveIssue,
+  setRelation,
+  updateIssue,
+} from '@orbit/core';
+import { db, eq, inArray, schema } from '@orbit/db';
+import { ISSUE_RELATION_TYPES, STATE_CATEGORIES } from '@orbit/shared/constants';
+import { notFound } from '@orbit/shared/errors';
+import type { Principal } from '@orbit/shared/policy';
+import { branchName } from '@orbit/shared/utils';
+import { z } from 'zod';
+import { createComment } from '../comments.ts';
+import {
+  resolveCycle,
+  resolveLabelIds,
+  resolveProject,
+  resolveStateId,
+  resolveTeam,
+  resolveUserId,
+} from '../resolve.ts';
+import { deltaViews, describeIssue, describeIssues } from '../views.ts';
+import { defineTool, publish } from './support.ts';
+
+const PRIORITY_VALUES = { none: 0, urgent: 1, high: 2, medium: 3, low: 4 } as const;
+
+const issueRef = z.string().min(1).describe('An issue identifier like "ENG-42", or an issue id.');
+
+const priorityRef = z
+  .enum(['none', 'urgent', 'high', 'medium', 'low'])
+  .describe('Issue priority, from "urgent" down to "low".');
+
+const dueDateRef = z.iso.date().describe('Due date as YYYY-MM-DD.');
+
+const labelsRef = z
+  .array(z.string().min(1))
+  .max(50)
+  .describe('Label names or ids. Replaces the labels already on the issue.');
+
+async function issueLabelNames(principal: Principal, issueId: string): Promise<string[]> {
+  const [assigned, labels] = await Promise.all([
+    listIssueLabels(principal, issueId),
+    listLabels(principal, {}),
+  ]);
+  const names = new Map(labels.map((label) => [label.id, label.name]));
+  return assigned.map((row) => names.get(row.labelId) ?? row.labelId);
+}
+
+async function issueRelationViews(
+  principal: Principal,
+  issueId: string,
+): Promise<{ type: string; identifier: string }[]> {
+  const relations = await listRelations(principal, issueId);
+  if (relations.length === 0) return [];
+  const rows = await db
+    .select({ id: schema.issue.id, identifier: schema.issue.identifier })
+    .from(schema.issue)
+    .where(
+      inArray(
+        schema.issue.id,
+        relations.map((relation) => relation.relatedIssueId),
+      ),
+    );
+  const identifiers = new Map(rows.map((row) => [row.id, row.identifier]));
+  return relations.map((relation) => ({
+    type: relation.type,
+    identifier: identifiers.get(relation.relatedIssueId) ?? relation.relatedIssueId,
+  }));
+}
+
+function registerCreateIssue(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'create_issue',
+      title: 'Create an issue',
+      description:
+        'Create an issue on a team. The workflow state defaults to the team first unstarted state. Returns the new issue with its identifier such as "ENG-42".',
+      readOnly: false,
+      inputSchema: {
+        team: z.string().min(1).describe('Team key like "ENG", team name, or team id.'),
+        title: z.string().min(1).max(255).describe('One line summary of the work.'),
+        description: z.string().max(100_000).optional().describe('Markdown body of the issue.'),
+        state: z.string().min(1).optional().describe('Workflow state name or id on that team.'),
+        priority: priorityRef.optional(),
+        assignee: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('Assignee name, handle, email, id, or "me".'),
+        project: z.string().min(1).optional().describe('Project name, slug or id.'),
+        cycle: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('Cycle name, number, id, or "active" for the running cycle.'),
+        parent: issueRef.optional().describe('Parent issue, making this a sub issue.'),
+        labels: labelsRef.optional(),
+        estimate: z.number().int().min(0).max(100).optional().describe('Estimate points.'),
+        dueDate: dueDateRef.optional(),
+      },
+    },
+    async (args) => {
+      const team = await resolveTeam(principal, args.team);
+      const patch = await buildIssuePatch(principal, team.id, args);
+      const created = await createIssue(principal, {
+        ...patch,
+        teamId: team.id,
+        title: args.title,
+        ...(args.parent === undefined
+          ? {}
+          : { parentId: (await getIssue(principal, args.parent)).id }),
+      });
+      await publish(created.actions);
+      return {
+        issue: await describeIssue(principal, created.issue),
+        deltas: deltaViews(created.actions),
+      };
+    },
+  );
+}
+
+function registerUpdateIssue(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'update_issue',
+      title: 'Update an issue',
+      description:
+        'Change fields on an existing issue. Only the fields you pass are touched. Pass null to assignee, project or cycle to clear it.',
+      readOnly: false,
+      inputSchema: {
+        issue: issueRef,
+        title: z.string().min(1).max(255).optional(),
+        description: z.string().max(100_000).optional().describe('Replaces the markdown body.'),
+        state: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('Workflow state name or id on the issue team.'),
+        priority: priorityRef.optional(),
+        assignee: z
+          .string()
+          .min(1)
+          .nullable()
+          .optional()
+          .describe('Assignee name, handle, email, id, "me", or null to unassign.'),
+        project: z
+          .string()
+          .min(1)
+          .nullable()
+          .optional()
+          .describe('Project name, slug, id or null.'),
+        cycle: z.string().min(1).nullable().optional().describe('Cycle name, number, id or null.'),
+        labels: labelsRef.optional(),
+        estimate: z.number().int().min(0).max(100).nullable().optional(),
+        dueDate: dueDateRef.nullable().optional(),
+      },
+    },
+    async (args) => {
+      const issue = await getIssue(principal, args.issue);
+      const patch = await buildIssuePatch(principal, issue.teamId, args);
+      const updated = await updateIssue(principal, issue.id, patch);
+      await publish(updated.actions);
+      return {
+        issue: await describeIssue(principal, updated.issue),
+        changed: updated.changes.map((change) => change.field),
+        deltas: deltaViews(updated.actions),
+      };
+    },
+  );
+}
+
+interface IssuePatchArgs {
+  readonly title?: string | undefined;
+  readonly description?: string | undefined;
+  readonly state?: string | undefined;
+  readonly priority?: keyof typeof PRIORITY_VALUES | undefined;
+  readonly assignee?: string | null | undefined;
+  readonly project?: string | null | undefined;
+  readonly cycle?: string | null | undefined;
+  readonly labels?: string[] | undefined;
+  readonly estimate?: number | null | undefined;
+  readonly dueDate?: string | null | undefined;
+}
+
+async function buildIssuePatch(
+  principal: Principal,
+  teamId: string,
+  args: IssuePatchArgs,
+): Promise<Record<string, unknown>> {
+  const patch: Record<string, unknown> = {};
+  if (args.title !== undefined) patch['title'] = args.title;
+  if (args.description !== undefined) patch['description'] = args.description;
+  if (args.estimate !== undefined) patch['estimate'] = args.estimate;
+  if (args.dueDate !== undefined) patch['dueDate'] = args.dueDate;
+  if (args.priority !== undefined) patch['priority'] = PRIORITY_VALUES[args.priority];
+  if (args.state !== undefined)
+    patch['stateId'] = await resolveStateId(principal, teamId, args.state);
+  if (args.labels !== undefined)
+    patch['labelIds'] = await resolveLabelIds(principal, args.labels, teamId);
+  if (args.assignee !== undefined) {
+    patch['assigneeId'] =
+      args.assignee === null ? null : await resolveUserId(principal, args.assignee);
+  }
+  if (args.project !== undefined) {
+    patch['projectId'] =
+      args.project === null ? null : (await resolveProject(principal, args.project)).id;
+  }
+  if (args.cycle !== undefined) {
+    patch['cycleId'] =
+      args.cycle === null ? null : (await resolveCycle(principal, teamId, args.cycle)).id;
+  }
+  return patch;
+}
+
+function registerGetIssue(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'get_issue',
+      title: 'Get an issue',
+      description:
+        'Fetch one issue by identifier such as "ENG-42" or by id, including its description, labels and relations.',
+      readOnly: true,
+      inputSchema: { issue: issueRef },
+    },
+    async (args) => {
+      const issue = await getIssue(principal, args.issue);
+      return {
+        issue: {
+          ...(await describeIssue(principal, issue)),
+          description: issue.description,
+          labels: await issueLabelNames(principal, issue.id),
+          relations: await issueRelationViews(principal, issue.id),
+        },
+      };
+    },
+  );
+}
+
+function registerSearchIssues(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'search_issues',
+      title: 'Search issues',
+      description:
+        'Search issues by free text and by team, project, cycle, assignee, state, state category, label or parent. Returns a page of issues plus a cursor for the next page.',
+      readOnly: true,
+      inputSchema: {
+        query: z
+          .string()
+          .max(200)
+          .optional()
+          .describe('Text matched against title, description and identifier.'),
+        team: z.string().min(1).optional().describe('Team key, name or id.'),
+        project: z.string().min(1).optional().describe('Project name, slug or id.'),
+        cycle: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('Cycle name, number, id or "active". Needs team.'),
+        assignee: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('Assignee name, handle, email, id, or "me".'),
+        state: z.string().min(1).optional().describe('Workflow state name or id. Needs team.'),
+        stateCategory: z.enum(STATE_CATEGORIES).optional().describe('Broad status bucket.'),
+        label: z.string().min(1).optional().describe('Label name or id.'),
+        parent: z.string().min(1).optional().describe('Parent issue identifier or id.'),
+        includeArchived: z.boolean().default(false),
+        includeSubIssues: z.boolean().default(true),
+        orderBy: z.enum(['manual', 'priority', 'created', 'updated', 'due']).default('updated'),
+        limit: z.number().int().min(1).max(200).default(25),
+        cursor: z.string().max(256).optional().describe('Cursor returned by a previous call.'),
+      },
+    },
+    async (args) => {
+      const teamId =
+        args.team === undefined ? undefined : (await resolveTeam(principal, args.team)).id;
+      const filter = await buildIssueFilter(principal, teamId, args);
+      const page = await listIssues(principal, filter);
+      return {
+        issues: await describeIssues(principal, page.issues),
+        nextCursor: page.nextCursor,
+      };
+    },
+  );
+}
+
+interface IssueFilterArgs {
+  readonly query?: string | undefined;
+  readonly project?: string | undefined;
+  readonly cycle?: string | undefined;
+  readonly assignee?: string | undefined;
+  readonly state?: string | undefined;
+  readonly stateCategory?: (typeof STATE_CATEGORIES)[number] | undefined;
+  readonly label?: string | undefined;
+  readonly parent?: string | undefined;
+  readonly includeArchived: boolean;
+  readonly includeSubIssues: boolean;
+  readonly orderBy: 'manual' | 'priority' | 'created' | 'updated' | 'due';
+  readonly limit: number;
+  readonly cursor?: string | undefined;
+}
+
+async function buildIssueFilter(
+  principal: Principal,
+  teamId: string | undefined,
+  args: IssueFilterArgs,
+): Promise<Record<string, unknown>> {
+  const filter: Record<string, unknown> = {
+    includeArchived: args.includeArchived,
+    includeSubIssues: args.includeSubIssues,
+    orderBy: args.orderBy,
+    limit: args.limit,
+  };
+  if (teamId !== undefined) filter['teamId'] = teamId;
+  if (args.query !== undefined) filter['query'] = args.query;
+  if (args.cursor !== undefined) filter['cursor'] = args.cursor;
+  if (args.stateCategory !== undefined) filter['stateCategory'] = args.stateCategory;
+  if (args.project !== undefined)
+    filter['projectId'] = (await resolveProject(principal, args.project)).id;
+  if (args.assignee !== undefined)
+    filter['assigneeId'] = await resolveUserId(principal, args.assignee);
+  if (args.parent !== undefined) filter['parentId'] = (await getIssue(principal, args.parent)).id;
+  if (args.label !== undefined) {
+    const [labelId] = await resolveLabelIds(principal, [args.label], teamId);
+    if (labelId !== undefined) filter['labelId'] = labelId;
+  }
+  if (args.state !== undefined) {
+    if (teamId === undefined) throw notFound('Pass a team when filtering by state name.');
+    filter['stateId'] = await resolveStateId(principal, teamId, args.state);
+  }
+  if (args.cycle !== undefined) {
+    if (teamId === undefined) throw notFound('Pass a team when filtering by cycle.');
+    filter['cycleId'] = (await resolveCycle(principal, teamId, args.cycle)).id;
+  }
+  return filter;
+}
+
+function registerListMyIssues(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'list_my_issues',
+      title: 'List my issues',
+      description:
+        'List the issues assigned to the caller, most recently updated first. Narrow with a state category such as "started" to see only work in flight.',
+      readOnly: true,
+      inputSchema: {
+        stateCategory: z
+          .enum(STATE_CATEGORIES)
+          .optional()
+          .describe('Narrow to one status bucket, for example "started".'),
+        limit: z.number().int().min(1).max(200).default(25),
+      },
+    },
+    async (args) => {
+      const page = await listIssues(principal, {
+        assigneeId: principal.userId,
+        orderBy: 'updated',
+        limit: args.limit,
+        ...(args.stateCategory === undefined ? {} : { stateCategory: args.stateCategory }),
+      });
+      return {
+        issues: await describeIssues(principal, page.issues),
+        nextCursor: page.nextCursor,
+      };
+    },
+  );
+}
+
+function registerMoveIssue(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'move_issue',
+      title: 'Move an issue',
+      description:
+        'Move an issue to another workflow state or team, and optionally place it between two issues in the column. This is the tool to use to change status.',
+      readOnly: false,
+      inputSchema: {
+        issue: issueRef,
+        state: z.string().min(1).optional().describe('Target workflow state name or id.'),
+        team: z.string().min(1).optional().describe('Target team key, name or id.'),
+        beforeIssue: issueRef.optional().describe('Place after this issue in the column.'),
+        afterIssue: issueRef.optional().describe('Place before this issue in the column.'),
+      },
+    },
+    async (args) => {
+      const issue = await getIssue(principal, args.issue);
+      const teamId =
+        args.team === undefined ? issue.teamId : (await resolveTeam(principal, args.team)).id;
+      const moved = await moveIssue(principal, issue.id, {
+        ...(args.team === undefined ? {} : { teamId }),
+        ...(args.state === undefined
+          ? {}
+          : { stateId: await resolveStateId(principal, teamId, args.state) }),
+        ...(args.beforeIssue === undefined
+          ? {}
+          : { beforeId: (await getIssue(principal, args.beforeIssue)).id }),
+        ...(args.afterIssue === undefined
+          ? {}
+          : { afterId: (await getIssue(principal, args.afterIssue)).id }),
+      });
+      await publish(moved.actions);
+      return {
+        issue: await describeIssue(principal, moved.issue),
+        rebalanced: moved.rebalanced.length,
+        deltas: deltaViews(moved.actions),
+      };
+    },
+  );
+}
+
+function registerAddComment(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'add_comment',
+      title: 'Comment on an issue',
+      description: 'Post a markdown comment on an issue, optionally as a reply to another comment.',
+      readOnly: false,
+      inputSchema: {
+        issue: issueRef,
+        body: z.string().min(1).max(100_000).describe('Markdown body of the comment.'),
+        replyTo: z.string().min(1).optional().describe('Id of the comment being replied to.'),
+      },
+    },
+    async (args) => {
+      const issue = await getIssue(principal, args.issue);
+      const created = await createComment(principal, issue, {
+        body: args.body,
+        parentId: args.replyTo ?? null,
+      });
+      await publish(created.actions);
+      return {
+        comment: {
+          id: created.comment.id,
+          issue: issue.identifier,
+          body: created.comment.body,
+          createdAt: created.comment.createdAt.toISOString(),
+        },
+        deltas: deltaViews(created.actions),
+      };
+    },
+  );
+}
+
+function registerSetRelation(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'set_relation',
+      title: 'Relate two issues',
+      description:
+        'Link two issues. The inverse link is written on the other issue automatically, so "blocks" also records "blocked by".',
+      readOnly: false,
+      inputSchema: {
+        issue: issueRef,
+        relatedIssue: issueRef.describe('The issue on the other end of the link.'),
+        type: z.enum(ISSUE_RELATION_TYPES).describe('How the first issue relates to the second.'),
+      },
+    },
+    async (args) => {
+      const issue = await getIssue(principal, args.issue);
+      const related = await getIssue(principal, args.relatedIssue);
+      const result = await setRelation(principal, issue.id, {
+        relatedIssueId: related.id,
+        type: args.type,
+      });
+      await publish(result.actions);
+      return {
+        issue: issue.identifier,
+        relatedIssue: related.identifier,
+        type: args.type,
+        deltas: deltaViews(result.actions),
+      };
+    },
+  );
+}
+
+function registerCopyBranchName(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'copy_branch_name',
+      title: 'Get the git branch name for an issue',
+      description:
+        'Return the git branch name Orbit uses for an issue, in the form handle/eng-42-short-title.',
+      readOnly: true,
+      inputSchema: { issue: issueRef },
+    },
+    async (args) => {
+      const issue = await getIssue(principal, args.issue);
+      const [user] = await db
+        .select({ handle: schema.user.handle })
+        .from(schema.user)
+        .where(eq(schema.user.id, principal.userId))
+        .limit(1);
+      if (user === undefined) throw notFound('That user no longer exists.');
+      return {
+        issue: issue.identifier,
+        branch: branchName({
+          username: user.handle,
+          identifier: issue.identifier,
+          title: issue.title,
+        }),
+      };
+    },
+  );
+}
+
+export function registerIssueTools(server: McpServer, principal: Principal): void {
+  registerCreateIssue(server, principal);
+  registerUpdateIssue(server, principal);
+  registerGetIssue(server, principal);
+  registerSearchIssues(server, principal);
+  registerListMyIssues(server, principal);
+  registerMoveIssue(server, principal);
+  registerAddComment(server, principal);
+  registerSetRelation(server, principal);
+  registerCopyBranchName(server, principal);
+}

--- a/apps/mcp/src/tools/issues.ts
+++ b/apps/mcp/src/tools/issues.ts
@@ -12,7 +12,7 @@ import {
 } from '@orbit/core';
 import { db, eq, inArray, schema } from '@orbit/db';
 import { ISSUE_RELATION_TYPES, STATE_CATEGORIES } from '@orbit/shared/constants';
-import { notFound } from '@orbit/shared/errors';
+import { notFound, validationFailed } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import { branchName } from '@orbit/shared/utils';
 import { z } from 'zod';
@@ -337,11 +337,11 @@ async function buildIssueFilter(
     if (labelId !== undefined) filter['labelId'] = labelId;
   }
   if (args.state !== undefined) {
-    if (teamId === undefined) throw notFound('Pass a team when filtering by state name.');
+    if (teamId === undefined) throw validationFailed('Pass a team when filtering by state.');
     filter['stateId'] = await resolveStateId(principal, teamId, args.state);
   }
   if (args.cycle !== undefined) {
-    if (teamId === undefined) throw notFound('Pass a team when filtering by cycle.');
+    if (teamId === undefined) throw validationFailed('Pass a team when filtering by cycle.');
     filter['cycleId'] = (await resolveCycle(principal, teamId, args.cycle)).id;
   }
   return filter;

--- a/apps/mcp/src/tools/planning.ts
+++ b/apps/mcp/src/tools/planning.ts
@@ -1,0 +1,214 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  activeCycle,
+  type CycleRow,
+  createProject,
+  cycleProgress,
+  getIssue,
+  listCycles,
+  listProjects,
+  type ProjectRow,
+  projectProgress,
+  updateIssue,
+} from '@orbit/core';
+import { PROJECT_HEALTHS, PROJECT_STATUSES } from '@orbit/shared/constants';
+import type { Principal } from '@orbit/shared/policy';
+import { z } from 'zod';
+import { resolveCycle, resolveProject, resolveTeam, resolveUserId } from '../resolve.ts';
+import { deltaViews, describeIssue } from '../views.ts';
+import { defineTool, publish } from './support.ts';
+
+const teamRef = z.string().min(1).describe('Team key like "ENG", team name, or team id.');
+
+function projectView(row: ProjectRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    status: row.status,
+    health: row.health,
+    summary: row.summary,
+    leadId: row.leadId,
+    startDate: row.startDate,
+    targetDate: row.targetDate,
+    archived: row.archivedAt !== null,
+  };
+}
+
+function cycleView(row: CycleRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    number: row.number,
+    name: row.name,
+    startsAt: row.startsAt.toISOString(),
+    endsAt: row.endsAt.toISOString(),
+    completed: row.completedAt !== null,
+  };
+}
+
+function registerProjectTools(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'list_projects',
+      title: 'List projects',
+      description: 'List the projects in the workspace with their status and health.',
+      readOnly: true,
+      inputSchema: {
+        includeArchived: z.boolean().default(false).describe('Include archived projects.'),
+      },
+    },
+    async (args) => {
+      const projects = await listProjects(principal, { includeArchived: args.includeArchived });
+      return { projects: projects.map(projectView) };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'create_project',
+      title: 'Create a project',
+      description:
+        'Create a project and optionally attach it to one or more teams. Requires a role that can manage projects.',
+      readOnly: false,
+      inputSchema: {
+        name: z.string().min(2).max(120).describe('Project name.'),
+        summary: z.string().max(500).optional().describe('One line summary.'),
+        description: z.string().max(100_000).optional().describe('Markdown brief.'),
+        status: z.enum(PROJECT_STATUSES).optional().describe('Delivery status.'),
+        health: z.enum(PROJECT_HEALTHS).optional().describe('Current health signal.'),
+        lead: z.string().min(1).optional().describe('Lead name, handle, email, id, or "me".'),
+        startDate: z.iso.date().optional().describe('Start date as YYYY-MM-DD.'),
+        targetDate: z.iso.date().optional().describe('Target date as YYYY-MM-DD.'),
+        teams: z.array(teamRef).max(50).optional().describe('Teams that own the project.'),
+      },
+    },
+    async (args) => {
+      const teamIds: string[] = [];
+      for (const ref of args.teams ?? []) teamIds.push((await resolveTeam(principal, ref)).id);
+      const created = await createProject(principal, {
+        name: args.name,
+        teamIds,
+        ...(args.summary === undefined ? {} : { summary: args.summary }),
+        ...(args.description === undefined ? {} : { description: args.description }),
+        ...(args.status === undefined ? {} : { status: args.status }),
+        ...(args.health === undefined ? {} : { health: args.health }),
+        ...(args.lead === undefined ? {} : { leadId: await resolveUserId(principal, args.lead) }),
+        ...(args.startDate === undefined ? {} : { startDate: args.startDate }),
+        ...(args.targetDate === undefined ? {} : { targetDate: args.targetDate }),
+      });
+      await publish(created.actions);
+      return { project: projectView(created.project), deltas: deltaViews(created.actions) };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'project_progress',
+      title: 'Get project progress',
+      description:
+        'Return the issue counts for a project, in total and per milestone, so you can report how far along it is.',
+      readOnly: true,
+      inputSchema: { project: z.string().min(1).describe('Project name, slug or id.') },
+    },
+    async (args) => {
+      const project = await resolveProject(principal, args.project);
+      const progress = await projectProgress(principal, project.id);
+      return { project: project.name, ...progress };
+    },
+  );
+}
+
+function registerCycleTools(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'list_cycles',
+      title: 'List cycles',
+      description: 'List the cycles of one team in number order.',
+      readOnly: true,
+      inputSchema: { team: teamRef },
+    },
+    async (args) => {
+      const team = await resolveTeam(principal, args.team);
+      const cycles = await listCycles(principal, team.id);
+      return { teamId: team.id, cycles: cycles.map(cycleView) };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'active_cycle',
+      title: 'Get the active cycle',
+      description: 'Return the cycle a team is currently running, or null when none is open.',
+      readOnly: true,
+      inputSchema: { team: teamRef },
+    },
+    async (args) => {
+      const team = await resolveTeam(principal, args.team);
+      const current = await activeCycle(principal, team.id);
+      return { teamId: team.id, cycle: current === undefined ? null : cycleView(current) };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'cycle_progress',
+      title: 'Get cycle progress',
+      description:
+        'Return scope, started and completed counts for a cycle plus a day by day burn up series.',
+      readOnly: true,
+      inputSchema: {
+        team: teamRef,
+        cycle: z.string().min(1).describe('Cycle name, number, id, or "active".'),
+      },
+    },
+    async (args) => {
+      const team = await resolveTeam(principal, args.team);
+      const cycle = await resolveCycle(principal, team.id, args.cycle);
+      const progress = await cycleProgress(principal, cycle.id);
+      return { cycle: cycleView(cycle), ...progress };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'move_to_cycle',
+      title: 'Move an issue into a cycle',
+      description:
+        'Put an issue into a cycle, or pass null to take it out of the cycle it is in. The cycle must belong to the issue team.',
+      readOnly: false,
+      inputSchema: {
+        issue: z.string().min(1).describe('Issue identifier like "ENG-42", or an issue id.'),
+        cycle: z
+          .string()
+          .min(1)
+          .nullable()
+          .describe(
+            'Cycle name, number, id, "active", or null to remove the issue from its cycle.',
+          ),
+      },
+    },
+    async (args) => {
+      const issue = await getIssue(principal, args.issue);
+      const cycleId =
+        args.cycle === null ? null : (await resolveCycle(principal, issue.teamId, args.cycle)).id;
+      const updated = await updateIssue(principal, issue.id, { cycleId });
+      await publish(updated.actions);
+      return {
+        issue: await describeIssue(principal, updated.issue),
+        deltas: deltaViews(updated.actions),
+      };
+    },
+  );
+}
+
+export function registerPlanningTools(server: McpServer, principal: Principal): void {
+  registerProjectTools(server, principal);
+  registerCycleTools(server, principal);
+}

--- a/apps/mcp/src/tools/support.ts
+++ b/apps/mcp/src/tools/support.ts
@@ -1,0 +1,78 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { publishDeltas } from '@orbit/core';
+import type { DomainError } from '@orbit/shared/errors';
+import { toDomainError, validationFailed } from '@orbit/shared/errors';
+import type { SyncAction } from '@orbit/shared/events';
+import { z } from 'zod';
+import { errorFields, logger } from '../logger.ts';
+
+export type ToolPayload = Record<string, unknown>;
+
+export function ok(payload: ToolPayload): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+    structuredContent: payload,
+  };
+}
+
+function asDomainError(error: unknown): DomainError {
+  if (error instanceof z.ZodError) {
+    const detail = error.issues
+      .map((issue) => `${issue.path.join('.') || 'input'}: ${issue.message}`)
+      .join('; ');
+    return validationFailed(detail);
+  }
+  return toDomainError(error);
+}
+
+export function failed(name: string, error: unknown): CallToolResult {
+  const domain = asDomainError(error);
+  logger.warn('tool failed', { tool: name, code: domain.code, ...errorFields(error) });
+  return {
+    isError: true,
+    content: [{ type: 'text', text: JSON.stringify(domain.toJSON()) }],
+  };
+}
+
+export async function publish(actions: readonly SyncAction[]): Promise<void> {
+  await publishDeltas([...actions]);
+}
+
+export interface ToolConfig<Shape extends z.ZodRawShape> {
+  readonly name: string;
+  readonly title: string;
+  readonly description: string;
+  readonly readOnly: boolean;
+  readonly inputSchema: Shape;
+}
+
+export function defineTool<Shape extends z.ZodRawShape>(
+  server: McpServer,
+  config: ToolConfig<Shape>,
+  run: (args: z.infer<z.ZodObject<Shape>>) => Promise<ToolPayload>,
+): void {
+  const inputSchema = z.object(config.inputSchema) as unknown as z.ZodObject<Shape>;
+  server.registerTool<z.ZodRawShape, z.ZodObject<Shape>>(
+    config.name,
+    {
+      title: config.title,
+      description: config.description,
+      inputSchema,
+      annotations: {
+        title: config.title,
+        readOnlyHint: config.readOnly,
+        destructiveHint: false,
+        idempotentHint: config.readOnly,
+        openWorldHint: false,
+      },
+    },
+    async (args) => {
+      try {
+        return ok(await run(args as z.infer<z.ZodObject<Shape>>));
+      } catch (error) {
+        return failed(config.name, error);
+      }
+    },
+  );
+}

--- a/apps/mcp/src/tools/support.ts
+++ b/apps/mcp/src/tools/support.ts
@@ -29,9 +29,13 @@ function asDomainError(error: unknown): DomainError {
 export function failed(name: string, error: unknown): CallToolResult {
   const domain = asDomainError(error);
   logger.warn('tool failed', { tool: name, code: domain.code, ...errorFields(error) });
+  const body =
+    domain.status >= 500
+      ? { error: { code: domain.code, message: 'Something went wrong on our side.' } }
+      : domain.toJSON();
   return {
     isError: true,
-    content: [{ type: 'text', text: JSON.stringify(domain.toJSON()) }],
+    content: [{ type: 'text', text: JSON.stringify(body) }],
   };
 }
 

--- a/apps/mcp/src/views.ts
+++ b/apps/mcp/src/views.ts
@@ -1,0 +1,93 @@
+import { type IssueRow, listMembers, listWorkflowStates } from '@orbit/core';
+import { PRIORITY_LABELS } from '@orbit/shared/constants';
+import type { SyncAction } from '@orbit/shared/events';
+import type { Principal } from '@orbit/shared/policy';
+
+const PRIORITY_NAMES: Record<number, string> = PRIORITY_LABELS;
+
+export interface IssueView {
+  readonly id: string;
+  readonly identifier: string;
+  readonly title: string;
+  readonly teamId: string;
+  readonly state: string | null;
+  readonly stateId: string;
+  readonly priority: string;
+  readonly assignee: string | null;
+  readonly assigneeId: string | null;
+  readonly projectId: string | null;
+  readonly cycleId: string | null;
+  readonly milestoneId: string | null;
+  readonly parentId: string | null;
+  readonly estimate: number | null;
+  readonly dueDate: string | null;
+  readonly archived: boolean;
+  readonly updatedAt: string;
+}
+
+export interface DeltaView {
+  readonly model: string;
+  readonly action: string;
+  readonly id: string;
+}
+
+export function deltaViews(actions: readonly SyncAction[]): DeltaView[] {
+  return actions.map((action) => ({
+    model: action.model,
+    action: action.action,
+    id: action.modelId,
+  }));
+}
+
+function toView(
+  row: IssueRow,
+  stateNames: ReadonlyMap<string, string>,
+  userNames: ReadonlyMap<string, string>,
+): IssueView {
+  return {
+    id: row.id,
+    identifier: row.identifier,
+    title: row.title,
+    teamId: row.teamId,
+    state: stateNames.get(row.stateId) ?? null,
+    stateId: row.stateId,
+    priority: PRIORITY_NAMES[row.priority] ?? 'No priority',
+    assignee: row.assigneeId === null ? null : (userNames.get(row.assigneeId) ?? null),
+    assigneeId: row.assigneeId,
+    projectId: row.projectId,
+    cycleId: row.cycleId,
+    milestoneId: row.milestoneId,
+    parentId: row.parentId,
+    estimate: row.estimate,
+    dueDate: row.dueDate,
+    archived: row.archivedAt !== null,
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export async function describeIssues(
+  principal: Principal,
+  rows: readonly IssueRow[],
+): Promise<IssueView[]> {
+  if (rows.length === 0) return [];
+
+  const stateNames = new Map<string, string>();
+  for (const teamId of new Set(rows.map((row) => row.teamId))) {
+    for (const state of await listWorkflowStates(principal, teamId)) {
+      stateNames.set(state.id, state.name);
+    }
+  }
+
+  const userNames = new Map<string, string>();
+  for (const member of await listMembers(principal)) {
+    userNames.set(member.user.id, member.user.name);
+  }
+
+  return rows.map((row) => toView(row, stateNames, userNames));
+}
+
+export async function describeIssue(principal: Principal, row: IssueRow): Promise<IssueView> {
+  const [view] = await describeIssues(principal, [row]);
+  if (view === undefined) throw new Error('The issue could not be described.');
+  return view;
+}

--- a/apps/mcp/tsconfig.json
+++ b/apps/mcp/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "vitest.config.ts"]
+}

--- a/apps/mcp/vitest.config.ts
+++ b/apps/mcp/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+
+const LOCAL_TEST_DATABASE_URL = 'postgres://orbit:orbit@localhost:5434/orbit_test_mcp';
+
+function resolveTestDatabaseUrl(): string {
+  const candidate =
+    process.env['TEST_DATABASE_URL'] ?? process.env['DATABASE_URL'] ?? LOCAL_TEST_DATABASE_URL;
+  const name = new URL(candidate).pathname.replace(/^\//, '');
+  if (!name.includes('test')) {
+    throw new Error(
+      `Refusing to run tests against "${name}". Point TEST_DATABASE_URL at a database whose name contains "test".`,
+    );
+  }
+  return candidate;
+}
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    fileParallelism: false,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    env: {
+      DATABASE_URL: resolveTestDatabaseUrl(),
+      REDIS_URL: '',
+    },
+  },
+});

--- a/apps/mcp/vitest.config.ts
+++ b/apps/mcp/vitest.config.ts
@@ -2,16 +2,29 @@ import { defineConfig } from 'vitest/config';
 
 const LOCAL_TEST_DATABASE_URL = 'postgres://orbit:orbit@localhost:5434/orbit_test_mcp';
 
-function resolveTestDatabaseUrl(): string {
-  const candidate =
-    process.env['TEST_DATABASE_URL'] ?? process.env['DATABASE_URL'] ?? LOCAL_TEST_DATABASE_URL;
-  const name = new URL(candidate).pathname.replace(/^\//, '');
+function databaseNameOf(candidate: string): string {
+  return new URL(candidate).pathname.replace(/^\//, '');
+}
+
+function assertTestDatabase(candidate: string, source: string): string {
+  const name = databaseNameOf(candidate);
   if (!name.includes('test')) {
     throw new Error(
-      `Refusing to run tests against "${name}". Point TEST_DATABASE_URL at a database whose name contains "test".`,
+      `Refusing to run tests against "${name}" from ${source}. Point it at a database whose name contains "test".`,
     );
   }
   return candidate;
+}
+
+function resolveTestDatabaseUrl(): string {
+  const explicit = process.env['TEST_DATABASE_URL'];
+  if (explicit !== undefined) return assertTestDatabase(explicit, 'TEST_DATABASE_URL');
+  const ambient = process.env['DATABASE_URL'];
+  if (ambient === undefined) return LOCAL_TEST_DATABASE_URL;
+  if (databaseNameOf(ambient).includes('test')) return ambient;
+  const url = new URL(ambient);
+  url.pathname = '/orbit_test_mcp';
+  return url.toString();
 }
 
 export default defineConfig({

--- a/packages/core/src/auth/api-key.ts
+++ b/packages/core/src/auth/api-key.ts
@@ -1,0 +1,97 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { db, eq, schema } from '@orbit/db';
+import { internal, unauthorized } from '@orbit/shared/errors';
+import type { Principal } from '@orbit/shared/policy';
+import { newId } from '../internal.ts';
+import { resolvePrincipal } from '../org/member-service.ts';
+
+export type ApiKeyRow = typeof schema.apiKey.$inferSelect;
+
+export const API_KEY_PREFIX = 'orb_';
+export const API_KEY_PREFIX_LENGTH = 12;
+const API_KEY_SECRET_BYTES = 24;
+
+export function hashApiKey(key: string): string {
+  return createHash('sha256').update(key, 'utf8').digest('hex');
+}
+
+export function generateApiKey(): string {
+  return `${API_KEY_PREFIX}${randomBytes(API_KEY_SECRET_BYTES).toString('base64url')}`;
+}
+
+export function apiKeyPrefix(key: string): string {
+  return key.slice(0, API_KEY_PREFIX_LENGTH);
+}
+
+function hashesMatch(stored: string, candidate: string): boolean {
+  const left = Buffer.from(stored, 'utf8');
+  const right = Buffer.from(candidate, 'utf8');
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}
+
+export interface CreateApiKeyInput {
+  readonly organizationId: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly expiresAt?: Date | null;
+}
+
+export interface CreatedApiKey {
+  readonly key: string;
+  readonly apiKey: ApiKeyRow;
+}
+
+export async function createApiKey(input: CreateApiKeyInput): Promise<CreatedApiKey> {
+  const key = generateApiKey();
+  const [row] = await db
+    .insert(schema.apiKey)
+    .values({
+      id: newId(),
+      organizationId: input.organizationId,
+      userId: input.userId,
+      name: input.name,
+      hashedKey: hashApiKey(key),
+      prefix: apiKeyPrefix(key),
+      expiresAt: input.expiresAt ?? null,
+    })
+    .returning();
+  if (row === undefined) throw internal('The API key could not be created.');
+  return { key, apiKey: row };
+}
+
+export interface ApiKeyIdentity {
+  readonly principal: Principal;
+  readonly apiKey: ApiKeyRow;
+}
+
+export async function verifyApiKey(key: string, now: Date = new Date()): Promise<ApiKeyIdentity> {
+  const rejection = unauthorized('That API key is not valid.');
+  if (!key.startsWith(API_KEY_PREFIX) || key.length <= API_KEY_PREFIX_LENGTH) throw rejection;
+
+  const candidate = hashApiKey(key);
+  const rows = await db
+    .select()
+    .from(schema.apiKey)
+    .where(eq(schema.apiKey.prefix, apiKeyPrefix(key)));
+  const found = rows.find((row) => hashesMatch(row.hashedKey, candidate));
+  if (found === undefined) throw rejection;
+  if (found.revokedAt !== null) throw unauthorized('That API key has been revoked.');
+  if (found.expiresAt !== null && found.expiresAt.getTime() <= now.getTime()) {
+    throw unauthorized('That API key has expired.');
+  }
+
+  await db.update(schema.apiKey).set({ lastUsedAt: now }).where(eq(schema.apiKey.id, found.id));
+  const principal = await resolvePrincipal(found.userId, found.organizationId);
+  return { principal, apiKey: found };
+}
+
+export async function revokeApiKey(apiKeyId: string, now: Date = new Date()): Promise<ApiKeyRow> {
+  const [row] = await db
+    .update(schema.apiKey)
+    .set({ revokedAt: now })
+    .where(eq(schema.apiKey.id, apiKeyId))
+    .returning();
+  if (row === undefined) throw internal('That API key does not exist.');
+  return row;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './activity/activity-service.ts';
+export * from './auth/api-key.ts';
 export * from './internal.ts';
 export * from './org/invite-service.ts';
 export * from './org/member-service.ts';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,40 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  apps/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.4.3)
+      '@orbit/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@orbit/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+      '@orbit/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      esbuild:
+        specifier: 0.28.1
+        version: 0.28.1
+      tsx:
+        specifier: 4.23.1
+        version: 4.23.1
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1))
+
   apps/realtime:
     dependencies:
       '@orbit/db':
@@ -1237,6 +1271,12 @@ packages:
   '@hexagon/base64@1.1.28':
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -1414,6 +1454,16 @@ packages:
 
   '@levischuck/tiny-cbor@0.2.11':
     resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -2521,9 +2571,24 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2626,6 +2691,10 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -2636,6 +2705,18 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
@@ -2664,8 +2745,36 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -2707,6 +2816,10 @@ packages:
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2837,8 +2950,19 @@ packages:
       sqlite3:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.395:
     resolution: {integrity: sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   enhanced-resolve@5.24.3:
     resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
@@ -2852,8 +2976,20 @@ packages:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -2874,15 +3010,46 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@8.6.0:
+    resolution: {integrity: sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2892,6 +3059,14 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
 
   framer-motion@12.42.2:
     resolution: {integrity: sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==}
@@ -2907,24 +3082,55 @@ packages:
       react-dom:
         optional: true
 
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
 
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.31:
+    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+    engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -2940,6 +3146,10 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -2948,9 +3158,16 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ioredis@5.11.1:
     resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
@@ -2960,8 +3177,22 @@ packages:
     resolution: {integrity: sha512-T3VieIilNumOJCXI9SDgo4NnF6sZkd6XcmPi6qWtw4xqbt8nNz/ZVNiIH1L9puMTSHZh1mUWA4xKa2nWPF4NwQ==}
     engines: {node: '>=12.22.0'}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   isomorphic-dompurify@3.19.0:
     resolution: {integrity: sha512-ynZ/6cVv4Trpt1FEd5TkHsHtLs+y/YQGb+ocIIVRdc+DkiYRbxlEL/IiSeSeQXwopQcG5FhoeIUJa1l26IgSpw==}
@@ -2999,6 +3230,12 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -3249,8 +3486,28 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -3288,6 +3545,10 @@ packages:
     resolution: {integrity: sha512-PGd3uPojJB9Z07d5NX3Db/SOSBbyy3wLMUGq0GpnEEJfVzY9mq7daPMAZ3jObV5D3Jn+YKND636eI5ULg7F80Q==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
@@ -3323,15 +3584,41 @@ packages:
     resolution: {integrity: sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==}
     engines: {node: '>=6.0.0'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3380,6 +3667,10 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   postal-mime@2.7.5:
     resolution: {integrity: sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==}
 
@@ -3420,6 +3711,10 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -3430,6 +3725,18 @@ packages:
   pvutils@1.1.5:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -3516,6 +3823,13 @@ packages:
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -3535,12 +3849,47 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@3.1.2:
     resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -3568,6 +3917,10 @@ packages:
 
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
@@ -3624,6 +3977,10 @@ packages:
     resolution: {integrity: sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==}
     hasBin: true
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@6.0.2:
     resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
@@ -3651,6 +4008,10 @@ packages:
     resolution: {integrity: sha512-3VfH7fK7WQ/ZHYjvfWyVnPRpcNaX3ZqXfGDMdc82eGdM0ESATyxFK4R4PM3wNsVFsdkUFZ4pZpkNeG37dxOv+g==}
     hasBin: true
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -3666,6 +4027,10 @@ packages:
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -3692,6 +4057,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
@@ -3793,10 +4162,18 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.21.1:
     resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
@@ -3823,6 +4200,11 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -4552,6 +4934,10 @@ snapshots:
 
   '@hexagon/base64@1.1.28': {}
 
+  '@hono/node-server@1.19.14(hono@4.12.31)':
+    dependencies:
+      hono: 4.12.31
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -4673,6 +5059,28 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@levischuck/tiny-cbor@0.2.11': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.31)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.6.0(express@5.2.1)
+      hono: 4.12.31
+      jose: 6.2.4
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -5745,7 +6153,23 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.4
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -5813,6 +6237,20 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   bowser@2.14.1: {}
 
   browserslist@4.28.7:
@@ -5824,6 +6262,18 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
   buffer-from@1.1.2: {}
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001806: {}
 
@@ -5851,7 +6301,28 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   css-tree@3.2.1:
     dependencies:
@@ -5887,6 +6358,8 @@ snapshots:
   defu@6.1.7: {}
 
   denque@2.1.0: {}
+
+  depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -5933,7 +6406,17 @@ snapshots:
       kysely: 0.29.4
       pg: 8.22.0
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.395: {}
+
+  encodeurl@2.0.0: {}
 
   enhanced-resolve@5.24.3:
     dependencies:
@@ -5944,7 +6427,15 @@ snapshots:
 
   entities@8.0.0: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.3.1: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -6031,17 +6522,85 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.4.0: {}
 
+  express-rate-limit@8.6.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
   fast-sha256@1.3.0: {}
+
+  fast-uri@3.1.4: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
 
   framer-motion@12.42.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -6052,18 +6611,50 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
+  fresh@2.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.31: {}
 
   html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
@@ -6088,6 +6679,14 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -6102,7 +6701,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   indent-string@4.0.0: {}
+
+  inherits@2.0.4: {}
 
   ioredis@5.11.1:
     dependencies:
@@ -6130,7 +6735,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
+
+  isexe@2.0.0: {}
 
   isomorphic-dompurify@3.19.0(@noble/hashes@2.2.0):
     dependencies:
@@ -6200,6 +6813,10 @@ snapshots:
       - '@noble/hashes'
 
   jsesc@3.1.0: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
 
@@ -6372,7 +6989,19 @@ snapshots:
 
   marked@18.0.7: {}
 
+  math-intrinsics@1.1.0: {}
+
   mdn-data@2.27.1: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   min-indent@1.0.1: {}
 
@@ -6395,6 +7024,8 @@ snapshots:
   nanoid@3.3.16: {}
 
   nanostores@1.4.1: {}
+
+  negotiator@1.0.0: {}
 
   next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -6429,7 +7060,19 @@ snapshots:
 
   nodemailer@9.0.3: {}
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obug@2.1.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   parse5@8.0.1:
     dependencies:
@@ -6439,6 +7082,12 @@ snapshots:
     dependencies:
       leac: 0.6.0
       peberminta: 0.9.0
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -6483,6 +7132,8 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  pkce-challenge@5.0.1: {}
+
   postal-mime@2.7.5: {}
 
   postcss@8.4.31:
@@ -6517,6 +7168,11 @@ snapshots:
 
   prismjs@1.30.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
 
   pvtsutils@1.3.6:
@@ -6524,6 +7180,20 @@ snapshots:
       tslib: 2.8.1
 
   pvutils@1.1.5: {}
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:
@@ -6610,6 +7280,18 @@ snapshots:
 
   rou3@0.7.12: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -6625,7 +7307,34 @@ snapshots:
   semver@7.8.5:
     optional: true
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@3.1.2: {}
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -6659,6 +7368,40 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -6680,6 +7423,8 @@ snapshots:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
+
+  statuses@2.0.2: {}
 
   std-env@4.2.0: {}
 
@@ -6719,6 +7464,8 @@ snapshots:
     dependencies:
       tldts-core: 7.4.9
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@6.0.2:
     dependencies:
       tldts: 7.4.9
@@ -6750,6 +7497,12 @@ snapshots:
       '@turbo/windows-64': 2.10.6
       '@turbo/windows-arm64': 2.10.6
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   ulid@3.0.2: {}
@@ -6757,6 +7510,8 @@ snapshots:
   undici-types@8.3.0: {}
 
   undici@7.28.0: {}
+
+  unpipe@1.0.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:
@@ -6778,6 +7533,8 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.17
+
+  vary@1.1.2: {}
 
   vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1):
     dependencies:
@@ -6865,10 +7622,16 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrappy@1.0.2: {}
 
   ws@8.21.1: {}
 
@@ -6879,5 +7642,9 @@ snapshots:
   xtend@4.0.2: {}
 
   yallist@3.1.1: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}


### PR DESCRIPTION
Adds `apps/mcp`, an API key authenticated MCP server that exposes 23 Orbit tools backed by the core service layer and the shared permission policy.