### PR TITLE
fix(files): encode download filenames so S3 accepts the content disposition

### DIFF
--- a/apps/web/src/lib/api/content-disposition.test.ts
+++ b/apps/web/src/lib/api/content-disposition.test.ts
@@ -26,12 +26,15 @@ describe('dispositionFor', () => {
     );
   });
 
-  it('keeps the presigned value ascii when the name has non latin1 characters', () => {
-    const disposition = dispositionFor('application/pdf', 'Designing–Data’s–O’Reilly (2017).pdf');
+  it('keeps the presigned value ascii and round trips the real name via filename*', () => {
+    const fileName = 'Designing–Data’s–O’Reilly (2017).pdf';
+    const disposition = dispositionFor('application/pdf', fileName);
     expect(/^[\x20-\x7e]*$/.test(disposition)).toBe(true);
     expect(disposition.startsWith('inline; filename="Designing_Data_s_O_Reilly (2017).pdf"')).toBe(
       true,
     );
-    expect(disposition).toContain("filename*=UTF-8''");
+    const encoded = disposition.split("filename*=UTF-8''")[1];
+    expect(encoded).toBeDefined();
+    expect(decodeURIComponent(encoded ?? '')).toBe(fileName);
   });
 });

--- a/apps/web/src/lib/api/content-disposition.test.ts
+++ b/apps/web/src/lib/api/content-disposition.test.ts
@@ -3,18 +3,35 @@ import { dispositionFor } from './content-disposition.ts';
 
 describe('dispositionFor', () => {
   it('previews the media types a browser renders safely', () => {
-    expect(dispositionFor('image/png', 'shot.png')).toBe('inline; filename="shot.png"');
-    expect(dispositionFor('application/pdf', 'spec.pdf')).toBe('inline; filename="spec.pdf"');
+    expect(dispositionFor('image/png', 'shot.png')).toBe(
+      `inline; filename="shot.png"; filename*=UTF-8''shot.png`,
+    );
+    expect(dispositionFor('application/pdf', 'spec.pdf')).toBe(
+      `inline; filename="spec.pdf"; filename*=UTF-8''spec.pdf`,
+    );
   });
 
   it('forces a download for anything that could execute in the app origin', () => {
-    expect(dispositionFor('image/svg+xml', 'logo.svg')).toBe('attachment; filename="logo.svg"');
-    expect(dispositionFor('text/html', 'page.html')).toBe('attachment; filename="page.html"');
+    expect(dispositionFor('image/svg+xml', 'logo.svg')).toBe(
+      `attachment; filename="logo.svg"; filename*=UTF-8''logo.svg`,
+    );
+    expect(dispositionFor('text/html', 'page.html')).toBe(
+      `attachment; filename="page.html"; filename*=UTF-8''page.html`,
+    );
   });
 
-  it('neutralizes quotes and newlines in the file name', () => {
+  it('neutralizes quotes and newlines in the ascii fallback name', () => {
     expect(dispositionFor('text/plain', 'we"ird\r\nname.txt')).toBe(
-      'attachment; filename="we_ird__name.txt"',
+      `attachment; filename="we_ird__name.txt"; filename*=UTF-8''we%22ird%0D%0Aname.txt`,
     );
+  });
+
+  it('keeps the presigned value ascii when the name has non latin1 characters', () => {
+    const disposition = dispositionFor('application/pdf', 'Designing–Data’s–O’Reilly (2017).pdf');
+    expect(/^[\x20-\x7e]*$/.test(disposition)).toBe(true);
+    expect(disposition.startsWith('inline; filename="Designing_Data_s_O_Reilly (2017).pdf"')).toBe(
+      true,
+    );
+    expect(disposition).toContain("filename*=UTF-8''");
   });
 });

--- a/apps/web/src/lib/api/content-disposition.ts
+++ b/apps/web/src/lib/api/content-disposition.ts
@@ -11,8 +11,16 @@ const INLINE_CONTENT_TYPES = [
   'audio/wav',
 ] as const;
 
+function rfc5987Encode(value: string): string {
+  return encodeURIComponent(value).replace(
+    /['()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
 export function dispositionFor(contentType: string, fileName: string): string {
   const inline = INLINE_CONTENT_TYPES.some((allowed) => allowed === contentType.toLowerCase());
-  const safeName = fileName.replace(/["\\\r\n]/g, '_');
-  return `${inline ? 'inline' : 'attachment'}; filename="${safeName}"`;
+  const type = inline ? 'inline' : 'attachment';
+  const asciiName = fileName.replace(/["\\\r\n]/g, '_').replace(/[^\x20-\x7e]/g, '_') || 'file';
+  return `${type}; filename="${asciiName}"; filename*=UTF-8''${rfc5987Encode(fileName)}`;
 }


### PR DESCRIPTION
Encode attachment download filenames so a non Latin-1 name no longer breaks the S3 presigned response-content-disposition.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes S3 presigned URL compatibility by encoding non-ASCII filenames in the `Content-Disposition` header using RFC 5987 (`filename*=UTF-8''...`), while keeping a sanitized ASCII-only `filename=` fallback for older clients.

- Adds `rfc5987Encode` which layers on top of `encodeURIComponent` to additionally percent-encode the four chars (`'`, `(`, `)`, `*`) that `encodeURIComponent` leaves unescaped but RFC 5987 forbids.
- Updates `dispositionFor` to emit both `filename="..."` (ASCII, sanitized) and `filename*=UTF-8''...` (full Unicode, RFC 5987-encoded), and adds an ASCII-guard fallback of `"file"` when the sanitized name would be empty.
- Four test cases cover ASCII names, XSS-risky media types, control-character neutralization, and an end-to-end Unicode round-trip.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a self-contained header-formatting fix with no side effects beyond the Content-Disposition value.

The RFC 5987 encoding is implemented correctly: encodeURIComponent is used as the base, and the four characters it leaves unescaped that are not valid RFC 5987 attr-char are all additionally encoded. The ASCII fallback correctly strips every non-printable-ASCII character and guards against an all-non-ASCII name producing an empty filename= parameter. Tests cover ASCII paths, control-character sanitization, and a full Unicode round-trip.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/api/content-disposition.ts | Adds RFC 5987 filename* encoding; implementation is spec-correct — the four characters left unencoded by encodeURIComponent but forbidden by attr-char are all handled by the replacement regex. |
| apps/web/src/lib/api/content-disposition.test.ts | Tests updated to match new dual-parameter format; new Unicode round-trip test validates both the ASCII-only constraint on the full disposition string and that decodeURIComponent recovers the original filename. |

<sub>Reviews (2): Last reviewed commit: ["test(files): round trip the encoded down..."](https://github.com/noveum/orbit/commit/ff30f6cee6ce968ad3a95823c3ff1b44a4fc8b1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46910522)</sub>

<!-- /greptile_comment -->