### PR TITLE
fix(deploy): run the schema migration before rolling out new code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,13 +124,20 @@ stage to `node:24-alpine`, `CMD` to `node`). Editing only the k8s manifest does
 nothing: in `oven/bun` images `node` is a symlink to `bun`, so
 `command: [..., "node", ...]` still runs Bun, silently.
 
-CodeBuild does not trigger automatically. Deploy by hand:
+Deploy by hand with:
 
 ```
 KUBE_API_SERVER=http://127.0.0.1:8080 ./extras/scripts/docker-build-push.sh -y
 ```
 
 Name services to narrow it, for example `... docker-build-push.sh web mcp -y`.
+
+The CodeBuild pipeline (`buildspec.yml`) runs the schema migration as a job at
+the deploy image tag, waits for it to complete, and only then rolls out web,
+realtime and mcp. A failed migration aborts the deploy before any new code goes
+live, so a schema change can no longer leave production querying columns that do
+not exist. The hand script above does not migrate: run `k8s/migrate.sh` after it
+when a deploy carries a schema change.
 
 ## Git
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ nothing: in `oven/bun` images `node` is a symlink to `bun`, so
 
 Deploy by hand with:
 
-```
+```sh
 KUBE_API_SERVER=http://127.0.0.1:8080 ./extras/scripts/docker-build-push.sh -y
 ```
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -102,7 +102,8 @@ phases:
         JOB=$(sed -e "s|__ECR_REGISTRY__|$ECR|g" -e "s|__IMAGE_TAG__|$IMAGE_TAG|g" \
           k8s/06-migrate-job.yaml | kubectl create -n "$EKS_NAMESPACE" -f - -o name)
         echo "created $JOB for schema migration"
-        DEADLINE=$(( $(date +%s) + $(printf '%s' "$ROLLOUT_TIMEOUT" | tr -dc '0-9') ))
+        TIMEOUT_SECONDS=$(printf '%s' "$ROLLOUT_TIMEOUT" | awk '{ s=0; n=""; for (i=1;i<=length($0);i++) { c=substr($0,i,1); if (c ~ /[0-9]/) { n=n c } else { if (c=="h") s+=n*3600; else if (c=="m") s+=n*60; else if (c=="s") s+=n; n="" } } if (n!="") s+=n; print s }')
+        DEADLINE=$(( $(date +%s) + TIMEOUT_SECONDS ))
         while true; do
           READY=$(kubectl get "$JOB" -n "$EKS_NAMESPACE" \
             -o 'jsonpath={.status.conditions[?(@.status=="True")].type}' 2>/dev/null || true)

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -102,13 +102,24 @@ phases:
         JOB=$(sed -e "s|__ECR_REGISTRY__|$ECR|g" -e "s|__IMAGE_TAG__|$IMAGE_TAG|g" \
           k8s/06-migrate-job.yaml | kubectl create -n "$EKS_NAMESPACE" -f - -o name)
         echo "created $JOB for schema migration"
-        if ! kubectl wait --for=condition=complete --timeout="$ROLLOUT_TIMEOUT" \
-            "$JOB" -n "$EKS_NAMESPACE"; then
-          echo "ERROR: schema migration did not complete, refusing to roll out new code" >&2
-          kubectl logs "$JOB" -n "$EKS_NAMESPACE" --tail=80 >&2 || true
-          exit 1
-        fi
-        echo "Schema migration applied, rolling out new code"
+        DEADLINE=$(( $(date +%s) + $(printf '%s' "$ROLLOUT_TIMEOUT" | tr -dc '0-9') ))
+        while true; do
+          READY=$(kubectl get "$JOB" -n "$EKS_NAMESPACE" \
+            -o 'jsonpath={.status.conditions[?(@.status=="True")].type}' 2>/dev/null || true)
+          case "$READY" in
+            *Complete*) echo "Schema migration applied, rolling out new code"; break ;;
+            *Failed*)
+              echo "ERROR: schema migration failed, refusing to roll out new code" >&2
+              kubectl logs "$JOB" -n "$EKS_NAMESPACE" --tail=80 >&2 || true
+              exit 1 ;;
+          esac
+          if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+            echo "ERROR: schema migration did not finish within $ROLLOUT_TIMEOUT" >&2
+            kubectl logs "$JOB" -n "$EKS_NAMESPACE" --tail=80 >&2 || true
+            exit 1
+          fi
+          sleep 3
+        done
 
         for NAME in web realtime mcp; do
           kubectl set image "deployment/orbit-$NAME" -n "$EKS_NAMESPACE" \

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -105,7 +105,7 @@ phases:
         TIMEOUT_SECONDS=$(printf '%s' "$ROLLOUT_TIMEOUT" | awk '{ s=0; n=""; for (i=1;i<=length($0);i++) { c=substr($0,i,1); if (c ~ /[0-9]/) { n=n c } else { if (c=="h") s+=n*3600; else if (c=="m") s+=n*60; else if (c=="s") s+=n; n="" } } if (n!="") s+=n; print s }')
         DEADLINE=$(( $(date +%s) + TIMEOUT_SECONDS ))
         while true; do
-          READY=$(kubectl get "$JOB" -n "$EKS_NAMESPACE" \
+          READY=$(kubectl get "$JOB" -n "$EKS_NAMESPACE" --request-timeout=10s \
             -o 'jsonpath={.status.conditions[?(@.status=="True")].type}' 2>/dev/null || true)
           case "$READY" in
             *Complete*) echo "Schema migration applied, rolling out new code"; break ;;

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -99,6 +99,17 @@ phases:
           exit 1
         fi
 
+        JOB=$(sed -e "s|__ECR_REGISTRY__|$ECR|g" -e "s|__IMAGE_TAG__|$IMAGE_TAG|g" \
+          k8s/06-migrate-job.yaml | kubectl create -n "$EKS_NAMESPACE" -f - -o name)
+        echo "created $JOB for schema migration"
+        if ! kubectl wait --for=condition=complete --timeout="$ROLLOUT_TIMEOUT" \
+            "$JOB" -n "$EKS_NAMESPACE"; then
+          echo "ERROR: schema migration did not complete, refusing to roll out new code" >&2
+          kubectl logs "$JOB" -n "$EKS_NAMESPACE" --tail=80 >&2 || true
+          exit 1
+        fi
+        echo "Schema migration applied, rolling out new code"
+
         for NAME in web realtime mcp; do
           kubectl set image "deployment/orbit-$NAME" -n "$EKS_NAMESPACE" \
             "orbit-$NAME=$ECR/orbit-$NAME:$IMAGE_TAG"


### PR DESCRIPTION
The pipeline set new images without applying the schema, so a schema-carrying deploy took production down with column-does-not-exist errors. It now runs the migrate job at the deploy tag, waits for it, and only then rolls out.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a production outage class where schema migrations were not applied before new code was rolled out, causing `column-does-not-exist` errors. It inserts a migration Job step in the CodeBuild `post_build` phase and blocks the rollout of `web`, `realtime`, and `mcp` until the Job completes (or aborts on failure).

- **Migration gating**: `kubectl create` launches the migrate Job at the deploy image tag; a polling loop checks `.status.conditions` every 3 seconds and exits immediately on `Complete` or `Failed`, with logs captured on any failure path.
- **Timeout handling**: `ROLLOUT_TIMEOUT` (a Go-duration string from Secrets Manager) is correctly converted to seconds with an awk parser that handles `h`, `m`, `s` and combined forms; the rollout's `--timeout` flag continues to receive the raw Go-duration string unchanged.
- **CLAUDE.md**: Updated to document the new pipeline behaviour and note that the hand-deploy script still requires a manual `k8s/migrate.sh` invocation for schema-carrying changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the migration gate is correct and the rollout is blocked until the Job either completes or explicitly fails.

The polling loop correctly watches for both Complete and Failed conditions, the awk-based duration parser handles all Go-duration formats, and set -e ensures any unexpected kubectl failure aborts the pipeline before touching running deployments. No correctness issues remain after the previously addressed fixes.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| buildspec.yml | Adds migration Job creation and a polling loop before rolling out services; timeout parsing correctly handles Go duration strings, and both Complete and Failed conditions are watched. |
| CLAUDE.md | Documentation updated to describe the new CodeBuild migration-before-rollout behaviour and the manual migration step required for hand deploys. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CB as CodeBuild
    participant K8s as Kubernetes API
    participant Job as migrate Job
    participant Deploy as web/realtime/mcp Deployments

    CB->>K8s: kubectl create job (from 06-migrate-job.yaml at IMAGE_TAG)
    K8s-->>CB: job.batch/orbit-migrate-suffix
    loop Poll every 3s until DEADLINE
        CB->>K8s: kubectl get job conditions where status is True
        K8s-->>CB: empty or Complete or Failed
        alt Complete
            CB->>CB: break and proceed to rollout
        else Failed
            CB->>K8s: kubectl logs tail 80
            CB->>CB: exit 1 abort deploy
        else timeout
            CB->>K8s: kubectl logs tail 80
            CB->>CB: exit 1 abort deploy
        end
    end
    CB->>K8s: kubectl set image web realtime mcp
    CB->>K8s: kubectl rollout status with timeout
    K8s-->>Deploy: Rolling update to new pods
    Deploy-->>CB: Rollout complete
```

<sub>Reviews (4): Last reviewed commit: ["fix(deploy): bound the migration poll re..."](https://github.com/noveum/orbit/commit/4f2bb3c573b4432a530516ef75b4b68f15f8b615) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46755590)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/noveum-ai/github/Noveum/orbit/-/custom-context?memory=b1d3c64d-731f-463a-94a4-788291e176f9))

<!-- /greptile_comment -->