### PR TITLE
fix(filters): stop the filter menu crashing on imported issues with malformed labelIds

### DIFF
--- a/apps/web/src/features/filters/filter-fields.tsx
+++ b/apps/web/src/features/filters/filter-fields.tsx
@@ -221,7 +221,10 @@ export function buildFilterFields(
         })),
         unsetOption('No label'),
       ],
-      countOf: (issue) => (issue.labelIds.length === 0 ? [UNSET_FILTER_VALUE] : issue.labelIds),
+      countOf: (issue) => {
+        const ids = Array.isArray(issue.labelIds) ? issue.labelIds : [];
+        return ids.length === 0 ? [UNSET_FILTER_VALUE] : ids;
+      },
     },
     {
       property: 'project',
@@ -305,7 +308,9 @@ export function countValues(
   const read = definition.countOf;
   if (read === null) return counts;
   for (const issue of issues) {
-    for (const key of read(issue)) counts.set(key, (counts.get(key) ?? 0) + 1);
+    const keys = read(issue);
+    if (!Array.isArray(keys)) continue;
+    for (const key of keys) counts.set(key, (counts.get(key) ?? 0) + 1);
   }
   return counts;
 }

--- a/apps/web/src/features/filters/grouping.test.ts
+++ b/apps/web/src/features/filters/grouping.test.ts
@@ -66,6 +66,11 @@ describe('groupKeysOf', () => {
     ]);
   });
 
+  it('does not throw when an imported issue has a non-array labelIds', () => {
+    const malformed = issue({ labelIds: null as unknown as string[] });
+    expect(groupKeysOf(malformed, 'label')).toEqual(['none']);
+  });
+
   it('falls back to the unset bucket when a field is empty', () => {
     expect(groupKeysOf(issue(), 'label')).toEqual(['none']);
     expect(groupKeysOf(issue(), 'assignee')).toEqual(['none']);

--- a/apps/web/src/features/filters/grouping.ts
+++ b/apps/web/src/features/filters/grouping.ts
@@ -131,8 +131,10 @@ export function groupKeysOf(issue: Issue, groupBy: GroupByField): readonly strin
       return [issue.projectId ?? UNGROUPED_ID];
     case 'cycle':
       return [issue.cycleId ?? UNGROUPED_ID];
-    case 'label':
-      return issue.labelIds.length === 0 ? [UNGROUPED_ID] : issue.labelIds;
+    case 'label': {
+      const ids = Array.isArray(issue.labelIds) ? issue.labelIds : [];
+      return ids.length === 0 ? [UNGROUPED_ID] : ids;
+    }
     case 'none':
       return ['all'];
   }

--- a/apps/web/src/lib/query/schemas.ts
+++ b/apps/web/src/lib/query/schemas.ts
@@ -36,7 +36,7 @@ export const issueSchema = z.object({
   createdAt: timestamp,
   updatedAt: timestamp,
   archivedAt: nullableTimestamp,
-  labelIds: z.array(z.string()).default([]),
+  labelIds: z.array(z.string()).catch([]).default([]),
 });
 
 export type Issue = z.infer<typeof issueSchema>;


### PR DESCRIPTION
Normalize labelIds at the parse boundary and guard the filter value counting and grouping so a non-array labelIds can no longer throw t is not iterable.