### PR TITLE
fix(layout): use full width on large screens instead of a fixed column cap

### DIFF
--- a/apps/web/src/app/(app)/analytics/page.tsx
+++ b/apps/web/src/app/(app)/analytics/page.tsx
@@ -88,7 +88,7 @@ export default async function AnalyticsPage({ searchParams }: PageProps) {
         )}
       </Card>
 
-      <div className="grid gap-4 lg:grid-cols-2">
+      <div className="grid gap-4 lg:grid-cols-2 4xl:grid-cols-4">
         <Card>
           <BarChart
             title="By assignee"

--- a/apps/web/src/app/(app)/settings/layout.tsx
+++ b/apps/web/src/app/(app)/settings/layout.tsx
@@ -3,7 +3,7 @@ import { SettingsNav } from '@/features/settings/settings-nav.tsx';
 
 export default function SettingsLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-6 py-8 3xl:max-w-5xl 4xl:max-w-6xl">
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-6 py-8 3xl:max-w-6xl 3xl:px-8 4xl:max-w-[88rem]">
       <header className="flex flex-col gap-1">
         <h1 className="font-semibold text-xl text-text">Settings</h1>
         <p className="text-muted text-xs">

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -279,7 +279,6 @@
 
   --container-prose: 540px;
   --container-detail: 700px;
-  --container-page: 1600px;
 
   --breakpoint-3xl: 120rem;
   --breakpoint-4xl: 160rem;

--- a/apps/web/src/components/layout/top-bar.test.ts
+++ b/apps/web/src/components/layout/top-bar.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { contentWidthClassName } from './top-bar.tsx';
+
+describe('contentWidthClassName', () => {
+  test('spans the full available width', () => {
+    expect(contentWidthClassName).toContain('w-full');
+  });
+
+  test('applies no hard column cap that leaves dead space on wide screens', () => {
+    expect(contentWidthClassName).not.toContain('max-w-page');
+    expect(contentWidthClassName).not.toMatch(/max-w-\[/);
+    expect(contentWidthClassName).not.toMatch(/\dxl:max-w/);
+  });
+});

--- a/apps/web/src/components/layout/top-bar.tsx
+++ b/apps/web/src/components/layout/top-bar.tsx
@@ -13,8 +13,7 @@ export interface Breadcrumb {
   readonly href?: string;
 }
 
-export const contentWidthClassName =
-  'mx-auto w-full max-w-page 3xl:max-w-[110rem] 4xl:max-w-[120rem]';
+export const contentWidthClassName = 'w-full';
 
 export interface TopBarProps {
   readonly breadcrumbs: readonly Breadcrumb[];


### PR DESCRIPTION
Remove the fixed max-w-page content cap so app surfaces fill the available width on wide monitors, keeping a readable measure for prose and settings.