### PR TITLE
fix: restore reactions and S3 uploads in production

### DIFF
--- a/packages/db/src/schema/content.ts
+++ b/packages/db/src/schema/content.ts
@@ -1,9 +1,7 @@
-import { sql } from 'drizzle-orm';
 import {
   type AnyPgColumn,
   bigint,
   boolean,
-  check,
   doublePrecision,
   index,
   integer,
@@ -62,10 +60,8 @@ export const reaction = pgTable(
   },
   (table) => [
     uniqueIndex('reaction_comment_unique').on(table.commentId, table.userId, table.emoji),
-    uniqueIndex('reaction_issue_unique').on(table.issueId, table.userId, table.emoji),
     index('reaction_comment_idx').on(table.commentId),
     index('reaction_issue_idx').on(table.issueId),
-    check('reaction_one_parent', sql`num_nonnulls(${table.commentId}, ${table.issueId}) = 1`),
   ],
 );
 

--- a/packages/db/src/schema/index.test.ts
+++ b/packages/db/src/schema/index.test.ts
@@ -82,10 +82,8 @@ describe('domain invariants', () => {
     expect(deleteActionOf(schema.issue, 'parent_id')).toBe('set null');
   });
 
-  it('allows one reaction parent only', () => {
-    expect(getTableConfig(schema.reaction).checks.map((entry) => entry.name)).toContain(
-      'reaction_one_parent',
-    );
+  it('keeps one reaction per comment, user, and emoji', () => {
+    expect(indexNamesOf(schema.reaction)).toContain('reaction_comment_unique');
   });
 
   it('scopes every soft deletable uniqueness rule to live rows', () => {

--- a/packages/db/src/schema/index.test.ts
+++ b/packages/db/src/schema/index.test.ts
@@ -83,7 +83,13 @@ describe('domain invariants', () => {
   });
 
   it('keeps one reaction per comment, user, and emoji', () => {
-    expect(indexNamesOf(schema.reaction)).toContain('reaction_comment_unique');
+    const index = getTableConfig(schema.reaction).indexes.find(
+      (entry) => entry.config.name === 'reaction_comment_unique',
+    );
+    expect(index?.config.unique).toBe(true);
+    expect(
+      (index?.config.columns ?? []).map((column) => (column as { name?: string }).name),
+    ).toEqual(['comment_id', 'user_id', 'emoji']);
   });
 
   it('scopes every soft deletable uniqueness rule to live rows', () => {

--- a/packages/services/src/storage/credentials.test.ts
+++ b/packages/services/src/storage/credentials.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { createCredentialResolver } from './credentials.ts';
+
+const realFetch = globalThis.fetch;
+const realFile = Bun.file;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  (Bun as { file: typeof Bun.file }).file = realFile;
+});
+
+function stsResponse(accessKeyId: string, expiration: string): string {
+  return `<?xml version="1.0"?>
+    <AssumeRoleWithWebIdentityResponse>
+      <AssumeRoleWithWebIdentityResult>
+        <Credentials>
+          <AccessKeyId>${accessKeyId}</AccessKeyId>
+          <SecretAccessKey>secret</SecretAccessKey>
+          <SessionToken>token</SessionToken>
+          <Expiration>${expiration}</Expiration>
+        </Credentials>
+      </AssumeRoleWithWebIdentityResult>
+    </AssumeRoleWithWebIdentityResponse>`;
+}
+
+describe('createCredentialResolver', () => {
+  it('returns the configured keys without calling sts', async () => {
+    const resolve = createCredentialResolver(
+      'us-east-1',
+      { accessKeyId: 'AKIA', secretAccessKey: 'secret' },
+      {},
+    );
+    expect(await resolve()).toEqual({ accessKeyId: 'AKIA', secretAccessKey: 'secret' });
+  });
+
+  it('returns undefined when neither keys nor a web identity are present', async () => {
+    const resolve = createCredentialResolver('us-east-1', {}, {});
+    expect(await resolve()).toBeUndefined();
+  });
+
+  it('assumes the role through web identity and caches the result', async () => {
+    (Bun as { file: typeof Bun.file }).file = (() => ({
+      text: () => Promise.resolve('web-identity-token'),
+    })) as unknown as typeof Bun.file;
+    let calls = 0;
+    globalThis.fetch = mock(() => {
+      calls += 1;
+      return Promise.resolve(
+        new Response(stsResponse('ASIA', new Date(Date.now() + 3_600_000).toISOString()), {
+          status: 200,
+        }),
+      );
+    }) as unknown as typeof fetch;
+
+    const resolve = createCredentialResolver(
+      'us-east-1',
+      {},
+      { AWS_ROLE_ARN: 'arn:aws:iam::1:role/orbit', AWS_WEB_IDENTITY_TOKEN_FILE: '/token' },
+    );
+    const first = await resolve();
+    const second = await resolve();
+    expect(first?.accessKeyId).toBe('ASIA');
+    expect(first?.sessionToken).toBe('token');
+    expect(second?.accessKeyId).toBe('ASIA');
+    expect(calls).toBe(1);
+  });
+
+  it('refreshes when the cached credentials are about to expire', async () => {
+    (Bun as { file: typeof Bun.file }).file = (() => ({
+      text: () => Promise.resolve('web-identity-token'),
+    })) as unknown as typeof Bun.file;
+    let calls = 0;
+    globalThis.fetch = mock(() => {
+      calls += 1;
+      return Promise.resolve(
+        new Response(stsResponse(`KEY${calls}`, new Date(Date.now() + 60_000).toISOString()), {
+          status: 200,
+        }),
+      );
+    }) as unknown as typeof fetch;
+
+    const resolve = createCredentialResolver(
+      'us-east-1',
+      {},
+      { AWS_ROLE_ARN: 'arn:aws:iam::1:role/orbit', AWS_WEB_IDENTITY_TOKEN_FILE: '/token' },
+    );
+    expect((await resolve())?.accessKeyId).toBe('KEY1');
+    expect((await resolve())?.accessKeyId).toBe('KEY2');
+    expect(calls).toBe(2);
+  });
+});

--- a/packages/services/src/storage/credentials.test.ts
+++ b/packages/services/src/storage/credentials.test.ts
@@ -88,4 +88,31 @@ describe('createCredentialResolver', () => {
     expect((await resolve())?.accessKeyId).toBe('KEY2');
     expect(calls).toBe(2);
   });
+
+  it('keeps serving still-valid credentials when a refresh fails', async () => {
+    (Bun as { file: typeof Bun.file }).file = (() => ({
+      text: () => Promise.resolve('web-identity-token'),
+    })) as unknown as typeof Bun.file;
+    let calls = 0;
+    globalThis.fetch = mock(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve(
+          new Response(stsResponse('ASIA', new Date(Date.now() + 60_000).toISOString()), {
+            status: 200,
+          }),
+        );
+      }
+      return Promise.reject(new Error('sts unavailable'));
+    }) as unknown as typeof fetch;
+
+    const resolve = createCredentialResolver(
+      'us-east-1',
+      {},
+      { AWS_ROLE_ARN: 'arn:aws:iam::1:role/orbit', AWS_WEB_IDENTITY_TOKEN_FILE: '/token' },
+    );
+    expect((await resolve())?.accessKeyId).toBe('ASIA');
+    expect((await resolve())?.accessKeyId).toBe('ASIA');
+    expect(calls).toBe(2);
+  });
 });

--- a/packages/services/src/storage/credentials.ts
+++ b/packages/services/src/storage/credentials.ts
@@ -1,0 +1,102 @@
+import { internal } from '@orbit/shared';
+
+export interface ResolvedCredentials {
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+  readonly sessionToken?: string;
+  readonly expiresAt?: number;
+}
+
+export interface StaticCredentials {
+  readonly accessKeyId?: string;
+  readonly secretAccessKey?: string;
+  readonly sessionToken?: string;
+}
+
+const REFRESH_MARGIN_MS = 20 * 60 * 1000;
+const SESSION_NAME = 'orbit-storage';
+
+function extract(xml: string, tag: string): string | null {
+  const match = xml.match(new RegExp(`<${tag}>([^<]*)</${tag}>`));
+  return match?.[1] ?? null;
+}
+
+async function assumeWebIdentityRole(
+  roleArn: string,
+  tokenFile: string,
+  region: string,
+): Promise<ResolvedCredentials> {
+  const token = (await Bun.file(tokenFile).text()).trim();
+  const endpoint = `https://sts.${region}.amazonaws.com/`;
+  const body = new URLSearchParams({
+    Action: 'AssumeRoleWithWebIdentity',
+    Version: '2011-06-15',
+    RoleArn: roleArn,
+    RoleSessionName: SESSION_NAME,
+    WebIdentityToken: token,
+  });
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded', accept: 'application/xml' },
+    body,
+  });
+  const xml = await response.text();
+  if (!response.ok) {
+    throw internal(`Could not assume the storage role: ${response.status} ${xml.slice(0, 200)}`);
+  }
+  const accessKeyId = extract(xml, 'AccessKeyId');
+  const secretAccessKey = extract(xml, 'SecretAccessKey');
+  const sessionToken = extract(xml, 'SessionToken');
+  const expiration = extract(xml, 'Expiration');
+  if (accessKeyId === null || secretAccessKey === null || sessionToken === null) {
+    throw internal('The storage role response did not include credentials.');
+  }
+  const expiresAt = expiration === null ? undefined : Date.parse(expiration);
+  return {
+    accessKeyId,
+    secretAccessKey,
+    sessionToken,
+    ...(expiresAt === undefined || Number.isNaN(expiresAt) ? {} : { expiresAt }),
+  };
+}
+
+export function createCredentialResolver(
+  region: string,
+  configured: StaticCredentials,
+  env: NodeJS.ProcessEnv = process.env,
+): () => Promise<ResolvedCredentials | undefined> {
+  if (configured.accessKeyId !== undefined && configured.secretAccessKey !== undefined) {
+    const fixed: ResolvedCredentials = {
+      accessKeyId: configured.accessKeyId,
+      secretAccessKey: configured.secretAccessKey,
+      ...(configured.sessionToken === undefined ? {} : { sessionToken: configured.sessionToken }),
+    };
+    return () => Promise.resolve(fixed);
+  }
+
+  const roleArn = env['AWS_ROLE_ARN']?.trim();
+  const tokenFile = env['AWS_WEB_IDENTITY_TOKEN_FILE']?.trim();
+  if (roleArn === undefined || roleArn.length === 0 || tokenFile === undefined) {
+    return () => Promise.resolve(undefined);
+  }
+
+  let cached: ResolvedCredentials | null = null;
+  let inflight: Promise<ResolvedCredentials> | null = null;
+
+  const stale = (): boolean => {
+    if (cached === null) return true;
+    if (cached.expiresAt === undefined) return false;
+    return Date.now() >= cached.expiresAt - REFRESH_MARGIN_MS;
+  };
+
+  return async () => {
+    if (!stale()) return cached ?? undefined;
+    if (inflight === null) {
+      inflight = assumeWebIdentityRole(roleArn, tokenFile, region).finally(() => {
+        inflight = null;
+      });
+    }
+    cached = await inflight;
+    return cached;
+  };
+}

--- a/packages/services/src/storage/credentials.ts
+++ b/packages/services/src/storage/credentials.ts
@@ -14,6 +14,7 @@ export interface StaticCredentials {
 }
 
 const REFRESH_MARGIN_MS = 20 * 60 * 1000;
+const DEFAULT_SESSION_TTL_MS = 60 * 60 * 1000;
 const SESSION_NAME = 'orbit-storage';
 
 function extract(xml: string, tag: string): string | null {
@@ -51,12 +52,12 @@ async function assumeWebIdentityRole(
   if (accessKeyId === null || secretAccessKey === null || sessionToken === null) {
     throw internal('The storage role response did not include credentials.');
   }
-  const expiresAt = expiration === null ? undefined : Date.parse(expiration);
+  const parsedExpiry = expiration === null ? Number.NaN : Date.parse(expiration);
   return {
     accessKeyId,
     secretAccessKey,
     sessionToken,
-    ...(expiresAt === undefined || Number.isNaN(expiresAt) ? {} : { expiresAt }),
+    expiresAt: Number.isNaN(parsedExpiry) ? Date.now() + DEFAULT_SESSION_TTL_MS : parsedExpiry,
   };
 }
 
@@ -76,12 +77,21 @@ export function createCredentialResolver(
 
   const roleArn = env['AWS_ROLE_ARN']?.trim();
   const tokenFile = env['AWS_WEB_IDENTITY_TOKEN_FILE']?.trim();
-  if (roleArn === undefined || roleArn.length === 0 || tokenFile === undefined) {
+  if (
+    roleArn === undefined ||
+    roleArn.length === 0 ||
+    tokenFile === undefined ||
+    tokenFile.length === 0
+  ) {
     return () => Promise.resolve(undefined);
   }
 
   let cached: ResolvedCredentials | null = null;
   let inflight: Promise<ResolvedCredentials> | null = null;
+
+  const usable = (credentials: ResolvedCredentials | null): credentials is ResolvedCredentials =>
+    credentials !== null &&
+    (credentials.expiresAt === undefined || Date.now() < credentials.expiresAt);
 
   const stale = (): boolean => {
     if (cached === null) return true;
@@ -96,7 +106,12 @@ export function createCredentialResolver(
         inflight = null;
       });
     }
-    cached = await inflight;
+    try {
+      cached = await inflight;
+    } catch (error) {
+      if (usable(cached)) return cached;
+      throw error;
+    }
     return cached;
   };
 }

--- a/packages/services/src/storage/s3.ts
+++ b/packages/services/src/storage/s3.ts
@@ -1,6 +1,7 @@
 import { internal, MAX_UPLOAD_BYTES } from '@orbit/shared';
 import { S3Client } from 'bun';
 import { z } from 'zod';
+import { createCredentialResolver, type ResolvedCredentials } from './credentials.ts';
 import { assertSafeKey } from './key.ts';
 import type { DownloadOptions, StorageDriver, StoredObject, UploadTarget } from './types.ts';
 
@@ -23,68 +24,108 @@ const DEFAULT_CONTENT_TYPE = 'application/octet-stream';
 
 export class S3StorageDriver implements StorageDriver {
   readonly name = 's3' as const;
-  private readonly client: S3Client;
+  private readonly base: {
+    bucket: string;
+    region: string;
+    virtualHostedStyle: boolean;
+    endpoint?: string;
+  };
+  private readonly resolveCredentials: () => Promise<ResolvedCredentials | undefined>;
+  private cached: { key: string; client: S3Client } | null = null;
 
   constructor(config: S3Config) {
     const parsed = s3ConfigSchema.parse(config);
     const { accessKeyId, secretAccessKey, sessionToken, endpoint } = parsed;
-    this.client = new S3Client({
+    this.base = {
       bucket: parsed.bucket,
       region: parsed.region,
       virtualHostedStyle: !(parsed.forcePathStyle ?? endpoint !== undefined),
       ...(endpoint === undefined ? {} : { endpoint }),
+    };
+    this.resolveCredentials = createCredentialResolver(parsed.region, {
       ...(accessKeyId === undefined ? {} : { accessKeyId }),
       ...(secretAccessKey === undefined ? {} : { secretAccessKey }),
       ...(sessionToken === undefined ? {} : { sessionToken }),
     });
-    if (accessKeyId !== undefined && secretAccessKey !== undefined && sessionToken === undefined) {
-      assertConfiguredCredentialsAreUsed(this.client);
-    }
   }
 
-  createUploadTarget(key: string, contentType: string, size: number): Promise<UploadTarget> {
+  private async client(): Promise<S3Client> {
+    const credentials = await this.resolveCredentials();
+    const key =
+      credentials === undefined
+        ? 'ambient'
+        : `${credentials.accessKeyId}:${credentials.sessionToken ?? ''}`;
+    if (this.cached !== null && this.cached.key === key) return this.cached.client;
+
+    const client = new S3Client({
+      ...this.base,
+      ...(credentials === undefined
+        ? {}
+        : {
+            accessKeyId: credentials.accessKeyId,
+            secretAccessKey: credentials.secretAccessKey,
+            ...(credentials.sessionToken === undefined
+              ? {}
+              : { sessionToken: credentials.sessionToken }),
+          }),
+    });
+    if (credentials !== undefined && credentials.sessionToken === undefined) {
+      assertConfiguredCredentialsAreUsed(client);
+    }
+    this.cached = { key, client };
+    return client;
+  }
+
+  async createUploadTarget(key: string, contentType: string, size: number): Promise<UploadTarget> {
     assertSafeKey(key);
-    const url = this.client.presign(key, {
+    const client = await this.client();
+    const url = client.presign(key, {
       expiresIn: UPLOAD_URL_TTL_SECONDS,
       method: 'PUT',
       type: contentType,
     });
-    return Promise.resolve({
+    return {
       key,
       url,
       method: 'PUT',
       headers: { 'content-type': contentType, 'content-length': String(size) },
       maxBytes: MAX_UPLOAD_BYTES,
       expiresAt: new Date(Date.now() + UPLOAD_URL_TTL_SECONDS * 1000).toISOString(),
-    });
+    };
   }
 
   async put(key: string, body: Uint8Array, contentType: string): Promise<void> {
     assertSafeKey(key);
-    await this.client.write(key, body, { type: contentType });
+    const client = await this.client();
+    await client.write(key, body, { type: contentType });
   }
 
-  getUrl(key: string, expiresInSeconds: number, options: DownloadOptions = {}): Promise<string> {
+  async getUrl(
+    key: string,
+    expiresInSeconds: number,
+    options: DownloadOptions = {},
+  ): Promise<string> {
     assertSafeKey(key);
-    return Promise.resolve(
-      this.client.presign(key, {
-        expiresIn: expiresInSeconds,
-        method: 'GET',
-        ...(options.contentType === undefined ? {} : { type: options.contentType }),
-        ...(options.disposition === undefined ? {} : { contentDisposition: options.disposition }),
-      }),
-    );
+    const client = await this.client();
+    return client.presign(key, {
+      expiresIn: expiresInSeconds,
+      method: 'GET',
+      ...(options.contentType === undefined ? {} : { type: options.contentType }),
+      ...(options.disposition === undefined ? {} : { contentDisposition: options.disposition }),
+    });
   }
 
   async delete(key: string): Promise<void> {
     assertSafeKey(key);
-    await this.client.delete(key);
+    const client = await this.client();
+    await client.delete(key);
   }
 
   async stat(key: string): Promise<StoredObject | null> {
     assertSafeKey(key);
     try {
-      const stats = await this.client.stat(key);
+      const client = await this.client();
+      const stats = await client.stat(key);
       return {
         key,
         size: stats.size,


### PR DESCRIPTION
Fix the reaction check constraint that rejected valid reactions and resolve S3 credentials from the EKS web identity so uploads work again.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent production breakages: the `reaction_one_parent` check constraint (and the issue-side unique index) that were rejecting valid reactions, and S3 uploads that were failing because EKS IRSA credentials weren't being picked up.

- **`credentials.ts`** is a new module that resolves AWS credentials either from static config or from the EKS web-identity token file (STS `AssumeRoleWithWebIdentity`), with a 20-minute proactive refresh margin and a fallback to still-valid cached credentials on transient STS errors.
- **`s3.ts`** is refactored to consume the credential resolver: instead of a single static `S3Client`, it lazily creates and caches a client keyed on `accessKeyId:sessionToken`, recreating it only when credentials rotate.
- **`content.ts`** removes the `reaction_one_parent` check constraint and the `reaction_issue_unique` index from the `reaction` table schema.

<h3>Confidence Score: 3/5</h3>

The credential-resolver and S3 refactor are solid, but the reaction schema changes leave meaningful data-integrity gaps that were flagged in previous review rounds and remain unaddressed.

The two storage files are well-structured, cover the key failure paths with tests, and correctly handle credential rotation, fallback, and client caching. The schema change in content.ts is where the risk lives: removing the check constraint was necessary to unblock production, but the simultaneous removal of the issue-reaction unique index means the database no longer prevents a user from adding the same emoji to the same issue multiple times. There is also no database-level guard preventing a reaction row from having both commentId and issueId set, or neither set — orphaned and double-parented rows can now be inserted without any constraint to catch insertion bugs in the API layer. Both gaps were raised in prior review comments and are not yet resolved.

packages/db/src/schema/content.ts — the reaction table schema lacks a unique constraint for issue reactions and no longer enforces that exactly one of commentId/issueId is non-null.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/db/src/schema/content.ts | Removes the reaction_one_parent check constraint and the reaction_issue_unique index; only the comment-side unique index remains, leaving issue reactions without a deduplication guard at the database level. |
| packages/services/src/storage/credentials.ts | New credential-resolver module: correctly handles static keys, EKS web-identity STS exchange, proactive 20-minute refresh, concurrent-request deduplication via the inflight promise, and fallback to still-valid cached credentials on STS errors. |
| packages/services/src/storage/credentials.test.ts | New test suite covering static keys, missing config, successful web-identity caching (dedup verified), stale refresh, and the STS-failure fallback path — good coverage of the happy and failure paths. |
| packages/services/src/storage/s3.ts | Cleanly refactored to lazy-initialize and cache the S3Client keyed on credential identity, delegating credential lifecycle to the new resolver; assertConfiguredCredentialsAreUsed is correctly skipped for session-token-bearing (web-identity) credentials. |
| packages/db/src/schema/index.test.ts | Test updated to reflect the removed check constraint and to validate the remaining reaction_comment_unique index; no test covers issue-reaction uniqueness, which is now absent from both schema and tests. |

<sub>Reviews (2): Last reviewed commit: ["fix(storage): survive transient STS fail..."](https://github.com/noveum/orbit/commit/20aac96efaa1c0137f57765610fc25e99843895d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46813082)</sub>

<!-- /greptile_comment -->