### PR TITLE
refactor(account): profile photos are S3-only, ingest OAuth avatars, drop URL input

### DIFF
--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { passkey } from '@better-auth/passkey';
-import { assertEmailDomainAllowed } from '@orbit/core';
+import { assertEmailDomainAllowed, ingestExternalAvatar, isExternalImageUrl } from '@orbit/core';
 import { db, eq, schema } from '@orbit/db';
 import { inviteEmail, magicLinkEmail, resetPasswordEmail, sendEmail } from '@orbit/services/email';
 import { DomainError } from '@orbit/shared/errors';
@@ -140,6 +140,10 @@ export const auth = betterAuth({
           return Promise.resolve({
             data: { ...user, handle: handleFor(user.email, user.name) },
           });
+        },
+        after: async (user) => {
+          const image = user.image ?? null;
+          if (isExternalImageUrl(image)) await ingestExternalAvatar(user.id, image);
         },
       },
     },

--- a/bun.lock
+++ b/bun.lock
@@ -112,6 +112,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@orbit/db": "workspace:*",
+        "@orbit/services": "workspace:*",
         "@orbit/shared": "workspace:*",
         "drizzle-orm": "0.45.2",
         "zod": "4.4.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@orbit/db": "workspace:*",
+    "@orbit/services": "workspace:*",
     "@orbit/shared": "workspace:*",
     "drizzle-orm": "0.45.2",
     "zod": "4.4.3"

--- a/packages/core/src/org/avatar-service.test.ts
+++ b/packages/core/src/org/avatar-service.test.ts
@@ -1,16 +1,49 @@
-import { beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { StorageDriver } from '@orbit/services/storage';
+import { db, eq, schema } from '@orbit/db';
 import { createUser, resetDatabase } from '../test-support.ts';
 import {
   avatarPublicUrl,
   avatarStorageKey,
   clearAvatar,
+  ingestExternalAvatar,
   isAvatarUrl,
+  isExternalImageUrl,
   saveAvatar,
 } from './avatar-service.ts';
 
 beforeEach(async () => {
   await resetDatabase();
 });
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function fakeDriver(): { driver: StorageDriver; puts: Array<{ key: string; type: string }> } {
+  const puts: Array<{ key: string; type: string }> = [];
+  const driver = {
+    name: 's3',
+    put: (key: string, _body: Uint8Array, type: string) => {
+      puts.push({ key, type });
+      return Promise.resolve();
+    },
+    createUploadTarget: () => Promise.reject(new Error('unused')),
+    getUrl: () => Promise.reject(new Error('unused')),
+    delete: () => Promise.resolve(),
+    stat: () => Promise.resolve(null),
+  } as unknown as StorageDriver;
+  return { driver, puts };
+}
+
+async function imageOf(userId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ image: schema.user.image })
+    .from(schema.user)
+    .where(eq(schema.user.id, userId));
+  return row?.image ?? null;
+}
 
 describe('avatar-service', () => {
   it('derives a user-scoped storage key', () => {
@@ -43,5 +76,59 @@ describe('avatar-service', () => {
     const cleared = await clearAvatar(user.id);
 
     expect(cleared.image).toBeNull();
+  });
+
+  it('flags external image urls but not its own or empty ones', () => {
+    expect(isExternalImageUrl('https://lh3.googleusercontent.com/a/x')).toBe(true);
+    expect(isExternalImageUrl('/api/avatars/user_123?v=1')).toBe(false);
+    expect(isExternalImageUrl(null)).toBe(false);
+    expect(isExternalImageUrl('')).toBe(false);
+  });
+
+  it('ingests an external photo into storage and points image at the avatar route', async () => {
+    const user = await createUser('Otto OAuth');
+    const { driver, puts } = fakeDriver();
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { 'content-type': 'image/png' },
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    const ok = await ingestExternalAvatar(user.id, 'https://provider.example/a.png', driver);
+
+    expect(ok).toBe(true);
+    expect(puts).toEqual([{ key: `avatars/${user.id}`, type: 'image/png' }]);
+    expect(await imageOf(user.id)).toStartWith(`/api/avatars/${user.id}?v=`);
+  });
+
+  it('drops the image to null when the external photo cannot be ingested', async () => {
+    const user = await createUser('Otto OAuth');
+    await saveAvatar(user.id);
+    const { driver } = fakeDriver();
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response('nope', { status: 404 })),
+    ) as unknown as typeof fetch;
+
+    const ok = await ingestExternalAvatar(user.id, 'https://provider.example/gone.png', driver);
+
+    expect(ok).toBe(false);
+    expect(await imageOf(user.id)).toBeNull();
+  });
+
+  it('rejects a non-image content type without storing anything', async () => {
+    const user = await createUser('Otto OAuth');
+    const { driver, puts } = fakeDriver();
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response('<html>', { status: 200, headers: { 'content-type': 'text/html' } })),
+    ) as unknown as typeof fetch;
+
+    const ok = await ingestExternalAvatar(user.id, 'https://provider.example/page', driver);
+
+    expect(ok).toBe(false);
+    expect(puts).toEqual([]);
+    expect(await imageOf(user.id)).toBeNull();
   });
 });

--- a/packages/core/src/org/avatar-service.test.ts
+++ b/packages/core/src/org/avatar-service.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-import type { StorageDriver } from '@orbit/services/storage';
 import { db, eq, schema } from '@orbit/db';
+import type { StorageDriver } from '@orbit/services/storage';
 import { createUser, resetDatabase } from '../test-support.ts';
 import {
   avatarPublicUrl,
@@ -122,7 +122,9 @@ describe('avatar-service', () => {
     const user = await createUser('Otto OAuth');
     const { driver, puts } = fakeDriver();
     globalThis.fetch = mock(() =>
-      Promise.resolve(new Response('<html>', { status: 200, headers: { 'content-type': 'text/html' } })),
+      Promise.resolve(
+        new Response('<html>', { status: 200, headers: { 'content-type': 'text/html' } }),
+      ),
     ) as unknown as typeof fetch;
 
     const ok = await ingestExternalAvatar(user.id, 'https://provider.example/page', driver);

--- a/packages/core/src/org/avatar-service.ts
+++ b/packages/core/src/org/avatar-service.ts
@@ -1,8 +1,11 @@
 import { db, eq, schema } from '@orbit/db';
+import { type StorageDriver, storageDriver } from '@orbit/services/storage';
+import { AVATAR_MAX_BYTES } from '@orbit/shared/constants';
 import { requireRow } from '../internal.ts';
 import type { UserRow } from './profile-service.ts';
 
 const AVATAR_KEY_PREFIX = 'avatars';
+const EXTERNAL_FETCH_TIMEOUT_MS = 10_000;
 
 export function avatarStorageKey(userId: string): string {
   return `${AVATAR_KEY_PREFIX}/${userId}`;
@@ -14,6 +17,10 @@ export function avatarPublicUrl(userId: string, version: number): string {
 
 export function isAvatarUrl(image: string | null): boolean {
   return (image ?? '').startsWith('/api/avatars/');
+}
+
+export function isExternalImageUrl(image: string | null): image is string {
+  return image !== null && image.length > 0 && !isAvatarUrl(image);
 }
 
 async function setImage(userId: string, image: string | null): Promise<UserRow> {
@@ -31,4 +38,29 @@ export async function saveAvatar(userId: string, at: Date = new Date()): Promise
 
 export async function clearAvatar(userId: string): Promise<UserRow> {
   return await setImage(userId, null);
+}
+
+export async function ingestExternalAvatar(
+  userId: string,
+  sourceUrl: string,
+  driver: StorageDriver = storageDriver(),
+): Promise<boolean> {
+  try {
+    const response = await fetch(sourceUrl, {
+      signal: AbortSignal.timeout(EXTERNAL_FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) throw new Error(`status ${response.status}`);
+    const contentType = (response.headers.get('content-type') ?? '').split(';')[0]?.trim() ?? '';
+    if (!contentType.startsWith('image/')) throw new Error(`not an image (${contentType})`);
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength === 0 || bytes.byteLength > AVATAR_MAX_BYTES) {
+      throw new Error(`unusable size ${bytes.byteLength}`);
+    }
+    await driver.put(avatarStorageKey(userId), bytes, contentType);
+    await saveAvatar(userId);
+    return true;
+  } catch {
+    await clearAvatar(userId).catch(() => undefined);
+    return false;
+  }
 }

--- a/packages/core/src/org/profile-service.test.ts
+++ b/packages/core/src/org/profile-service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
+import { db, eq, schema } from '@orbit/db';
 import { createUser, resetDatabase } from '../test-support.ts';
 import { updateProfile } from './profile-service.ts';
 
@@ -7,20 +8,28 @@ beforeEach(async () => {
 });
 
 describe('updateProfile', () => {
-  it('saves the display name, handle, avatar and timezone', async () => {
+  it('saves the display name, handle and timezone', async () => {
     const user = await createUser('Nia New');
 
     const updated = await updateProfile(user.id, {
       name: 'Nia Newton',
       handle: 'nia-newton',
-      image: 'https://example.com/nia.png',
       timezone: 'Asia/Kolkata',
     });
 
     expect(updated.name).toBe('Nia Newton');
     expect(updated.handle).toBe('nia-newton');
-    expect(updated.image).toBe('https://example.com/nia.png');
     expect(updated.timezone).toBe('Asia/Kolkata');
+  });
+
+  it('never lets the profile update touch the avatar image', async () => {
+    const user = await createUser('Nia New');
+    await updateProfile(user.id, { name: 'Nia N.', image: 'https://evil.example.com/x.png' });
+    const [row] = await db
+      .select({ image: schema.user.image })
+      .from(schema.user)
+      .where(eq(schema.user.id, user.id));
+    expect(row?.image ?? null).toBeNull();
   });
 
   it('leaves untouched fields alone', async () => {

--- a/packages/core/src/org/profile-service.ts
+++ b/packages/core/src/org/profile-service.ts
@@ -23,7 +23,6 @@ export async function updateProfile(userId: string, input: unknown): Promise<Use
   const values: Partial<typeof schema.user.$inferInsert> = {};
   if (parsed.name !== undefined) values.name = parsed.name;
   if (parsed.handle !== undefined) values.handle = parsed.handle;
-  if (parsed.image !== undefined) values.image = parsed.image;
   if (parsed.timezone !== undefined) values.timezone = parsed.timezone;
 
   if (parsed.handle !== undefined) {

--- a/packages/shared/src/validators/profile.ts
+++ b/packages/shared/src/validators/profile.ts
@@ -13,7 +13,6 @@ export const profileUpdateSchema = z
   .object({
     name: z.string().trim().min(1).max(64),
     handle: handleSchema,
-    image: z.string().url().max(2048).nullable(),
     timezone: z.string().trim().min(1).max(64),
   })
   .partial();

--- a/scripts/ingest-external-avatars.ts
+++ b/scripts/ingest-external-avatars.ts
@@ -1,0 +1,27 @@
+import { ingestExternalAvatar } from '../packages/core/src/org/avatar-service.ts';
+import { and, db, ilike, isNotNull, not, schema } from '../packages/db/src/index.ts';
+
+const rows = await db
+  .select({ id: schema.user.id, name: schema.user.name, image: schema.user.image })
+  .from(schema.user)
+  .where(and(isNotNull(schema.user.image), not(ilike(schema.user.image, '/api/avatars/%'))));
+
+console.info(`found ${rows.length} users with an external image url`);
+
+let ingested = 0;
+const dropped: string[] = [];
+for (const row of rows) {
+  if (row.image === null) continue;
+  const ok = await ingestExternalAvatar(row.id, row.image);
+  if (ok) {
+    ingested += 1;
+    console.info(`ok   ${row.name} (${row.id})`);
+  } else {
+    dropped.push(row.name);
+    console.warn(`drop ${row.name} (${row.id}): external image unreachable, cleared`);
+  }
+}
+
+console.info(`\ningested ${ingested}/${rows.length}; cleared ${dropped.length}`);
+if (dropped.length > 0) console.info(`cleared: ${dropped.join(', ')}`);
+process.exit(0);


### PR DESCRIPTION
Remove the pasted avatar-URL path and ingest Google/GitHub sign-in photos into S3 so user.image only ever holds our own /api/avatars link.