### PR TITLE
feat(landing): serve the landing page at /home for everyone

### DIFF
--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -1,7 +1,7 @@
 import { landingMetadata, landingStructuredData } from '@/features/landing/landing-meta.ts';
 import { LandingPage } from '@/features/landing/landing-page.tsx';
 
-export const metadata = landingMetadata('/home');
+export const metadata = landingMetadata('/');
 
 export default function HomeLandingPage() {
   return (

--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -1,14 +1,9 @@
-import { redirect } from 'next/navigation';
 import { landingMetadata, landingStructuredData } from '@/features/landing/landing-meta.ts';
 import { LandingPage } from '@/features/landing/landing-page.tsx';
-import { getSession } from '@/lib/auth/session.ts';
 
-export const metadata = landingMetadata('/');
+export const metadata = landingMetadata('/home');
 
-export default async function HomePage() {
-  const session = await getSession();
-  if (session !== null) redirect('/my-issues');
-
+export default function HomeLandingPage() {
   return (
     <>
       <script

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -4,7 +4,6 @@ import { absoluteUrl } from '@/lib/env.ts';
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     { url: absoluteUrl('/'), changeFrequency: 'weekly', priority: 1 },
-    { url: absoluteUrl('/home'), changeFrequency: 'weekly', priority: 0.9 },
     { url: absoluteUrl('/login'), changeFrequency: 'monthly', priority: 0.5 },
   ];
 }

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -4,6 +4,7 @@ import { absoluteUrl } from '@/lib/env.ts';
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     { url: absoluteUrl('/'), changeFrequency: 'weekly', priority: 1 },
+    { url: absoluteUrl('/home'), changeFrequency: 'weekly', priority: 0.9 },
     { url: absoluteUrl('/login'), changeFrequency: 'monthly', priority: 0.5 },
   ];
 }

--- a/apps/web/src/features/landing/landing-meta.test.ts
+++ b/apps/web/src/features/landing/landing-meta.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'bun:test';
+import { landingMetadata, landingStructuredData } from './landing-meta.ts';
+
+describe('landingMetadata', () => {
+  it('canonicalises each entry point independently and stays indexable', () => {
+    expect(landingMetadata('/').alternates?.canonical).toBe('/');
+    expect(landingMetadata('/home').alternates?.canonical).toBe('/home');
+    expect(landingMetadata('/home').robots).toMatchObject({ index: true, follow: true });
+  });
+});
+
+describe('landingStructuredData', () => {
+  it('describes a free software application for crawlers', () => {
+    const data = JSON.parse(landingStructuredData());
+    expect(data['@type']).toBe('SoftwareApplication');
+    expect(data.offers.price).toBe('0');
+    expect(Array.isArray(data.featureList)).toBe(true);
+  });
+});

--- a/apps/web/src/features/landing/landing-meta.test.ts
+++ b/apps/web/src/features/landing/landing-meta.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'bun:test';
 import { landingMetadata, landingStructuredData } from './landing-meta.ts';
 
 describe('landingMetadata', () => {
-  it('canonicalises each entry point independently and stays indexable', () => {
-    expect(landingMetadata('/').alternates?.canonical).toBe('/');
-    expect(landingMetadata('/home').alternates?.canonical).toBe('/home');
-    expect(landingMetadata('/home').robots).toMatchObject({ index: true, follow: true });
+  it('builds an absolute, indexable canonical shared by the open graph url', () => {
+    const meta = landingMetadata('/');
+    const canonical = String(meta.alternates?.canonical);
+    expect(canonical).toMatch(/^https?:\/\//);
+    expect(meta.robots).toMatchObject({ index: true, follow: true });
+    expect(meta.openGraph?.url).toBe(canonical);
   });
 });
 

--- a/apps/web/src/features/landing/landing-meta.ts
+++ b/apps/web/src/features/landing/landing-meta.ts
@@ -1,11 +1,12 @@
 import type { Metadata } from 'next';
-import { publicAppUrl } from '@/lib/env.ts';
+import { absoluteUrl, publicAppUrl } from '@/lib/env.ts';
 
 const TITLE = 'Orbit: the free, realtime, keyboard-first work tracker';
 const DESCRIPTION =
   'Orbit is a free, realtime, keyboard-first work tracker for teams: issues, boards, cycles, projects, and docs that sync instantly for everyone. No pricing, no paid tiers, ever.';
 
-export function landingMetadata(canonical: string): Metadata {
+export function landingMetadata(canonicalPath: string): Metadata {
+  const canonical = absoluteUrl(canonicalPath);
   return {
     title: { absolute: TITLE },
     description: DESCRIPTION,

--- a/apps/web/src/features/landing/landing-meta.ts
+++ b/apps/web/src/features/landing/landing-meta.ts
@@ -1,0 +1,54 @@
+import type { Metadata } from 'next';
+import { publicAppUrl } from '@/lib/env.ts';
+
+const TITLE = 'Orbit: the free, realtime, keyboard-first work tracker';
+const DESCRIPTION =
+  'Orbit is a free, realtime, keyboard-first work tracker for teams: issues, boards, cycles, projects, and docs that sync instantly for everyone. No pricing, no paid tiers, ever.';
+
+export function landingMetadata(canonical: string): Metadata {
+  return {
+    title: { absolute: TITLE },
+    description: DESCRIPTION,
+    alternates: { canonical },
+    robots: { index: true, follow: true },
+    openGraph: {
+      type: 'website',
+      url: canonical,
+      siteName: 'Orbit',
+      title: TITLE,
+      description: DESCRIPTION,
+      locale: 'en_US',
+    },
+    twitter: {
+      card: 'summary',
+      title: TITLE,
+      description: DESCRIPTION,
+    },
+  };
+}
+
+export function landingStructuredData(): string {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'Orbit',
+    applicationCategory: 'BusinessApplication',
+    operatingSystem: 'Web',
+    url: publicAppUrl(),
+    description: DESCRIPTION,
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+    featureList: [
+      'Issues and boards',
+      'Cycles and sprints',
+      'Projects',
+      'Docs with a rich editor',
+      'Realtime sync over WebSockets',
+      'Command palette and keyboard shortcuts',
+      'Filters and saved views',
+      'GitHub integration',
+      'Slack integration',
+      'Notifications',
+      'MCP server for agents',
+    ],
+  });
+}


### PR DESCRIPTION
Serve the landing page at /home so signed-in users can reach it too, sharing metadata with the root route.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the landing page metadata into a shared `landing-meta.ts` module and adds a `/home` route so authenticated users (who are redirected away from `/`) can still reach the landing page.

- **Metadata extraction**: `landingMetadata(canonicalPath)` and `landingStructuredData()` are pulled into `apps/web/src/features/landing/landing-meta.ts`, eliminating the inline duplication that existed in `app/page.tsx`.
- **New `/home` route**: `apps/web/src/app/home/page.tsx` renders the landing page with `landingMetadata('/')`, setting the canonical and Open Graph URL to `/` so search engines consolidate ranking on the root and not `/home`. `/home` is excluded from the sitemap.
- **Tests**: `landing-meta.test.ts` verifies that the canonical is an absolute URL, the page is indexable, and the Open Graph URL matches the canonical.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is a clean metadata extraction with a new unauthenticated-accessible route, no auth or data-handling paths are touched.

The refactor is mechanical: inline metadata moves to a dedicated module consumed identically by both routes. The /home route adds no new session logic, shares the same canonical URL as /, and is excluded from the sitemap. Tests cover the key invariants.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/landing/landing-meta.ts | New shared module exporting landingMetadata and landingStructuredData; correctly uses absoluteUrl to produce canonical and OG URLs from a given path |
| apps/web/src/app/home/page.tsx | New /home route serving the landing page; passes '/' to landingMetadata so the canonical points to root, preventing SEO signal dilution |
| apps/web/src/app/page.tsx | Refactored to use shared landingMetadata/landingStructuredData; auth redirect and rendering logic unchanged |
| apps/web/src/features/landing/landing-meta.test.ts | Tests using bun:test verify canonical is absolute, page is indexable, OG URL matches canonical, and structured data describes a free software application |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits /] --> B{Authenticated?}
    B -- yes --> C[redirect to /my-issues]
    B -- no --> D[Render LandingPage with canonical /]

    E[User visits /home] --> F[Render LandingPage with canonical /]

    G[landingMetadata called with path /] --> H[absoluteUrl builds absolute root URL]
    H --> I[alternates.canonical = absolute root]
    H --> J[openGraph.url = absolute root]

    D & F -.->|both use| G
    K[Sitemap] --> L[Only / is listed]
```

<sub>Reviews (2): Last reviewed commit: ["fix(landing): canonicalise /home to the ..."](https://github.com/noveum/orbit/commit/d4dcaac0ecae6548ba5509af6ad8ece795bd2ddf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46911187)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/noveum-ai/github/Noveum/orbit/-/custom-context?memory=b1d3c64d-731f-463a-94a4-788291e176f9))

<!-- /greptile_comment -->