### PR TITLE
feat(web): instant loading skeletons for cycles, inbox, settings, and issue detail

### DIFF
--- a/apps/web/src/app/(app)/cycles/loading.tsx
+++ b/apps/web/src/app/(app)/cycles/loading.tsx
@@ -1,0 +1,5 @@
+import { CycleSkeleton } from '@/features/cycles/cycle-skeleton.tsx';
+
+export default function CyclesLoading() {
+  return <CycleSkeleton panels={2} />;
+}

--- a/apps/web/src/app/(app)/inbox/loading.tsx
+++ b/apps/web/src/app/(app)/inbox/loading.tsx
@@ -1,0 +1,5 @@
+import { InboxSkeleton } from '@/features/inbox/inbox-skeleton.tsx';
+
+export default function InboxLoading() {
+  return <InboxSkeleton />;
+}

--- a/apps/web/src/app/(app)/issue/[identifier]/loading.tsx
+++ b/apps/web/src/app/(app)/issue/[identifier]/loading.tsx
@@ -1,0 +1,5 @@
+import { IssueDetailSkeleton } from '@/features/issues/issue-detail-skeleton.tsx';
+
+export default function IssueLoading() {
+  return <IssueDetailSkeleton />;
+}

--- a/apps/web/src/app/(app)/settings/general/loading.tsx
+++ b/apps/web/src/app/(app)/settings/general/loading.tsx
@@ -1,0 +1,5 @@
+import { GeneralSettingsSkeleton } from '@/features/settings/settings-skeletons.tsx';
+
+export default function GeneralSettingsLoading() {
+  return <GeneralSettingsSkeleton />;
+}

--- a/apps/web/src/app/(app)/settings/integrations/loading.tsx
+++ b/apps/web/src/app/(app)/settings/integrations/loading.tsx
@@ -1,0 +1,5 @@
+import { IntegrationsSettingsSkeleton } from '@/features/settings/settings-skeletons.tsx';
+
+export default function IntegrationsSettingsLoading() {
+  return <IntegrationsSettingsSkeleton />;
+}

--- a/apps/web/src/app/(app)/settings/loading.tsx
+++ b/apps/web/src/app/(app)/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { GeneralSettingsSkeleton } from '@/features/settings/settings-skeletons.tsx';
+
+export default function SettingsLoading() {
+  return <GeneralSettingsSkeleton />;
+}

--- a/apps/web/src/app/(app)/settings/members/loading.tsx
+++ b/apps/web/src/app/(app)/settings/members/loading.tsx
@@ -1,0 +1,5 @@
+import { MembersSettingsSkeleton } from '@/features/settings/settings-skeletons.tsx';
+
+export default function MembersSettingsLoading() {
+  return <MembersSettingsSkeleton />;
+}

--- a/apps/web/src/app/(app)/settings/notifications/loading.tsx
+++ b/apps/web/src/app/(app)/settings/notifications/loading.tsx
@@ -1,0 +1,5 @@
+import { NotificationsSettingsSkeleton } from '@/features/settings/settings-skeletons.tsx';
+
+export default function NotificationsSettingsLoading() {
+  return <NotificationsSettingsSkeleton />;
+}

--- a/apps/web/src/app/(app)/settings/teams/loading.tsx
+++ b/apps/web/src/app/(app)/settings/teams/loading.tsx
@@ -1,0 +1,5 @@
+import { TeamsSettingsSkeleton } from '@/features/settings/settings-skeletons.tsx';
+
+export default function TeamsSettingsLoading() {
+  return <TeamsSettingsSkeleton />;
+}

--- a/apps/web/src/app/(app)/team/[key]/cycle/active/loading.tsx
+++ b/apps/web/src/app/(app)/team/[key]/cycle/active/loading.tsx
@@ -1,0 +1,5 @@
+import { CycleSkeleton } from '@/features/cycles/cycle-skeleton.tsx';
+
+export default function ActiveCycleLoading() {
+  return <CycleSkeleton panels={1} />;
+}

--- a/apps/web/src/features/cycles/cycle-skeleton.test.tsx
+++ b/apps/web/src/features/cycles/cycle-skeleton.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'bun:test';
+import { render } from '@testing-library/react';
+import { CycleSkeleton } from './cycle-skeleton.tsx';
+
+describe('CycleSkeleton', () => {
+  it('renders the cycles skeleton', () => {
+    const { getByTestId } = render(<CycleSkeleton />);
+    expect(getByTestId('cycles-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders a single panel when asked', () => {
+    const { getByTestId } = render(<CycleSkeleton panels={1} />);
+    expect(getByTestId('cycles-skeleton')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/cycles/cycle-skeleton.tsx
+++ b/apps/web/src/features/cycles/cycle-skeleton.tsx
@@ -1,0 +1,119 @@
+import { Skeleton } from '@/components/ui/skeleton.tsx';
+
+const ISSUE_GROUPS = [
+  { id: 'group-a', rows: ['a', 'b', 'c', 'd'] },
+  { id: 'group-b', rows: ['a', 'b', 'c'] },
+];
+
+const ASSIGNEES = ['first', 'second', 'third'];
+
+const UPCOMING = ['first', 'second'];
+
+const PANEL_IDS = ['primary', 'secondary'];
+
+function CycleIssueListSkeleton() {
+  return (
+    <div className="flex flex-col gap-5">
+      {ISSUE_GROUPS.map((group) => (
+        <section key={group.id} className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-2">
+            <Skeleton className="size-2 rounded-full" />
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-3 w-4" />
+          </div>
+          <ul className="flex flex-col rounded-lg border border-border">
+            {group.rows.map((row) => (
+              <li
+                key={row}
+                className="flex items-center gap-3 border-border border-b px-3 py-1.5 last:border-b-0"
+              >
+                <Skeleton className="h-3 w-16 shrink-0" />
+                <Skeleton className="h-3 min-w-0 flex-1" />
+                <Skeleton className="size-4.5 shrink-0 rounded-full" />
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function CycleAnalyticsSkeleton() {
+  return (
+    <aside className="flex flex-col gap-5 rounded-lg border border-border p-4">
+      <div className="grid grid-cols-3 gap-2">
+        {['scope', 'started', 'completed'].map((stat) => (
+          <div key={stat} className="flex flex-col items-center gap-1">
+            <Skeleton className="h-6 w-8" />
+            <Skeleton className="h-2 w-12" />
+          </div>
+        ))}
+      </div>
+      <Skeleton className="h-36 w-full rounded-md" />
+      <div className="flex flex-col gap-2.5">
+        <Skeleton className="h-3 w-24" />
+        {ASSIGNEES.map((assignee) => (
+          <div key={assignee} className="flex flex-col gap-1">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-1.5">
+                <Skeleton className="size-4 rounded-full" />
+                <Skeleton className="h-3 w-20" />
+              </div>
+              <Skeleton className="h-2 w-8" />
+            </div>
+            <Skeleton className="h-1.5 w-full rounded-full" />
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+function CyclePanelSkeleton() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center gap-2">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-5 w-12 rounded-full" />
+        <Skeleton className="h-3 w-32" />
+      </div>
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <CycleIssueListSkeleton />
+        <CycleAnalyticsSkeleton />
+      </div>
+      <section className="flex flex-col gap-2">
+        <Skeleton className="h-3 w-32" />
+        <ul className="flex flex-col gap-1.5">
+          {UPCOMING.map((entry) => (
+            <li
+              key={entry}
+              className="flex items-center justify-between gap-2 rounded-md border border-border px-3 py-1.5"
+            >
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-4 w-10 rounded-full" />
+                <Skeleton className="h-3 w-40" />
+              </div>
+              <Skeleton className="h-2 w-24" />
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+export function CycleSkeleton({ panels = 2 }: { readonly panels?: number }) {
+  const ids = PANEL_IDS.slice(0, Math.max(1, panels));
+  return (
+    <div className="flex flex-col gap-10 px-6 py-6" data-testid="cycles-skeleton">
+      <header className="flex flex-col gap-1">
+        <Skeleton className="h-6 w-32" />
+        <Skeleton className="h-3 w-80 max-w-full" />
+      </header>
+      {ids.map((id) => (
+        <CyclePanelSkeleton key={id} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/inbox/inbox-skeleton.test.tsx
+++ b/apps/web/src/features/inbox/inbox-skeleton.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'bun:test';
+import { render } from '@testing-library/react';
+import { InboxSkeleton } from './inbox-skeleton.tsx';
+
+describe('InboxSkeleton', () => {
+  it('renders the inbox skeleton', () => {
+    const { getByTestId } = render(<InboxSkeleton />);
+    expect(getByTestId('inbox-skeleton')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/inbox/inbox-skeleton.tsx
+++ b/apps/web/src/features/inbox/inbox-skeleton.tsx
@@ -1,0 +1,49 @@
+import { Skeleton } from '@/components/ui/skeleton.tsx';
+
+const TABS = ['all', 'unread', 'mentions', 'pulls'];
+
+const ROWS = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+
+export function InboxSkeleton() {
+  return (
+    <div className="flex min-h-full flex-col" data-testid="inbox-skeleton">
+      <header className="flex flex-col gap-3 border-border border-b px-5 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-5 w-16" />
+            <Skeleton className="h-5 w-20 rounded-full" />
+          </div>
+          <Skeleton className="hidden h-4 w-64 sm:block" />
+        </div>
+        <nav className="flex items-center gap-1" aria-label="Inbox filters">
+          {TABS.map((tab) => (
+            <Skeleton key={tab} className="h-6 w-20 rounded-md" />
+          ))}
+        </nav>
+      </header>
+
+      <div className="grid flex-1 grid-cols-1 md:grid-cols-[22rem_minmax(0,1fr)]">
+        <ul className="flex flex-col border-border border-r">
+          {ROWS.map((row) => (
+            <li key={row} className="flex items-start gap-2.5 border-border border-b px-3 py-2.5">
+              <Skeleton className="mt-1.5 size-1.5 shrink-0 rounded-full" />
+              <Skeleton className="mt-0.5 size-3.5 shrink-0 rounded-sm" />
+              <div className="flex min-w-0 flex-1 flex-col gap-1">
+                <Skeleton className="h-3 w-48 max-w-full" />
+                <Skeleton className="h-2 w-28" />
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <section className="hidden flex-col gap-3 p-5 md:flex">
+          <Skeleton className="h-6 w-2/3" />
+          <Skeleton className="h-2 w-40" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-3 w-24" />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/issues/issue-detail-skeleton.test.tsx
+++ b/apps/web/src/features/issues/issue-detail-skeleton.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'bun:test';
+import { render } from '@testing-library/react';
+import { IssueDetailSkeleton } from './issue-detail-skeleton.tsx';
+
+describe('IssueDetailSkeleton', () => {
+  it('renders the issue detail skeleton', () => {
+    const { getByTestId } = render(<IssueDetailSkeleton />);
+    expect(getByTestId('issue-detail-skeleton')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/issues/issue-detail-skeleton.tsx
+++ b/apps/web/src/features/issues/issue-detail-skeleton.tsx
@@ -1,0 +1,54 @@
+import { Skeleton } from '@/components/ui/skeleton.tsx';
+
+const PROPERTY_ROWS = ['status', 'priority', 'assignee', 'estimate', 'labels', 'project', 'cycle'];
+
+const DESCRIPTION_LINES = ['a', 'b', 'c', 'd'];
+
+function IssuePropertiesSkeleton() {
+  return (
+    <aside className="flex w-full shrink-0 flex-col gap-0.5 border-border border-t p-3 lg:w-64 lg:border-t-0 lg:border-l">
+      {PROPERTY_ROWS.map((row) => (
+        <div key={row} className="flex flex-col gap-0.5">
+          <div className="flex items-center gap-1.5 px-2 pt-2">
+            <Skeleton className="h-2 w-14" />
+          </div>
+          <div className="flex items-center gap-2 px-2 py-1.5">
+            <Skeleton className="size-4 rounded-full" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+        </div>
+      ))}
+    </aside>
+  );
+}
+
+export function IssueDetailSkeleton() {
+  return (
+    <div className="flex h-full min-h-0 flex-col lg:flex-row" data-testid="issue-detail-skeleton">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <header className="flex items-center gap-2 border-border border-b px-5 py-2.5">
+          <Skeleton className="h-3 w-12" />
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="size-3.5 rounded-sm" />
+          <Skeleton className="ml-auto h-6 w-24 rounded-md" />
+        </header>
+
+        <div className="mx-auto flex max-w-3xl flex-col gap-6 px-5 py-6">
+          <Skeleton className="h-7 w-2/3" />
+          <div className="flex flex-col gap-2">
+            {DESCRIPTION_LINES.map((line) => (
+              <Skeleton key={line} className="h-4 w-full" />
+            ))}
+            <Skeleton className="h-4 w-1/2" />
+          </div>
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-3 w-28" />
+            <Skeleton className="h-16 w-full rounded-md" />
+          </div>
+        </div>
+      </div>
+
+      <IssuePropertiesSkeleton />
+    </div>
+  );
+}

--- a/apps/web/src/features/settings/settings-skeletons.test.tsx
+++ b/apps/web/src/features/settings/settings-skeletons.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+import { render } from '@testing-library/react';
+import {
+  GeneralSettingsSkeleton,
+  IntegrationsSettingsSkeleton,
+  MembersSettingsSkeleton,
+  NotificationsSettingsSkeleton,
+  TeamsSettingsSkeleton,
+} from './settings-skeletons.tsx';
+
+describe('settings skeletons', () => {
+  it('renders the general settings skeleton', () => {
+    const { getByTestId } = render(<GeneralSettingsSkeleton />);
+    expect(getByTestId('settings-general-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders the integrations settings skeleton', () => {
+    const { getByTestId } = render(<IntegrationsSettingsSkeleton />);
+    expect(getByTestId('settings-integrations-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders the teams settings skeleton', () => {
+    const { getByTestId } = render(<TeamsSettingsSkeleton />);
+    expect(getByTestId('settings-teams-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders the members settings skeleton', () => {
+    const { getByTestId } = render(<MembersSettingsSkeleton />);
+    expect(getByTestId('settings-members-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders the notifications settings skeleton', () => {
+    const { getByTestId } = render(<NotificationsSettingsSkeleton />);
+    expect(getByTestId('settings-notifications-skeleton')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/settings/settings-skeletons.tsx
+++ b/apps/web/src/features/settings/settings-skeletons.tsx
@@ -1,0 +1,231 @@
+import { Skeleton } from '@/components/ui/skeleton.tsx';
+
+function SettingsHeading({ subtitle = true }: { readonly subtitle?: boolean }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <Skeleton className="h-6 w-32" />
+      {subtitle ? <Skeleton className="h-3 w-80 max-w-full" /> : null}
+    </div>
+  );
+}
+
+function FormRowSkeleton({ hint = false }: { readonly hint?: boolean }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Skeleton className="h-3 w-32" />
+      <Skeleton className="h-9 w-full rounded-md" />
+      {hint ? <Skeleton className="h-2 w-56 max-w-full" /> : null}
+    </div>
+  );
+}
+
+export function GeneralSettingsSkeleton() {
+  return (
+    <section className="flex flex-col gap-4" data-testid="settings-general-skeleton">
+      <Skeleton className="h-6 w-24" />
+      <div className="flex flex-col gap-5">
+        <FormRowSkeleton />
+        <FormRowSkeleton hint />
+        <FormRowSkeleton hint />
+        <Skeleton className="h-9 w-32 rounded-md" />
+      </div>
+    </section>
+  );
+}
+
+const INTEGRATION_CARDS = ['github', 'slack', 'mcp'];
+
+export function IntegrationsSettingsSkeleton() {
+  return (
+    <section className="flex flex-col gap-5" data-testid="settings-integrations-skeleton">
+      <SettingsHeading />
+      <div className="flex flex-col gap-6">
+        {INTEGRATION_CARDS.map((card) => (
+          <section
+            key={card}
+            className="flex flex-col gap-3 rounded-xl border border-border bg-surface p-4 sm:p-5"
+          >
+            <div className="flex flex-col gap-1.5">
+              <div className="flex items-center justify-between gap-3">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-5 w-24 rounded-full" />
+              </div>
+              <Skeleton className="h-3 w-full max-w-lg" />
+            </div>
+            <div className="flex flex-col gap-2 rounded-lg border border-border p-3">
+              <Skeleton className="h-3 w-40" />
+              <Skeleton className="h-3 w-28" />
+            </div>
+          </section>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+const TEAM_CARDS = ['first', 'second'];
+const MEMBERSHIP_CHIPS = ['a', 'b', 'c', 'd'];
+
+export function TeamsSettingsSkeleton() {
+  return (
+    <section className="flex flex-col gap-5" data-testid="settings-teams-skeleton">
+      <SettingsHeading />
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-wrap items-end gap-3 rounded-lg border border-border bg-surface p-4">
+          <div className="flex flex-1 flex-col gap-1.5">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-9 w-full rounded-md" />
+          </div>
+          <div className="flex w-32 flex-col gap-1.5">
+            <Skeleton className="h-3 w-10" />
+            <Skeleton className="h-9 w-full rounded-md" />
+          </div>
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <ul className="flex flex-col gap-3">
+          {TEAM_CARDS.map((team) => (
+            <li key={team} className="flex flex-col gap-3 rounded-lg border border-border p-4">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-5 w-12 rounded-full" />
+                  <Skeleton className="h-3 w-32" />
+                </div>
+                <div className="flex items-center gap-1">
+                  <Skeleton className="h-7 w-16 rounded-md" />
+                  <Skeleton className="h-7 w-16 rounded-md" />
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-x-4 gap-y-2">
+                {MEMBERSHIP_CHIPS.map((chip) => (
+                  <div key={chip} className="flex items-center gap-1.5">
+                    <Skeleton className="size-4 rounded-sm" />
+                    <Skeleton className="size-4 rounded-full" />
+                    <Skeleton className="h-3 w-20" />
+                  </div>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+const MEMBER_ROWS = ['a', 'b', 'c', 'd', 'e'];
+const MEMBER_COLUMNS = ['member', 'email', 'role', 'teams', 'joined', 'actions'];
+
+export function MembersSettingsSkeleton() {
+  return (
+    <section className="flex flex-col gap-5" data-testid="settings-members-skeleton">
+      <SettingsHeading />
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <table className="w-full border-collapse md:min-w-[52rem]">
+          <thead>
+            <tr className="border-border border-b">
+              {MEMBER_COLUMNS.map((column) => (
+                <th key={column} className="px-3 py-2 text-left">
+                  <Skeleton className="h-2 w-12" />
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {MEMBER_ROWS.map((row) => (
+              <tr key={row} className="border-border border-b last:border-b-0">
+                <td className="px-3 py-2">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="size-6 rounded-full" />
+                    <Skeleton className="h-3 w-24" />
+                  </div>
+                </td>
+                <td className="px-3 py-2">
+                  <Skeleton className="h-3 w-36" />
+                </td>
+                <td className="px-3 py-2">
+                  <Skeleton className="h-7 w-36 rounded-md" />
+                </td>
+                <td className="px-3 py-2">
+                  <Skeleton className="h-4 w-12 rounded-full" />
+                </td>
+                <td className="px-3 py-2">
+                  <Skeleton className="h-3 w-20" />
+                </td>
+                <td className="px-3 py-2 text-right">
+                  <Skeleton className="ml-auto h-7 w-16 rounded-md" />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex flex-col gap-4 rounded-lg border border-border bg-surface p-4">
+        <div className="flex flex-col gap-1">
+          <Skeleton className="h-3 w-28" />
+          <Skeleton className="h-2 w-72 max-w-full" />
+        </div>
+        <Skeleton className="h-20 w-full rounded-md" />
+        <div className="flex flex-wrap items-center gap-3">
+          <Skeleton className="h-7 w-36 rounded-md" />
+          <Skeleton className="h-7 w-40 rounded-md" />
+        </div>
+        <Skeleton className="h-8 w-28 rounded-md" />
+      </div>
+    </section>
+  );
+}
+
+const MATRIX_ROWS = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+const MATRIX_CHANNELS = ['inbox', 'email', 'slack', 'push'];
+
+export function NotificationsSettingsSkeleton() {
+  return (
+    <section className="flex flex-col gap-5" data-testid="settings-notifications-skeleton">
+      <SettingsHeading />
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <table className="w-full min-w-[36rem] border-collapse">
+          <thead>
+            <tr className="border-border border-b">
+              <th className="px-3 py-2 text-left">
+                <Skeleton className="h-2 w-20" />
+              </th>
+              {MATRIX_CHANNELS.map((channel) => (
+                <th key={channel} className="px-3 py-2">
+                  <Skeleton className="mx-auto h-2 w-10" />
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {MATRIX_ROWS.map((row) => (
+              <tr key={row} className="border-border border-b last:border-b-0">
+                <th scope="row" className="px-3 py-1.5 text-left">
+                  <Skeleton className="h-3 w-32" />
+                </th>
+                {MATRIX_CHANNELS.map((channel) => (
+                  <td key={channel} className="px-3 py-1.5">
+                    <Skeleton className="mx-auto size-4 rounded-sm" />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-2 w-64 max-w-full" />
+          </div>
+          <Skeleton className="h-5 w-9 rounded-full" />
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <Skeleton className="h-7 w-28 rounded-md" />
+          <Skeleton className="h-7 w-28 rounded-md" />
+        </div>
+      </div>
+      <Skeleton className="h-9 w-36 rounded-md" />
+    </section>
+  );
+}


### PR DESCRIPTION
Add App Router loading.tsx skeletons that mirror each page layout for cycles, inbox, settings panels, and issue detail.