### PR TITLE
feat(auth): allow linking a provider whose email differs from the account

### DIFF
--- a/apps/web/src/lib/auth/server.test.ts
+++ b/apps/web/src/lib/auth/server.test.ts
@@ -15,6 +15,11 @@ describe('password authentication', () => {
     );
   });
 
+  it('lets an authenticated user link a provider whose email differs', () => {
+    expect(auth.options.account?.accountLinking?.enabled).toBe(true);
+    expect(auth.options.account?.accountLinking?.allowDifferentEmails).toBe(true);
+  });
+
   it('hashes with argon2id and verifies the hash', async () => {
     const hash = await Bun.password.hash('a-very-long-password', { algorithm: 'argon2id' });
     expect(hash.startsWith('$argon2id$')).toBe(true);

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -101,7 +101,9 @@ export const auth = betterAuth({
   emailAndPassword: emailAndPassword(),
   ...rateLimit(),
   socialProviders: socialProviders(),
-  account: { accountLinking: { enabled: true, allowUnlinkingAll: true } },
+  account: {
+    accountLinking: { enabled: true, allowUnlinkingAll: true, allowDifferentEmails: true },
+  },
   session: {
     expiresIn: SESSION_MAX_AGE_SECONDS,
     cookieCache: { enabled: true, maxAge: SESSION_CACHE_SECONDS },


### PR DESCRIPTION
Set accountLinking.allowDifferentEmails so an authenticated user can link a GitHub or Google account whose verified email differs from their Orbit email.