### PR TITLE
fix(keyboard): scope the hotkey registry and stop advertising shortcuts that do nothing

### DIFF
--- a/apps/web/src/components/command-palette.test.tsx
+++ b/apps/web/src/components/command-palette.test.tsx
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactNode, useState } from 'react';
+import { CommandPalette } from '@/components/command-palette.tsx';
+import { ShortcutsOverlay } from '@/components/shortcuts-overlay.tsx';
+import { HOTKEY_PRIORITY, HotkeyProvider, useHotkey } from '@/lib/keyboard/index.ts';
+import { buildNavigation } from '@/lib/navigation.ts';
+
+const push = mock();
+const setTheme = mock();
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ push, replace: mock(), refresh: mock() }),
+  usePathname: () => '/inbox',
+}));
+
+mock.module('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'dark', setTheme }),
+}));
+
+const sections = buildNavigation([{ id: 'team_1', key: 'ENG', name: 'Engineering' }]);
+
+const noop = () => undefined;
+
+function Palette({
+  startOpen = false,
+  onToggleSidebar = noop,
+  onShowShortcuts = noop,
+  children,
+}: {
+  readonly startOpen?: boolean;
+  readonly onToggleSidebar?: () => void;
+  readonly onShowShortcuts?: () => void;
+  readonly children?: ReactNode;
+}) {
+  const [open, setOpen] = useState(startOpen);
+  return (
+    <HotkeyProvider>
+      <CommandPalette
+        open={open}
+        onOpenChange={setOpen}
+        sections={sections}
+        onToggleSidebar={onToggleSidebar}
+        onShowShortcuts={onShowShortcuts}
+      />
+      {children}
+    </HotkeyProvider>
+  );
+}
+
+function CreateIssue({ run }: { readonly run: () => void }) {
+  useHotkey('c', run, { label: 'Create issue', section: 'Issues' });
+  return null;
+}
+
+function NewDoc({ run }: { readonly run: () => void }) {
+  useHotkey('c', run, {
+    label: 'New doc',
+    section: 'Navigation',
+    scope: 'docs',
+    priority: HOTKEY_PRIORITY.surface,
+  });
+  return null;
+}
+
+function ArchiveIssue({ enabled }: { readonly enabled: boolean }) {
+  useHotkey('shift+a', noop, { label: 'Archive issue', section: 'Issues', enabled });
+  return null;
+}
+
+async function select(name: RegExp) {
+  await userEvent.setup().click(await screen.findByRole('option', { name }));
+}
+
+beforeEach(() => {
+  push.mockClear();
+  setTheme.mockClear();
+});
+
+describe('command palette', () => {
+  it('opens on its own binding and lists every navigable surface', async () => {
+    const user = userEvent.setup();
+    render(<Palette />);
+
+    await user.keyboard('{Meta>}k{/Meta}');
+
+    for (const label of [
+      /Go to Inbox/,
+      /Go to My issues/,
+      /Go to Projects/,
+      /Go to Cycles/,
+      /Go to Views/,
+      /Go to Docs/,
+      /Go to Engineering issues/,
+      /Go to Engineering board/,
+      /Go to Engineering active cycle/,
+      /Go to Settings/,
+    ]) {
+      expect(await screen.findByRole('option', { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it('routes the same way whether the command is run or the binding is pressed', async () => {
+    const user = userEvent.setup();
+    render(<Palette startOpen />);
+
+    await select(/Go to Inbox/);
+    expect(push).toHaveBeenCalledWith('/inbox');
+
+    push.mockClear();
+    await user.keyboard('gi');
+    expect(push).toHaveBeenCalledWith('/inbox');
+  });
+
+  it('runs the toggles it advertises', async () => {
+    const toggleSidebar = mock();
+    const showShortcuts = mock();
+    render(<Palette startOpen onToggleSidebar={toggleSidebar} onShowShortcuts={showShortcuts} />);
+
+    await select(/Switch to light theme/);
+    expect(setTheme).toHaveBeenCalledWith('light');
+
+    await userEvent.setup().keyboard('[[');
+    expect(toggleSidebar).toHaveBeenCalled();
+
+    await userEvent.setup().keyboard('?');
+    expect(showShortcuts).toHaveBeenCalled();
+  });
+
+  it('leaves the binding to a focused editor', async () => {
+    const user = userEvent.setup();
+    render(
+      <Palette>
+        <textarea aria-label="Description" />
+      </Palette>,
+    );
+
+    await user.click(screen.getByLabelText('Description'));
+    await user.keyboard('{Meta>}k{/Meta}');
+
+    expect(screen.queryByPlaceholderText('Type a command or search')).not.toBeInTheDocument();
+  });
+
+  it('runs a context command through the handler that owns its binding', async () => {
+    const create = mock();
+    render(
+      <Palette startOpen>
+        <CreateIssue run={create} />
+      </Palette>,
+    );
+
+    await select(/Create issue/);
+    expect(create).toHaveBeenCalled();
+  });
+
+  it('drops the key from a command whose binding another surface has taken', async () => {
+    render(
+      <Palette startOpen>
+        <CreateIssue run={noop} />
+        <NewDoc run={noop} />
+      </Palette>,
+    );
+
+    expect(await screen.findByRole('option', { name: /New doc C/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Create issue' })).toBeInTheDocument();
+  });
+});
+
+describe('shortcuts overlay', () => {
+  it('lists the live winner of a shared binding and hides disabled ones', async () => {
+    render(
+      <HotkeyProvider>
+        <ShortcutsOverlay open onOpenChange={noop} />
+        <CreateIssue run={noop} />
+        <NewDoc run={noop} />
+        <ArchiveIssue enabled={false} />
+      </HotkeyProvider>,
+    );
+
+    const list = await screen.findByTestId('shortcuts-sections');
+    expect(list.textContent).toContain('New doc');
+    expect(list.textContent).not.toContain('Create issue');
+    expect(list.textContent).not.toContain('Archive issue');
+  });
+
+  it('groups what it lists by section', async () => {
+    render(
+      <HotkeyProvider>
+        <ShortcutsOverlay open onOpenChange={noop} />
+        <CreateIssue run={noop} />
+        <ArchiveIssue enabled />
+      </HotkeyProvider>,
+    );
+
+    const list = await screen.findByTestId('shortcuts-sections');
+    const headings = [...list.querySelectorAll('h3')].map((node) => node.textContent);
+    expect(headings).toEqual(['Issues']);
+  });
+});

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -1,117 +1,216 @@
 'use client';
 
 import { Command } from 'cmdk';
-import { Moon, PanelLeft, Search, Sun } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { ArrowRight, CircleDot, Search, SlidersHorizontal, Terminal } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useTheme } from 'next-themes';
+import { useMemo } from 'react';
+import { resolvedHotkeys, SECTION_ORDER } from '@/components/shortcuts-overlay.tsx';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog.tsx';
 import { Kbd } from '@/components/ui/kbd.tsx';
-import type { NavSection } from '@/lib/navigation.ts';
+import {
+  formatBinding,
+  type HotkeyEntry,
+  type HotkeySection,
+  useHotkey,
+  useHotkeyList,
+} from '@/lib/keyboard/index.ts';
+import { type AppCommand, buildCommands, type NavSection } from '@/lib/navigation.ts';
+
+const PALETTE_BINDING = 'mod+k';
+const DISMISS_BINDING = 'escape';
+
+const SECTION_ICONS: Record<HotkeySection, LucideIcon> = {
+  Navigation: ArrowRight,
+  Issues: CircleDot,
+  View: SlidersHorizontal,
+  General: Terminal,
+};
+
+interface PaletteEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly section: HotkeySection;
+  readonly icon: LucideIcon;
+  readonly binding: string | undefined;
+  readonly run: () => void;
+}
 
 export interface CommandPaletteProps {
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
   readonly sections: readonly NavSection[];
   readonly onToggleSidebar: () => void;
+  readonly onShowShortcuts: () => void;
 }
 
 const itemClassName =
   'flex h-9 cursor-default select-none items-center gap-2.5 rounded-md px-2.5 text-dense text-muted outline-none data-[selected=true]:bg-surface-2 data-[selected=true]:text-text';
+
+const groupClassName =
+  '[&_[cmdk-group-heading]]:px-2.5 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-2xs [&_[cmdk-group-heading]]:text-faint [&_[cmdk-group-heading]]:uppercase';
+
+function CommandBinding({
+  binding,
+  label,
+  section,
+  run,
+}: {
+  readonly binding: string;
+  readonly label: string;
+  readonly section: HotkeySection;
+  readonly run: () => void;
+}) {
+  useHotkey(binding, run, { label, section });
+  return null;
+}
+
+function replayEvent(entry: HotkeyEntry): KeyboardEvent {
+  const step = entry.steps.at(-1);
+  return new KeyboardEvent('keydown', {
+    key: step?.key ?? '',
+    metaKey: step?.mod ?? false,
+    altKey: step?.alt ?? false,
+    shiftKey: step?.shift ?? false,
+  });
+}
+
+function contextEntries(
+  entries: readonly HotkeyEntry[],
+  ownedBindings: ReadonlySet<string>,
+): PaletteEntry[] {
+  const live = resolvedHotkeys(entries);
+  return entries
+    .filter(
+      (entry) =>
+        entry.enabled &&
+        entry.advertised &&
+        entry.binding !== DISMISS_BINDING &&
+        !ownedBindings.has(entry.binding),
+    )
+    .map((entry) => ({
+      id: entry.id,
+      label: entry.label,
+      section: entry.section,
+      icon: SECTION_ICONS[entry.section],
+      binding: live.includes(entry) ? entry.binding : undefined,
+      run: () => entry.run(replayEvent(entry)),
+    }));
+}
 
 export function CommandPalette({
   open,
   onOpenChange,
   sections,
   onToggleSidebar,
+  onShowShortcuts,
 }: CommandPaletteProps) {
   const router = useRouter();
   const { resolvedTheme, setTheme } = useTheme();
+  const registered = useHotkeyList();
 
-  const run = (action: () => void) => {
+  const commands = useMemo<AppCommand[]>(
+    () =>
+      buildCommands({
+        sections,
+        navigate: (href) => router.push(href),
+        toggleSidebar: onToggleSidebar,
+        toggleTheme: () => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark'),
+        showShortcuts: onShowShortcuts,
+        dark: resolvedTheme === 'dark',
+      }),
+    [sections, router, onToggleSidebar, onShowShortcuts, setTheme, resolvedTheme],
+  );
+
+  const owned = new Set([
+    PALETTE_BINDING,
+    ...commands.flatMap((command) => (command.binding === undefined ? [] : [command.binding])),
+  ]);
+
+  const entries: PaletteEntry[] = [
+    ...commands.map((command) => ({ ...command, binding: command.binding })),
+    ...contextEntries(registered, owned),
+  ];
+
+  useHotkey(PALETTE_BINDING, () => onOpenChange(true), {
+    label: 'Open command palette',
+    section: 'General',
+  });
+
+  const run = (entry: PaletteEntry) => {
     onOpenChange(false);
-    action();
+    entry.run();
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        showClose={false}
-        aria-describedby={undefined}
-        className="top-[12vh] max-w-xl translate-y-0 p-0"
-      >
-        <DialogTitle className="sr-only">Command palette</DialogTitle>
-        <Command
-          loop
-          className="flex flex-col overflow-hidden"
-          filter={(value, search) =>
-            value.toLowerCase().includes(search.toLowerCase().trim()) ? 1 : 0
-          }
+    <>
+      {commands.map((command) =>
+        command.binding === undefined ? null : (
+          <CommandBinding
+            key={command.id}
+            binding={command.binding}
+            label={command.label}
+            section={command.section}
+            run={command.run}
+          />
+        ),
+      )}
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          showClose={false}
+          aria-describedby={undefined}
+          className="top-[12vh] max-w-xl translate-y-0 p-0"
         >
-          <div className="flex items-center gap-2 border-border border-b px-3">
-            <Search className="size-4 shrink-0 text-faint" aria-hidden="true" />
-            <Command.Input
-              autoFocus
-              placeholder="Type a command or search"
-              className="h-11 w-full bg-transparent text-base text-text outline-none placeholder:text-faint"
-            />
-            <Kbd keys={['escape']} />
-          </div>
-          <Command.List className="max-h-80 overflow-y-auto p-1.5">
-            <Command.Empty className="px-2.5 py-6 text-center text-muted text-dense">
-              No matching commands.
-            </Command.Empty>
-            {sections.map((section) => (
-              <Command.Group
-                key={section.id}
-                heading={section.title ?? 'Jump to'}
-                className="[&_[cmdk-group-heading]]:px-2.5 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-2xs [&_[cmdk-group-heading]]:text-faint [&_[cmdk-group-heading]]:uppercase"
-              >
-                {section.links.map((link) => {
-                  const Icon = link.icon;
-                  return (
-                    <Command.Item
-                      key={link.href}
-                      value={`${section.title ?? ''} ${link.label} ${link.href}`}
-                      className={itemClassName}
-                      onSelect={() => run(() => router.push(link.href))}
-                    >
-                      <Icon className="size-4 shrink-0" strokeWidth={1.75} aria-hidden="true" />
-                      <span className="flex-1 truncate">{link.label}</span>
-                      {link.shortcut ? <Kbd keys={link.shortcut} /> : null}
-                    </Command.Item>
-                  );
-                })}
-              </Command.Group>
-            ))}
-            <Command.Group
-              heading="General"
-              className="[&_[cmdk-group-heading]]:px-2.5 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-2xs [&_[cmdk-group-heading]]:text-faint [&_[cmdk-group-heading]]:uppercase"
-            >
-              <Command.Item
-                value="toggle sidebar"
-                className={itemClassName}
-                onSelect={() => run(onToggleSidebar)}
-              >
-                <PanelLeft className="size-4 shrink-0" strokeWidth={1.75} aria-hidden="true" />
-                <span className="flex-1">Toggle sidebar</span>
-                <Kbd keys={['[']} />
-              </Command.Item>
-              <Command.Item
-                value="toggle theme dark light"
-                className={itemClassName}
-                onSelect={() => run(() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark'))}
-              >
-                {resolvedTheme === 'dark' ? (
-                  <Sun className="size-4 shrink-0" strokeWidth={1.75} aria-hidden="true" />
-                ) : (
-                  <Moon className="size-4 shrink-0" strokeWidth={1.75} aria-hidden="true" />
-                )}
-                <span className="flex-1">Toggle theme</span>
-              </Command.Item>
-            </Command.Group>
-          </Command.List>
-        </Command>
-      </DialogContent>
-    </Dialog>
+          <DialogTitle className="sr-only">Command palette</DialogTitle>
+          <Command
+            loop
+            className="flex flex-col overflow-hidden"
+            filter={(value, search) =>
+              value.toLowerCase().includes(search.toLowerCase().trim()) ? 1 : 0
+            }
+          >
+            <div className="flex items-center gap-2 border-border border-b px-3">
+              <Search className="size-4 shrink-0 text-faint" aria-hidden="true" />
+              <Command.Input
+                autoFocus
+                placeholder="Type a command or search"
+                className="h-11 w-full bg-transparent text-base text-text outline-none placeholder:text-faint"
+              />
+            </div>
+            <Command.List className="max-h-80 overflow-y-auto p-1.5">
+              <Command.Empty className="px-2.5 py-6 text-center text-muted text-dense">
+                No matching commands.
+              </Command.Empty>
+              {SECTION_ORDER.map((section) => {
+                const items = entries.filter((entry) => entry.section === section);
+                if (items.length === 0) return null;
+                return (
+                  <Command.Group key={section} heading={section} className={groupClassName}>
+                    {items.map((entry) => {
+                      const Icon = entry.icon;
+                      return (
+                        <Command.Item
+                          key={entry.id}
+                          value={`${section} ${entry.label} ${entry.binding ?? ''}`}
+                          className={itemClassName}
+                          onSelect={() => run(entry)}
+                        >
+                          <Icon className="size-4 shrink-0" strokeWidth={1.75} aria-hidden="true" />
+                          <span className="flex-1 truncate">{entry.label}</span>
+                          {entry.binding === undefined ? null : (
+                            <Kbd keys={formatBinding(entry.binding)} />
+                          )}
+                        </Command.Item>
+                      );
+                    })}
+                  </Command.Group>
+                );
+              })}
+            </Command.List>
+          </Command>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/apps/web/src/components/keyboard-hints.test.tsx
+++ b/apps/web/src/components/keyboard-hints.test.tsx
@@ -1,0 +1,174 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { CommandPalette } from '@/components/command-palette.tsx';
+import { Sidebar } from '@/components/layout/sidebar.tsx';
+import { ShortcutsOverlay } from '@/components/shortcuts-overlay.tsx';
+import { Kbd, keyGlyph } from '@/components/ui/kbd.tsx';
+import { TooltipProvider } from '@/components/ui/tooltip.tsx';
+import { DocsWorkspace } from '@/features/docs/docs-workspace.tsx';
+import { InboxView } from '@/features/inbox/inbox-view.tsx';
+import { IssueProperties } from '@/features/issues/issue-properties.tsx';
+import { IssueWorkspaceProvider } from '@/features/issues/workspace-provider.tsx';
+import {
+  formatBinding,
+  type HotkeyEntry,
+  HotkeyProvider,
+  useHotkeyList,
+} from '@/lib/keyboard/index.ts';
+import { buildNavigation } from '@/lib/navigation.ts';
+import type { Issue } from '@/lib/query/schemas.ts';
+import * as docsQuery from '@/lib/query/use-docs.ts';
+import * as issuesQuery from '@/lib/query/use-issues.ts';
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ push: mock(), replace: mock(), refresh: mock() }),
+  usePathname: () => '/inbox',
+}));
+
+mock.module('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'dark', setTheme: mock() }),
+}));
+
+mock.module('@orbit/realtime-client/react', () => ({
+  useScopeSubscription: () => undefined,
+  useDeltaHandler: () => undefined,
+}));
+
+mock.module('@/lib/auth/client.ts', () => ({
+  authClient: {
+    organization: { setActive: mock() },
+    signOut: mock(() => Promise.resolve()),
+  },
+}));
+
+mock.module('@/components/ui/toast.tsx', () => ({
+  useToast: () => ({ toast: mock(), dismiss: mock() }),
+}));
+
+mock.module('@/lib/query/use-issues.ts', () => ({
+  ...issuesQuery,
+  useBootstrap: () => ({ data: undefined }),
+  useCreateIssue: () => ({ mutate: mock(), isPending: false }),
+  useUpdateIssue: () => ({ mutate: mock(), isPending: false }),
+}));
+
+mock.module('@/lib/query/use-docs.ts', () => ({
+  ...docsQuery,
+  useDocs: () => ({ data: { docs: [], collections: [], projects: [] } }),
+  useCreateCollection: () => ({ mutate: mock() }),
+  useRenameCollection: () => ({ mutate: mock() }),
+  useDeleteCollection: () => ({ mutate: mock() }),
+}));
+
+const issue: Issue = {
+  id: 'issue_1',
+  organizationId: 'org_1',
+  teamId: 'team_1',
+  number: 1,
+  identifier: 'ENG-1',
+  title: 'Domain auto join',
+  description: '',
+  stateId: 'state_todo',
+  priority: 0,
+  creatorId: 'user_1',
+  assigneeId: null,
+  projectId: null,
+  milestoneId: null,
+  cycleId: null,
+  parentId: null,
+  estimate: null,
+  dueDate: null,
+  sortOrder: 1024,
+  startedAt: null,
+  completedAt: null,
+  canceledAt: null,
+  stateEnteredAt: '2026-01-01T00:00:00.000Z',
+  syncId: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  archivedAt: null,
+  labelIds: [],
+};
+
+const sections = buildNavigation([{ id: 'team_1', key: 'ENG', name: 'Engineering' }], 3);
+
+const noop = () => undefined;
+
+let registered: readonly HotkeyEntry[] = [];
+
+function HotkeyProbe() {
+  registered = useHotkeyList();
+  return null;
+}
+
+function Surfaces({ extra }: { readonly extra?: ReactNode }) {
+  return (
+    <TooltipProvider>
+      <HotkeyProvider>
+        <IssueWorkspaceProvider>
+          <HotkeyProbe />
+          <Sidebar
+            workspace={{ id: 'org_1', name: 'Noveum', slug: 'noveum' }}
+            workspaces={[]}
+            user={{ name: 'Pulkit', email: 'pulkit@noveum.ai', image: null }}
+            sections={sections}
+            collapsed={false}
+            onToggleCollapsed={noop}
+            onOpenPalette={noop}
+          />
+          <CommandPalette
+            open
+            onOpenChange={noop}
+            sections={sections}
+            onToggleSidebar={noop}
+            onShowShortcuts={noop}
+          />
+          <ShortcutsOverlay open onOpenChange={noop} />
+          <IssueProperties issue={issue} />
+          <InboxView items={[]} unreadCount={0} userId="user_1" />
+          <DocsWorkspace docId={null} canWrite canPublish={false} />
+          {extra}
+        </IssueWorkspaceProvider>
+      </HotkeyProvider>
+    </TooltipProvider>
+  );
+}
+
+function advertisedHints(): string[] {
+  const byHost = new Map<Element, string[]>();
+  for (const key of document.querySelectorAll('kbd')) {
+    const host = key.parentElement;
+    if (host === null) continue;
+    byHost.set(host, [...(byHost.get(host) ?? []), key.textContent ?? '']);
+  }
+  return [...byHost.values()].map((keys) => keys.join(' '));
+}
+
+function boundHints(entries: readonly HotkeyEntry[]): Set<string> {
+  return new Set(
+    entries
+      .filter((entry) => entry.enabled)
+      .map((entry) => formatBinding(entry.binding).map(keyGlyph).join(' ')),
+  );
+}
+
+function unbackedHints(): string[] {
+  const bound = boundHints(registered);
+  return advertisedHints().filter((hint) => !bound.has(hint));
+}
+
+describe('rendered keyboard hints', () => {
+  it('never advertises a key the registry does not bind', () => {
+    render(<Surfaces />);
+
+    expect(advertisedHints().length).toBeGreaterThan(0);
+    expect(unbackedHints()).toEqual([]);
+  });
+
+  it('catches a hint whose key nothing handles', () => {
+    render(<Surfaces extra={<Kbd keys={['q']} />} />);
+
+    expect(unbackedHints()).toEqual(['Q']);
+  });
+});

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { type ReactNode, useCallback, useMemo, useState } from 'react';
 import { CommandPalette } from '@/components/command-palette.tsx';
 import { ShortcutsOverlay } from '@/components/shortcuts-overlay.tsx';
 import { overlayClassName } from '@/components/ui/dialog.tsx';
-import { useHotkey } from '@/lib/keyboard/index.ts';
 import {
   buildNavigation,
   type ShellTeam,
@@ -39,10 +38,11 @@ export function AppShell({
   actions,
   children,
 }: AppShellProps) {
-  const router = useRouter();
+  const pathname = usePathname();
   const isDesktop = useMediaQuery(DESKTOP_QUERY);
   const [collapsed, setCollapsed] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerPath, setDrawerPath] = useState(pathname);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
@@ -53,27 +53,12 @@ export function AppShell({
     else setDrawerOpen((value) => !value);
   }, [isDesktop]);
 
-  const go = useCallback(
-    (href: string) => {
-      setDrawerOpen(false);
-      router.push(href);
-    },
-    [router],
-  );
+  const openShortcuts = useCallback(() => setShortcutsOpen(true), []);
 
-  useHotkey('mod+k', () => setPaletteOpen(true), {
-    label: 'Open command palette',
-    section: 'General',
-    allowInInput: true,
-  });
-  useHotkey('?', () => setShortcutsOpen(true), {
-    label: 'Show keyboard shortcuts',
-    section: 'General',
-  });
-  useHotkey('[', toggleSidebar, { label: 'Toggle sidebar', section: 'View' });
-  useHotkey('g i', () => go('/inbox'), { label: 'Go to inbox', section: 'Navigation' });
-  useHotkey('g m', () => go('/my-issues'), { label: 'Go to my issues', section: 'Navigation' });
-  useHotkey('g p', () => go('/projects'), { label: 'Go to projects', section: 'Navigation' });
+  if (drawerPath !== pathname) {
+    setDrawerPath(pathname);
+    setDrawerOpen(false);
+  }
 
   const sidebar = (onNavigate?: () => void) => (
     <Sidebar
@@ -128,6 +113,7 @@ export function AppShell({
         onOpenChange={setPaletteOpen}
         sections={sections}
         onToggleSidebar={toggleSidebar}
+        onShowShortcuts={openShortcuts}
       />
       <ShortcutsOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
     </div>

--- a/apps/web/src/components/layout/nav-item.tsx
+++ b/apps/web/src/components/layout/nav-item.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Tooltip } from '@/components/ui/tooltip.tsx';
 import { cn } from '@/lib/cn.ts';
+import { formatBinding } from '@/lib/keyboard/index.ts';
 import type { NavLink } from '@/lib/navigation.ts';
 
 export interface NavItemProps {
@@ -52,7 +53,7 @@ export function NavItem({ link, collapsed, onNavigate }: NavItemProps) {
     <Tooltip
       label={link.label}
       side="right"
-      {...(link.shortcut === undefined ? {} : { shortcut: link.shortcut })}
+      {...(link.binding === undefined ? {} : { shortcut: formatBinding(link.binding) })}
     >
       {anchor}
     </Tooltip>

--- a/apps/web/src/components/shortcuts-overlay.tsx
+++ b/apps/web/src/components/shortcuts-overlay.tsx
@@ -9,7 +9,28 @@ import {
 } from '@/components/ui/dialog.tsx';
 import { Kbd } from '@/components/ui/kbd.tsx';
 import { ScrollArea } from '@/components/ui/scroll-area.tsx';
-import { formatBinding, SEQUENCE_TIMEOUT_MS, useHotkeyList } from '@/lib/keyboard/index.ts';
+import {
+  type BufferedStep,
+  formatBinding,
+  type HotkeyEntry,
+  type HotkeySection,
+  SEQUENCE_TIMEOUT_MS,
+  selectMatch,
+  useHotkeyList,
+} from '@/lib/keyboard/index.ts';
+
+export const SECTION_ORDER: readonly HotkeySection[] = ['Navigation', 'Issues', 'View', 'General'];
+
+function bufferFor(entry: HotkeyEntry): BufferedStep[] {
+  return entry.steps.map((step, index) => ({ ...step, at: index }));
+}
+
+export function resolvedHotkeys(entries: readonly HotkeyEntry[]): HotkeyEntry[] {
+  const live = entries.filter((entry) => entry.enabled);
+  return live.filter(
+    (entry) => entry.advertised && selectMatch(live, bufferFor(entry), false) === entry,
+  );
+}
 
 export interface ShortcutsOverlayProps {
   readonly open: boolean;
@@ -17,15 +38,7 @@ export interface ShortcutsOverlayProps {
 }
 
 export function ShortcutsOverlay({ open, onOpenChange }: ShortcutsOverlayProps) {
-  const entries = useHotkeyList();
-  const sections = new Map<string, { binding: string; label: string }[]>();
-
-  for (const entry of entries) {
-    const bucket = sections.get(entry.section);
-    const item = { binding: entry.binding, label: entry.label };
-    if (bucket === undefined) sections.set(entry.section, [item]);
-    else bucket.push(item);
-  }
+  const live = resolvedHotkeys(useHotkeyList());
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -33,27 +46,34 @@ export function ShortcutsOverlay({ open, onOpenChange }: ShortcutsOverlayProps) 
         <DialogHeader>
           <DialogTitle className="font-medium text-base text-text">Keyboard shortcuts</DialogTitle>
           <DialogDescription className="text-muted text-xs">
-            Press the keys in order. Sequences must be typed within {SEQUENCE_TIMEOUT_MS}ms.
+            Every shortcut listed is live on this screen. Sequences must be typed within{' '}
+            {SEQUENCE_TIMEOUT_MS}ms.
           </DialogDescription>
         </DialogHeader>
         <ScrollArea className="max-h-[60vh]">
-          <div className="flex flex-col gap-5 pr-2">
-            {[...sections.entries()].map(([section, items]) => (
-              <section key={section} className="flex flex-col gap-1">
-                <h3 className="font-medium text-2xs text-faint uppercase tracking-wide">
-                  {section}
-                </h3>
-                {items.map((item) => (
-                  <div
-                    key={`${section}-${item.binding}`}
-                    className="flex items-center justify-between gap-4 rounded-sm px-1 py-1 text-dense"
-                  >
-                    <span className="min-w-0 truncate text-muted">{item.label}</span>
-                    <Kbd keys={formatBinding(item.binding)} />
-                  </div>
-                ))}
-              </section>
-            ))}
+          <div className="flex flex-col gap-5 pr-2" data-testid="shortcuts-sections">
+            {SECTION_ORDER.map((section) => {
+              const items = live
+                .filter((entry) => entry.section === section)
+                .sort((left, right) => left.label.localeCompare(right.label));
+              if (items.length === 0) return null;
+              return (
+                <section key={section} className="flex flex-col gap-1">
+                  <h3 className="font-medium text-2xs text-faint uppercase tracking-wide">
+                    {section}
+                  </h3>
+                  {items.map((item) => (
+                    <div
+                      key={item.id}
+                      className="flex items-center justify-between gap-4 rounded-sm px-1 py-1 text-dense"
+                    >
+                      <span className="min-w-0 truncate text-muted">{item.label}</span>
+                      <Kbd keys={formatBinding(item.binding)} />
+                    </div>
+                  ))}
+                </section>
+              );
+            })}
           </div>
         </ScrollArea>
       </DialogContent>

--- a/apps/web/src/features/docs/docs-workspace.test.tsx
+++ b/apps/web/src/features/docs/docs-workspace.test.tsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { TooltipProvider } from '@/components/ui/tooltip.tsx';
+import { IssueWorkspaceProvider } from '@/features/issues/workspace-provider.tsx';
+import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+import * as docsQuery from '@/lib/query/use-docs.ts';
+import * as issuesQuery from '@/lib/query/use-issues.ts';
+import { DocsWorkspace } from './docs-workspace.tsx';
+
+const push = mock();
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ push, replace: mock(), refresh: mock() }),
+  usePathname: () => '/docs',
+}));
+
+mock.module('@/lib/query/use-docs.ts', () => ({
+  ...docsQuery,
+  useDocs: () => ({ data: { docs: [], collections: [], projects: [] } }),
+  useCreateCollection: () => ({ mutate: mock() }),
+  useRenameCollection: () => ({ mutate: mock() }),
+  useDeleteCollection: () => ({ mutate: mock() }),
+}));
+
+mock.module('@/lib/query/use-issues.ts', () => ({
+  ...issuesQuery,
+  useBootstrap: () => ({ data: undefined }),
+  useCreateIssue: () => ({ mutate: mock(), isPending: false }),
+}));
+
+function Tree({ docs, canWrite }: { readonly docs: boolean; readonly canWrite: boolean }) {
+  const shell = (children: ReactNode) => (
+    <TooltipProvider>
+      <HotkeyProvider>
+        <IssueWorkspaceProvider>{children}</IssueWorkspaceProvider>
+      </HotkeyProvider>
+    </TooltipProvider>
+  );
+  return shell(docs ? <DocsWorkspace docId={null} canWrite={canWrite} canPublish={false} /> : null);
+}
+
+function mountShellThenDocs(canWrite = true) {
+  const view = render(<Tree docs={false} canWrite={canWrite} />);
+  view.rerender(<Tree docs canWrite={canWrite} />);
+  return view;
+}
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+describe('c on the docs page', () => {
+  it('creates a doc even though the workspace registered its own c first', async () => {
+    const user = userEvent.setup();
+    mountShellThenDocs();
+    expect(screen.getByTestId('docs-workspace')).toBeInTheDocument();
+
+    await user.keyboard('c');
+
+    expect(push).toHaveBeenCalledWith('/docs/new');
+    expect(screen.queryByTestId('quick-create')).not.toBeInTheDocument();
+  });
+
+  it('does nothing rather than creating an issue when docs are read only', async () => {
+    const user = userEvent.setup();
+    mountShellThenDocs(false);
+
+    await user.keyboard('c');
+
+    expect(push).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('quick-create')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/docs/docs-workspace.tsx
+++ b/apps/web/src/features/docs/docs-workspace.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
 import { Kbd } from '@/components/ui/kbd.tsx';
-import { useHotkey } from '@/lib/keyboard/index.ts';
+import { HOTKEY_PRIORITY, useHotkey } from '@/lib/keyboard/index.ts';
 import {
   useCreateCollection,
   useDeleteCollection,
@@ -46,7 +46,19 @@ export function DocsWorkspace({
   const deleteCollection = useDeleteCollection();
 
   const newDoc = useCallback(() => router.push('/docs/new'), [router]);
-  useHotkey('c', newDoc, { label: 'New doc', section: 'Navigation', enabled: canWrite });
+  useHotkey(
+    'c',
+    () => {
+      if (canWrite) newDoc();
+    },
+    {
+      label: 'New doc',
+      section: 'Navigation',
+      scope: 'docs',
+      priority: HOTKEY_PRIORITY.surface,
+      advertised: canWrite,
+    },
+  );
 
   const docs = list.data?.docs ?? [];
   const collections = list.data?.collections ?? [];

--- a/apps/web/src/features/docs/markdown-preview.test.ts
+++ b/apps/web/src/features/docs/markdown-preview.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { renderMarkdown, renderPlainText } from '@orbit/services/markdown';
+
+const REWRITER = 'HTMLRewriter';
+
+describe('markdown rendering without HTMLRewriter', () => {
+  let saved: unknown;
+
+  beforeEach(() => {
+    saved = Reflect.get(globalThis, REWRITER);
+    Reflect.deleteProperty(globalThis, REWRITER);
+  });
+
+  afterEach(() => {
+    Reflect.set(globalThis, REWRITER, saved);
+  });
+
+  it('renders a preview in the browser', () => {
+    expect(renderMarkdown('# Title\n\nHello **world**')).toContain('<strong>world</strong>');
+  });
+
+  it('drops scripts, comments and unsafe urls', () => {
+    const html = renderMarkdown(
+      ['<script>alert(1)</script>', '', '<!-- secret -->', '', '[x](javascript:alert(1))'].join(
+        '\n',
+      ),
+    );
+    expect(html).not.toContain('alert(1)');
+    expect(html).not.toContain('secret');
+    expect(html).not.toContain('javascript:');
+  });
+
+  it('opens absolute links in a new tab and leaves relative links alone', () => {
+    const external = renderMarkdown('[out](https://example.com)');
+    expect(external).toContain('target="_blank"');
+    expect(external).toContain('rel="noopener noreferrer"');
+    expect(renderMarkdown('[in](/docs/1)')).not.toContain('target="_blank"');
+  });
+
+  it('reads text out of rendered markdown', () => {
+    expect(renderPlainText('# Title\n\nfirst\n\nsecond')).toBe('Title\n\nfirst\n\nsecond');
+  });
+});

--- a/apps/web/src/features/filters/filter-bar.test.tsx
+++ b/apps/web/src/features/filters/filter-bar.test.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from 'react';
 import { ToastProvider } from '@/components/ui/toast.tsx';
 import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
-import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+import { HotkeyProvider, useHotkey } from '@/lib/keyboard/index.ts';
 import { createQueryClient } from '@/lib/query/provider.tsx';
 import { FilterBar } from './filter-bar.tsx';
 import { defaultViewConfig, type ViewConfig } from './view-config.ts';
@@ -184,6 +184,45 @@ describe('filter hotkeys', () => {
     await user.keyboard('{Alt>}v{/Alt}');
     await waitFor(() => expect(screen.getByTestId('save-view-dialog')).toBeInTheDocument());
     expect(screen.getByTestId('save-view-name')).toHaveValue('Engineering: Aditi Rao');
+  });
+});
+
+function SelectionOwner({ onClear }: { readonly onClear: () => void }) {
+  useHotkey('escape', onClear, {
+    label: 'Clear selection',
+    section: 'Issues',
+    scope: 'issues',
+    preventDefault: false,
+  });
+  return null;
+}
+
+describe('escape ownership', () => {
+  it('closes the filter menu first and only then clears the selection', async () => {
+    const user = userEvent.setup();
+    const onClear = mock();
+    render(
+      <Providers>
+        <SelectionOwner onClear={onClear} />
+        <FilterBar
+          teamId="team-1"
+          teamName="Engineering"
+          layout="list"
+          config={defaultViewConfig('list')}
+          onChange={onChange}
+        />
+      </Providers>,
+    );
+
+    await user.keyboard('f');
+    await waitFor(() => expect(screen.getByTestId('filter-menu')).toBeInTheDocument());
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByTestId('filter-menu')).not.toBeInTheDocument());
+    expect(onClear).not.toHaveBeenCalled();
+
+    await user.keyboard('{Escape}');
+    expect(onClear).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/src/features/filters/filter-bar.tsx
+++ b/apps/web/src/features/filters/filter-bar.tsx
@@ -6,7 +6,7 @@ import { Bookmark, ListFilter, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
-import { useHotkey } from '@/lib/keyboard/index.ts';
+import { HOTKEY_PRIORITY, useHotkey } from '@/lib/keyboard/index.ts';
 import { DisplayMenu } from './display-menu.tsx';
 import type { FilterFieldDefinition } from './filter-fields.tsx';
 import { buildFilterFields, operatorLabel, valueLabel } from './filter-fields.tsx';
@@ -36,19 +36,31 @@ export function FilterBar({ teamId, teamName, layout, config, onChange }: Filter
     onChange({ ...config, predicates: next });
   };
 
-  useHotkey('f', () => setTarget('new'), { label: 'Add filter', section: 'View' });
+  useHotkey('f', () => setTarget('new'), {
+    label: 'Add filter',
+    section: 'View',
+    scope: 'filters',
+  });
   useHotkey('shift+f', () => setPredicates(dropLastPredicate(predicates)), {
     label: 'Remove the last filter',
     section: 'View',
+    scope: 'filters',
   });
   useHotkey('alt+shift+f', () => setPredicates([]), {
     label: 'Clear all filters',
     section: 'View',
+    scope: 'filters',
   });
-  useHotkey('alt+v', () => setSaveOpen(true), { label: 'Save as a view', section: 'View' });
+  useHotkey('alt+v', () => setSaveOpen(true), {
+    label: 'Save as a view',
+    section: 'View',
+    scope: 'filters',
+  });
   useHotkey('escape', () => setTarget(null), {
     label: 'Close the filter menu',
     section: 'View',
+    scope: 'filters',
+    priority: HOTKEY_PRIORITY.layer,
     enabled: target !== null,
     preventDefault: false,
   });

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -112,28 +112,36 @@ export function InboxView({ items, unreadCount, userId }: InboxViewProps) {
     router.refresh();
   }, [current, router]);
 
-  useHotkey('j', () => move(1), { label: 'Next notification', section: 'Navigation' });
-  useHotkey('k', () => move(-1), { label: 'Previous notification', section: 'Navigation' });
+  useHotkey('j', () => move(1), {
+    label: 'Next notification',
+    section: 'Navigation',
+    scope: 'inbox',
+  });
+  useHotkey('k', () => move(-1), {
+    label: 'Previous notification',
+    section: 'Navigation',
+    scope: 'inbox',
+  });
   useHotkey(
     'u',
     () => {
       toggleRead();
     },
-    { label: 'Toggle read', section: 'General' },
+    { label: 'Toggle read', section: 'General', scope: 'inbox' },
   );
   useHotkey(
     'h',
     () => {
       snooze();
     },
-    { label: 'Snooze for a day', section: 'General' },
+    { label: 'Snooze for a day', section: 'General', scope: 'inbox' },
   );
   useHotkey(
     'backspace',
     () => {
       remove();
     },
-    { label: 'Delete notification', section: 'General' },
+    { label: 'Delete notification', section: 'General', scope: 'inbox' },
   );
 
   return (

--- a/apps/web/src/features/issues/issue-list.test.tsx
+++ b/apps/web/src/features/issues/issue-list.test.tsx
@@ -1,0 +1,130 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { groupIssues } from '@/features/filters/grouping.ts';
+import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+import type { Issue, WorkflowState } from '@/lib/query/schemas.ts';
+import * as issuesQuery from '@/lib/query/use-issues.ts';
+import { IssueList } from './issue-list.tsx';
+import type { WorkspaceData } from './workspace-provider.tsx';
+import * as workspaceProvider from './workspace-provider.tsx';
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ push: mock(), replace: mock(), refresh: mock() }),
+  usePathname: () => '/team/eng/issues',
+}));
+
+mock.module('@/lib/query/use-issues.ts', () => ({
+  ...issuesQuery,
+  useUpdateIssue: () => ({ mutate: mock(), isPending: false }),
+}));
+
+const todo: WorkflowState = {
+  id: 'state_todo',
+  teamId: 'team_1',
+  name: 'Todo',
+  category: 'unstarted',
+  color: '#5d6272',
+  position: 1,
+};
+
+function issue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'issue_1',
+    organizationId: 'org_1',
+    teamId: 'team_1',
+    number: 1,
+    identifier: 'ENG-1',
+    title: 'Domain auto join',
+    description: '',
+    stateId: 'state_todo',
+    priority: 0,
+    creatorId: 'user_1',
+    assigneeId: null,
+    projectId: null,
+    milestoneId: null,
+    cycleId: null,
+    parentId: null,
+    estimate: null,
+    dueDate: null,
+    sortOrder: 1024,
+    startedAt: null,
+    completedAt: null,
+    canceledAt: null,
+    stateEnteredAt: '2026-01-01T00:00:00.000Z',
+    syncId: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    archivedAt: null,
+    labelIds: [],
+    ...overrides,
+  };
+}
+
+const issues = [issue(), issue({ id: 'issue_2', number: 2, identifier: 'ENG-2', sortOrder: 2048 })];
+
+const workspace: WorkspaceData = {
+  ready: true,
+  userId: 'user_1',
+  teams: [{ id: 'team_1', name: 'Engineering', key: 'ENG', icon: 'circle', color: '#5a63c8' }],
+  states: [todo],
+  labels: [],
+  members: [],
+  projects: [],
+  cycles: [],
+  seedIssues: [],
+  stateById: new Map([[todo.id, todo]]),
+  labelById: new Map(),
+  memberById: new Map(),
+  openQuickCreate: () => undefined,
+};
+
+mock.module('./workspace-provider.tsx', () => ({
+  ...workspaceProvider,
+  useWorkspace: () => workspace,
+}));
+
+function renderList() {
+  const groups = groupIssues(
+    issues,
+    'state',
+    { states: [todo], members: [], projects: [], cycles: [], labels: [] },
+    { showEmptyGroups: false, ordering: 'manual' },
+  );
+  render(
+    <HotkeyProvider>
+      <IssueList teamId="team_1" states={[todo]} groups={groups} />
+    </HotkeyProvider>,
+  );
+}
+
+describe('the first issue is active on arrival', () => {
+  it('selects without needing a j or k first', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await user.keyboard('x');
+
+    expect(await screen.findByTestId('bulk-edit-bar')).toBeInTheDocument();
+  });
+});
+
+describe('escape on the issue list', () => {
+  it('closes the peek first and keeps the selection', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await user.keyboard('jx');
+    expect(await screen.findByTestId('bulk-edit-bar')).toBeInTheDocument();
+
+    await user.keyboard('[Space]');
+    expect(await screen.findByTestId('issue-peek')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByTestId('issue-peek')).not.toBeInTheDocument());
+    expect(screen.getByTestId('bulk-edit-bar')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByTestId('bulk-edit-bar')).not.toBeInTheDocument());
+  });
+});

--- a/apps/web/src/features/issues/issue-list.tsx
+++ b/apps/web/src/features/issues/issue-list.tsx
@@ -88,11 +88,11 @@ export function IssueList({
   );
 
   useEffect(() => {
-    if (activeRow === undefined && issueIndexes[0] !== undefined) setActiveIndex(issueIndexes[0]);
-  }, [activeRow, issueIndexes]);
+    if (activeIssue === undefined && issueIndexes[0] !== undefined) setActiveIndex(issueIndexes[0]);
+  }, [activeIssue, issueIndexes]);
 
-  useHotkey('j', () => step(1), { label: 'Next issue', section: 'Issues' });
-  useHotkey('k', () => step(-1), { label: 'Previous issue', section: 'Issues' });
+  useHotkey('j', () => step(1), { label: 'Next issue', section: 'Issues', scope: 'issues' });
+  useHotkey('k', () => step(-1), { label: 'Previous issue', section: 'Issues', scope: 'issues' });
   useHotkey(
     'x',
     () => {
@@ -103,29 +103,37 @@ export function IssueList({
           : [...current, activeIssue.id],
       );
     },
-    { label: 'Select issue', section: 'Issues' },
+    { label: 'Select issue', section: 'Issues', scope: 'issues' },
   );
   useHotkey(
     'space',
     () => {
       if (activeIssue !== undefined) setPeekId(activeIssue.id);
     },
-    { label: 'Peek issue', section: 'Issues' },
+    { label: 'Peek issue', section: 'Issues', scope: 'issues' },
   );
   useHotkey(
     'enter',
     () => {
       if (activeIssue !== undefined) router.push(`/issue/${activeIssue.identifier}`);
     },
-    { label: 'Open issue', section: 'Issues' },
+    { label: 'Open issue', section: 'Issues', scope: 'issues' },
   );
   useHotkey(
     'escape',
     () => {
+      if (peekId !== null) {
+        setPeekId(null);
+        return;
+      }
       setSelected([]);
-      setPeekId(null);
     },
-    { label: 'Clear selection', section: 'Issues' },
+    {
+      label: 'Close the peek, then clear the selection',
+      section: 'Issues',
+      scope: 'issues',
+      preventDefault: false,
+    },
   );
 
   const peekIssue = issues.find((issue) => issue.id === peekId);

--- a/apps/web/src/features/issues/issue-properties.tsx
+++ b/apps/web/src/features/issues/issue-properties.tsx
@@ -43,14 +43,35 @@ export function IssueProperties({ issue }: IssuePropertiesProps) {
 
   const toggle = (key: MenuKey) => (open: boolean) => setOpenMenu(open ? key : null);
 
-  useHotkey('s', () => setOpenMenu('status'), { label: 'Change status', section: 'Issues' });
-  useHotkey('p', () => setOpenMenu('priority'), { label: 'Change priority', section: 'Issues' });
-  useHotkey('a', () => setOpenMenu('assignee'), { label: 'Assign issue', section: 'Issues' });
-  useHotkey('i', () => setOpenMenu('project'), { label: 'Change project', section: 'Issues' });
-  useHotkey('l', () => setOpenMenu('labels'), { label: 'Change labels', section: 'Issues' });
+  useHotkey('s', () => setOpenMenu('status'), {
+    label: 'Change status',
+    section: 'Issues',
+    scope: 'issues',
+  });
+  useHotkey('p', () => setOpenMenu('priority'), {
+    label: 'Change priority',
+    section: 'Issues',
+    scope: 'issues',
+  });
+  useHotkey('a', () => setOpenMenu('assignee'), {
+    label: 'Assign issue',
+    section: 'Issues',
+    scope: 'issues',
+  });
+  useHotkey('i', () => setOpenMenu('project'), {
+    label: 'Change project',
+    section: 'Issues',
+    scope: 'issues',
+  });
+  useHotkey('l', () => setOpenMenu('labels'), {
+    label: 'Change labels',
+    section: 'Issues',
+    scope: 'issues',
+  });
   useHotkey('shift+e', () => setOpenMenu('estimate'), {
     label: 'Change estimate',
     section: 'Issues',
+    scope: 'issues',
   });
 
   return (

--- a/apps/web/src/features/issues/team-view.tsx
+++ b/apps/web/src/features/issues/team-view.tsx
@@ -67,7 +67,7 @@ export function TeamView({ teamKey, layout }: TeamViewProps) {
     () => {
       router.push(`/team/${teamKey.toLowerCase()}/${other}`);
     },
-    { label: 'Toggle board and list', section: 'View' },
+    { label: 'Toggle board and list', section: 'View', scope: 'issues' },
   );
 
   if (!workspace.ready) return <ListSkeleton layout={layout} />;

--- a/apps/web/src/lib/keyboard/binding.test.ts
+++ b/apps/web/src/lib/keyboard/binding.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import {
+  activatesFocusedControl,
   type BufferedStep,
   bufferMatches,
   eventToStep,
@@ -10,7 +11,7 @@ import {
   pruneBuffer,
   SEQUENCE_TIMEOUT_MS,
 } from './binding.ts';
-import { type HotkeyEntry, selectMatch } from './registry.ts';
+import { HOTKEY_PRIORITY, type HotkeyEntry, selectMatch } from './registry.ts';
 
 function keyEvent(key: string, modifiers: Partial<KeyEventLike> = {}): KeyEventLike {
   return {
@@ -34,7 +35,10 @@ function entry(binding: string, overrides: Partial<HotkeyEntry> = {}): HotkeyEnt
     binding,
     label: binding,
     section: 'Navigation',
+    scope: 'global',
+    priority: HOTKEY_PRIORITY.global,
     enabled: true,
+    advertised: true,
     preventDefault: true,
     allowInInput: false,
     run: () => undefined,
@@ -179,5 +183,85 @@ describe('selectMatch', () => {
     const step = eventToStep(keyEvent('Ï', { altKey: true, shiftKey: true, code: 'KeyF' }));
     expect(step.key).toBe('f');
     expect(bufferMatches(parseBinding('alt+shift+f'), [{ ...step, at: 0 }])).toBe(true);
+  });
+});
+
+describe('selectMatch priority', () => {
+  const newIssue = entry('c', { id: 'issue', label: 'Create issue' });
+  const newDoc = entry('c', {
+    id: 'doc',
+    label: 'New doc',
+    scope: 'docs',
+    priority: HOTKEY_PRIORITY.surface,
+  });
+
+  it('resolves to the higher priority binding whatever the registration order', () => {
+    const buffer = press([], 'c', 0);
+    expect(selectMatch([newIssue, newDoc], buffer, false)?.id).toBe('doc');
+    expect(selectMatch([newDoc, newIssue], buffer, false)?.id).toBe('doc');
+  });
+
+  it('falls back to the global binding when the surface binding is disabled', () => {
+    const readOnlyDoc = { ...newDoc, enabled: false };
+    const buffer = press([], 'c', 0);
+    expect(selectMatch([newIssue, readOnlyDoc], buffer, false)?.id).toBe('issue');
+    expect(selectMatch([readOnlyDoc, newIssue], buffer, false)?.id).toBe('issue');
+  });
+
+  it('gives the innermost layer the escape key while it is open', () => {
+    const clearSelection = entry('escape', { id: 'selection', scope: 'issues' });
+    const closeMenu = entry('escape', {
+      id: 'menu',
+      scope: 'filters',
+      priority: HOTKEY_PRIORITY.layer,
+    });
+    const buffer = press([], 'Escape', 0);
+    expect(selectMatch([clearSelection, closeMenu], buffer, false)?.id).toBe('menu');
+    expect(selectMatch([closeMenu, clearSelection], buffer, false)?.id).toBe('menu');
+    expect(selectMatch([clearSelection], buffer, false)?.id).toBe('selection');
+  });
+});
+
+describe('activatesFocusedControl', () => {
+  function node(tag: string, attributes: Record<string, string> = {}): Element {
+    const element = document.createElement(tag);
+    for (const [name, value] of Object.entries(attributes)) element.setAttribute(name, value);
+    return element;
+  }
+
+  it('keeps enter and space for every focusable control', () => {
+    const controls = [
+      node('button'),
+      node('a', { href: '/issue/ENG-1' }),
+      node('summary'),
+      node('div', { role: 'button' }),
+      node('div', { role: 'menuitem' }),
+      node('div', { role: 'option' }),
+    ];
+    for (const control of controls) {
+      expect(activatesFocusedControl(keyEvent('Enter'), control)).toBe(true);
+      expect(activatesFocusedControl(keyEvent(' '), control)).toBe(true);
+    }
+  });
+
+  it('looks past the label a control renders inside itself', () => {
+    const button = node('button');
+    const label = document.createElement('span');
+    button.append(label);
+    expect(activatesFocusedControl(keyEvent('Enter'), label)).toBe(true);
+  });
+
+  it('leaves plain elements and anchors without a target to the registry', () => {
+    expect(activatesFocusedControl(keyEvent('Enter'), node('a'))).toBe(false);
+    expect(activatesFocusedControl(keyEvent('Enter'), node('div'))).toBe(false);
+    expect(activatesFocusedControl(keyEvent('Enter'), null)).toBe(false);
+  });
+
+  it('guards only unmodified activation keys', () => {
+    const button = node('button');
+    expect(activatesFocusedControl(keyEvent('j'), button)).toBe(false);
+    expect(activatesFocusedControl(keyEvent('Escape'), button)).toBe(false);
+    expect(activatesFocusedControl(keyEvent('Enter', { metaKey: true }), button)).toBe(false);
+    expect(activatesFocusedControl(keyEvent(' ', { altKey: true }), button)).toBe(false);
   });
 });

--- a/apps/web/src/lib/keyboard/binding.ts
+++ b/apps/web/src/lib/keyboard/binding.ts
@@ -116,6 +116,18 @@ export function isEditableTarget(target: EventTarget | null): boolean {
   return target.getAttribute('role') === 'textbox';
 }
 
+const ACTIVATION_KEYS = new Set(['enter', ' ']);
+
+const ACTIVATION_CONTROLS =
+  'a[href], button, summary, [role="button"], [role="menuitem"], [role="option"]';
+
+export function activatesFocusedControl(event: KeyEventLike, target: EventTarget | null): boolean {
+  if (event.metaKey || event.ctrlKey || event.altKey) return false;
+  if (!ACTIVATION_KEYS.has(normalizeKey(event.key))) return false;
+  if (target === null || !(target instanceof Element)) return false;
+  return target.closest(ACTIVATION_CONTROLS) !== null;
+}
+
 export function formatBinding(binding: string): string[] {
   return binding
     .trim()

--- a/apps/web/src/lib/keyboard/index.ts
+++ b/apps/web/src/lib/keyboard/index.ts
@@ -1,4 +1,5 @@
 export {
+  activatesFocusedControl,
   type BufferedStep,
   bufferMatches,
   eventToStep,
@@ -14,5 +15,12 @@ export {
   stepMatches,
 } from './binding.ts';
 export { HotkeyProvider, useHotkeyList, useHotkeyRegistry } from './provider.tsx';
-export { type HotkeyEntry, HotkeyRegistry, type HotkeySection, selectMatch } from './registry.ts';
+export {
+  HOTKEY_PRIORITY,
+  type HotkeyEntry,
+  HotkeyRegistry,
+  type HotkeyScope,
+  type HotkeySection,
+  selectMatch,
+} from './registry.ts';
 export { type HotkeyOptions, useHotkey } from './use-hotkey.ts';

--- a/apps/web/src/lib/keyboard/provider.test.tsx
+++ b/apps/web/src/lib/keyboard/provider.test.tsx
@@ -1,0 +1,165 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HOTKEY_PRIORITY, HotkeyProvider, useHotkey } from './index.ts';
+
+interface SurfaceProps {
+  readonly onEnter: () => void;
+  readonly onSpace: () => void;
+  readonly onActivate: () => void;
+}
+
+function IssueSurface({ onEnter, onSpace, onActivate }: SurfaceProps) {
+  useHotkey('enter', onEnter, { label: 'Open issue', section: 'Issues', scope: 'issues' });
+  useHotkey('space', onSpace, { label: 'Peek issue', section: 'Issues', scope: 'issues' });
+
+  return (
+    <div>
+      <button type="button" data-testid="new-issue" onClick={onActivate}>
+        New issue
+      </button>
+      <a href="/team/eng/board" data-testid="view-board" onClick={onActivate}>
+        Board
+      </a>
+      <div role="option" aria-selected="false" tabIndex={0} data-testid="filter-chip">
+        Assignee is Aditi
+      </div>
+      <div data-testid="rows" tabIndex={-1}>
+        ENG-1
+      </div>
+    </div>
+  );
+}
+
+function renderSurface() {
+  const handlers = { onEnter: mock(), onSpace: mock(), onActivate: mock() };
+  render(
+    <HotkeyProvider>
+      <IssueSurface {...handlers} />
+    </HotkeyProvider>,
+  );
+  return handlers;
+}
+
+describe('activation keys', () => {
+  it('activates a focused button instead of running the enter binding', async () => {
+    const user = userEvent.setup();
+    const handlers = renderSurface();
+
+    await user.tab();
+    expect(screen.getByTestId('new-issue')).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    expect(handlers.onActivate).toHaveBeenCalledTimes(1);
+    expect(handlers.onEnter).not.toHaveBeenCalled();
+  });
+
+  it('leaves enter and space to a focused link and to a role=option row', async () => {
+    const user = userEvent.setup();
+    const handlers = renderSurface();
+
+    screen.getByTestId('view-board').focus();
+    await user.keyboard('{Enter}');
+    expect(handlers.onEnter).not.toHaveBeenCalled();
+
+    screen.getByTestId('filter-chip').focus();
+    await user.keyboard('{Enter}[Space]');
+    expect(handlers.onEnter).not.toHaveBeenCalled();
+    expect(handlers.onSpace).not.toHaveBeenCalled();
+  });
+
+  it('still runs the bindings when no control holds focus', async () => {
+    const user = userEvent.setup();
+    const handlers = renderSurface();
+
+    screen.getByTestId('rows').focus();
+    await user.keyboard('{Enter}[Space]');
+    expect(handlers.onEnter).toHaveBeenCalledTimes(1);
+    expect(handlers.onSpace).toHaveBeenCalledTimes(1);
+  });
+});
+
+function LayerSurface({ onEscape }: { readonly onEscape: () => void }) {
+  useHotkey('escape', onEscape, {
+    label: 'Clear the selection',
+    section: 'Issues',
+    scope: 'issues',
+    preventDefault: false,
+  });
+
+  return (
+    <div
+      data-testid="layer"
+      role="menu"
+      tabIndex={-1}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') event.preventDefault();
+      }}
+    >
+      menu
+    </div>
+  );
+}
+
+describe('an open layer that handles the key itself', () => {
+  it('keeps the global binding out of an escape the layer already handled', async () => {
+    const user = userEvent.setup();
+    const onEscape = mock();
+    render(
+      <HotkeyProvider>
+        <LayerSurface onEscape={onEscape} />
+      </HotkeyProvider>,
+    );
+
+    screen.getByTestId('layer').focus();
+    await user.keyboard('{Escape}');
+    expect(onEscape).not.toHaveBeenCalled();
+
+    document.body.focus();
+    await user.keyboard('{Escape}');
+    expect(onEscape).toHaveBeenCalledTimes(1);
+  });
+});
+
+function GlobalCreate({ onRun }: { readonly onRun: () => void }) {
+  useHotkey('c', onRun, { label: 'Create issue', section: 'Issues' });
+  return null;
+}
+
+function DocsCreate({ onRun }: { readonly onRun: () => void }) {
+  useHotkey('c', onRun, {
+    label: 'New doc',
+    section: 'Navigation',
+    scope: 'docs',
+    priority: HOTKEY_PRIORITY.surface,
+  });
+  return null;
+}
+
+describe('scoped bindings', () => {
+  async function pressC(globalFirst: boolean) {
+    const user = userEvent.setup();
+    const onGlobal = mock();
+    const onDocs = mock();
+    render(
+      <HotkeyProvider>
+        {globalFirst ? <GlobalCreate onRun={onGlobal} /> : <DocsCreate onRun={onDocs} />}
+        {globalFirst ? <DocsCreate onRun={onDocs} /> : <GlobalCreate onRun={onGlobal} />}
+      </HotkeyProvider>,
+    );
+    await user.keyboard('c');
+    return { onGlobal, onDocs };
+  }
+
+  it('runs the surface binding when the global one registered first', async () => {
+    const { onGlobal, onDocs } = await pressC(true);
+    expect(onDocs).toHaveBeenCalledTimes(1);
+    expect(onGlobal).not.toHaveBeenCalled();
+  });
+
+  it('runs the surface binding when it registered first', async () => {
+    const { onGlobal, onDocs } = await pressC(false);
+    expect(onDocs).toHaveBeenCalledTimes(1);
+    expect(onGlobal).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/keyboard/provider.tsx
+++ b/apps/web/src/lib/keyboard/provider.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 import { createContext, useContext, useEffect, useState, useSyncExternalStore } from 'react';
 import {
+  activatesFocusedControl,
   type BufferedStep,
   eventToStep,
   isEditableTarget,
@@ -32,7 +33,9 @@ export function HotkeyProvider({ children }: { children: ReactNode }) {
     let buffer: BufferedStep[] = [];
 
     const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
       if (isModifierKey(event.key)) return;
+      if (activatesFocusedControl(event, event.target)) return;
       const editable = isEditableTarget(event.target);
       const now = Date.now();
       buffer = editable ? [] : pruneBuffer(buffer, now, SEQUENCE_TIMEOUT_MS);

--- a/apps/web/src/lib/keyboard/registry.ts
+++ b/apps/web/src/lib/keyboard/registry.ts
@@ -2,12 +2,23 @@ import { type BufferedStep, bufferMatches, type HotkeyStep, parseBinding } from 
 
 export type HotkeySection = 'Navigation' | 'General' | 'Issues' | 'View';
 
+export type HotkeyScope = 'global' | 'issues' | 'docs' | 'inbox' | 'filters';
+
+export const HOTKEY_PRIORITY = {
+  global: 0,
+  surface: 1,
+  layer: 2,
+} as const;
+
 export interface HotkeyEntryInput {
   readonly id: string;
   readonly binding: string;
   readonly label: string;
   readonly section: HotkeySection;
+  readonly scope: HotkeyScope;
+  readonly priority: number;
   readonly enabled: boolean;
+  readonly advertised: boolean;
   readonly preventDefault: boolean;
   readonly allowInInput: boolean;
   readonly run: (event: KeyboardEvent) => void;
@@ -22,6 +33,7 @@ function shiftSpecificity(entry: HotkeyEntry): number {
 }
 
 function beats(candidate: HotkeyEntry, current: HotkeyEntry): boolean {
+  if (candidate.priority !== current.priority) return candidate.priority > current.priority;
   if (candidate.steps.length !== current.steps.length) {
     return candidate.steps.length > current.steps.length;
   }

--- a/apps/web/src/lib/keyboard/use-hotkey.ts
+++ b/apps/web/src/lib/keyboard/use-hotkey.ts
@@ -2,12 +2,15 @@
 
 import { useEffect, useId, useRef } from 'react';
 import { useHotkeyRegistry } from './provider.tsx';
-import type { HotkeySection } from './registry.ts';
+import { HOTKEY_PRIORITY, type HotkeyScope, type HotkeySection } from './registry.ts';
 
 export interface HotkeyOptions {
   readonly label: string;
   readonly section?: HotkeySection;
+  readonly scope?: HotkeyScope;
+  readonly priority?: number;
   readonly enabled?: boolean;
+  readonly advertised?: boolean;
   readonly preventDefault?: boolean;
   readonly allowInInput?: boolean;
 }
@@ -22,7 +25,10 @@ export function useHotkey(
   const {
     label,
     section = 'General',
+    scope = 'global',
+    priority = HOTKEY_PRIORITY.global,
     enabled = true,
+    advertised = true,
     preventDefault = true,
     allowInInput = false,
   } = options;
@@ -40,11 +46,26 @@ export function useHotkey(
         binding,
         label,
         section,
+        scope,
+        priority,
         enabled,
+        advertised,
         preventDefault,
         allowInInput,
         run: (event) => handlerRef.current(event),
       }),
-    [registry, id, binding, label, section, enabled, preventDefault, allowInInput],
+    [
+      registry,
+      id,
+      binding,
+      label,
+      section,
+      scope,
+      priority,
+      enabled,
+      advertised,
+      preventDefault,
+      allowInInput,
+    ],
   );
 }

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -4,10 +4,16 @@ import {
   FileText,
   FolderKanban,
   Inbox,
+  Keyboard,
   LayoutList,
+  Moon,
+  PanelLeft,
   RefreshCcw,
+  Settings,
+  Sun,
   Target,
 } from 'lucide-react';
+import type { HotkeySection } from '@/lib/keyboard/index.ts';
 
 export interface ShellTeam {
   readonly id: string;
@@ -32,9 +38,8 @@ export interface NavLink {
   readonly href: string;
   readonly label: string;
   readonly icon: LucideIcon;
-  readonly shortcut?: readonly string[] | undefined;
+  readonly binding?: string | undefined;
   readonly count?: number | undefined;
-  readonly unbuilt?: boolean | undefined;
 }
 
 export interface NavSection {
@@ -43,33 +48,31 @@ export interface NavSection {
   readonly links: readonly NavLink[];
 }
 
-function built(links: readonly NavLink[]): NavLink[] {
-  return links.filter((link) => link.unbuilt !== true);
-}
+const TEAM_SECTION_PREFIX = 'team-';
 
 export function buildNavigation(teams: readonly ShellTeam[], inboxCount = 0): NavSection[] {
   return [
     {
       id: 'personal',
-      links: built([
-        { href: '/inbox', label: 'Inbox', icon: Inbox, shortcut: ['g', 'i'], count: inboxCount },
-        { href: '/my-issues', label: 'My issues', icon: CircleDot, shortcut: ['g', 'm'] },
-      ]),
+      links: [
+        { href: '/inbox', label: 'Inbox', icon: Inbox, binding: 'g i', count: inboxCount },
+        { href: '/my-issues', label: 'My issues', icon: CircleDot, binding: 'g m' },
+      ],
     },
     {
       id: 'workspace',
       title: 'Workspace',
-      links: built([
-        { href: '/projects', label: 'Projects', icon: FolderKanban, shortcut: ['g', 'p'] },
+      links: [
+        { href: '/projects', label: 'Projects', icon: FolderKanban, binding: 'g p' },
         { href: '/cycles', label: 'Cycles', icon: RefreshCcw },
-        { href: '/views', label: 'Views', icon: LayoutList },
-        { href: '/docs', label: 'Docs', icon: FileText },
-      ]),
+        { href: '/views', label: 'Views', icon: LayoutList, binding: 'g v' },
+        { href: '/docs', label: 'Docs', icon: FileText, binding: 'g d' },
+      ],
     },
     ...teams.map((team) => ({
-      id: `team-${team.id}`,
+      id: `${TEAM_SECTION_PREFIX}${team.id}`,
       title: team.name,
-      links: built([
+      links: [
         {
           href: `/team/${team.key.toLowerCase()}/issues`,
           label: 'Issues',
@@ -82,7 +85,79 @@ export function buildNavigation(teams: readonly ShellTeam[], inboxCount = 0): Na
           label: 'Active cycle',
           icon: RefreshCcw,
         },
-      ]),
+      ],
     })),
+  ];
+}
+
+export interface AppCommand {
+  readonly id: string;
+  readonly label: string;
+  readonly section: HotkeySection;
+  readonly icon: LucideIcon;
+  readonly binding?: string | undefined;
+  readonly run: () => void;
+}
+
+export interface CommandContext {
+  readonly sections: readonly NavSection[];
+  readonly navigate: (href: string) => void;
+  readonly toggleSidebar: () => void;
+  readonly toggleTheme: () => void;
+  readonly showShortcuts: () => void;
+  readonly dark: boolean;
+}
+
+function surfaceLabel(section: NavSection, link: NavLink): string {
+  if (!section.id.startsWith(TEAM_SECTION_PREFIX) || section.title === undefined) {
+    return `Go to ${link.label}`;
+  }
+  return `Go to ${section.title} ${link.label.toLowerCase()}`;
+}
+
+export function buildCommands(context: CommandContext): AppCommand[] {
+  const surfaces = context.sections.flatMap((section) =>
+    section.links.map((link) => ({
+      id: `navigate:${link.href}`,
+      label: surfaceLabel(section, link),
+      section: 'Navigation' as const,
+      icon: link.icon,
+      binding: link.binding,
+      run: () => context.navigate(link.href),
+    })),
+  );
+
+  return [
+    ...surfaces,
+    {
+      id: 'navigate:/settings',
+      label: 'Go to Settings',
+      section: 'Navigation',
+      icon: Settings,
+      run: () => context.navigate('/settings'),
+    },
+    {
+      id: 'view:theme',
+      label: context.dark ? 'Switch to light theme' : 'Switch to dark theme',
+      section: 'View',
+      icon: context.dark ? Sun : Moon,
+      run: context.toggleTheme,
+    },
+    {
+      id: 'view:sidebar',
+      label: 'Toggle sidebar',
+      section: 'View',
+      icon: PanelLeft,
+      binding: '[',
+      run: context.toggleSidebar,
+    },
+    {
+      id: 'general:shortcuts',
+      label: 'Keyboard shortcuts',
+      section: 'General',
+      icon: Keyboard,
+      binding: '?',
+      run: context.showShortcuts,
+    },
   ];
 }

--- a/packages/services/src/markdown/sanitize.ts
+++ b/packages/services/src/markdown/sanitize.ts
@@ -143,58 +143,136 @@ function isSafeUrl(raw: string): boolean {
   return SAFE_SCHEMES.has(value.slice(0, colon).toLowerCase());
 }
 
-const sanitizer = new HTMLRewriter()
-  .on('*', {
-    element(element) {
-      const tag = element.tagName.toLowerCase();
-      if (DROP_WITH_CONTENT.has(tag)) {
-        element.remove();
-        return;
-      }
-      if (!ALLOWED_TAGS.has(tag)) {
-        element.removeAndKeepContent();
-        return;
-      }
-      const present: [string, string][] = [];
-      for (const attribute of element.attributes) present.push(attribute);
+function keptAttributes(present: readonly (readonly [string, string])[]): Map<string, string> {
+  const keep = new Map<string, string>();
+  for (const [name, value] of present) {
+    const key = name.toLowerCase();
+    if (keep.has(key)) continue;
+    if (!ALLOWED_ATTR.has(key)) continue;
+    if (URL_ATTR.has(key) && !isSafeUrl(value)) continue;
+    keep.set(key, value);
+  }
+  return keep;
+}
 
-      const keep = new Map<string, string>();
-      for (const [name, value] of present) {
-        const key = name.toLowerCase();
-        element.removeAttribute(name);
-        if (keep.has(key)) continue;
-        if (!ALLOWED_ATTR.has(key)) continue;
-        if (URL_ATTR.has(key) && !isSafeUrl(value)) continue;
-        keep.set(key, value);
-      }
-      for (const [key, value] of keep) element.setAttribute(key, value);
+function externalLinkTarget(keep: ReadonlyMap<string, string>): boolean {
+  const href = stripIgnorable(decodeEntities(keep.get('href') ?? ''));
+  return href.length > 0 && ABSOLUTE_URL.test(href);
+}
 
-      if (tag !== 'a') return;
-      const href = stripIgnorable(decodeEntities(keep.get('href') ?? ''));
-      element.removeAttribute('target');
-      element.removeAttribute('rel');
-      if (href.length === 0 || !ABSOLUTE_URL.test(href)) return;
-      element.setAttribute('target', '_blank');
-      element.setAttribute('rel', 'noopener noreferrer');
-    },
-  })
-  .onDocument({
-    comments(comment) {
-      comment.remove();
-    },
-  });
+let rewriter: HTMLRewriter | null = null;
+
+function bunSanitizer(): HTMLRewriter {
+  rewriter ??= new HTMLRewriter()
+    .on('*', {
+      element(element) {
+        const tag = element.tagName.toLowerCase();
+        if (DROP_WITH_CONTENT.has(tag)) {
+          element.remove();
+          return;
+        }
+        if (!ALLOWED_TAGS.has(tag)) {
+          element.removeAndKeepContent();
+          return;
+        }
+        const present: [string, string][] = [];
+        for (const attribute of element.attributes) present.push(attribute);
+        for (const [name] of present) element.removeAttribute(name);
+
+        const keep = keptAttributes(present);
+        for (const [key, value] of keep) element.setAttribute(key, value);
+
+        if (tag !== 'a') return;
+        element.removeAttribute('target');
+        element.removeAttribute('rel');
+        if (!externalLinkTarget(keep)) return;
+        element.setAttribute('target', '_blank');
+        element.setAttribute('rel', 'noopener noreferrer');
+      },
+    })
+    .onDocument({
+      comments(comment) {
+        comment.remove();
+      },
+    });
+  return rewriter;
+}
+
+function cleanDomNode(node: ChildNode): void {
+  if (node instanceof Comment) {
+    node.remove();
+    return;
+  }
+  if (!(node instanceof Element)) return;
+
+  const tag = node.tagName.toLowerCase();
+  if (DROP_WITH_CONTENT.has(tag)) {
+    node.remove();
+    return;
+  }
+
+  const children = Array.from(node.childNodes);
+  if (ALLOWED_TAGS.has(tag)) {
+    const present = Array.from(node.attributes).map((attribute): [string, string] => [
+      attribute.name,
+      attribute.value,
+    ]);
+    for (const [name] of present) node.removeAttribute(name);
+
+    const keep = keptAttributes(present);
+    for (const [key, value] of keep) node.setAttribute(key, value);
+
+    if (tag === 'a' && externalLinkTarget(keep)) {
+      node.setAttribute('target', '_blank');
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+  } else {
+    node.replaceWith(...children);
+  }
+
+  for (const child of children) cleanDomNode(child);
+}
+
+function sanitizeInDom(html: string): string {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  for (const node of Array.from(template.content.childNodes)) cleanDomNode(node);
+  return template.innerHTML;
+}
 
 export function sanitizeHtml(html: string): string {
   if (html.length === 0) return '';
-  return sanitizer.transform(html);
+  if (typeof HTMLRewriter === 'undefined') return sanitizeInDom(html);
+  return bunSanitizer().transform(html);
 }
 
 const VOID_TEXT_TAGS = new Set(['br', 'hr', 'img', 'input']);
 
+function collectDomText(node: Node, parts: string[]): void {
+  for (const child of Array.from(node.childNodes)) {
+    if (child instanceof Text) {
+      parts.push(child.data);
+      continue;
+    }
+    if (!(child instanceof Element)) continue;
+    if (VOID_TEXT_TAGS.has(child.tagName.toLowerCase())) parts.push(' ');
+    collectDomText(child, parts);
+  }
+}
+
+function textInDom(html: string): string {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  const parts: string[] = [];
+  collectDomText(template.content, parts);
+  return parts.join('');
+}
+
 export function htmlToText(html: string): string {
   if (html.length === 0) return '';
+  if (typeof HTMLRewriter === 'undefined') return textInDom(html);
   const parts: string[] = [];
-  const collector = new HTMLRewriter()
+  new HTMLRewriter()
     .on('*', {
       element(element) {
         if (VOID_TEXT_TAGS.has(element.tagName.toLowerCase())) parts.push(' ');
@@ -207,7 +285,7 @@ export function htmlToText(html: string): string {
       comments(comment) {
         comment.remove();
       },
-    });
-  collector.transform(html);
+    })
+    .transform(html);
   return parts.join('');
 }


### PR DESCRIPTION
Give hotkey entries a scope and a priority so the page decides which shortcut wins rather than registration order, stop the registry eating Enter and Space on focused controls, and define every command once so a key hint cannot drift from what it does.