### PR TITLE
fix(filters): stop the filter menu crashing on the paged issues cache shape

### DIFF
--- a/apps/web/src/features/filters/filter-fields.test.tsx
+++ b/apps/web/src/features/filters/filter-fields.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import type { Issue } from '@/lib/query/schemas.ts';
+import { countValues, type FilterFieldDefinition } from './filter-fields.tsx';
+
+const labelDef = {
+  property: 'label',
+  input: 'values',
+  label: 'Label',
+  options: [],
+  countOf: (issue: Issue) => (Array.isArray(issue.labelIds) ? issue.labelIds : []),
+} as unknown as FilterFieldDefinition;
+
+describe('countValues', () => {
+  it('never throws when the issues argument is not an array', () => {
+    const infiniteDataShape = { pages: [], pageParams: [] } as unknown as readonly Issue[];
+    expect(countValues(labelDef, infiniteDataShape).size).toBe(0);
+    expect(countValues(labelDef, undefined as unknown as readonly Issue[]).size).toBe(0);
+  });
+
+  it('counts values for a normal issue array', () => {
+    const rows = [
+      { labelIds: ['bug'] },
+      { labelIds: ['bug', 'perf'] },
+    ] as unknown as readonly Issue[];
+    const counts = countValues(labelDef, rows);
+    expect(counts.get('bug')).toBe(2);
+    expect(counts.get('perf')).toBe(1);
+  });
+});

--- a/apps/web/src/features/filters/filter-fields.tsx
+++ b/apps/web/src/features/filters/filter-fields.tsx
@@ -307,7 +307,8 @@ export function countValues(
   const counts = new Map<string, number>();
   const read = definition.countOf;
   if (read === null) return counts;
-  for (const issue of issues) {
+  const list: readonly Issue[] = Array.isArray(issues) ? issues : [];
+  for (const issue of list) {
     const keys = read(issue);
     if (!Array.isArray(keys)) continue;
     for (const key of keys) counts.set(key, (counts.get(key) ?? 0) + 1);

--- a/apps/web/src/features/issues/team-view.tsx
+++ b/apps/web/src/features/issues/team-view.tsx
@@ -24,9 +24,20 @@ import { viewConfigToState } from '@/features/filters/view-config.ts';
 import { useProvideViewControls } from '@/features/filters/view-controls.tsx';
 import { cn } from '@/lib/cn.ts';
 import { useHotkey } from '@/lib/keyboard/index.ts';
-import type { View, WorkflowState } from '@/lib/query/schemas.ts';
+import type { Issue, View, WorkflowState } from '@/lib/query/schemas.ts';
+import type { IssuePages } from '@/lib/query/sync.ts';
+import { flattenIssuePages } from '@/lib/query/sync.ts';
 import { teamIssuesQuery, useIssues } from '@/lib/query/use-issues.ts';
 import { useViews } from '@/lib/query/use-views.ts';
+
+function toIssueArray(data: unknown, fallback: readonly Issue[]): readonly Issue[] {
+  if (Array.isArray(data)) return data as readonly Issue[];
+  if (data !== null && typeof data === 'object' && 'pages' in data) {
+    return flattenIssuePages(data as IssuePages);
+  }
+  return fallback;
+}
+
 import { Board } from './board.tsx';
 import { IssueList } from './issue-list.tsx';
 import { ListSkeleton } from './list-skeleton.tsx';
@@ -100,9 +111,14 @@ export function TeamView({ teamKey, layout }: TeamViewProps) {
     ],
   );
 
+  const unfilteredRows = useMemo(
+    () => toIssueArray(unfiltered.data, rows),
+    [unfiltered.data, rows],
+  );
+
   const hiddenByFilters =
     filtered && unfiltered.data !== undefined
-      ? Math.max(0, unfiltered.data.length - rows.length)
+      ? Math.max(0, unfilteredRows.length - rows.length)
       : 0;
 
   const other = layout === 'board' ? 'issues' : 'board';
@@ -160,7 +176,7 @@ export function TeamView({ teamKey, layout }: TeamViewProps) {
         config={config}
         onChange={setConfig}
         controls={controls}
-        issues={unfiltered.data ?? rows}
+        issues={unfilteredRows}
         savedView={savedView}
         dirty={savedView !== null && isDirty(config, layout, savedView)}
       />


### PR DESCRIPTION
The team view feeds the filter bar unfiltered.data, which shares a query key with the infinite issues query and can be the paged {pages} object rather than a flat array, so normalize it and guard countValues against a non-array issues argument.