### PR TITLE
fix(realtime): load catchup models sequentially to avoid a bun sql statement collision

### DIFF
--- a/packages/core/src/realtime/backfill.ts
+++ b/packages/core/src/realtime/backfill.ts
@@ -501,12 +501,10 @@ export async function catchUp(
 ): Promise<SyncCatchupResult> {
   assertCan(principal, 'issue:read');
   const perModel = Math.max(1, limit);
-  const loaded = await Promise.all(
-    SYNC_CATCHUP_MODELS.map(async (model) => ({
-      model,
-      rows: await LOADERS[model](principal, since, perModel + 1),
-    })),
-  );
+  const loaded: { model: SyncModel; rows: BackfilledRow[] }[] = [];
+  for (const model of SYNC_CATCHUP_MODELS) {
+    loaded.push({ model, rows: await LOADERS[model](principal, since, perModel + 1) });
+  }
 
   const all: SyncAction[] = [];
   let saturated = false;


### PR DESCRIPTION
Load reconnect backfill models one at a time so concurrent queries no longer collide Bun.SQL prepared statements.