### PR TITLE
test(web): seed a clean database before each end to end run

### DIFF
--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -1,0 +1,11 @@
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+export default function globalSetup(): void {
+  const repoRoot = resolve(import.meta.dirname, '../../..');
+  execFileSync('pnpm', ['--filter', '@orbit/db', 'seed'], {
+    cwd: repoRoot,
+    stdio: 'ignore',
+    env: process.env,
+  });
+}

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -2,7 +2,9 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
-  timeout: 120_000,
+  globalSetup: './e2e/global-setup.ts',
+  timeout: 180_000,
+  expect: { timeout: 45_000 },
   fullyParallel: false,
   workers: 1,
   reporter: [['list']],


### PR DESCRIPTION
Adds a Playwright global setup that reseeds, so the suite no longer carries state between runs.