### PR TITLE
fix(realtime): reject a malformed stated organization

### DIFF
--- a/apps/realtime/src/active-organization.test.ts
+++ b/apps/realtime/src/active-organization.test.ts
@@ -111,6 +111,16 @@ describe('client stated organization', () => {
     expect(await client.waitForClose()).toBe(ORGANIZATION_FORBIDDEN_CLOSE_CODE);
   });
 
+  it('rejects an empty stated organization instead of choosing one', async () => {
+    const client = await connectClient(server.port, ambiguous.token, '');
+    expect(await client.waitForClose()).toBe(ORGANIZATION_FORBIDDEN_CLOSE_CODE);
+  });
+
+  it('rejects a stated organization longer than an identifier can be', async () => {
+    const client = await connectClient(server.port, ambiguous.token, 'x'.repeat(200));
+    expect(await client.waitForClose()).toBe(ORGANIZATION_FORBIDDEN_CLOSE_CODE);
+  });
+
   it('falls back to the oldest membership when the client states nothing', async () => {
     const client = await connectClient(server.port, ambiguous.token);
     const ready = await client.waitFor('ready');

--- a/apps/realtime/src/server.ts
+++ b/apps/realtime/src/server.ts
@@ -67,16 +67,19 @@ const CLOSE_CODES: Record<ConnectionRejection, number> = {
   organization_forbidden: ORGANIZATION_FORBIDDEN_CLOSE_CODE,
 };
 
-function credentialsFrom(request: IncomingMessage): {
-  token: string;
-  organizationId: string | null;
-} {
+interface ConnectionCredentials {
+  readonly token: string;
+  readonly organizationId: string | null;
+}
+
+function credentialsFrom(request: IncomingMessage): ConnectionCredentials | null {
   const url = new URL(request.url ?? '/', 'http://realtime.local');
-  const stated = connectionOrganizationIdSchema.safeParse(url.searchParams.get('organizationId'));
-  return {
-    token: url.searchParams.get('token') ?? '',
-    organizationId: stated.success ? stated.data : null,
-  };
+  const token = url.searchParams.get('token') ?? '';
+  const stated = url.searchParams.get('organizationId');
+  if (stated === null) return { token, organizationId: null };
+  const parsed = connectionOrganizationIdSchema.safeParse(stated);
+  if (!parsed.success) return null;
+  return { token, organizationId: parsed.data };
 }
 
 function parseJson(payload: string): unknown {
@@ -264,6 +267,11 @@ export async function createRealtimeServer(
   async function accept(socket: WebSocket, request: IncomingMessage): Promise<void> {
     socket.pause();
     const credentials = credentialsFrom(request);
+    if (credentials === null) {
+      socket.resume();
+      socket.close(CLOSE_CODES.organization_forbidden, 'organization_forbidden');
+      return;
+    }
     const authenticated = await authenticateConnection(
       credentials.token,
       credentials.organizationId,


### PR DESCRIPTION
A blank or over long organizationId query parameter fell back to the server's own choice instead of being rejected, reintroducing the workspace mismatch the parameter exists to prevent.