### PR TITLE
feat(account): upload and crop a profile photo, stored in S3

### DIFF
--- a/apps/web/src/app/api/account/avatar/presign/route.ts
+++ b/apps/web/src/app/api/account/avatar/presign/route.ts
@@ -1,0 +1,14 @@
+import { avatarStorageKey } from '@orbit/core';
+import { storageDriver } from '@orbit/services/storage';
+import { avatarUploadSchema } from '@orbit/shared/validators';
+import { handle, readJson } from '@/lib/api/handler.ts';
+
+export async function POST(request: Request): Promise<Response> {
+  const body = await readJson(request);
+  return await handle(async (principal) => {
+    const { contentType } = avatarUploadSchema.parse(body);
+    const key = avatarStorageKey(principal.userId);
+    const target = await storageDriver().createUploadTarget(key, contentType);
+    return { upload: target };
+  });
+}

--- a/apps/web/src/app/api/account/avatar/route.ts
+++ b/apps/web/src/app/api/account/avatar/route.ts
@@ -1,0 +1,48 @@
+import { avatarStorageKey, clearAvatar, isAvatarUrl, saveAvatar } from '@orbit/core';
+import { db, eq, schema } from '@orbit/db';
+import { storageDriver } from '@orbit/services/storage';
+import { unauthorized, validationFailed } from '@orbit/shared/errors';
+import { handleRoute, publish } from '@/lib/api/handler.ts';
+import { republishMemberships } from '@/lib/api/profile-sync.ts';
+import { getSession } from '@/lib/auth/session.ts';
+
+async function currentImage(userId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ image: schema.user.image })
+    .from(schema.user)
+    .where(eq(schema.user.id, userId))
+    .limit(1);
+  return row?.image ?? null;
+}
+
+export async function POST(): Promise<Response> {
+  return await handleRoute(async () => {
+    const session = await getSession();
+    if (session === null) throw unauthorized();
+    const userId = session.user.id;
+
+    const key = avatarStorageKey(userId);
+    const stored = await storageDriver().stat(key);
+    if (stored === null) throw validationFailed('That photo never reached storage.');
+
+    const user = await saveAvatar(userId);
+    await publish(await republishMemberships(user));
+
+    return { user: { image: user.image } };
+  });
+}
+
+export async function DELETE(): Promise<Response> {
+  return await handleRoute(async () => {
+    const session = await getSession();
+    if (session === null) throw unauthorized();
+    const userId = session.user.id;
+
+    const hadAvatar = isAvatarUrl(await currentImage(userId));
+    const user = await clearAvatar(userId);
+    if (hadAvatar) await storageDriver().delete(avatarStorageKey(userId));
+    await publish(await republishMemberships(user));
+
+    return { user: { image: user.image } };
+  });
+}

--- a/apps/web/src/app/api/account/profile/route.ts
+++ b/apps/web/src/app/api/account/profile/route.ts
@@ -1,8 +1,7 @@
-import { buildSyncAction, nextSyncId, updateProfile } from '@orbit/core';
-import { db, eq, schema } from '@orbit/db';
+import { updateProfile } from '@orbit/core';
 import { unauthorized } from '@orbit/shared/errors';
-import { scopes } from '@orbit/shared/events';
 import { handleRoute, publish, readJson } from '@/lib/api/handler.ts';
+import { republishMemberships } from '@/lib/api/profile-sync.ts';
 import { getSession } from '@/lib/auth/session.ts';
 
 export async function PATCH(request: Request): Promise<Response> {
@@ -11,26 +10,7 @@ export async function PATCH(request: Request): Promise<Response> {
     if (session === null) throw unauthorized();
     const user = await updateProfile(session.user.id, await readJson(request));
 
-    const syncId = await nextSyncId(db);
-    const memberships = await db
-      .update(schema.member)
-      .set({ syncId })
-      .where(eq(schema.member.userId, user.id))
-      .returning();
-    await publish(
-      memberships.map((row) =>
-        buildSyncAction({
-          syncId: row.syncId,
-          organizationId: row.organizationId,
-          scopes: [scopes.organization(row.organizationId), scopes.user(row.userId)],
-          action: 'update',
-          model: 'member',
-          modelId: row.id,
-          data: row,
-          actor: { type: 'user', id: user.id, name: user.name },
-        }),
-      ),
-    );
+    await publish(await republishMemberships(user));
 
     return {
       user: {

--- a/apps/web/src/app/api/avatars/[userId]/route.ts
+++ b/apps/web/src/app/api/avatars/[userId]/route.ts
@@ -1,0 +1,39 @@
+import { avatarStorageKey, isAvatarUrl } from '@orbit/core';
+import { db, eq, schema } from '@orbit/db';
+import { storageDriver } from '@orbit/services/storage';
+import { notFound, unauthorized } from '@orbit/shared/errors';
+import { errorResponse } from '@/lib/api/handler.ts';
+import { getSession } from '@/lib/auth/session.ts';
+
+interface RouteContext {
+  readonly params: Promise<{ userId: string }>;
+}
+
+const DOWNLOAD_URL_TTL_SECONDS = 300;
+const REDIRECT_CACHE_SECONDS = 60;
+
+export async function GET(_request: Request, context: RouteContext): Promise<Response> {
+  try {
+    const session = await getSession();
+    if (session === null) throw unauthorized();
+
+    const { userId } = await context.params;
+    const [row] = await db
+      .select({ image: schema.user.image })
+      .from(schema.user)
+      .where(eq(schema.user.id, userId))
+      .limit(1);
+    if (row === undefined || !isAvatarUrl(row.image)) throw notFound('That photo does not exist.');
+
+    const url = await storageDriver().getUrl(avatarStorageKey(userId), DOWNLOAD_URL_TTL_SECONDS);
+    return new Response(null, {
+      status: 302,
+      headers: {
+        location: url,
+        'cache-control': `private, max-age=${REDIRECT_CACHE_SECONDS}`,
+      },
+    });
+  } catch (error: unknown) {
+    return errorResponse(error);
+  }
+}

--- a/apps/web/src/features/account/avatar-cropper.tsx
+++ b/apps/web/src/features/account/avatar-cropper.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { AVATAR_CONTENT_TYPE, AVATAR_DIMENSION } from '@orbit/shared/constants';
+import { ZoomIn, ZoomOut } from 'lucide-react';
+import { type PointerEvent as ReactPointerEvent, useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button.tsx';
+import { clampOffset, displayGeometry, type Point, type Size, sourceCrop } from './crop.ts';
+
+const VIEWPORT = 288;
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 3;
+const ZOOM_STEP = 0.01;
+const OUTPUT_QUALITY = 0.92;
+
+export interface AvatarCropperProps {
+  readonly file: File;
+  readonly pending?: boolean;
+  readonly onCancel: () => void;
+  readonly onConfirm: (blob: Blob) => void;
+}
+
+interface DragState {
+  readonly pointerX: number;
+  readonly pointerY: number;
+  readonly offset: Point;
+}
+
+export function AvatarCropper({ file, pending = false, onCancel, onConfirm }: AvatarCropperProps) {
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [natural, setNatural] = useState<Size | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [zoom, setZoom] = useState(MIN_ZOOM);
+  const [offset, setOffset] = useState<Point>({ x: 0, y: 0 });
+  const [rendering, setRendering] = useState(false);
+  const imageRef = useRef<HTMLImageElement | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+
+  useEffect(() => {
+    const url = URL.createObjectURL(file);
+    setObjectUrl(url);
+    setNatural(null);
+    setFailed(false);
+    setZoom(MIN_ZOOM);
+    setOffset({ x: 0, y: 0 });
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  function onImageLoad(event: React.SyntheticEvent<HTMLImageElement>): void {
+    const image = event.currentTarget;
+    setNatural({ width: image.naturalWidth, height: image.naturalHeight });
+  }
+
+  function onPointerDown(event: ReactPointerEvent<HTMLDivElement>): void {
+    if (natural === null) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    dragRef.current = { pointerX: event.clientX, pointerY: event.clientY, offset };
+  }
+
+  function onPointerMove(event: ReactPointerEvent<HTMLDivElement>): void {
+    const drag = dragRef.current;
+    if (drag === null || natural === null) return;
+    const next = {
+      x: drag.offset.x + (event.clientX - drag.pointerX),
+      y: drag.offset.y + (event.clientY - drag.pointerY),
+    };
+    setOffset(clampOffset(next, natural, VIEWPORT, zoom));
+  }
+
+  function endDrag(event: ReactPointerEvent<HTMLDivElement>): void {
+    dragRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  }
+
+  function onZoomChange(value: number): void {
+    if (natural === null) return;
+    setOffset((current) => clampOffset(current, natural, VIEWPORT, value));
+    setZoom(value);
+  }
+
+  function confirm(): void {
+    const image = imageRef.current;
+    if (image === null || natural === null) return;
+    const crop = sourceCrop(natural, VIEWPORT, zoom, offset);
+    const canvas = document.createElement('canvas');
+    canvas.width = AVATAR_DIMENSION;
+    canvas.height = AVATAR_DIMENSION;
+    const context = canvas.getContext('2d');
+    if (context === null) return;
+    context.fillStyle = '#ffffff';
+    context.fillRect(0, 0, AVATAR_DIMENSION, AVATAR_DIMENSION);
+    context.drawImage(
+      image,
+      crop.sx,
+      crop.sy,
+      crop.size,
+      crop.size,
+      0,
+      0,
+      AVATAR_DIMENSION,
+      AVATAR_DIMENSION,
+    );
+    setRendering(true);
+    canvas.toBlob(
+      (blob) => {
+        setRendering(false);
+        if (blob !== null) onConfirm(blob);
+      },
+      AVATAR_CONTENT_TYPE,
+      OUTPUT_QUALITY,
+    );
+  }
+
+  const geometry = natural === null ? null : displayGeometry(natural, VIEWPORT, zoom, offset);
+  const busy = pending || rendering;
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      {failed ? (
+        <p role="alert" className="py-10 text-center text-danger text-dense">
+          That image could not be opened. Pick a different photo.
+        </p>
+      ) : (
+        <>
+          <div
+            role="group"
+            aria-label="Drag to reposition your photo"
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={endDrag}
+            onPointerCancel={endDrag}
+            className="relative touch-none overflow-hidden rounded-full border border-border bg-surface-2 [&_img]:pointer-events-none"
+            style={{ width: VIEWPORT, height: VIEWPORT, cursor: natural === null ? 'default' : 'grab' }}
+          >
+            {objectUrl === null ? null : (
+              <img
+                ref={imageRef}
+                src={objectUrl}
+                alt=""
+                draggable={false}
+                onLoad={onImageLoad}
+                onError={() => setFailed(true)}
+                className="absolute max-w-none select-none"
+                style={
+                  geometry === null
+                    ? { visibility: 'hidden' }
+                    : {
+                        width: geometry.width,
+                        height: geometry.height,
+                        left: geometry.left,
+                        top: geometry.top,
+                      }
+                }
+              />
+            )}
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 rounded-full ring-1 ring-white/25 ring-inset"
+            />
+          </div>
+
+          <div className="flex w-full max-w-[288px] items-center gap-2">
+            <ZoomOut className="size-4 shrink-0 text-faint" aria-hidden />
+            <input
+              type="range"
+              min={MIN_ZOOM}
+              max={MAX_ZOOM}
+              step={ZOOM_STEP}
+              value={zoom}
+              disabled={natural === null || busy}
+              aria-label="Zoom"
+              onChange={(event) => onZoomChange(Number(event.target.value))}
+              className="h-1 w-full cursor-pointer appearance-none rounded-full bg-surface-3 accent-accent"
+            />
+            <ZoomIn className="size-4 shrink-0 text-faint" aria-hidden />
+          </div>
+        </>
+      )}
+
+      <div className="flex w-full justify-end gap-2">
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={busy}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          onClick={confirm}
+          disabled={busy || natural === null || failed}
+        >
+          {busy ? 'Saving' : 'Set photo'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/account/avatar-cropper.tsx
+++ b/apps/web/src/features/account/avatar-cropper.tsx
@@ -124,16 +124,19 @@ export function AvatarCropper({ file, pending = false, onCancel, onConfirm }: Av
       ) : (
         <>
           <div
-            role="group"
-            aria-label="Drag to reposition your photo"
             onPointerDown={onPointerDown}
             onPointerMove={onPointerMove}
             onPointerUp={endDrag}
             onPointerCancel={endDrag}
             className="relative touch-none overflow-hidden rounded-full border border-border bg-surface-2 [&_img]:pointer-events-none"
-            style={{ width: VIEWPORT, height: VIEWPORT, cursor: natural === null ? 'default' : 'grab' }}
+            style={{
+              width: VIEWPORT,
+              height: VIEWPORT,
+              cursor: natural === null ? 'default' : 'grab',
+            }}
           >
             {objectUrl === null ? null : (
+              // biome-ignore lint/performance/noImgElement: the cropper draws from a raw element onto a canvas
               <img
                 ref={imageRef}
                 src={objectUrl}

--- a/apps/web/src/features/account/avatar-upload.ts
+++ b/apps/web/src/features/account/avatar-upload.ts
@@ -1,0 +1,44 @@
+import { AVATAR_CONTENT_TYPE } from '@orbit/shared/constants';
+import { z } from 'zod';
+import { apiRequest } from '@/lib/api/client.ts';
+
+const presignSchema = z.object({
+  upload: z.object({
+    url: z.string(),
+    method: z.literal('PUT'),
+    headers: z.record(z.string(), z.string()),
+  }),
+});
+
+const avatarSchema = z.object({ user: z.object({ image: z.string().nullable() }) });
+
+async function putBlob(
+  url: string,
+  headers: Readonly<Record<string, string>>,
+  blob: Blob,
+): Promise<void> {
+  const response = await fetch(url, { method: 'PUT', headers, body: blob });
+  if (!response.ok) {
+    throw new Error(`Uploading your photo failed with status ${response.status}.`);
+  }
+}
+
+export async function uploadAvatar(blob: Blob): Promise<string | null> {
+  const contentType = blob.type.length > 0 ? blob.type : AVATAR_CONTENT_TYPE;
+  const presigned = presignSchema.parse(
+    await apiRequest('/api/account/avatar/presign', {
+      method: 'POST',
+      body: { contentType, size: blob.size },
+    }),
+  );
+
+  await putBlob(presigned.upload.url, presigned.upload.headers, blob);
+
+  const saved = avatarSchema.parse(await apiRequest('/api/account/avatar', { method: 'POST' }));
+  return saved.user.image;
+}
+
+export async function removeAvatar(): Promise<string | null> {
+  const cleared = avatarSchema.parse(await apiRequest('/api/account/avatar', { method: 'DELETE' }));
+  return cleared.user.image;
+}

--- a/apps/web/src/features/account/crop.test.ts
+++ b/apps/web/src/features/account/crop.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test';
+import { clampOffset, coverScale, displayGeometry, maxOffset, sourceCrop } from './crop.ts';
+
+const viewport = 300;
+
+describe('crop geometry', () => {
+  it('covers the viewport by scaling the shorter side', () => {
+    expect(coverScale({ width: 600, height: 900 }, viewport)).toBe(0.5);
+    expect(coverScale({ width: 900, height: 600 }, viewport)).toBe(0.5);
+  });
+
+  it('has no pannable room for a square image at zoom 1', () => {
+    expect(maxOffset({ width: 600, height: 600 }, viewport, 1)).toEqual({ x: 0, y: 0 });
+  });
+
+  it('allows panning along the longer axis', () => {
+    const limit = maxOffset({ width: 600, height: 1200 }, viewport, 1);
+    expect(limit.x).toBe(0);
+    expect(limit.y).toBeGreaterThan(0);
+  });
+
+  it('clamps an offset within the pannable room', () => {
+    const natural = { width: 600, height: 1200 };
+    const clamped = clampOffset({ x: 9999, y: 9999 }, natural, viewport, 1);
+    const limit = maxOffset(natural, viewport, 1);
+    expect(clamped).toEqual({ x: limit.x, y: limit.y });
+  });
+
+  it('crops the centre square of a centred square image', () => {
+    const crop = sourceCrop({ width: 800, height: 800 }, viewport, 1, { x: 0, y: 0 });
+    expect(crop.sx).toBe(0);
+    expect(crop.sy).toBe(0);
+    expect(crop.size).toBe(800);
+  });
+
+  it('shrinks the source region as zoom increases', () => {
+    const wide = sourceCrop({ width: 800, height: 800 }, viewport, 1, { x: 0, y: 0 });
+    const tight = sourceCrop({ width: 800, height: 800 }, viewport, 2, { x: 0, y: 0 });
+    expect(tight.size).toBeLessThan(wide.size);
+  });
+
+  it('keeps the source crop inside the image bounds', () => {
+    const natural = { width: 800, height: 1200 };
+    const crop = sourceCrop(natural, viewport, 1, { x: 0, y: -99999 });
+    expect(crop.sy).toBeGreaterThanOrEqual(0);
+    expect(crop.sy + crop.size).toBeLessThanOrEqual(natural.height + 0.001);
+  });
+
+  it('positions the display image to cover the viewport', () => {
+    const geo = displayGeometry({ width: 600, height: 600 }, viewport, 1, { x: 0, y: 0 });
+    expect(geo.width).toBe(300);
+    expect(geo.left).toBe(0);
+    expect(geo.top).toBe(0);
+  });
+});

--- a/apps/web/src/features/account/crop.ts
+++ b/apps/web/src/features/account/crop.ts
@@ -59,7 +59,12 @@ export function displayGeometry(
   viewport: number,
   zoom: number,
   offset: Point,
-): { readonly width: number; readonly height: number; readonly left: number; readonly top: number } {
+): {
+  readonly width: number;
+  readonly height: number;
+  readonly left: number;
+  readonly top: number;
+} {
   const scale = coverScale(natural, viewport) * zoom;
   const width = natural.width * scale;
   const height = natural.height * scale;

--- a/apps/web/src/features/account/crop.ts
+++ b/apps/web/src/features/account/crop.ts
@@ -1,0 +1,72 @@
+export interface Size {
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface SourceCrop {
+  readonly sx: number;
+  readonly sy: number;
+  readonly size: number;
+}
+
+export function coverScale(natural: Size, viewport: number): number {
+  return Math.max(viewport / natural.width, viewport / natural.height);
+}
+
+export function maxOffset(natural: Size, viewport: number, zoom: number): Point {
+  const scale = coverScale(natural, viewport) * zoom;
+  return {
+    x: Math.max(0, (natural.width * scale - viewport) / 2),
+    y: Math.max(0, (natural.height * scale - viewport) / 2),
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function clampOffset(offset: Point, natural: Size, viewport: number, zoom: number): Point {
+  const limit = maxOffset(natural, viewport, zoom);
+  return { x: clamp(offset.x, -limit.x, limit.x), y: clamp(offset.y, -limit.y, limit.y) };
+}
+
+export function sourceCrop(
+  natural: Size,
+  viewport: number,
+  zoom: number,
+  offset: Point,
+): SourceCrop {
+  const scale = coverScale(natural, viewport) * zoom;
+  const displayWidth = natural.width * scale;
+  const displayHeight = natural.height * scale;
+  const size = viewport / scale;
+  const sx = ((displayWidth - viewport) / 2 - offset.x) / scale;
+  const sy = ((displayHeight - viewport) / 2 - offset.y) / scale;
+  return {
+    sx: clamp(sx, 0, Math.max(0, natural.width - size)),
+    sy: clamp(sy, 0, Math.max(0, natural.height - size)),
+    size,
+  };
+}
+
+export function displayGeometry(
+  natural: Size,
+  viewport: number,
+  zoom: number,
+  offset: Point,
+): { readonly width: number; readonly height: number; readonly left: number; readonly top: number } {
+  const scale = coverScale(natural, viewport) * zoom;
+  const width = natural.width * scale;
+  const height = natural.height * scale;
+  return {
+    width,
+    height,
+    left: (viewport - width) / 2 + offset.x,
+    top: (viewport - height) / 2 + offset.y,
+  };
+}

--- a/apps/web/src/features/account/profile-form.test.tsx
+++ b/apps/web/src/features/account/profile-form.test.tsx
@@ -53,12 +53,44 @@ describe('ProfileForm', () => {
       expect(refresh).toHaveBeenCalledTimes(1);
     });
     const [, init] = fetchSpy.mock.calls[0] as [string, { body: string }];
-    expect(JSON.parse(init.body)).toMatchObject({
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({
       name: 'Pulkit S',
       handle: 'pulkit',
-      image: null,
       timezone: 'Asia/Kolkata',
     });
+    expect(body).not.toHaveProperty('image');
+  });
+
+  it('offers an upload control and no remove when there is no photo', () => {
+    render(<ProfileForm name="Pulkit Sharma" handle="pulkit" image={null} timezone="UTC" />);
+
+    expect(screen.getByRole('button', { name: 'Upload photo' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+  });
+
+  it('removes the photo through the avatar endpoint', async () => {
+    const fetchSpy = mockFetch(200, { user: { image: null } });
+    const user = userEvent.setup();
+    render(
+      <ProfileForm
+        name="Pulkit Sharma"
+        handle="pulkit"
+        image="/api/avatars/u1?v=1"
+        timezone="UTC"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Change photo' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
+    const [url, init] = fetchSpy.mock.calls[0] as [string, { method: string }];
+    expect(url).toBe('/api/account/avatar');
+    expect(init.method).toBe('DELETE');
+    expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
   });
 
   it('shows the handle conflict inline on the handle field', async () => {

--- a/apps/web/src/features/account/profile-form.tsx
+++ b/apps/web/src/features/account/profile-form.tsx
@@ -109,7 +109,8 @@ export function ProfileForm({ name, handle, image, timezone }: ProfileFormProps)
       toast({ title: 'Profile updated', tone: 'success' });
       router.refresh();
     } catch (caught) {
-      if (caught instanceof ApiRequestError && caught.is('conflict')) setHandleError(caught.message);
+      if (caught instanceof ApiRequestError && caught.is('conflict'))
+        setHandleError(caught.message);
       else setFormError(messageOf(caught));
     } finally {
       setPending(false);
@@ -147,9 +148,7 @@ export function ProfileForm({ name, handle, image, timezone }: ProfileFormProps)
                 type="button"
                 variant="ghost"
                 size="sm"
-                onClick={() => {
-                  void onRemovePhoto();
-                }}
+                onClick={onRemovePhoto}
                 disabled={avatarPending}
               >
                 Remove
@@ -171,7 +170,7 @@ export function ProfileForm({ name, handle, image, timezone }: ProfileFormProps)
       <Dialog
         open={cropFile !== null}
         onOpenChange={(open) => {
-          if (!open && !avatarPending) setCropFile(null);
+          if (!(open || avatarPending)) setCropFile(null);
         }}
       >
         <DialogContent showClose={!avatarPending} className="max-w-md">
@@ -186,9 +185,7 @@ export function ProfileForm({ name, handle, image, timezone }: ProfileFormProps)
               file={cropFile}
               pending={avatarPending}
               onCancel={() => setCropFile(null)}
-              onConfirm={(blob) => {
-                void onCropped(blob);
-              }}
+              onConfirm={onCropped}
             />
           )}
         </DialogContent>

--- a/apps/web/src/features/account/profile-form.tsx
+++ b/apps/web/src/features/account/profile-form.tsx
@@ -1,12 +1,23 @@
 'use client';
 
+import { AVATAR_MAX_BYTES } from '@orbit/shared/constants';
+import { formatBytes } from '@orbit/shared/utils';
 import { useRouter } from 'next/navigation';
-import { type FormEvent, useState } from 'react';
+import { type ChangeEvent, type FormEvent, useRef, useState } from 'react';
 import { Avatar } from '@/components/ui/avatar.tsx';
 import { Button } from '@/components/ui/button.tsx';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog.tsx';
 import { Input } from '@/components/ui/input.tsx';
 import { useToast } from '@/components/ui/toast.tsx';
 import { ApiRequestError, apiRequest, messageOf } from '@/lib/api/client.ts';
+import { AvatarCropper } from './avatar-cropper.tsx';
+import { removeAvatar, uploadAvatar } from './avatar-upload.ts';
 
 export interface ProfileFormProps {
   readonly name: string;
@@ -26,6 +37,61 @@ export function ProfileForm({ name, handle, image, timezone }: ProfileFormProps)
   const [handleError, setHandleError] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
 
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [cropFile, setCropFile] = useState<File | null>(null);
+  const [avatarPending, setAvatarPending] = useState(false);
+
+  function pickPhoto(): void {
+    fileInputRef.current?.click();
+  }
+
+  function onFileSelected(event: ChangeEvent<HTMLInputElement>): void {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (file === undefined) return;
+    if (!file.type.startsWith('image/')) {
+      toast({ title: 'That file is not an image.', tone: 'danger' });
+      return;
+    }
+    if (file.size > AVATAR_MAX_BYTES) {
+      toast({
+        title: `Photos must be ${formatBytes(AVATAR_MAX_BYTES)} or smaller.`,
+        tone: 'danger',
+      });
+      return;
+    }
+    setCropFile(file);
+  }
+
+  async function onCropped(blob: Blob): Promise<void> {
+    setAvatarPending(true);
+    try {
+      const nextImage = await uploadAvatar(blob);
+      setAvatarUrl(nextImage ?? '');
+      setCropFile(null);
+      toast({ title: 'Profile photo updated', tone: 'success' });
+      router.refresh();
+    } catch (caught) {
+      toast({ title: messageOf(caught), tone: 'danger' });
+    } finally {
+      setAvatarPending(false);
+    }
+  }
+
+  async function onRemovePhoto(): Promise<void> {
+    setAvatarPending(true);
+    try {
+      await removeAvatar();
+      setAvatarUrl('');
+      toast({ title: 'Profile photo removed', tone: 'success' });
+      router.refresh();
+    } catch (caught) {
+      toast({ title: messageOf(caught), tone: 'danger' });
+    } finally {
+      setAvatarPending(false);
+    }
+  }
+
   async function onSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
     setPending(true);
@@ -37,34 +103,96 @@ export function ProfileForm({ name, handle, image, timezone }: ProfileFormProps)
         body: {
           name: displayName,
           handle: userHandle,
-          image: avatarUrl.trim().length === 0 ? null : avatarUrl.trim(),
           timezone: zone,
         },
       });
       toast({ title: 'Profile updated', tone: 'success' });
       router.refresh();
     } catch (caught) {
-      if (caught instanceof ApiRequestError && caught.is('conflict'))
-        setHandleError(caught.message);
+      if (caught instanceof ApiRequestError && caught.is('conflict')) setHandleError(caught.message);
       else setFormError(messageOf(caught));
     } finally {
       setPending(false);
     }
   }
 
+  const hasAvatar = avatarUrl.trim().length > 0;
+
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-5" data-testid="profile-form">
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-4">
         <Avatar
           name={displayName}
-          src={avatarUrl.trim().length === 0 ? null : avatarUrl}
+          src={hasAvatar ? avatarUrl : null}
           size="lg"
+          className="size-16 text-lg"
         />
-        <div className="min-w-0">
-          <p className="truncate font-medium text-dense text-text">{displayName}</p>
-          <p className="truncate text-2xs text-faint">@{userHandle}</p>
+        <div className="flex min-w-0 flex-col gap-2">
+          <div>
+            <p className="truncate font-medium text-dense text-text">{displayName}</p>
+            <p className="truncate text-2xs text-faint">@{userHandle}</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={pickPhoto}
+              disabled={avatarPending}
+            >
+              {hasAvatar ? 'Change photo' : 'Upload photo'}
+            </Button>
+            {hasAvatar ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  void onRemovePhoto();
+                }}
+                disabled={avatarPending}
+              >
+                Remove
+              </Button>
+            ) : null}
+          </div>
         </div>
       </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={onFileSelected}
+        data-testid="avatar-file-input"
+      />
+
+      <Dialog
+        open={cropFile !== null}
+        onOpenChange={(open) => {
+          if (!open && !avatarPending) setCropFile(null);
+        }}
+      >
+        <DialogContent showClose={!avatarPending} className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Crop your photo</DialogTitle>
+            <DialogDescription>
+              Drag to reposition and use the slider to zoom. This is how you appear everywhere.
+            </DialogDescription>
+          </DialogHeader>
+          {cropFile === null ? null : (
+            <AvatarCropper
+              file={cropFile}
+              pending={avatarPending}
+              onCancel={() => setCropFile(null)}
+              onConfirm={(blob) => {
+                void onCropped(blob);
+              }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
 
       <fieldset disabled={pending} className="flex flex-col gap-5">
         <div className="flex flex-col gap-1.5">
@@ -106,20 +234,6 @@ export function ProfileForm({ name, handle, image, timezone }: ProfileFormProps)
               {handleError}
             </span>
           )}
-        </div>
-
-        <div className="flex flex-col gap-1.5">
-          <label htmlFor="profile-image" className="font-medium text-dense text-text">
-            Avatar URL
-          </label>
-          <Input
-            id="profile-image"
-            name="image"
-            type="url"
-            value={avatarUrl}
-            onChange={(event) => setAvatarUrl(event.target.value)}
-            placeholder="https://example.com/avatar.png"
-          />
         </div>
 
         <div className="flex flex-col gap-1.5">

--- a/apps/web/src/lib/api/profile-sync.ts
+++ b/apps/web/src/lib/api/profile-sync.ts
@@ -1,0 +1,31 @@
+import { buildSyncAction, nextSyncId } from '@orbit/core';
+import { db, eq, schema } from '@orbit/db';
+import type { SyncAction } from '@orbit/shared/events';
+import { scopes } from '@orbit/shared/events';
+
+interface ProfileActor {
+  readonly id: string;
+  readonly name: string;
+}
+
+export async function republishMemberships(user: ProfileActor): Promise<readonly SyncAction[]> {
+  const syncId = await nextSyncId(db);
+  const memberships = await db
+    .update(schema.member)
+    .set({ syncId })
+    .where(eq(schema.member.userId, user.id))
+    .returning();
+
+  return memberships.map((row) =>
+    buildSyncAction({
+      syncId: row.syncId,
+      organizationId: row.organizationId,
+      scopes: [scopes.organization(row.organizationId), scopes.user(row.userId)],
+      action: 'update',
+      model: 'member',
+      modelId: row.id,
+      data: row,
+      actor: { type: 'user', id: user.id, name: user.name },
+    }),
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from './content/comment-service.ts';
 export * from './content/doc-service.ts';
 export * from './internal.ts';
 export * from './org/active-organization.ts';
+export * from './org/avatar-service.ts';
 export * from './org/invite-service.ts';
 export * from './org/member-service.ts';
 export * from './org/onboarding-service.ts';

--- a/packages/core/src/org/avatar-service.test.ts
+++ b/packages/core/src/org/avatar-service.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { createUser, resetDatabase } from '../test-support.ts';
+import {
+  avatarPublicUrl,
+  avatarStorageKey,
+  clearAvatar,
+  isAvatarUrl,
+  saveAvatar,
+} from './avatar-service.ts';
+
+beforeEach(async () => {
+  await resetDatabase();
+});
+
+describe('avatar-service', () => {
+  it('derives a user-scoped storage key', () => {
+    expect(avatarStorageKey('user_123')).toBe('avatars/user_123');
+  });
+
+  it('builds a cache-busted public url from the version', () => {
+    expect(avatarPublicUrl('user_123', 42)).toBe('/api/avatars/user_123?v=42');
+  });
+
+  it('recognises its own avatar urls and ignores external ones', () => {
+    expect(isAvatarUrl('/api/avatars/user_123?v=1')).toBe(true);
+    expect(isAvatarUrl('https://example.com/a.png')).toBe(false);
+    expect(isAvatarUrl(null)).toBe(false);
+  });
+
+  it('points the user image at the avatar route when saved', async () => {
+    const user = await createUser('Ada Avatar');
+    const at = new Date('2026-07-24T00:00:00.000Z');
+
+    const updated = await saveAvatar(user.id, at);
+
+    expect(updated.image).toBe(`/api/avatars/${user.id}?v=${at.getTime()}`);
+  });
+
+  it('clears the image back to null when removed', async () => {
+    const user = await createUser('Ada Avatar');
+    await saveAvatar(user.id);
+
+    const cleared = await clearAvatar(user.id);
+
+    expect(cleared.image).toBeNull();
+  });
+});

--- a/packages/core/src/org/avatar-service.ts
+++ b/packages/core/src/org/avatar-service.ts
@@ -13,7 +13,7 @@ export function avatarPublicUrl(userId: string, version: number): string {
 }
 
 export function isAvatarUrl(image: string | null): boolean {
-  return image !== null && image.startsWith('/api/avatars/');
+  return (image ?? '').startsWith('/api/avatars/');
 }
 
 async function setImage(userId: string, image: string | null): Promise<UserRow> {

--- a/packages/core/src/org/avatar-service.ts
+++ b/packages/core/src/org/avatar-service.ts
@@ -1,0 +1,34 @@
+import { db, eq, schema } from '@orbit/db';
+import { requireRow } from '../internal.ts';
+import type { UserRow } from './profile-service.ts';
+
+const AVATAR_KEY_PREFIX = 'avatars';
+
+export function avatarStorageKey(userId: string): string {
+  return `${AVATAR_KEY_PREFIX}/${userId}`;
+}
+
+export function avatarPublicUrl(userId: string, version: number): string {
+  return `/api/avatars/${encodeURIComponent(userId)}?v=${version}`;
+}
+
+export function isAvatarUrl(image: string | null): boolean {
+  return image !== null && image.startsWith('/api/avatars/');
+}
+
+async function setImage(userId: string, image: string | null): Promise<UserRow> {
+  const [updated] = await db
+    .update(schema.user)
+    .set({ image, updatedAt: new Date() })
+    .where(eq(schema.user.id, userId))
+    .returning();
+  return requireRow(updated, 'That account does not exist.');
+}
+
+export async function saveAvatar(userId: string, at: Date = new Date()): Promise<UserRow> {
+  return await setImage(userId, avatarPublicUrl(userId, at.getTime()));
+}
+
+export async function clearAvatar(userId: string): Promise<UserRow> {
+  return await setImage(userId, null);
+}

--- a/packages/shared/src/constants/upload.ts
+++ b/packages/shared/src/constants/upload.ts
@@ -1,5 +1,9 @@
 export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
 
+export const AVATAR_MAX_BYTES = 5 * 1024 * 1024;
+export const AVATAR_DIMENSION = 512;
+export const AVATAR_CONTENT_TYPE = 'image/jpeg';
+
 export const ALLOWED_UPLOAD_MIME_PREFIXES = [
   'image/',
   'video/',

--- a/packages/shared/src/validators/avatar.ts
+++ b/packages/shared/src/validators/avatar.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+import { AVATAR_MAX_BYTES } from '../constants/index.ts';
+
+export const avatarUploadSchema = z.object({
+  contentType: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .refine((value) => value.startsWith('image/'), 'A profile photo has to be an image.'),
+  size: z.number().int().positive().max(AVATAR_MAX_BYTES),
+});
+
+export type AvatarUploadInput = z.infer<typeof avatarUploadSchema>;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1,4 +1,5 @@
 export * from './auth.ts';
+export * from './avatar.ts';
 export * from './bootstrap.ts';
 export * from './comment.ts';
 export * from './common.ts';

--- a/scripts/import-avatars.ts
+++ b/scripts/import-avatars.ts
@@ -1,0 +1,79 @@
+import { avatarStorageKey, saveAvatar } from '../packages/core/src/org/avatar-service.ts';
+import { db, eq, ilike, schema } from '../packages/db/src/index.ts';
+import { storageDriver } from '../packages/services/src/storage/index.ts';
+
+interface AvatarSource {
+  readonly slug: string;
+  readonly url: string;
+}
+
+const SOURCES: readonly AvatarSource[] = [
+  { slug: 'pulkit', url: 'https://ca.slack-edge.com/T04V91GUX2T-U092J4H80JK-1871fd7d634f-512' },
+  { slug: 'shashank', url: 'https://ca.slack-edge.com/T04V91GUX2T-U050N5XDQ0H-bdfb7bac8308-512' },
+  { slug: 'shivam', url: 'https://ca.slack-edge.com/T04V91GUX2T-U08GZEJ53D1-bfd6cb4160dd-512' },
+  { slug: 'aditi', url: 'https://ca.slack-edge.com/T04V91GUX2T-U086XCML82U-1cf562c133d0-512' },
+  { slug: 'pragati', url: 'https://ca.slack-edge.com/T04V91GUX2T-U0AT9SYCLV6-a8fbe43f3c25-512' },
+  { slug: 'tanzeela', url: 'https://ca.slack-edge.com/T04V91GUX2T-U094HMMC7U6-a2a0f9442abe-512' },
+  { slug: 'harkirat', url: 'https://ca.slack-edge.com/T04V91GUX2T-U0ABKEK80NM-80672da20575-512' },
+  { slug: 'koushik', url: 'https://ca.slack-edge.com/T04V91GUX2T-U09NX929PFW-d66216abe870-512' },
+  { slug: 'vidushi', url: 'https://ca.slack-edge.com/T04V91GUX2T-U092J4H80JK-1871fd7d634f-512' },
+];
+
+type FoundUser = { readonly id: string; readonly name: string };
+
+async function findUser(slug: string): Promise<FoundUser | null> {
+  const byHandle = await db
+    .select({ id: schema.user.id, name: schema.user.name })
+    .from(schema.user)
+    .where(eq(schema.user.handle, slug))
+    .limit(1);
+  if (byHandle[0] !== undefined) return byHandle[0];
+
+  const byEmail = await db
+    .select({ id: schema.user.id, name: schema.user.name })
+    .from(schema.user)
+    .where(ilike(schema.user.email, `${slug}@%`))
+    .limit(1);
+  if (byEmail[0] !== undefined) return byEmail[0];
+
+  const byName = await db
+    .select({ id: schema.user.id, name: schema.user.name })
+    .from(schema.user)
+    .where(ilike(schema.user.name, `${slug}%`))
+    .limit(2);
+  return byName.length === 1 && byName[0] !== undefined ? byName[0] : null;
+}
+
+async function download(url: string): Promise<{ bytes: Uint8Array; contentType: string }> {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`download failed with status ${response.status}`);
+  const contentType = response.headers.get('content-type') ?? 'image/jpeg';
+  if (!contentType.startsWith('image/')) throw new Error(`not an image (${contentType})`);
+  return { bytes: new Uint8Array(await response.arrayBuffer()), contentType };
+}
+
+async function main(): Promise<void> {
+  const storage = storageDriver();
+  let applied = 0;
+  const missing: string[] = [];
+
+  for (const source of SOURCES) {
+    const user = await findUser(source.slug);
+    if (user === null) {
+      missing.push(source.slug);
+      console.warn(`skip ${source.slug}: no matching user`);
+      continue;
+    }
+    const { bytes, contentType } = await download(source.url);
+    await storage.put(avatarStorageKey(user.id), bytes, contentType);
+    await saveAvatar(user.id);
+    applied += 1;
+    console.info(`ok   ${source.slug} -> ${user.name} (${user.id})`);
+  }
+
+  console.info(`\napplied ${applied}/${SOURCES.length} avatars`);
+  if (missing.length > 0) console.info(`unmatched: ${missing.join(', ')}`);
+}
+
+await main();
+process.exit(0);


### PR DESCRIPTION
Add an in-browser crop-and-upload flow for profile photos, served from S3 through a per-user avatar route.