### PR TITLE
feat(issues): non-modal resizable peek that opens from board cards

### DIFF
--- a/apps/web/src/features/issues/board.test.tsx
+++ b/apps/web/src/features/issues/board.test.tsx
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { ToastProvider } from '@/components/ui/toast.tsx';
+import { groupIssues } from '@/features/filters/grouping.ts';
+import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+import type { Issue, WorkflowState } from '@/lib/query/schemas.ts';
+import type { WorkspaceData } from './workspace-provider.tsx';
+import * as workspaceProvider from './workspace-provider.tsx';
+
+const push = mock();
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ push, replace: mock(), refresh: mock() }),
+  usePathname: () => '/team/eng/board',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const todo: WorkflowState = {
+  id: 'state_todo',
+  teamId: 'team_1',
+  name: 'Todo',
+  category: 'unstarted',
+  color: '#5d6272',
+  position: 1,
+};
+
+function issue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'issue_1',
+    organizationId: 'org_1',
+    teamId: 'team_1',
+    number: 1,
+    identifier: 'ENG-1',
+    title: 'Domain auto join',
+    description: '',
+    stateId: 'state_todo',
+    priority: 0,
+    creatorId: 'user_1',
+    assigneeId: null,
+    projectId: null,
+    milestoneId: null,
+    cycleId: null,
+    parentId: null,
+    estimate: null,
+    dueDate: null,
+    sortOrder: 1024,
+    startedAt: null,
+    completedAt: null,
+    canceledAt: null,
+    stateEnteredAt: '2026-01-01T00:00:00.000Z',
+    syncId: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    archivedAt: null,
+    labelIds: [],
+    ...overrides,
+  };
+}
+
+const workspace: WorkspaceData = {
+  ready: true,
+  userId: 'user_1',
+  teams: [{ id: 'team_1', name: 'Engineering', key: 'ENG', icon: 'circle', color: '#5a63c8' }],
+  states: [todo],
+  labels: [],
+  members: [],
+  projects: [],
+  cycles: [],
+  seedIssues: [],
+  stateById: new Map([[todo.id, todo]]),
+  labelById: new Map(),
+  memberById: new Map(),
+  openQuickCreate: () => undefined,
+};
+
+mock.module('./workspace-provider.tsx', () => ({
+  ...workspaceProvider,
+  useWorkspace: () => workspace,
+}));
+
+const { Board } = await import('./board.tsx');
+
+const second = issue({
+  id: 'issue_2',
+  number: 2,
+  identifier: 'ENG-2',
+  sortOrder: 2048,
+  title: 'Second task',
+});
+
+function renderBoard() {
+  const groups = groupIssues(
+    [issue(), second],
+    'state',
+    { states: [todo], members: [], projects: [], cycles: [], labels: [] },
+    { showEmptyGroups: false, ordering: 'manual' },
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <HotkeyProvider>
+          <Board teamId="team_1" groups={groups} draggable={false} />
+        </HotkeyProvider>
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function cardLink(identifier: string, title: string): HTMLElement {
+  const card = screen.getByTestId(`issue-card-${identifier}`);
+  return within(card).getByRole('link', { name: title });
+}
+
+describe('Board peek', () => {
+  beforeEach(() => {
+    push.mockClear();
+  });
+
+  it('opens the peek on a plain card click instead of navigating', () => {
+    renderBoard();
+    expect(screen.queryByTestId('issue-peek')).toBeNull();
+
+    act(() => {
+      fireEvent.click(cardLink('ENG-1', 'Domain auto join'));
+    });
+
+    expect(screen.getByTestId('issue-peek')).toHaveAttribute('aria-label', 'Peek ENG-1');
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('lets a modified click fall through to the link without opening the peek', () => {
+    renderBoard();
+
+    act(() => {
+      fireEvent.click(cardLink('ENG-1', 'Domain auto join'), { metaKey: true });
+    });
+
+    expect(screen.queryByTestId('issue-peek')).toBeNull();
+  });
+
+  it('switches the peeked issue when another card is clicked', () => {
+    renderBoard();
+
+    act(() => {
+      fireEvent.click(cardLink('ENG-1', 'Domain auto join'));
+    });
+    expect(screen.getByTestId('issue-peek')).toHaveAttribute('aria-label', 'Peek ENG-1');
+
+    act(() => {
+      fireEvent.click(cardLink('ENG-2', 'Second task'));
+    });
+    expect(screen.getByTestId('issue-peek')).toHaveAttribute('aria-label', 'Peek ENG-2');
+  });
+
+  it('stays non-modal so the board behind it keeps its pointer events', () => {
+    renderBoard();
+
+    act(() => {
+      fireEvent.click(cardLink('ENG-1', 'Domain auto join'));
+    });
+
+    expect(screen.getByTestId('issue-peek')).toBeInTheDocument();
+    expect(document.body.style.pointerEvents).not.toBe('none');
+    expect(screen.getByTestId('board-column-Todo')).toBeInTheDocument();
+  });
+
+  it('renders a resize handle on the peek', () => {
+    renderBoard();
+
+    act(() => {
+      fireEvent.click(cardLink('ENG-1', 'Domain auto join'));
+    });
+
+    expect(screen.getByRole('button', { name: 'Resize panel' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/issues/board.tsx
+++ b/apps/web/src/features/issues/board.tsx
@@ -22,6 +22,7 @@ import { CSS } from '@dnd-kit/utilities';
 import type { DisplayProperty } from '@orbit/shared/filters';
 import { DEFAULT_DISPLAY_PROPERTIES } from '@orbit/shared/filters';
 import { Plus } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import type { IssueGroup } from '@/features/filters/grouping.ts';
 import { cn } from '@/lib/cn.ts';
@@ -29,6 +30,7 @@ import type { Issue } from '@/lib/query/schemas.ts';
 import { type MoveInput, useMoveIssue } from '@/lib/query/use-issues.ts';
 import { GroupGlyph } from './group-glyph.tsx';
 import { IssueCard } from './issue-card.tsx';
+import { IssuePeek } from './issue-peek.tsx';
 import { useWorkspace } from './workspace-provider.tsx';
 
 export interface BoardProps {
@@ -71,9 +73,11 @@ export function planDrop(
 function SortableCard({
   issue,
   properties,
+  onOpen,
 }: {
   issue: Issue;
   properties: readonly DisplayProperty[];
+  onOpen: (id: string) => void;
 }) {
   const { labelById, memberById } = useWorkspace();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -97,6 +101,7 @@ function SortableCard({
     >
       <IssueCard
         issue={issue}
+        onOpen={onOpen}
         properties={properties}
         labels={issue.labelIds.flatMap((id) => {
           const label = labelById.get(id);
@@ -115,8 +120,10 @@ export function Board({
   properties = DEFAULT_DISPLAY_PROPERTIES,
 }: BoardProps) {
   const { labelById, memberById, openQuickCreate } = useWorkspace();
+  const router = useRouter();
   const move = useMoveIssue(teamId);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [peekId, setPeekId] = useState<string | null>(null);
 
   const issues = useMemo(() => groups.flatMap((group) => [...group.issues]), [groups]);
   const sensors = useSensors(
@@ -125,6 +132,7 @@ export function Board({
   );
 
   const activeIssue = issues.find((issue) => issue.id === activeId);
+  const peekIssue = issues.find((issue) => issue.id === peekId);
 
   const onDragStart = (event: DragStartEvent) => {
     setActiveId(String(event.active.id));
@@ -146,12 +154,30 @@ export function Board({
           draggable={draggable}
           properties={properties}
           onCreate={() => openQuickCreate()}
+          onOpen={setPeekId}
         />
       ))}
     </div>
   );
 
-  if (!draggable) return columns;
+  const peek = (
+    <IssuePeek
+      issue={peekIssue}
+      onClose={() => setPeekId(null)}
+      onOpen={() => {
+        if (peekIssue !== undefined) router.push(`/issue/${peekIssue.identifier}`);
+      }}
+    />
+  );
+
+  if (!draggable) {
+    return (
+      <>
+        {columns}
+        {peek}
+      </>
+    );
+  }
 
   return (
     <DndContext
@@ -179,6 +205,8 @@ export function Board({
           />
         )}
       </DragOverlay>
+
+      {peek}
     </DndContext>
   );
 }
@@ -188,16 +216,17 @@ interface BoardColumnProps {
   readonly draggable: boolean;
   readonly properties: readonly DisplayProperty[];
   readonly onCreate: () => void;
+  readonly onOpen: (id: string) => void;
 }
 
-function BoardColumn({ group, draggable, properties, onCreate }: BoardColumnProps) {
+function BoardColumn({ group, draggable, properties, onCreate, onOpen }: BoardColumnProps) {
   const { setNodeRef } = useDroppable({ id: group.id, data: { isColumn: true } });
 
   const cards = group.issues.map((issue) =>
     draggable ? (
-      <SortableCard key={issue.id} issue={issue} properties={properties} />
+      <SortableCard key={issue.id} issue={issue} properties={properties} onOpen={onOpen} />
     ) : (
-      <StaticCard key={issue.id} issue={issue} properties={properties} />
+      <StaticCard key={issue.id} issue={issue} properties={properties} onOpen={onOpen} />
     ),
   );
 
@@ -249,15 +278,18 @@ function BoardColumn({ group, draggable, properties, onCreate }: BoardColumnProp
 function StaticCard({
   issue,
   properties,
+  onOpen,
 }: {
   issue: Issue;
   properties: readonly DisplayProperty[];
+  onOpen: (id: string) => void;
 }) {
   const { labelById, memberById } = useWorkspace();
   return (
     <li className="list-none">
       <IssueCard
         issue={issue}
+        onOpen={onOpen}
         properties={properties}
         labels={issue.labelIds.flatMap((id) => {
           const label = labelById.get(id);

--- a/apps/web/src/features/issues/issue-card.tsx
+++ b/apps/web/src/features/issues/issue-card.tsx
@@ -3,6 +3,7 @@
 import type { DisplayProperty } from '@orbit/shared/filters';
 import { DEFAULT_DISPLAY_PROPERTIES } from '@orbit/shared/filters';
 import Link from 'next/link';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 import { Avatar } from '@/components/ui/avatar.tsx';
 import { cn } from '@/lib/cn.ts';
 import type { Issue, Label, Member } from '@/lib/query/schemas.ts';
@@ -15,6 +16,11 @@ export interface IssueCardProps {
   readonly dragging?: boolean;
   readonly properties?: readonly DisplayProperty[];
   readonly className?: string;
+  readonly onOpen?: (issueId: string) => void;
+}
+
+function isPlainClick(event: ReactMouseEvent<HTMLElement>): boolean {
+  return event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
 }
 
 export function IssueCard({
@@ -24,14 +30,21 @@ export function IssueCard({
   dragging = false,
   properties = DEFAULT_DISPLAY_PROPERTIES,
   className,
+  onOpen,
 }: IssueCardProps) {
   const shows = (property: DisplayProperty) => properties.includes(property);
+
+  const open = (event: ReactMouseEvent<HTMLElement>) => {
+    if (onOpen === undefined || event.defaultPrevented || !isPlainClick(event)) return;
+    event.preventDefault();
+    onOpen(issue.id);
+  };
 
   return (
     <article
       data-testid={`issue-card-${issue.identifier}`}
       className={cn(
-        'flex select-none flex-col gap-2 rounded-lg border border-border bg-surface p-2.5',
+        'relative flex select-none flex-col gap-2 rounded-lg border border-border bg-surface p-2.5',
         'transition-[transform,box-shadow,opacity,background-color,border-color] ease-[var(--ease-standard)] motion-reduce:transition-none',
         'duration-[var(--duration-instant)] hover:duration-[var(--duration-base)]',
         'hover:border-border-strong hover:bg-surface-2',
@@ -58,7 +71,9 @@ export function IssueCard({
 
       <Link
         href={`/issue/${issue.identifier}`}
-        className="line-clamp-3 text-dense text-text leading-snug hover:text-accent"
+        onClick={open}
+        draggable={false}
+        className="line-clamp-3 text-dense text-text leading-snug after:absolute after:inset-0 hover:text-accent"
       >
         {issue.title}
       </Link>

--- a/apps/web/src/features/issues/issue-peek.tsx
+++ b/apps/web/src/features/issues/issue-peek.tsx
@@ -89,6 +89,12 @@ export function IssuePeek({ issue, onClose, onOpen }: IssuePeekProps) {
           data-testid="issue-peek"
           aria-label={`Peek ${issue.identifier}`}
           style={{ width }}
+          onInteractOutside={(event) => {
+            const target = event.target instanceof Element ? event.target : null;
+            if (target?.closest('[data-testid^="issue-row-"], [data-testid^="issue-card-"]')) {
+              event.preventDefault();
+            }
+          }}
           className={cn(
             'fixed inset-y-0 right-0 z-50 flex max-w-[90vw] flex-col border-border border-l bg-surface shadow-pop',
             'data-[state=open]:animate-panel-in data-[state=closed]:animate-panel-out',

--- a/apps/web/src/features/issues/issue-peek.tsx
+++ b/apps/web/src/features/issues/issue-peek.tsx
@@ -2,10 +2,40 @@
 
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { ArrowUpRight, X } from 'lucide-react';
-import { overlayClassName } from '@/components/ui/dialog.tsx';
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  useState,
+} from 'react';
 import { cn } from '@/lib/cn.ts';
 import type { Issue } from '@/lib/query/schemas.ts';
 import { IssueDetailView } from './issue-detail.tsx';
+
+const MIN_WIDTH = 380;
+const DEFAULT_WIDTH = 640;
+const KEYBOARD_STEP = 24;
+const WIDTH_STORAGE_KEY = 'orbit:peek-width';
+
+function maxWidth(): number {
+  if (typeof window === 'undefined') return 900;
+  return Math.min(window.innerWidth * 0.9, 900);
+}
+
+function clampWidth(value: number): number {
+  return Math.max(MIN_WIDTH, Math.min(value, maxWidth()));
+}
+
+function readStoredWidth(): number {
+  if (typeof window === 'undefined') return DEFAULT_WIDTH;
+  const raw = window.localStorage.getItem(WIDTH_STORAGE_KEY);
+  const parsed = raw === null ? Number.NaN : Number.parseInt(raw, 10);
+  return clampWidth(Number.isNaN(parsed) ? DEFAULT_WIDTH : parsed);
+}
+
+function storeWidth(value: number): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(WIDTH_STORAGE_KEY, String(Math.round(value)));
+}
 
 export interface IssuePeekProps {
   readonly issue: Issue | undefined;
@@ -14,22 +44,53 @@ export interface IssuePeekProps {
 }
 
 export function IssuePeek({ issue, onClose, onOpen }: IssuePeekProps) {
+  const [width, setWidth] = useState(readStoredWidth);
+
   if (issue === undefined) return null;
+
+  const startResize = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    const handle = event.currentTarget;
+    handle.setPointerCapture(event.pointerId);
+    let next = width;
+    const onMove = (moveEvent: PointerEvent) => {
+      next = clampWidth(window.innerWidth - moveEvent.clientX);
+      setWidth(next);
+    };
+    const stop = () => {
+      handle.removeEventListener('pointermove', onMove);
+      handle.removeEventListener('pointerup', stop);
+      handle.removeEventListener('pointercancel', stop);
+      storeWidth(next);
+    };
+    handle.addEventListener('pointermove', onMove);
+    handle.addEventListener('pointerup', stop);
+    handle.addEventListener('pointercancel', stop);
+  };
+
+  const nudge = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+    event.preventDefault();
+    const next = clampWidth(width + (event.key === 'ArrowLeft' ? KEYBOARD_STEP : -KEYBOARD_STEP));
+    setWidth(next);
+    storeWidth(next);
+  };
 
   return (
     <DialogPrimitive.Root
       open
+      modal={false}
       onOpenChange={(open) => {
         if (!open) onClose();
       }}
     >
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className={overlayClassName} />
         <DialogPrimitive.Content
           data-testid="issue-peek"
           aria-label={`Peek ${issue.identifier}`}
+          style={{ width }}
           className={cn(
-            'fixed inset-y-0 right-0 z-50 flex w-full max-w-2xl flex-col border-border border-l bg-surface shadow-pop',
+            'fixed inset-y-0 right-0 z-50 flex max-w-[90vw] flex-col border-border border-l bg-surface shadow-pop',
             'data-[state=open]:animate-panel-in data-[state=closed]:animate-panel-out',
             'motion-reduce:animate-none',
           )}
@@ -60,6 +121,17 @@ export function IssuePeek({ issue, onClose, onOpen }: IssuePeekProps) {
           <div className="min-h-0 flex-1 overflow-y-auto">
             <IssueDetailView identifier={issue.identifier} />
           </div>
+          <button
+            type="button"
+            aria-label="Resize panel"
+            onPointerDown={startResize}
+            onKeyDown={nudge}
+            className={cn(
+              'absolute inset-y-0 left-0 z-10 w-1 cursor-col-resize touch-none bg-transparent',
+              'transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)] motion-reduce:transition-none',
+              'hover:bg-accent focus-visible:bg-accent focus-visible:outline-none',
+            )}
+          />
         </DialogPrimitive.Content>
       </DialogPrimitive.Portal>
     </DialogPrimitive.Root>


### PR DESCRIPTION
Make the issue peek a non-modal, left-edge-resizable side panel and open it from board cards in-app while preserving deep links.