### PR TITLE
fix(auth): surface OAuth sign-in and account-linking errors to the user

### DIFF
--- a/apps/web/src/app/(app)/settings/account/connections/page.tsx
+++ b/apps/web/src/app/(app)/settings/account/connections/page.tsx
@@ -1,10 +1,17 @@
+import { AuthErrorNotice } from '@/components/auth/auth-error-notice.tsx';
 import { ConnectedAccounts } from '@/features/account/connected-accounts.tsx';
 import { countPasskeys, listConnectedAccounts } from '@/features/account/data.ts';
+import { authErrorCode } from '@/lib/auth/oauth-error.ts';
 import { enabledSocialProviders } from '@/lib/auth/server.ts';
 import { requireSession } from '@/lib/auth/session.ts';
 
-export default async function ConnectedAccountsPage() {
+export default async function ConnectedAccountsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   const session = await requireSession();
+  const errorCode = authErrorCode((await searchParams)['error']);
   const [accounts, passkeyCount] = await Promise.all([
     listConnectedAccounts(),
     countPasskeys(session.user.id),
@@ -23,6 +30,9 @@ export default async function ConnectedAccountsPage() {
         passkeyCount={passkeyCount}
         availableProviders={enabledSocialProviders}
       />
+      {errorCode === undefined ? null : (
+        <AuthErrorNotice code={errorCode} title="Couldn't connect account" />
+      )}
     </section>
   );
 }

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
+import { AuthErrorNotice } from '@/components/auth/auth-error-notice.tsx';
 import { DevSignIn } from '@/components/auth/dev-sign-in.tsx';
 import { LoginForm } from '@/components/auth/login-form.tsx';
 import { devLoginEnabled } from '@/lib/api/dev-login.ts';
 import { listDevUsers } from '@/lib/api/dev-users.ts';
+import { authErrorCode } from '@/lib/auth/oauth-error.ts';
 import { enabledSocialProviders, passwordAuthEnabled } from '@/lib/auth/server.ts';
 import { getSession } from '@/lib/auth/session.ts';
 
@@ -21,6 +23,7 @@ export default async function LoginPage({
 }) {
   const params = await searchParams;
   const callbackUrl = safeCallback(params['next']);
+  const errorCode = authErrorCode(params['error']);
   const session = await getSession();
   if (session !== null) redirect(callbackUrl ?? '/my-issues');
 
@@ -38,6 +41,7 @@ export default async function LoginPage({
           <DevSignIn users={devUsers} callbackUrl={callbackUrl ?? '/my-issues'} />
         ) : null}
       </div>
+      {errorCode === undefined ? null : <AuthErrorNotice code={errorCode} />}
     </main>
   );
 }

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -25,7 +25,7 @@ describe('HomePage', () => {
   });
 
   it('renders the landing hero for a logged-out visitor', async () => {
-    render(await HomePage());
+    render(await HomePage({ searchParams: Promise.resolve({}) }));
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
       'Issue tracking at the speed of typing.',
     );
@@ -34,6 +34,8 @@ describe('HomePage', () => {
 
   it('redirects a logged-in visitor to their issues', async () => {
     sessionHolder.value = { user: { id: 'user-1' } };
-    await expect(HomePage()).rejects.toThrow('redirect:/my-issues');
+    await expect(HomePage({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+      'redirect:/my-issues',
+    );
   });
 });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,13 +1,21 @@
 import { redirect } from 'next/navigation';
+import { AuthErrorNotice } from '@/components/auth/auth-error-notice.tsx';
 import { landingMetadata, landingStructuredData } from '@/features/landing/landing-meta.ts';
 import { LandingPage } from '@/features/landing/landing-page.tsx';
+import { authErrorCode } from '@/lib/auth/oauth-error.ts';
 import { getSession } from '@/lib/auth/session.ts';
 
 export const metadata = landingMetadata('/');
 
-export default async function HomePage() {
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   const session = await getSession();
   if (session !== null) redirect('/my-issues');
+
+  const errorCode = authErrorCode((await searchParams)['error']);
 
   return (
     <>
@@ -17,6 +25,7 @@ export default async function HomePage() {
         dangerouslySetInnerHTML={{ __html: landingStructuredData() }}
       />
       <LandingPage />
+      {errorCode === undefined ? null : <AuthErrorNotice code={errorCode} />}
     </>
   );
 }

--- a/apps/web/src/components/auth/auth-error-notice.test.tsx
+++ b/apps/web/src/components/auth/auth-error-notice.test.tsx
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { render, waitFor } from '@testing-library/react';
+import { AuthErrorNotice } from './auth-error-notice.tsx';
+
+const replace = mock();
+const toast = mock();
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ replace, push: mock(), refresh: mock() }),
+}));
+
+mock.module('@/components/ui/toast.tsx', () => ({
+  useToast: () => ({ toast, dismiss: mock() }),
+}));
+
+beforeEach(() => {
+  replace.mockReset();
+  toast.mockReset();
+  window.history.replaceState({}, '', '/login');
+});
+
+describe('AuthErrorNotice', () => {
+  it('toasts a friendly message for the callback error code', async () => {
+    window.history.replaceState({}, '', '/login?error=access_denied');
+    render(<AuthErrorNotice code="access_denied" />);
+    await waitFor(() => expect(toast).toHaveBeenCalledTimes(1));
+    const options = toast.mock.calls[0]?.[0] as {
+      description: string;
+      tone: string;
+      title: string;
+    };
+    expect(options.tone).toBe('danger');
+    expect(options.title).toBe('Sign in failed');
+    expect(options.description).toContain('cancelled');
+  });
+
+  it('uses a custom title when provided', async () => {
+    window.history.replaceState({}, '', "/settings/account/connections?error=email_doesn't_match");
+    render(<AuthErrorNotice code="email_doesn't_match" title="Couldn't connect account" />);
+    await waitFor(() => expect(toast).toHaveBeenCalledTimes(1));
+    const options = toast.mock.calls[0]?.[0] as { title: string };
+    expect(options.title).toBe("Couldn't connect account");
+  });
+
+  it('strips the error params from the URL after showing it', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/login?error=access_denied&error_description=nope&next=/x',
+    );
+    render(<AuthErrorNotice code="access_denied" />);
+    await waitFor(() => expect(replace).toHaveBeenCalledTimes(1));
+    const target = replace.mock.calls[0]?.[0] as string;
+    expect(target).not.toContain('error');
+    expect(target).toContain('next=%2Fx');
+  });
+});

--- a/apps/web/src/components/auth/auth-error-notice.tsx
+++ b/apps/web/src/components/auth/auth-error-notice.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { useToast } from '@/components/ui/toast.tsx';
+import { describeAuthError } from '@/lib/auth/oauth-error.ts';
+
+export interface AuthErrorNoticeProps {
+  readonly code: string;
+  readonly title?: string;
+}
+
+export function AuthErrorNotice({ code, title = 'Sign in failed' }: AuthErrorNoticeProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const handled = useRef(false);
+
+  useEffect(() => {
+    if (handled.current) return;
+    handled.current = true;
+    toast({ title, description: describeAuthError(code), tone: 'danger' });
+    const url = new URL(window.location.href);
+    url.searchParams.delete('error');
+    url.searchParams.delete('error_description');
+    router.replace(`${url.pathname}${url.search}${url.hash}`, { scroll: false });
+  }, [code, title, router, toast]);
+
+  return null;
+}

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -161,7 +161,11 @@ export function LoginForm({
 
   const signInWithSocial = (provider: 'google' | 'github') =>
     withPending(provider, async () => {
-      const result = await authClient.signIn.social({ provider, callbackURL: callbackUrl });
+      const result = await authClient.signIn.social({
+        provider,
+        callbackURL: callbackUrl,
+        errorCallbackURL: '/login',
+      });
       if (result.error) throw new Error(result.error.message ?? 'That provider is unavailable.');
     });
 

--- a/apps/web/src/features/account/connected-accounts.test.tsx
+++ b/apps/web/src/features/account/connected-accounts.test.tsx
@@ -144,6 +144,7 @@ describe('ConnectedAccounts', () => {
       expect(linkSocial).toHaveBeenCalledWith({
         provider: 'google',
         callbackURL: '/settings/account/connections',
+        errorCallbackURL: '/settings/account/connections',
       });
     });
   });

--- a/apps/web/src/features/account/connected-accounts.tsx
+++ b/apps/web/src/features/account/connected-accounts.tsx
@@ -54,6 +54,7 @@ export function ConnectedAccounts({
       const result = await authClient.linkSocial({
         provider,
         callbackURL: '/settings/account/connections',
+        errorCallbackURL: '/settings/account/connections',
       });
       if (result.error) throw new Error(result.error.message ?? 'That provider is unavailable.');
     } catch (caught) {

--- a/apps/web/src/lib/auth/oauth-error.test.ts
+++ b/apps/web/src/lib/auth/oauth-error.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test';
+import { authErrorCode, describeAuthError } from './oauth-error.ts';
+
+describe('describeAuthError', () => {
+  it('maps the email mismatch code returned by the GitHub callback', () => {
+    expect(describeAuthError("email_doesn't_match")).toContain('different email');
+  });
+
+  it('is case insensitive and trims the code', () => {
+    expect(describeAuthError('  ACCESS_DENIED ')).toBe(describeAuthError('access_denied'));
+  });
+
+  it('maps the server domain-restriction code', () => {
+    expect(describeAuthError('EMAIL_DOMAIN_NOT_ALLOWED')).toContain('domain is not allowed');
+  });
+
+  it('falls back to a friendly message for unknown codes', () => {
+    expect(describeAuthError('some_brand_new_code')).toBe(
+      'We could not complete that sign in. Please try again.',
+    );
+  });
+});
+
+describe('authErrorCode', () => {
+  it('returns a present code', () => {
+    expect(authErrorCode("email_doesn't_match")).toBe("email_doesn't_match");
+  });
+
+  it('takes the first value of an array', () => {
+    expect(authErrorCode(['access_denied', 'other'])).toBe('access_denied');
+  });
+
+  it('treats missing or empty values as no error', () => {
+    expect(authErrorCode(undefined)).toBeUndefined();
+    expect(authErrorCode('')).toBeUndefined();
+    expect(authErrorCode([])).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/auth/oauth-error.ts
+++ b/apps/web/src/lib/auth/oauth-error.ts
@@ -1,0 +1,34 @@
+const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  "email_doesn't_match":
+    'That provider account uses a different email than your Orbit account. Connect one whose primary email matches, or line up the emails first.',
+  account_already_linked_to_different_user:
+    'That provider account is already linked to a different Orbit user. Sign in as that user, or disconnect it there first.',
+  unable_to_link_account:
+    'We could not link that account. The provider did not return a verified email, so linking was declined.',
+  unable_to_get_user_info:
+    'The provider did not share your account details. Check the connection permissions and try again.',
+  email_not_found: 'No Orbit account matches that provider email. Sign up first, then connect it.',
+  email_domain_not_allowed:
+    'Your email domain is not allowed on this workspace. Ask an admin to invite you.',
+  signup_disabled: 'New accounts are not open on this server. Ask an admin for an invite.',
+  access_denied: 'You cancelled before granting access. Try again when you are ready.',
+  no_code: 'The sign in did not finish. Start again.',
+  invalid_code: 'The sign in link expired before it completed. Start again.',
+  oauth_code_verification_failed: 'The sign in could not be verified. Start again.',
+  state_not_found: 'This sign in took too long and expired. Start again.',
+  please_restart_the_process: 'This sign in took too long and expired. Start again.',
+  no_callback_url: 'Something went wrong finishing the sign in. Start again.',
+  oauth_provider_not_found: 'That provider is not configured on this server.',
+  internal_server_error: 'Something went wrong on our end. Try again in a moment.',
+};
+
+export function describeAuthError(rawCode: string): string {
+  const known = OAUTH_ERROR_MESSAGES[rawCode.trim().toLowerCase()];
+  if (known !== undefined) return known;
+  return 'We could not complete that sign in. Please try again.';
+}
+
+export function authErrorCode(value: string | string[] | undefined): string | undefined {
+  const code = Array.isArray(value) ? value[0] : value;
+  return code !== undefined && code.length > 0 ? code : undefined;
+}


### PR DESCRIPTION
Route OAuth callback errors (e.g. email_doesn't_match) back into the login and connections UI with friendly messages instead of a silent redirect.