### PR TITLE
feat(web): instant loading skeletons for docs, projects, pulls, views and analytics

### DIFF
--- a/apps/web/src/app/(app)/analytics/loading.tsx
+++ b/apps/web/src/app/(app)/analytics/loading.tsx
@@ -1,0 +1,5 @@
+import { AnalyticsSkeleton } from '@/features/analytics/analytics-skeleton.tsx';
+
+export default function AnalyticsLoading() {
+  return <AnalyticsSkeleton />;
+}

--- a/apps/web/src/app/(app)/docs/[id]/loading.tsx
+++ b/apps/web/src/app/(app)/docs/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { DocsSkeleton } from '@/features/docs/docs-skeleton.tsx';
+
+export default function DocLoading() {
+  return <DocsSkeleton />;
+}

--- a/apps/web/src/app/(app)/docs/loading.tsx
+++ b/apps/web/src/app/(app)/docs/loading.tsx
@@ -1,0 +1,5 @@
+import { DocsSkeleton } from '@/features/docs/docs-skeleton.tsx';
+
+export default function DocsLoading() {
+  return <DocsSkeleton />;
+}

--- a/apps/web/src/app/(app)/docs/new/loading.tsx
+++ b/apps/web/src/app/(app)/docs/new/loading.tsx
@@ -1,0 +1,5 @@
+import { NewDocSkeleton } from '@/features/docs/docs-skeleton.tsx';
+
+export default function NewDocLoading() {
+  return <NewDocSkeleton />;
+}

--- a/apps/web/src/app/(app)/projects/[slug]/loading.tsx
+++ b/apps/web/src/app/(app)/projects/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { ProjectDetailSkeleton } from '@/features/projects/projects-skeleton.tsx';
+
+export default function ProjectDetailLoading() {
+  return <ProjectDetailSkeleton />;
+}

--- a/apps/web/src/app/(app)/projects/loading.tsx
+++ b/apps/web/src/app/(app)/projects/loading.tsx
@@ -1,0 +1,5 @@
+import { ProjectsSkeleton } from '@/features/projects/projects-skeleton.tsx';
+
+export default function ProjectsLoading() {
+  return <ProjectsSkeleton />;
+}

--- a/apps/web/src/app/(app)/pulls/loading.tsx
+++ b/apps/web/src/app/(app)/pulls/loading.tsx
@@ -1,0 +1,5 @@
+import { PullsSkeleton } from '@/features/pulls/pulls-skeleton.tsx';
+
+export default function PullsLoading() {
+  return <PullsSkeleton />;
+}

--- a/apps/web/src/app/(app)/views/loading.tsx
+++ b/apps/web/src/app/(app)/views/loading.tsx
@@ -1,0 +1,5 @@
+import { ViewsSkeleton } from '@/features/views/views-skeleton.tsx';
+
+export default function ViewsLoading() {
+  return <ViewsSkeleton />;
+}

--- a/apps/web/src/app/(app)/views/page.tsx
+++ b/apps/web/src/app/(app)/views/page.tsx
@@ -1,8 +1,26 @@
+import { listViews } from '@orbit/core';
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 import type { Metadata } from 'next';
 import { ViewsPage } from '@/features/views/views-page.tsx';
+import { pageContext } from '@/lib/api/handler.ts';
+import { toViewPayload } from '@/lib/api/views.ts';
+import { queryKeys } from '@/lib/query/keys.ts';
+import { viewListSchema } from '@/lib/query/schemas.ts';
 
 export const metadata: Metadata = { title: 'Views' };
 
-export default function Views() {
-  return <ViewsPage />;
+export default async function Views() {
+  const { principal } = await pageContext();
+  const rows = await listViews(principal);
+  const client = new QueryClient();
+  client.setQueryData(
+    queryKeys.views(),
+    viewListSchema.parse(JSON.parse(JSON.stringify({ views: rows.map(toViewPayload) }))).views,
+  );
+
+  return (
+    <HydrationBoundary state={dehydrate(client)}>
+      <ViewsPage />
+    </HydrationBoundary>
+  );
 }

--- a/apps/web/src/features/analytics/analytics-skeleton.test.tsx
+++ b/apps/web/src/features/analytics/analytics-skeleton.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { AnalyticsSkeleton } from './analytics-skeleton.tsx';
+
+describe('analytics skeleton', () => {
+  it('renders the analytics skeleton', () => {
+    render(<AnalyticsSkeleton />);
+    expect(screen.getByTestId('analytics-skeleton')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/analytics/analytics-skeleton.tsx
+++ b/apps/web/src/features/analytics/analytics-skeleton.tsx
@@ -1,0 +1,87 @@
+import { Skeleton } from '@/components/ui/skeleton.tsx';
+
+function Card({ children }: { readonly children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
+      {children}
+    </section>
+  );
+}
+
+function BarChartSkeleton() {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <Skeleton className="h-3.5 w-28" />
+        <Skeleton className="h-2.5 w-12" />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {['a', 'b', 'c', 'd', 'e'].map((key) => (
+          <div key={key} className="grid grid-cols-[minmax(4rem,8rem)_1fr_auto] items-center gap-2">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-2 w-full rounded-full" />
+            <Skeleton className="h-3 w-8" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function AnalyticsSkeleton() {
+  return (
+    <div className="flex flex-col gap-6 px-6 py-6" data-testid="analytics-skeleton">
+      <header className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-6 w-32" />
+            <Skeleton className="h-3 w-72" />
+          </div>
+          <Skeleton className="h-8 w-40 rounded-md" />
+        </div>
+        <Skeleton className="h-8 w-full max-w-md rounded-md" />
+      </header>
+
+      <Card>
+        <Skeleton className="h-4 w-56" />
+        <Skeleton className="h-33 w-full" />
+        <div className="flex justify-between">
+          <Skeleton className="h-2.5 w-16" />
+          <Skeleton className="h-2.5 w-16" />
+        </div>
+      </Card>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {['assignee', 'project', 'label', 'estimate'].map((key) => (
+          <Card key={key}>
+            <BarChartSkeleton />
+          </Card>
+        ))}
+      </div>
+
+      <Card>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <Skeleton className="h-4 w-48" />
+          <Skeleton className="h-7 w-24 rounded-md" />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-3 w-full" />
+          {['r1', 'r2', 'r3', 'r4', 'r5'].map((key) => (
+            <Skeleton key={key} className="h-5 w-full" />
+          ))}
+        </div>
+      </Card>
+
+      <section className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-3 w-64" />
+          </div>
+          <Skeleton className="h-8 w-32 rounded-md" />
+        </div>
+        <Skeleton className="h-48 w-full rounded-lg" />
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/features/docs/docs-skeleton.test.tsx
+++ b/apps/web/src/features/docs/docs-skeleton.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { DocsSkeleton, NewDocSkeleton } from './docs-skeleton.tsx';
+
+describe('docs skeletons', () => {
+  it('renders the docs workspace skeleton', () => {
+    render(<DocsSkeleton />);
+    expect(screen.getByTestId('docs-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders the new doc skeleton', () => {
+    render(<NewDocSkeleton />);
+    expect(screen.getByTestId('new-doc-skeleton')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/docs/docs-skeleton.tsx
+++ b/apps/web/src/features/docs/docs-skeleton.tsx
@@ -1,0 +1,59 @@
+import { Skeleton } from '@/components/ui/skeleton.tsx';
+
+const TREE_GROUPS = [
+  { id: 'a', rows: ['a1', 'a2', 'a3', 'a4'] },
+  { id: 'b', rows: ['b1', 'b2', 'b3'] },
+  { id: 'c', rows: ['c1', 'c2'] },
+];
+
+function TreeSkeleton() {
+  return (
+    <div className="hidden h-full w-64 shrink-0 flex-col border-border border-r bg-surface lg:flex">
+      <div className="border-border border-b p-2">
+        <Skeleton className="h-8 w-full rounded-md" />
+      </div>
+      <div className="flex flex-col gap-4 p-2">
+        {TREE_GROUPS.map((group) => (
+          <div key={group.id} className="flex flex-col gap-1">
+            <Skeleton className="mx-2 h-3 w-24" />
+            {group.rows.map((row) => (
+              <Skeleton key={row} className="h-7 w-full rounded-md" />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function DocsSkeleton() {
+  return (
+    <div className="flex h-full min-h-0" data-testid="docs-skeleton">
+      <TreeSkeleton />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex h-11 shrink-0 items-center gap-2 border-border border-b px-3">
+          <span className="flex-1" />
+          <Skeleton className="h-7 w-20 rounded-md" />
+          <Skeleton className="h-7 w-24 rounded-md" />
+        </div>
+        <div className="mx-auto flex w-full max-w-[45rem] flex-col gap-4 px-6 py-10">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-8 w-2/3" />
+          <Skeleton className="h-40 w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function NewDocSkeleton() {
+  return (
+    <div
+      className="mx-auto flex w-full max-w-[45rem] flex-col gap-4 px-6 py-10"
+      data-testid="new-doc-skeleton"
+    >
+      <Skeleton className="h-8 w-2/3" />
+      <Skeleton className="h-40 w-full" />
+    </div>
+  );
+}

--- a/apps/web/src/features/projects/projects-skeleton.test.tsx
+++ b/apps/web/src/features/projects/projects-skeleton.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { ProjectDetailSkeleton, ProjectsSkeleton } from './projects-skeleton.tsx';
+
+describe('projects skeletons', () => {
+  it('renders the projects list skeleton', () => {
+    render(<ProjectsSkeleton />);
+    expect(screen.getByTestId('projects-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders the project detail skeleton', () => {
+    render(<ProjectDetailSkeleton />);
+    expect(screen.getByTestId('project-detail-skeleton')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/projects/projects-skeleton.tsx
+++ b/apps/web/src/features/projects/projects-skeleton.tsx
@@ -1,0 +1,79 @@
+import { Skeleton } from '@/components/ui/skeleton.tsx';
+
+const ROW_KEYS = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+export function ProjectsSkeleton() {
+  return (
+    <div className="flex flex-col gap-4 px-6 py-6" data-testid="projects-skeleton">
+      <div className="flex flex-col gap-1.5">
+        <Skeleton className="h-6 w-32" />
+        <Skeleton className="h-3 w-40" />
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-border">
+        <div className="flex items-center gap-3 border-border border-b px-3 py-2.5">
+          <Skeleton className="h-3 w-20" />
+        </div>
+        {ROW_KEYS.map((key) => (
+          <div
+            key={key}
+            className="flex items-center gap-3 border-border border-b px-3 py-3 last:border-b-0"
+          >
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+              <Skeleton className="h-3.5 w-48" />
+              <Skeleton className="h-2.5 w-64" />
+            </div>
+            <Skeleton className="hidden h-5 w-16 rounded-full sm:block" />
+            <Skeleton className="hidden size-5 rounded-full md:block" />
+            <Skeleton className="hidden h-3 w-12 lg:block" />
+            <Skeleton className="size-6 rounded-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ProjectDetailSkeleton() {
+  return (
+    <div className="flex flex-col gap-6 px-6 py-6" data-testid="project-detail-skeleton">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Skeleton className="h-7 w-56" />
+          <Skeleton className="h-5 w-20 rounded-full" />
+          <Skeleton className="h-5 w-16 rounded-full" />
+        </div>
+        <Skeleton className="h-4 w-full max-w-2xl" />
+        <div className="flex flex-wrap gap-x-8 gap-y-2">
+          {['lead', 'start', 'target', 'teams', 'progress'].map((key) => (
+            <Skeleton key={key} className="h-4 w-24" />
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-4 w-28" />
+            {['m1', 'm2', 'm3'].map((key) => (
+              <Skeleton key={key} className="h-24 w-full rounded-lg" />
+            ))}
+          </div>
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-20 w-full rounded-lg" />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-4 rounded-lg border border-border p-4">
+          <div className="grid grid-cols-3 gap-2">
+            {['scope', 'started', 'done'].map((key) => (
+              <Skeleton key={key} className="h-12 w-full" />
+            ))}
+          </div>
+          <Skeleton className="h-33 w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/pulls/pulls-skeleton.test.tsx
+++ b/apps/web/src/features/pulls/pulls-skeleton.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { PullsSkeleton } from './pulls-skeleton.tsx';
+
+describe('pulls skeleton', () => {
+  it('renders the pulls skeleton', () => {
+    render(<PullsSkeleton />);
+    expect(screen.getByTestId('pulls-skeleton')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/pulls/pulls-skeleton.tsx
+++ b/apps/web/src/features/pulls/pulls-skeleton.tsx
@@ -1,0 +1,43 @@
+import { Skeleton } from '@/components/ui/skeleton.tsx';
+
+const GROUPS = [
+  { id: 'first', rows: ['a', 'b', 'c'] },
+  { id: 'second', rows: ['a', 'b'] },
+];
+
+export function PullsSkeleton() {
+  return (
+    <div className="flex min-h-full flex-col" data-testid="pulls-skeleton">
+      <header className="flex items-center justify-between gap-3 border-border border-b px-5 py-3">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-6 w-36" />
+          <Skeleton className="size-5 rounded-full" />
+        </div>
+      </header>
+
+      <div className="flex flex-col gap-6 p-5">
+        {GROUPS.map((group) => (
+          <section key={group.id} className="flex flex-col gap-1.5">
+            <Skeleton className="mx-1 h-3 w-24" />
+            <div className="flex flex-col overflow-hidden rounded-lg border border-border">
+              {group.rows.map((row) => (
+                <div
+                  key={row}
+                  className="flex items-center gap-3 border-border border-b px-3 py-2.5 last:border-b-0"
+                >
+                  <Skeleton className="size-4 shrink-0 rounded-sm" />
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <Skeleton className="h-3.5 w-2/3" />
+                    <Skeleton className="h-2.5 w-1/2" />
+                  </div>
+                  <Skeleton className="hidden h-3 w-14 sm:block" />
+                  <Skeleton className="h-5 w-16 rounded-full" />
+                </div>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/views/views-page.tsx
+++ b/apps/web/src/features/views/views-page.tsx
@@ -15,12 +15,12 @@ import {
 } from '@/components/ui/dialog.tsx';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
 import { Input } from '@/components/ui/input.tsx';
-import { Skeleton } from '@/components/ui/skeleton.tsx';
 import { buildFilterFields, describeCondition } from '@/features/filters/filter-fields.tsx';
 import { VIEW_PARAM, withViewParam } from '@/features/filters/use-view-config.ts';
 import type { ViewLayoutMode } from '@/features/filters/view-config.ts';
 import { viewConfigFromState, viewConfigSearch } from '@/features/filters/view-config.ts';
 import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
+import { ViewsSkeleton } from '@/features/views/views-skeleton.tsx';
 import { cn } from '@/lib/cn.ts';
 import type { View } from '@/lib/query/schemas.ts';
 import {
@@ -44,14 +44,7 @@ export function ViewsPage() {
   const shared = rows.filter((view) => !view.virtual && view.ownerId !== workspace.userId);
 
   if (views.isPending) {
-    return (
-      <div className="flex flex-col gap-3 px-6 py-6" data-testid="views-skeleton">
-        <Skeleton className="h-6 w-32" />
-        {[0, 1, 2].map((index) => (
-          <Skeleton key={index} className="h-16 w-full rounded-lg" />
-        ))}
-      </div>
-    );
+    return <ViewsSkeleton />;
   }
 
   return (

--- a/apps/web/src/features/views/views-skeleton.test.tsx
+++ b/apps/web/src/features/views/views-skeleton.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { ViewsSkeleton } from './views-skeleton.tsx';
+
+describe('views skeleton', () => {
+  it('renders the views skeleton', () => {
+    render(<ViewsSkeleton />);
+    expect(screen.getByTestId('views-skeleton')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/views/views-skeleton.tsx
+++ b/apps/web/src/features/views/views-skeleton.tsx
@@ -1,0 +1,42 @@
+import { Skeleton } from '@/components/ui/skeleton.tsx';
+
+const SECTIONS = [
+  { id: 'built-in', rows: ['a', 'b'] },
+  { id: 'mine', rows: ['a', 'b', 'c'] },
+];
+
+export function ViewsSkeleton() {
+  return (
+    <div className="flex flex-col gap-6 px-6 py-6" data-testid="views-skeleton">
+      <div className="flex flex-col gap-1.5">
+        <Skeleton className="h-6 w-24" />
+        <Skeleton className="h-3 w-80 max-w-full" />
+      </div>
+
+      {SECTIONS.map((section) => (
+        <div key={section.id} className="flex flex-col gap-2">
+          <Skeleton className="h-3 w-28" />
+          <div className="flex flex-col">
+            <div className="flex items-center gap-3 border-border border-b py-1.5">
+              <Skeleton className="h-2.5 w-16" />
+            </div>
+            {section.rows.map((row) => (
+              <div key={row} className="flex items-start gap-3 border-border border-b py-2.5">
+                <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                  <Skeleton className="h-3.5 w-40" />
+                  <Skeleton className="h-2.5 w-64 max-w-full" />
+                </div>
+                <Skeleton className="hidden h-3 w-16 sm:block" />
+                <Skeleton className="hidden h-3 w-20 md:block" />
+                <div className="flex items-center gap-1">
+                  <Skeleton className="size-6 rounded-md" />
+                  <Skeleton className="size-6 rounded-md" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Add route-level loading.tsx skeletons that mirror each page layout for docs, projects, pulls, views and analytics, and prefetch views on the server.