### PR TITLE
fix(realtime): authenticate the websocket with a short-lived signed ticket instead of the session token in the url

### DIFF
--- a/apps/realtime/src/active-organization.test.ts
+++ b/apps/realtime/src/active-organization.test.ts
@@ -68,9 +68,9 @@ async function publish(action: ReturnType<typeof syncAction>): Promise<void> {
   await publisher.publish(DELTA_CHANNEL, JSON.stringify(action));
 }
 
-describe('client stated organization', () => {
-  it('authorizes the stated organization and delivers only its deltas', async () => {
-    const client = await connectClient(server.port, dual.token, orgB);
+describe('ticket organization', () => {
+  it('honors the organization named in the ticket and delivers only its deltas', async () => {
+    const client = await connectClient(server.port, dual, orgB);
     const ready = await client.waitFor('ready');
     expect(ready.organizationId).toBe(orgB);
 
@@ -106,23 +106,13 @@ describe('client stated organization', () => {
     client.close();
   });
 
-  it('rejects a stated organization the user does not belong to', async () => {
-    const client = await connectClient(server.port, dual.token, outsiderOrg);
+  it('rejects a ticket for an organization the user does not belong to', async () => {
+    const client = await connectClient(server.port, dual, outsiderOrg);
     expect(await client.waitForClose()).toBe(ORGANIZATION_FORBIDDEN_CLOSE_CODE);
   });
 
-  it('rejects an empty stated organization instead of choosing one', async () => {
-    const client = await connectClient(server.port, ambiguous.token, '');
-    expect(await client.waitForClose()).toBe(ORGANIZATION_FORBIDDEN_CLOSE_CODE);
-  });
-
-  it('rejects a stated organization longer than an identifier can be', async () => {
-    const client = await connectClient(server.port, ambiguous.token, 'x'.repeat(200));
-    expect(await client.waitForClose()).toBe(ORGANIZATION_FORBIDDEN_CLOSE_CODE);
-  });
-
-  it('falls back to the oldest membership when the client states nothing', async () => {
-    const client = await connectClient(server.port, ambiguous.token);
+  it('honors the second workspace of a multi-organization member', async () => {
+    const client = await connectClient(server.port, ambiguous, orgA);
     const ready = await client.waitFor('ready');
     expect(ready.organizationId).toBe(orgA);
     client.close();

--- a/apps/realtime/src/auth.test.ts
+++ b/apps/realtime/src/auth.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  REALTIME_TICKET_TTL_MS,
+  type RealtimeTicketPayload,
+  signRealtimeTicket,
+} from '@orbit/shared/events/ticket';
+import { readTicketFrame } from './auth.ts';
+
+const SECRET = 'secret-value-that-is-long-enough';
+const NOW = 1_800_000_000_000;
+
+function payload(overrides: Partial<RealtimeTicketPayload> = {}): RealtimeTicketPayload {
+  return {
+    userId: 'user_1',
+    organizationId: 'org_1',
+    sessionId: 'session_1',
+    exp: NOW + REALTIME_TICKET_TTL_MS,
+    ...overrides,
+  };
+}
+
+function frame(ticket: string): string {
+  return JSON.stringify({ type: 'auth', ticket });
+}
+
+describe('readTicketFrame', () => {
+  it('returns the payload of a valid first frame', () => {
+    const raw = frame(signRealtimeTicket(payload(), SECRET));
+    expect(readTicketFrame(raw, SECRET, NOW)).toEqual(payload());
+  });
+
+  it('rejects a frame that is not valid json', () => {
+    expect(readTicketFrame('not json', SECRET, NOW)).toBeNull();
+  });
+
+  it('rejects a frame that is not an auth message', () => {
+    expect(readTicketFrame(JSON.stringify({ type: 'ping' }), SECRET, NOW)).toBeNull();
+    expect(readTicketFrame(JSON.stringify({ type: 'auth' }), SECRET, NOW)).toBeNull();
+  });
+
+  it('rejects a forged ticket', () => {
+    expect(readTicketFrame(frame('forged.ticket'), SECRET, NOW)).toBeNull();
+  });
+
+  it('rejects a ticket signed with the wrong secret', () => {
+    const raw = frame(signRealtimeTicket(payload(), 'a-different-secret-value'));
+    expect(readTicketFrame(raw, SECRET, NOW)).toBeNull();
+  });
+
+  it('rejects an expired ticket', () => {
+    const raw = frame(signRealtimeTicket(payload({ exp: NOW - 1 }), SECRET));
+    expect(readTicketFrame(raw, SECRET, NOW)).toBeNull();
+  });
+});

--- a/apps/realtime/src/auth.ts
+++ b/apps/realtime/src/auth.ts
@@ -1,11 +1,12 @@
-import { selectActiveMembership } from '@orbit/core';
 import { and, db, eq, gt, schema } from '@orbit/db';
 import { ORG_ROLES, type OrgRole } from '@orbit/shared/constants';
+import { authMessageSchema } from '@orbit/shared/events';
+import { type RealtimeTicketPayload, verifyRealtimeTicket } from '@orbit/shared/events/ticket';
 import { z } from 'zod';
 
 export interface ConnectionPrincipal {
   readonly userId: string;
-  readonly sessionToken: string;
+  readonly sessionId: string;
   readonly name: string;
   readonly image: string | null;
   readonly organizationId: string;
@@ -44,12 +45,12 @@ interface SessionUser {
 async function toPrincipal(
   user: SessionUser,
   membership: { readonly organizationId: string; readonly role: string },
-  sessionToken: string,
+  sessionId: string,
 ): Promise<ConnectionPrincipal> {
   const role = roleSchema.parse(membership.role);
   return {
     userId: user.userId,
-    sessionToken,
+    sessionId,
     name: user.name,
     image: user.image,
     organizationId: membership.organizationId,
@@ -64,52 +65,76 @@ export type ConnectionAuthentication =
   | { readonly ok: true; readonly principal: ConnectionPrincipal }
   | { readonly ok: false; readonly reason: ConnectionRejection };
 
-export async function authenticateConnection(
-  token: string,
-  statedOrganizationId: string | null,
+export function readTicketFrame(
+  raw: string,
+  secret: string,
+  now?: number,
+): RealtimeTicketPayload | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const frame = authMessageSchema.safeParse(parsed);
+  if (!frame.success) return null;
+  return verifyRealtimeTicket(frame.data.ticket, secret, now);
+}
+
+export async function authenticateTicket(
+  payload: RealtimeTicketPayload,
 ): Promise<ConnectionAuthentication> {
   const sessions = await db
     .select({
       userId: schema.user.id,
       name: schema.user.name,
       image: schema.user.image,
-      activeOrganizationId: schema.session.activeOrganizationId,
     })
     .from(schema.session)
     .innerJoin(schema.user, eq(schema.user.id, schema.session.userId))
-    .where(and(eq(schema.session.token, token), gt(schema.session.expiresAt, new Date())))
+    .where(
+      and(
+        eq(schema.session.id, payload.sessionId),
+        eq(schema.session.userId, payload.userId),
+        gt(schema.session.expiresAt, new Date()),
+      ),
+    )
     .limit(1);
 
   const found = sessions[0];
   if (found === undefined) return { ok: false, reason: 'unauthorized' };
 
   const memberships = await db
-    .select({
-      organizationId: schema.member.organizationId,
-      role: schema.member.role,
-      createdAt: schema.member.createdAt,
-    })
+    .select({ role: schema.member.role })
     .from(schema.member)
-    .where(eq(schema.member.userId, found.userId));
+    .where(
+      and(
+        eq(schema.member.userId, found.userId),
+        eq(schema.member.organizationId, payload.organizationId),
+      ),
+    )
+    .limit(1);
 
-  if (statedOrganizationId !== null) {
-    const stated = memberships.find((row) => row.organizationId === statedOrganizationId);
-    if (stated === undefined) return { ok: false, reason: 'organization_forbidden' };
-    return { ok: true, principal: await toPrincipal(found, stated, token) };
-  }
+  const membership = memberships[0];
+  if (membership === undefined) return { ok: false, reason: 'organization_forbidden' };
 
-  const active = selectActiveMembership(memberships, found.activeOrganizationId);
-  if (active === undefined) return { ok: false, reason: 'unauthorized' };
-  return { ok: true, principal: await toPrincipal(found, active, token) };
+  return {
+    ok: true,
+    principal: await toPrincipal(
+      found,
+      { organizationId: payload.organizationId, role: membership.role },
+      payload.sessionId,
+    ),
+  };
 }
 
 export const memberDeleteSchema = z.object({ userId: z.string().min(1) });
 
-export async function sessionStillValid(sessionToken: string): Promise<boolean> {
+export async function sessionStillValid(sessionId: string): Promise<boolean> {
   const rows = await db
     .select({ id: schema.session.id })
     .from(schema.session)
-    .where(and(eq(schema.session.token, sessionToken), gt(schema.session.expiresAt, new Date())))
+    .where(and(eq(schema.session.id, sessionId), gt(schema.session.expiresAt, new Date())))
     .limit(1);
   return rows.length > 0;
 }

--- a/apps/realtime/src/client-reconnect.test.ts
+++ b/apps/realtime/src/client-reconnect.test.ts
@@ -12,6 +12,7 @@ import {
   redisUrl,
   type SeedMember,
   syncAction,
+  ticketFor,
 } from './test-helpers.ts';
 
 const DELTA_CHANNEL = 'orbit:delta';
@@ -46,8 +47,7 @@ it('reconnects and resubscribes after the server drops the socket', async () => 
 
   const client = createRealtimeClient({
     url: `ws://127.0.0.1:${port}`,
-    token: member.token,
-    organizationId,
+    fetchTicket: () => Promise.resolve(ticketFor(member, organizationId)),
     maxBackoffMs: 500,
     onStatus: (status) => statuses.push(status),
     onDelta: (actions) => received.push(...actions),

--- a/apps/realtime/src/connection.test.ts
+++ b/apps/realtime/src/connection.test.ts
@@ -6,7 +6,7 @@ import { Connection, type ConnectionLimits, type SocketData } from './connection
 
 const principal: ConnectionPrincipal = {
   userId: 'user_1',
-  sessionToken: 'token_1',
+  sessionId: 'session_1',
   name: 'Ada',
   image: null,
   organizationId: 'org_1',

--- a/apps/realtime/src/connection.ts
+++ b/apps/realtime/src/connection.ts
@@ -1,6 +1,6 @@
 import type { ServerMessage, SyncAction } from '@orbit/shared/events';
 import type { ServerWebSocket } from 'bun';
-import type { ConnectionPrincipal, ConnectionRejection } from './auth.ts';
+import type { ConnectionPrincipal } from './auth.ts';
 import { logger } from './logger.ts';
 
 export interface ConnectionLimits {
@@ -11,9 +11,11 @@ export interface ConnectionLimits {
   readonly messagesPerSecond: number;
 }
 
-export type SocketData =
-  | { readonly rejection: ConnectionRejection }
-  | { readonly principal: ConnectionPrincipal; connection: Connection | null };
+export interface SocketData {
+  connection: Connection | null;
+  authenticating: boolean;
+  authTimer: ReturnType<typeof setTimeout> | undefined;
+}
 
 export class Connection {
   readonly scopes = new Set<string>();

--- a/apps/realtime/src/env.ts
+++ b/apps/realtime/src/env.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 const envSchema = z.object({
   REALTIME_PORT: z.coerce.number().int().min(0).max(65535).default(3100),
   REDIS_URL: z.string().min(1).default('redis://localhost:6380'),
+  BETTER_AUTH_SECRET: z.string().min(16),
 });
 
 export const env = envSchema.parse(process.env);

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -6,6 +6,7 @@ import { createRealtimeServer } from './server.ts';
 const server = await createRealtimeServer({
   port: env.REALTIME_PORT,
   redisUrl: env.REDIS_URL,
+  ticketSecret: env.BETTER_AUTH_SECRET,
 });
 
 let shuttingDown = false;

--- a/apps/realtime/src/membership-revocation.test.ts
+++ b/apps/realtime/src/membership-revocation.test.ts
@@ -54,7 +54,7 @@ async function publishMemberDelete(userId: string, organization: string): Promis
 describe('membership revocation', () => {
   it('closes the socket of a member who was removed', async () => {
     const removed = await createMember({ organizationId, teamIds: [teamId] });
-    const client = await connectClient(server.port, removed.token, organizationId);
+    const client = await connectClient(server.port, removed, organizationId);
     await client.waitFor('ready');
 
     await db
@@ -73,7 +73,7 @@ describe('membership revocation', () => {
 
   it('keeps a member connected when the delta only drops a team membership', async () => {
     const staying = await createMember({ organizationId, teamIds: [teamId] });
-    const client = await connectClient(server.port, staying.token, organizationId);
+    const client = await connectClient(server.port, staying, organizationId);
     await client.waitFor('ready');
 
     await db.delete(schema.teamMember).where(eq(schema.teamMember.userId, staying.userId));

--- a/apps/realtime/src/server.test.ts
+++ b/apps/realtime/src/server.test.ts
@@ -1,20 +1,25 @@
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { randomBytes } from 'node:crypto';
 import { scopes } from '@orbit/shared/events';
+import { signRealtimeTicket } from '@orbit/shared/events/ticket';
 import { connect, type RedisClient, type Socket } from 'bun';
 import { createRealtimeServer, type RealtimeServer } from './server.ts';
 import {
   cleanupFixtures,
   connectClient,
+  connectWithTicket,
   createIssue,
   createMember,
   createOrganization,
   createPublisher,
   createTeam,
   delay,
+  maskedTextFrame,
   redisUrl,
   type SeedMember,
   syncAction,
+  ticketFor,
+  ticketSecret,
 } from './test-helpers.ts';
 
 const BATCH_WINDOW_MS = 80;
@@ -60,7 +65,7 @@ async function publish(action: ReturnType<typeof syncAction>): Promise<void> {
 const HANDSHAKE_TIMEOUT_MS = 5_000;
 const HANDSHAKE_SETTLE_MS = 25;
 
-async function connectSilently(port: number, token: string): Promise<Socket<undefined>> {
+async function connectSilently(port: number, member: SeedMember): Promise<Socket<undefined>> {
   let markUpgraded: (() => void) | undefined;
   let failUpgrade: ((error: Error) => void) | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -100,7 +105,7 @@ async function connectSilently(port: number, token: string): Promise<Socket<unde
 
   socket.write(
     [
-      `GET /?token=${encodeURIComponent(token)} HTTP/1.1`,
+      'GET / HTTP/1.1',
       `Host: 127.0.0.1:${port}`,
       'Upgrade: websocket',
       'Connection: Upgrade',
@@ -116,18 +121,19 @@ async function connectSilently(port: number, token: string): Promise<Socket<unde
   } finally {
     clearTimeout(timer);
   }
+  socket.write(maskedTextFrame(JSON.stringify({ type: 'auth', ticket: ticketFor(member) })));
   await delay(HANDSHAKE_SETTLE_MS);
   return socket;
 }
 
 describe('fan-out', () => {
   it('delivers a delta only to connections subscribed to the scope', async () => {
-    const subscribed = await connectClient(server.port, alice.token);
+    const subscribed = await connectClient(server.port, alice);
     await subscribed.waitFor('ready');
     subscribed.send({ type: 'subscribe', scopes: [scopes.team(teamA)] });
     await subscribed.waitFor('subscribed');
 
-    const other = await connectClient(server.port, bob.token);
+    const other = await connectClient(server.port, bob);
     await other.waitFor('ready');
     other.send({ type: 'subscribe', scopes: [scopes.team(teamB)] });
     await other.waitFor('subscribed');
@@ -151,7 +157,7 @@ describe('fan-out', () => {
   });
 
   it('never delivers a delta from another organization', async () => {
-    const client = await connectClient(server.port, carol.token);
+    const client = await connectClient(server.port, carol);
     await client.waitFor('ready');
     client.send({ type: 'subscribe', scopes: [scopes.organization(orgB)] });
     await client.waitFor('subscribed');
@@ -171,7 +177,7 @@ describe('fan-out', () => {
   });
 
   it('batches rapid actions into one delta and collapses duplicates', async () => {
-    const client = await connectClient(server.port, alice.token);
+    const client = await connectClient(server.port, alice);
     await client.waitFor('ready');
     client.send({ type: 'subscribe', scopes: [scopes.team(teamA)] });
     await client.waitFor('subscribed');
@@ -203,8 +209,8 @@ describe('fan-out', () => {
 
 describe('multi tab and multi tenant fan-out', () => {
   it('delivers the same delta to both tabs of one user exactly once each', async () => {
-    const tabOne = await connectClient(server.port, alice.token);
-    const tabTwo = await connectClient(server.port, alice.token);
+    const tabOne = await connectClient(server.port, alice);
+    const tabTwo = await connectClient(server.port, alice);
     await tabOne.waitFor('ready');
     await tabTwo.waitFor('ready');
     tabOne.send({ type: 'subscribe', scopes: [scopes.team(teamA)] });
@@ -238,8 +244,8 @@ describe('multi tab and multi tenant fan-out', () => {
   });
 
   it('keeps two organizations apart even when both subscribe at the same moment', async () => {
-    const inside = await connectClient(server.port, alice.token);
-    const outside = await connectClient(server.port, carol.token);
+    const inside = await connectClient(server.port, alice);
+    const outside = await connectClient(server.port, carol);
     await inside.waitFor('ready');
     await outside.waitFor('ready');
     inside.send({ type: 'subscribe', scopes: [scopes.organization(orgA), scopes.team(teamA)] });
@@ -287,7 +293,7 @@ describe('multi tab and multi tenant fan-out', () => {
   });
 
   it('skips deltas the resubscribing client already applied', async () => {
-    const client = await connectClient(server.port, alice.token);
+    const client = await connectClient(server.port, alice);
     await client.waitFor('ready');
     client.send({ type: 'subscribe', scopes: [scopes.team(teamA)], since: 500 });
     await client.waitFor('subscribed');
@@ -323,17 +329,33 @@ describe('authorization', () => {
       teamIds: [teamA],
       expiresAt: new Date(Date.now() - 60_000),
     });
-    const client = await connectClient(server.port, expired.token);
+    const client = await connectClient(server.port, expired);
     expect(await client.waitForClose()).toBe(4001);
   });
 
-  it('rejects an unknown token with 4001', async () => {
-    const client = await connectClient(server.port, 'token_does_not_exist');
+  it('rejects a forged ticket with 4001', async () => {
+    const client = await connectWithTicket(server.port, 'forged.ticket');
+    expect(await client.waitForClose()).toBe(4001);
+  });
+
+  it('rejects a ticket for a session that no longer exists with 4001', async () => {
+    const client = await connectWithTicket(
+      server.port,
+      signRealtimeTicket(
+        {
+          userId: alice.userId,
+          organizationId: orgA,
+          sessionId: 'session_does_not_exist',
+          exp: Date.now() + 60_000,
+        },
+        ticketSecret(),
+      ),
+    );
     expect(await client.waitForClose()).toBe(4001);
   });
 
   it('drops scopes for organizations and teams the connection does not belong to', async () => {
-    const client = await connectClient(server.port, alice.token);
+    const client = await connectClient(server.port, alice);
     await client.waitFor('ready');
     client.send({
       type: 'subscribe',
@@ -357,14 +379,14 @@ describe('authorization', () => {
   it('scopes an issue subscription to the teams a member can read, matching the read path', async () => {
     const issueId = await createIssue(orgA, teamB, bob.userId);
 
-    const otherTeam = await connectClient(server.port, alice.token);
+    const otherTeam = await connectClient(server.port, alice);
     await otherTeam.waitFor('ready');
     otherTeam.send({ type: 'subscribe', scopes: [scopes.issue(issueId)] });
     const denied = await otherTeam.waitFor('subscribed');
     expect(denied.scopes).toEqual([]);
     expect(denied.denied).toEqual([scopes.issue(issueId)]);
 
-    const owningTeam = await connectClient(server.port, bob.token);
+    const owningTeam = await connectClient(server.port, bob);
     await owningTeam.waitFor('ready');
     owningTeam.send({ type: 'subscribe', scopes: [scopes.issue(issueId)] });
     const granted = await owningTeam.waitFor('subscribed');
@@ -378,7 +400,7 @@ describe('authorization', () => {
   it('refuses an issue scope that belongs to another organization', async () => {
     const issueId = await createIssue(orgA, teamA, alice.userId);
 
-    const outsider = await connectClient(server.port, carol.token);
+    const outsider = await connectClient(server.port, carol);
     await outsider.waitFor('ready');
     outsider.send({ type: 'subscribe', scopes: [scopes.issue(issueId)] });
     const refused = await outsider.waitFor('subscribed');
@@ -389,7 +411,7 @@ describe('authorization', () => {
   });
 
   it('never fans out to a connection whose subscription was refused', async () => {
-    const client = await connectClient(server.port, carol.token);
+    const client = await connectClient(server.port, carol);
     await client.waitFor('ready');
     client.send({ type: 'subscribe', scopes: [scopes.team(teamA)] });
     expect((await client.waitFor('subscribed')).scopes).toEqual([]);
@@ -410,7 +432,7 @@ describe('authorization', () => {
 
 describe('protocol', () => {
   it('answers a ping with a pong', async () => {
-    const client = await connectClient(server.port, alice.token);
+    const client = await connectClient(server.port, alice);
     await client.waitFor('ready');
     client.send({ type: 'ping' });
     expect(await client.waitFor('pong')).toMatchObject({ type: 'pong' });
@@ -418,7 +440,7 @@ describe('protocol', () => {
   });
 
   it('unsubscribes and stops receiving deltas', async () => {
-    const client = await connectClient(server.port, alice.token);
+    const client = await connectClient(server.port, alice);
     await client.waitFor('ready');
     client.send({ type: 'subscribe', scopes: [scopes.team(teamA)] });
     await client.waitFor('subscribed', (message) => message.scopes.length === 1);
@@ -439,7 +461,7 @@ describe('protocol', () => {
   });
 
   it('reports an invalid message without closing the socket', async () => {
-    const client = await connectClient(server.port, alice.token);
+    const client = await connectClient(server.port, alice);
     await client.waitFor('ready');
     client.socket.send('not json');
     expect(await client.waitFor('error')).toMatchObject({ code: 'invalid_message' });
@@ -453,7 +475,7 @@ describe('protocol', () => {
       messagesPerSecond: 0,
     });
     try {
-      const client = await connectClient(strict.port, alice.token);
+      const client = await connectClient(strict.port, alice);
       await client.waitFor('ready');
       for (let index = 0; index < 12; index += 1) client.send({ type: 'ping' });
 
@@ -487,17 +509,17 @@ describe('protocol', () => {
 
 describe('presence', () => {
   it('broadcasts to others in the scope but not to the sender', async () => {
-    const sender = await connectClient(server.port, alice.token);
+    const sender = await connectClient(server.port, alice);
     await sender.waitFor('ready');
     sender.send({ type: 'subscribe', scopes: [scopes.team(teamA)] });
     await sender.waitFor('subscribed');
 
-    const watcher = await connectClient(server.port, dave.token);
+    const watcher = await connectClient(server.port, dave);
     await watcher.waitFor('ready');
     watcher.send({ type: 'subscribe', scopes: [scopes.team(teamA)] });
     await watcher.waitFor('subscribed');
 
-    const bystander = await connectClient(server.port, bob.token);
+    const bystander = await connectClient(server.port, bob);
     await bystander.waitFor('ready');
     bystander.send({ type: 'subscribe', scopes: [scopes.team(teamB)] });
     await bystander.waitFor('subscribed');
@@ -521,7 +543,7 @@ describe('presence', () => {
   });
 
   it('refuses presence on a scope the connection cannot access', async () => {
-    const client = await connectClient(server.port, carol.token);
+    const client = await connectClient(server.port, carol);
     await client.waitFor('ready');
     client.send({ type: 'presence', scope: scopes.team(teamA), kind: 'viewing' });
     expect(await client.waitFor('error')).toMatchObject({ code: 'forbidden_scope' });
@@ -531,18 +553,18 @@ describe('presence', () => {
   it('replays a live viewer to a joiner and withholds one that outlived the ttl', async () => {
     const shortLived = await createRealtimeServer({ redisUrl: redisUrl(), presenceTtlMs: 120 });
     try {
-      const viewer = await connectClient(shortLived.port, alice.token);
+      const viewer = await connectClient(shortLived.port, alice);
       await viewer.waitFor('ready');
       viewer.send({ type: 'presence', scope: scopes.team(teamA), kind: 'viewing' });
 
-      const joiner = await connectClient(shortLived.port, dave.token);
+      const joiner = await connectClient(shortLived.port, dave);
       await joiner.waitFor('ready');
       joiner.send({ type: 'subscribe', scopes: [scopes.team(teamA)] });
       const replayed = await joiner.waitFor('presence');
       expect(replayed.messages.map((message) => message.userId)).toEqual([alice.userId]);
 
       await delay(200);
-      const late = await connectClient(shortLived.port, bob.token);
+      const late = await connectClient(shortLived.port, bob);
       await late.waitFor('ready');
       late.send({ type: 'subscribe', scopes: [scopes.team(teamA)] });
       await late.waitFor('subscribed');
@@ -563,12 +585,16 @@ describe('liveness', () => {
     const strict = await createRealtimeServer({
       redisUrl: redisUrl(),
       heartbeatIntervalMs: 25,
-      heartbeatTimeoutMs: 60,
+      heartbeatTimeoutMs: 150,
     });
     try {
-      const silent = await connectSilently(strict.port, alice.token);
-      expect(strict.stats().connections).toBe(1);
-      await delay(400);
+      const silent = await connectSilently(strict.port, alice);
+      const authorizedBy = Date.now() + 3_000;
+      while (strict.stats().connections === 0) {
+        if (Date.now() > authorizedBy) throw new Error('silent socket never authenticated');
+        await delay(10);
+      }
+      await delay(600);
       expect(strict.stats().connections).toBe(0);
       silent.end();
     } finally {

--- a/apps/realtime/src/server.ts
+++ b/apps/realtime/src/server.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import {
   clientMessageSchema,
-  connectionOrganizationIdSchema,
   controlMessageSchema,
   DELTA_BATCH_WINDOW_MS,
   HEARTBEAT_INTERVAL_MS,
@@ -21,11 +20,12 @@ import {
 import { RedisClient, type Server, type ServerWebSocket, type WebSocketHandler } from 'bun';
 import { z } from 'zod';
 import {
-  authenticateConnection,
+  authenticateTicket,
   authorizeScope,
   type ConnectionRejection,
   memberDeleteSchema,
   membershipStillValid,
+  readTicketFrame,
   sessionStillValid,
 } from './auth.ts';
 import { Connection, type SocketData } from './connection.ts';
@@ -36,6 +36,7 @@ export const MAX_SUBSCRIPTIONS_PER_CONNECTION = 256;
 export const MAX_BUFFERED_BYTES = 1_048_576;
 export const MESSAGE_BURST = 60;
 export const MESSAGES_PER_SECOND = 20;
+export const AUTH_TIMEOUT_MS = 10_000;
 const SHUTDOWN_GRACE_MS = 1_000;
 const MAX_IDLE_TIMEOUT_SECONDS = 960;
 
@@ -43,6 +44,8 @@ export interface RealtimeServerOptions {
   port?: number;
   host?: string;
   redisUrl?: string;
+  ticketSecret?: string;
+  authTimeoutMs?: number;
   batchWindowMs?: number;
   heartbeatIntervalMs?: number;
   heartbeatTimeoutMs?: number;
@@ -74,20 +77,6 @@ const CLOSE_CODES: Record<ConnectionRejection, number> = {
   unauthorized: UNAUTHORIZED_CLOSE_CODE,
   organization_forbidden: ORGANIZATION_FORBIDDEN_CLOSE_CODE,
 };
-
-interface ConnectionCredentials {
-  readonly token: string;
-  readonly organizationId: string | null;
-}
-
-function credentialsFrom(url: URL): ConnectionCredentials | null {
-  const token = url.searchParams.get('token') ?? '';
-  const stated = url.searchParams.get('organizationId');
-  if (stated === null) return { token, organizationId: null };
-  const parsed = connectionOrganizationIdSchema.safeParse(stated);
-  if (!parsed.success) return null;
-  return { token, organizationId: parsed.data };
-}
 
 function parseJson(payload: string): unknown {
   try {
@@ -125,7 +114,12 @@ export async function createRealtimeServer(
   const heartbeatIntervalMs = options.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS;
   const heartbeatTimeoutMs = options.heartbeatTimeoutMs ?? HEARTBEAT_TIMEOUT_MS;
   const presenceTtlMs = options.presenceTtlMs ?? PRESENCE_TTL_MS;
+  const authTimeoutMs = options.authTimeoutMs ?? AUTH_TIMEOUT_MS;
   const redisUrl = options.redisUrl ?? process.env['REDIS_URL'] ?? 'redis://localhost:6380';
+  const ticketSecret = options.ticketSecret ?? process.env['BETTER_AUTH_SECRET'] ?? '';
+  if (ticketSecret.length === 0) {
+    throw new Error('BETTER_AUTH_SECRET is required to verify realtime tickets.');
+  }
 
   const connections = new Map<string, Connection>();
   const presence = new PresenceStore(presenceTtlMs);
@@ -165,7 +159,7 @@ export async function createRealtimeServer(
   async function revalidateSession(connection: Connection): Promise<void> {
     let valid = false;
     try {
-      valid = await sessionStillValid(connection.principal.sessionToken);
+      valid = await sessionStillValid(connection.principal.sessionId);
     } catch (error: unknown) {
       logger.error('session revalidation failed, closing to fail closed', {
         connectionId: connection.id,
@@ -350,37 +344,52 @@ export async function createRealtimeServer(
     await handlePresence(connection, message.scope, message.kind);
   }
 
-  function connectionOf(socket: ServerWebSocket<SocketData>): Connection | null {
-    const data = socket.data;
-    return 'rejection' in data ? null : data.connection;
-  }
-
-  async function socketDataFor(request: Request): Promise<SocketData> {
-    const credentials = credentialsFrom(new URL(request.url));
-    if (credentials === null) return { rejection: 'organization_forbidden' };
-    const authenticated = await authenticateConnection(
-      credentials.token,
-      credentials.organizationId,
-    );
-    if (!authenticated.ok) return { rejection: authenticated.reason };
-    return { principal: authenticated.principal, connection: null };
-  }
-
-  async function upgrade(
-    request: Request,
-    server: Server<SocketData>,
-  ): Promise<Response | undefined> {
-    let data: SocketData;
-    try {
-      data = await socketDataFor(request);
-    } catch (error: unknown) {
-      logger.error('connection rejected', errorFields(error));
-      data = { rejection: 'unauthorized' };
-    }
+  function upgrade(request: Request, server: Server<SocketData>): Response | undefined {
+    const data: SocketData = { connection: null, authenticating: false, authTimer: undefined };
     if (server.upgrade(request, { data })) return;
     return new Response(JSON.stringify({ status: 'upgrade_failed' }), {
       status: 400,
       headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  function clearAuthTimer(data: SocketData): void {
+    if (data.authTimer !== undefined) {
+      clearTimeout(data.authTimer);
+      data.authTimer = undefined;
+    }
+  }
+
+  async function authenticate(socket: ServerWebSocket<SocketData>, raw: string): Promise<void> {
+    const data = socket.data;
+    if (data.connection !== null || data.authenticating) return;
+    const payload = readTicketFrame(raw, ticketSecret);
+    if (payload === null) {
+      socket.close(UNAUTHORIZED_CLOSE_CODE, 'unauthorized');
+      return;
+    }
+    data.authenticating = true;
+    const authenticated = await authenticateTicket(payload);
+    if (socket.readyState !== WebSocket.OPEN) return;
+    if (!authenticated.ok) {
+      socket.close(CLOSE_CODES[authenticated.reason], authenticated.reason);
+      return;
+    }
+    clearAuthTimer(data);
+    const connection = new Connection(randomUUID(), socket, authenticated.principal, limits);
+    data.connection = connection;
+    connections.set(connection.id, connection);
+    connection.send({
+      type: 'ready',
+      connectionId: connection.id,
+      userId: authenticated.principal.userId,
+      organizationId: authenticated.principal.organizationId,
+      scopes: [],
+    });
+    logger.info('connection ready', {
+      connectionId: connection.id,
+      userId: authenticated.principal.userId,
+      organizationId: authenticated.principal.organizationId,
     });
   }
 
@@ -389,29 +398,23 @@ export async function createRealtimeServer(
     idleTimeout: idleTimeoutSeconds(heartbeatTimeoutMs, heartbeatIntervalMs),
     open(socket) {
       const data = socket.data;
-      if ('rejection' in data) {
-        socket.close(CLOSE_CODES[data.rejection], data.rejection);
-        return;
-      }
-      const connection = new Connection(randomUUID(), socket, data.principal, limits);
-      data.connection = connection;
-      connections.set(connection.id, connection);
-      connection.send({
-        type: 'ready',
-        connectionId: connection.id,
-        userId: data.principal.userId,
-        organizationId: data.principal.organizationId,
-        scopes: [],
-      });
-      logger.info('connection ready', {
-        connectionId: connection.id,
-        userId: data.principal.userId,
-        organizationId: data.principal.organizationId,
-      });
+      data.authTimer = setTimeout(() => {
+        data.authTimer = undefined;
+        if (data.connection === null) socket.close(UNAUTHORIZED_CLOSE_CODE, 'auth_timeout');
+      }, authTimeoutMs);
+      data.authTimer.unref();
     },
     message(socket, raw) {
-      const connection = connectionOf(socket);
-      if (connection === null) return;
+      const connection = socket.data.connection;
+      if (connection === null) {
+        authenticate(socket, raw.toString()).catch((error: unknown) => {
+          logger.error('authentication failed', errorFields(error));
+          if (socket.readyState === WebSocket.OPEN) {
+            socket.close(UNAUTHORIZED_CLOSE_CODE, 'unauthorized');
+          }
+        });
+        return;
+      }
       handleMessage(connection, raw.toString()).catch((error: unknown) => {
         logger.error('message handling failed', {
           connectionId: connection.id,
@@ -420,14 +423,15 @@ export async function createRealtimeServer(
       });
     },
     pong(socket) {
-      const connection = connectionOf(socket);
+      const connection = socket.data.connection;
       if (connection === null) return;
       connection.lastSeenAt = Date.now();
     },
     close(socket) {
-      const connection = connectionOf(socket);
-      if (connection === null) return;
-      connections.delete(connection.id);
+      const data = socket.data;
+      clearAuthTimer(data);
+      if (data.connection === null) return;
+      connections.delete(data.connection.id);
     },
   };
 

--- a/apps/realtime/src/session-revocation.test.ts
+++ b/apps/realtime/src/session-revocation.test.ts
@@ -14,6 +14,8 @@ import {
   createTeam,
   delay,
   redisUrl,
+  type SeedMember,
+  ticketFor,
 } from './test-helpers.ts';
 
 let server: RealtimeServer;
@@ -34,16 +36,17 @@ afterAll(async () => {
   await cleanupFixtures();
 });
 
-async function addSessionFor(userId: string): Promise<string> {
+async function addSessionFor(userId: string): Promise<SeedMember> {
   const token = `token_${randomUUID()}`;
+  const sessionId = `session_${randomUUID()}`;
   await db.insert(schema.session).values({
-    id: `session_${randomUUID()}`,
+    id: sessionId,
     token,
     userId,
     activeOrganizationId: organizationId,
     expiresAt: new Date(Date.now() + 60 * 60 * 1000),
   });
-  return token;
+  return { userId, token, sessionId, organizationId, name: 'Surviving' };
 }
 
 async function announceRevocation(userId: string): Promise<void> {
@@ -56,7 +59,7 @@ async function announceRevocation(userId: string): Promise<void> {
 describe('session revocation', () => {
   it('closes the socket whose session row was deleted', async () => {
     const member = await createMember({ organizationId, teamIds: [teamId] });
-    const client = await connectClient(server.port, member.token, organizationId);
+    const client = await connectClient(server.port, member, organizationId);
     await client.waitFor('ready');
 
     await db.delete(schema.session).where(eq(schema.session.token, member.token));
@@ -68,10 +71,10 @@ describe('session revocation', () => {
 
   it('keeps the other still-valid sessions of the same user connected', async () => {
     const member = await createMember({ organizationId, teamIds: [teamId] });
-    const survivingToken = await addSessionFor(member.userId);
+    const survivingSession = await addSessionFor(member.userId);
 
-    const revoked = await connectClient(server.port, member.token, organizationId);
-    const surviving = await connectClient(server.port, survivingToken, organizationId);
+    const revoked = await connectClient(server.port, member, organizationId);
+    const surviving = await connectClient(server.port, survivingSession, organizationId);
     await revoked.waitFor('ready');
     await surviving.waitFor('ready');
 
@@ -91,8 +94,7 @@ describe('session revocation', () => {
 
     const client = createRealtimeClient({
       url: `ws://127.0.0.1:${server.port}`,
-      token: member.token,
-      organizationId,
+      fetchTicket: () => Promise.resolve(ticketFor(member, organizationId)),
       maxBackoffMs: 200,
       onStatus: (status) => statuses.push(status),
       onTerminal: (code) => {

--- a/apps/realtime/src/test-helpers.ts
+++ b/apps/realtime/src/test-helpers.ts
@@ -2,7 +2,24 @@ import { randomUUID } from 'node:crypto';
 import { db, eq, inArray, schema } from '@orbit/db';
 import type { ClientMessage, ServerMessage, SyncAction } from '@orbit/shared/events';
 import { serverMessageSchema } from '@orbit/shared/events';
+import { REALTIME_TICKET_TTL_MS, signRealtimeTicket } from '@orbit/shared/events/ticket';
 import { RedisClient } from 'bun';
+
+export function ticketSecret(): string {
+  return process.env['BETTER_AUTH_SECRET'] ?? 'dev-secret-change-me-in-production-0123456789abcdef';
+}
+
+export function ticketFor(member: SeedMember, organizationId?: string): string {
+  return signRealtimeTicket(
+    {
+      userId: member.userId,
+      organizationId: organizationId ?? member.organizationId,
+      sessionId: member.sessionId,
+      exp: Date.now() + REALTIME_TICKET_TTL_MS,
+    },
+    ticketSecret(),
+  );
+}
 
 const createdOrganizationIds: string[] = [];
 const createdUserIds: string[] = [];
@@ -39,6 +56,8 @@ export interface SeedMemberOptions {
 export interface SeedMember {
   userId: string;
   token: string;
+  sessionId: string;
+  organizationId: string;
   name: string;
 }
 
@@ -59,9 +78,10 @@ export async function createMember(options: SeedMemberOptions): Promise<SeedMemb
   });
 
   const token = `token_${randomUUID()}`;
+  const sessionId = `session_${randomUUID()}`;
   const expiresAt = options.expiresAt ?? new Date(Date.now() + 60 * 60 * 1000);
   await db.insert(schema.session).values({
-    id: `session_${randomUUID()}`,
+    id: sessionId,
     token,
     userId,
     activeOrganizationId:
@@ -71,7 +91,7 @@ export async function createMember(options: SeedMemberOptions): Promise<SeedMemb
     expiresAt,
   });
 
-  return { userId, token, name };
+  return { userId, token, sessionId, organizationId: options.organizationId, name };
 }
 
 export interface MembershipOptions {
@@ -173,12 +193,14 @@ export interface TestClient {
 
 export function connectClient(
   port: number,
-  token: string,
+  member: SeedMember,
   organizationId?: string,
 ): Promise<TestClient> {
-  const query = new URLSearchParams({ token });
-  if (organizationId !== undefined) query.set('organizationId', organizationId);
-  const socket = new WebSocket(`ws://127.0.0.1:${port}/?${query.toString()}`);
+  return connectWithTicket(port, ticketFor(member, organizationId));
+}
+
+export function connectWithTicket(port: number, ticket: string): Promise<TestClient> {
+  const socket = new WebSocket(`ws://127.0.0.1:${port}/`);
   const messages: ServerMessage[] = [];
   const listeners = new Set<() => void>();
   let closeCode: number | undefined;
@@ -253,6 +275,7 @@ export function connectClient(
       'open',
       () => {
         clearTimeout(timer);
+        socket.send(JSON.stringify({ type: 'auth', ticket }));
         resolve(client);
       },
       { once: true },
@@ -266,6 +289,29 @@ export function connectClient(
       { once: true },
     );
   });
+}
+
+export function maskedTextFrame(text: string): Buffer {
+  const payload = Buffer.from(text, 'utf8');
+  const mask = Buffer.from([
+    Math.floor(Math.random() * 256),
+    Math.floor(Math.random() * 256),
+    Math.floor(Math.random() * 256),
+    Math.floor(Math.random() * 256),
+  ]);
+  const masked = Buffer.alloc(payload.length);
+  for (let index = 0; index < payload.length; index += 1) {
+    const source = payload[index] ?? 0;
+    const key = mask[index % 4] ?? 0;
+    masked[index] = source ^ key;
+  }
+  const header: number[] = [0x81];
+  if (payload.length < 126) {
+    header.push(0x80 | payload.length);
+  } else {
+    header.push(0x80 | 126, (payload.length >> 8) & 0xff, payload.length & 0xff);
+  }
+  return Buffer.concat([Buffer.from(header), mask, masked]);
 }
 
 export function createPublisher(): RedisClient {

--- a/apps/web/src/app/(app)/inbox/page.tsx
+++ b/apps/web/src/app/(app)/inbox/page.tsx
@@ -19,7 +19,6 @@ export default async function InboxPage() {
       userId={context.principal.userId}
       organizationId={context.principal.organizationId}
       realtimeUrl={process.env['NEXT_PUBLIC_REALTIME_URL'] ?? DEFAULT_REALTIME_URL}
-      token={context.sessionToken}
     />
   );
 }

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -70,7 +70,6 @@ export default async function WorkspaceLayout({ children }: { children: ReactNod
     <HydrationBoundary state={await dehydratedWorkspace(membership.principal)}>
       <WorkspaceRealtime
         url={realtimeUrl()}
-        token={session.session.token}
         userId={membership.principal.userId}
         organizationId={membership.principal.organizationId}
         teamIds={teams.map((team) => team.id)}

--- a/apps/web/src/app/(app)/pulls/page.tsx
+++ b/apps/web/src/app/(app)/pulls/page.tsx
@@ -17,7 +17,6 @@ export default async function PullsPage() {
       userId={context.principal.userId}
       organizationId={context.principal.organizationId}
       realtimeUrl={process.env['NEXT_PUBLIC_REALTIME_URL'] ?? DEFAULT_REALTIME_URL}
-      token={context.sessionToken}
     />
   );
 }

--- a/apps/web/src/app/api/realtime/ticket/route.ts
+++ b/apps/web/src/app/api/realtime/ticket/route.ts
@@ -1,0 +1,42 @@
+import { forbidden, unauthorized } from '@orbit/shared/errors';
+import {
+  REALTIME_TICKET_TTL_MS,
+  realtimeTicketRequestSchema,
+  signRealtimeTicket,
+} from '@orbit/shared/events/ticket';
+import { handleRoute, readJson } from '@/lib/api/handler.ts';
+import { resolveMembership } from '@/lib/auth/principal.ts';
+import { getSession } from '@/lib/auth/session.ts';
+import { serverEnv } from '@/lib/env.ts';
+
+export async function POST(request: Request): Promise<Response> {
+  return await handleRoute(async () => {
+    const session = await getSession();
+    if (session === null) throw unauthorized();
+
+    const body = realtimeTicketRequestSchema.parse(await readJson(request));
+    const membership = await resolveMembership(
+      session.user.id,
+      body.organizationId ?? session.session.activeOrganizationId ?? null,
+    );
+    if (membership === null) throw forbidden('You are not a member of this workspace.');
+    if (
+      body.organizationId !== undefined &&
+      membership.principal.organizationId !== body.organizationId
+    ) {
+      throw forbidden('You are not a member of this workspace.');
+    }
+
+    const ticket = signRealtimeTicket(
+      {
+        userId: session.user.id,
+        organizationId: membership.principal.organizationId,
+        sessionId: session.session.id,
+        exp: Date.now() + REALTIME_TICKET_TTL_MS,
+      },
+      serverEnv().BETTER_AUTH_SECRET,
+    );
+
+    return { ticket };
+  });
+}

--- a/apps/web/src/features/inbox/inbox-realtime.tsx
+++ b/apps/web/src/features/inbox/inbox-realtime.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { RealtimeProvider } from '@orbit/realtime-client/react';
+import { useCallback } from 'react';
+import { fetchRealtimeTicket } from '@/lib/realtime/ticket.ts';
 import type { InboxItem } from './data.ts';
 import { InboxView } from './inbox-view.tsx';
 
@@ -11,7 +13,6 @@ export interface InboxRealtimeProps {
   readonly userId: string;
   readonly organizationId: string;
   readonly realtimeUrl: string;
-  readonly token: string;
 }
 
 export function InboxRealtime({
@@ -21,10 +22,10 @@ export function InboxRealtime({
   userId,
   organizationId,
   realtimeUrl,
-  token,
 }: InboxRealtimeProps) {
+  const fetchTicket = useCallback(() => fetchRealtimeTicket(organizationId), [organizationId]);
   return (
-    <RealtimeProvider url={realtimeUrl} token={token} organizationId={organizationId}>
+    <RealtimeProvider url={realtimeUrl} organizationId={organizationId} fetchTicket={fetchTicket}>
       <InboxView
         items={items}
         unreadCount={unreadCount}

--- a/apps/web/src/features/pulls/pulls-realtime.tsx
+++ b/apps/web/src/features/pulls/pulls-realtime.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { RealtimeProvider } from '@orbit/realtime-client/react';
+import { useCallback } from 'react';
+import { fetchRealtimeTicket } from '@/lib/realtime/ticket.ts';
 import type { PullRequestRow } from './data.ts';
 import { PullsView } from './pulls-view.tsx';
 
@@ -9,18 +11,12 @@ export interface PullsRealtimeProps {
   readonly userId: string;
   readonly organizationId: string;
   readonly realtimeUrl: string;
-  readonly token: string;
 }
 
-export function PullsRealtime({
-  pulls,
-  userId,
-  organizationId,
-  realtimeUrl,
-  token,
-}: PullsRealtimeProps) {
+export function PullsRealtime({ pulls, userId, organizationId, realtimeUrl }: PullsRealtimeProps) {
+  const fetchTicket = useCallback(() => fetchRealtimeTicket(organizationId), [organizationId]);
   return (
-    <RealtimeProvider url={realtimeUrl} token={token} organizationId={organizationId}>
+    <RealtimeProvider url={realtimeUrl} organizationId={organizationId} fetchTicket={fetchTicket}>
       <PullsView pulls={pulls} userId={userId} />
     </RealtimeProvider>
   );

--- a/apps/web/src/lib/api/handler.ts
+++ b/apps/web/src/lib/api/handler.ts
@@ -14,7 +14,6 @@ import { getSession, requireSession } from '@/lib/auth/session.ts';
 export interface ApiContext extends MembershipContext {
   readonly userName: string;
   readonly userEmail: string;
-  readonly sessionToken: string;
 }
 
 async function contextFor(session: ActiveSession): Promise<ApiContext | null> {
@@ -27,7 +26,6 @@ async function contextFor(session: ActiveSession): Promise<ApiContext | null> {
     ...membership,
     userName: session.user.name,
     userEmail: session.user.email,
-    sessionToken: session.session.token,
   };
 }
 

--- a/apps/web/src/lib/realtime/provider.tsx
+++ b/apps/web/src/lib/realtime/provider.tsx
@@ -8,6 +8,7 @@ import { authClient } from '@/lib/auth/client.ts';
 import { ConnectionBanner } from './connection-banner.tsx';
 import { DeltaBridge } from './delta-bridge.tsx';
 import { SessionProvider } from './session.tsx';
+import { fetchRealtimeTicket } from './ticket.ts';
 
 const SIGNED_OUT_CLOSE_CODES: readonly number[] = [
   SESSION_REVOKED_CLOSE_CODE,
@@ -16,7 +17,6 @@ const SIGNED_OUT_CLOSE_CODES: readonly number[] = [
 
 export interface WorkspaceRealtimeProps {
   readonly url: string;
-  readonly token: string;
   readonly userId: string;
   readonly organizationId: string;
   readonly teamIds: readonly string[];
@@ -25,7 +25,6 @@ export interface WorkspaceRealtimeProps {
 
 export function WorkspaceRealtime({
   url,
-  token,
   userId,
   organizationId,
   teamIds,
@@ -38,12 +37,14 @@ export function WorkspaceRealtime({
     });
   }, []);
 
+  const fetchTicket = useCallback(() => fetchRealtimeTicket(organizationId), [organizationId]);
+
   return (
     <SessionProvider userId={userId}>
       <RealtimeProvider
         url={url}
-        token={token}
         organizationId={organizationId}
+        fetchTicket={fetchTicket}
         onTerminal={handleTerminal}
       >
         <DeltaBridge organizationId={organizationId} teamIds={teamIds} />

--- a/apps/web/src/lib/realtime/ticket.ts
+++ b/apps/web/src/lib/realtime/ticket.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+const ticketResponseSchema = z.object({ ticket: z.string().min(1) });
+
+export async function fetchRealtimeTicket(organizationId: string): Promise<string> {
+  const response = await fetch('/api/realtime/ticket', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ organizationId }),
+    credentials: 'same-origin',
+  });
+  if (!response.ok) throw new Error('Could not mint a realtime ticket.');
+  return ticketResponseSchema.parse(await response.json()).ticket;
+}

--- a/packages/realtime-client/src/index.test.ts
+++ b/packages/realtime-client/src/index.test.ts
@@ -66,6 +66,25 @@ function delta(syncId: number): SyncAction {
   };
 }
 
+const TICKET = 'ticket_1';
+
+function readyMessage(): ServerMessage {
+  return {
+    type: 'ready',
+    connectionId: 'connection_1',
+    userId: 'user_1',
+    organizationId: 'org_1',
+    scopes: [],
+  };
+}
+
+async function firstSocket(): Promise<FakeWebSocket> {
+  await wait(0);
+  const socket = FakeWebSocket.instances[0];
+  if (socket === undefined) throw new Error('socket was never created');
+  return socket;
+}
+
 describe('realtime client lifecycle', () => {
   beforeEach(() => {
     FakeWebSocket.instances = [];
@@ -76,18 +95,76 @@ describe('realtime client lifecycle', () => {
     FakeWebSocket.instances = [];
   });
 
-  it('treats an unauthorized close as terminal and never reconnects', async () => {
+  it('fetches a ticket, opens without it in the url, and authenticates in the first frame', async () => {
     const statuses: RealtimeStatus[] = [];
     const client = createRealtimeClient({
       url: 'ws://localhost:3100',
-      token: 'token_1',
-      organizationId: 'org_1',
+      fetchTicket: () => Promise.resolve(TICKET),
+      onStatus: (status) => statuses.push(status),
+    });
+
+    const socket = await firstSocket();
+    expect(socket.url).toBe('ws://localhost:3100');
+    socket.open();
+
+    expect(socket.sent.map((payload) => JSON.parse(payload))).toEqual([
+      { type: 'auth', ticket: TICKET },
+    ]);
+    expect(statuses).not.toContain('open');
+
+    socket.deliver(readyMessage());
+    expect(client.status()).toBe('open');
+    client.close();
+  });
+
+  it('waits for ready before it subscribes', async () => {
+    const client = createRealtimeClient({
+      url: 'ws://localhost:3100',
+      fetchTicket: () => Promise.resolve(TICKET),
+    });
+
+    const socket = await firstSocket();
+    socket.open();
+    client.subscribe(['team:team_1']);
+    expect(subscribesOf(socket)).toEqual([{ scopes: ['team:team_1'], since: 0 }]);
+    client.close();
+  });
+
+  it('reconnects after a fetch failure', async () => {
+    const statuses: RealtimeStatus[] = [];
+    let attempts = 0;
+    const client = createRealtimeClient({
+      url: 'ws://localhost:3100',
+      fetchTicket: () => {
+        attempts += 1;
+        return attempts === 1 ? Promise.reject(new Error('nope')) : Promise.resolve(TICKET);
+      },
       maxBackoffMs: 10,
       onStatus: (status) => statuses.push(status),
     });
 
-    FakeWebSocket.instances[0]?.open();
-    FakeWebSocket.instances[0]?.close(UNAUTHORIZED_CLOSE_CODE);
+    await wait(60);
+    const socket = await firstSocket();
+    socket.open();
+    socket.deliver(readyMessage());
+
+    expect(statuses).toContain('reconnecting');
+    expect(client.status()).toBe('open');
+    client.close();
+  });
+
+  it('treats an unauthorized close as terminal and never reconnects', async () => {
+    const statuses: RealtimeStatus[] = [];
+    const client = createRealtimeClient({
+      url: 'ws://localhost:3100',
+      fetchTicket: () => Promise.resolve(TICKET),
+      maxBackoffMs: 10,
+      onStatus: (status) => statuses.push(status),
+    });
+
+    const socket = await firstSocket();
+    socket.open();
+    socket.close(UNAUTHORIZED_CLOSE_CODE);
     await wait(60);
 
     expect(FakeWebSocket.instances).toHaveLength(1);
@@ -99,13 +176,13 @@ describe('realtime client lifecycle', () => {
   it('treats a forbidden organization close as terminal too', async () => {
     const client = createRealtimeClient({
       url: 'ws://localhost:3100',
-      token: 'token_1',
-      organizationId: 'org_1',
+      fetchTicket: () => Promise.resolve(TICKET),
       maxBackoffMs: 10,
     });
 
-    FakeWebSocket.instances[0]?.open();
-    FakeWebSocket.instances[0]?.close(ORGANIZATION_FORBIDDEN_CLOSE_CODE);
+    const socket = await firstSocket();
+    socket.open();
+    socket.close(ORGANIZATION_FORBIDDEN_CLOSE_CODE);
     await wait(60);
 
     expect(FakeWebSocket.instances).toHaveLength(1);
@@ -117,25 +194,26 @@ describe('realtime client lifecycle', () => {
     const resumes: number[] = [];
     const client = createRealtimeClient({
       url: 'ws://localhost:3100',
-      token: 'token_1',
-      organizationId: 'org_1',
+      fetchTicket: () => Promise.resolve(TICKET),
       maxBackoffMs: 10,
       onResume: (since) => resumes.push(since),
     });
 
-    const first = FakeWebSocket.instances[0];
-    first?.open();
+    const first = await firstSocket();
+    first.open();
+    first.deliver(readyMessage());
     client.subscribe(['team:team_1']);
-    first?.deliver({ type: 'delta', actions: [delta(70), delta(64)] });
+    first.deliver({ type: 'delta', actions: [delta(70), delta(64)] });
     expect(client.seen()).toBe(70);
     expect(resumes).toHaveLength(0);
 
-    first?.close(1006);
+    first.close(1006);
     await wait(60);
 
     const second = FakeWebSocket.instances[1];
     expect(second).toBeDefined();
     second?.open();
+    second?.deliver(readyMessage());
 
     expect(subscribesOf(second)).toEqual([{ scopes: ['team:team_1'], since: 70 }]);
     expect(resumes).toEqual([70]);
@@ -146,39 +224,40 @@ describe('realtime client lifecycle', () => {
     const denied: string[][] = [];
     const client = createRealtimeClient({
       url: 'ws://localhost:3100',
-      token: 'token_1',
-      organizationId: 'org_1',
+      fetchTicket: () => Promise.resolve(TICKET),
       maxBackoffMs: 10,
       onDenied: (scopes) => denied.push(scopes),
     });
 
-    const first = FakeWebSocket.instances[0];
-    first?.open();
+    const first = await firstSocket();
+    first.open();
+    first.deliver(readyMessage());
     client.subscribe(['team:team_1', 'team:not_mine']);
-    first?.deliver({ type: 'subscribed', scopes: ['team:team_1'], denied: ['team:not_mine'] });
+    first.deliver({ type: 'subscribed', scopes: ['team:team_1'], denied: ['team:not_mine'] });
     expect(denied).toEqual([['team:not_mine']]);
 
-    first?.close(1006);
+    first.close(1006);
     await wait(60);
     const second = FakeWebSocket.instances[1];
     second?.open();
+    second?.deliver(readyMessage());
 
     expect(subscribesOf(second)).toEqual([{ scopes: ['team:team_1'], since: 0 }]);
     client.close();
   });
 
-  it('reports presence messages without advancing the delta watermark', () => {
+  it('reports presence messages without advancing the delta watermark', async () => {
     const presence: PresenceMessage[][] = [];
     const client = createRealtimeClient({
       url: 'ws://localhost:3100',
-      token: 'token_1',
-      organizationId: 'org_1',
+      fetchTicket: () => Promise.resolve(TICKET),
       onPresence: (messages) => presence.push(messages),
     });
 
-    const socket = FakeWebSocket.instances[0];
-    socket?.open();
-    socket?.deliver({
+    const socket = await firstSocket();
+    socket.open();
+    socket.deliver(readyMessage());
+    socket.deliver({
       type: 'presence',
       messages: [
         {

--- a/packages/realtime-client/src/index.ts
+++ b/packages/realtime-client/src/index.ts
@@ -1,4 +1,5 @@
 import type {
+  AuthMessage,
   ClientMessage,
   PresenceKind,
   PresenceMessage,
@@ -15,8 +16,7 @@ export type RealtimeStatus = 'connecting' | 'open' | 'reconnecting' | 'closed';
 
 export interface RealtimeClientOptions {
   url: string;
-  token: string;
-  organizationId: string;
+  fetchTicket: () => Promise<string>;
   onDelta?: (actions: SyncAction[]) => void;
   onPresence?: (messages: PresenceMessage[]) => void;
   onStatus?: (status: RealtimeStatus) => void;
@@ -49,13 +49,6 @@ const TERMINAL_CLOSE_CODES: readonly number[] = [
 function backoffDelay(attempt: number, maxBackoffMs: number): number {
   const exponential = Math.min(maxBackoffMs, BASE_BACKOFF_MS * 2 ** attempt);
   return Math.round(exponential * (0.5 + Math.random() * 0.5));
-}
-
-function endpoint(url: string, token: string, organizationId: string): string {
-  const target = new URL(url);
-  target.searchParams.set('token', token);
-  target.searchParams.set('organizationId', organizationId);
-  return target.toString();
 }
 
 export function createRealtimeClient(options: RealtimeClientOptions): RealtimeClient {
@@ -91,6 +84,25 @@ export function createRealtimeClient(options: RealtimeClientOptions): RealtimeCl
     if (syncId > maxSeenSyncId) maxSeenSyncId = syncId;
   }
 
+  function handleReady(): void {
+    attempt = 0;
+    const reconnected = resumed;
+    resumed = true;
+    setStatus('open');
+    sendSubscribe([...scopes]);
+    if (reconnected) options.onResume?.(maxSeenSyncId);
+  }
+
+  function handleDelta(actions: SyncAction[]): void {
+    for (const action of actions) observe(action.syncId);
+    options.onDelta?.(actions);
+  }
+
+  function handleDenied(denied: readonly string[]): void {
+    for (const scope of denied) scopes.delete(scope);
+    options.onDenied?.([...denied]);
+  }
+
   function receive(payload: string): void {
     let parsedJson: unknown;
     try {
@@ -101,9 +113,12 @@ export function createRealtimeClient(options: RealtimeClientOptions): RealtimeCl
     const parsed = serverMessageSchema.safeParse(parsedJson);
     if (!parsed.success) return;
     const message = parsed.data;
+    if (message.type === 'ready') {
+      handleReady();
+      return;
+    }
     if (message.type === 'delta') {
-      for (const action of message.actions) observe(action.syncId);
-      options.onDelta?.(message.actions);
+      handleDelta(message.actions);
       return;
     }
     if (message.type === 'presence') {
@@ -111,8 +126,7 @@ export function createRealtimeClient(options: RealtimeClientOptions): RealtimeCl
       return;
     }
     if (message.type === 'subscribed' && message.denied.length > 0) {
-      for (const scope of message.denied) scopes.delete(scope);
-      options.onDenied?.([...message.denied]);
+      handleDenied(message.denied);
     }
   }
 
@@ -123,41 +137,48 @@ export function createRealtimeClient(options: RealtimeClientOptions): RealtimeCl
     attempt += 1;
     reconnectTimer = setTimeout(() => {
       reconnectTimer = undefined;
-      try {
-        connect();
-      } catch {
-        scheduleReconnect();
-      }
+      connect();
     }, delay);
   }
 
   function connect(): void {
     if (disposed) return;
-    const next = new WebSocket(endpoint(options.url, options.token, options.organizationId));
-    socket = next;
-    next.onopen = () => {
-      attempt = 0;
-      const reconnected = resumed;
-      resumed = true;
-      setStatus('open');
-      sendSubscribe([...scopes]);
-      if (reconnected) options.onResume?.(maxSeenSyncId);
-    };
-    next.onmessage = (event) => {
-      const payload: unknown = event.data;
-      if (typeof payload === 'string') receive(payload);
-    };
-    next.onclose = (event) => {
-      if (socket === next) socket = null;
-      const terminal = TERMINAL_CLOSE_CODES.includes(event.code);
-      if (terminal) disposed = true;
-      if (disposed) {
-        setStatus('closed');
-        if (terminal) options.onTerminal?.(event.code);
-        return;
-      }
+    openSocket().catch(() => scheduleReconnect());
+  }
+
+  async function openSocket(): Promise<void> {
+    let ticket: string;
+    try {
+      ticket = await options.fetchTicket();
+    } catch {
       scheduleReconnect();
-    };
+      return;
+    }
+    if (disposed) return;
+    try {
+      const next = new WebSocket(options.url);
+      socket = next;
+      next.onopen = () => {
+        next.send(JSON.stringify({ type: 'auth', ticket } satisfies AuthMessage));
+      };
+      next.onmessage = (event) => {
+        const payload: unknown = event.data;
+        if (typeof payload === 'string') receive(payload);
+      };
+      next.onclose = (event) => {
+        if (socket === next) socket = null;
+        const terminal = TERMINAL_CLOSE_CODES.includes(event.code);
+        if (terminal) disposed = true;
+        if (disposed) {
+          setStatus('closed');
+          if (terminal) options.onTerminal?.(event.code);
+          return;
+        }
+        scheduleReconnect();
+      };
+    } catch {
+      scheduleReconnect();
+    }
   }
 
   connect();

--- a/packages/realtime-client/src/react.test.tsx
+++ b/packages/realtime-client/src/react.test.tsx
@@ -50,10 +50,26 @@ function Subscriber() {
   return null;
 }
 
+function deliverReady(socket: FakeWebSocket | undefined) {
+  socket?.onmessage?.({
+    data: JSON.stringify({
+      type: 'ready',
+      connectionId: 'connection_1',
+      userId: 'user_1',
+      organizationId: 'org_1',
+      scopes: [],
+    }),
+  });
+}
+
 function Tree() {
   return (
     <StrictMode>
-      <RealtimeProvider url="ws://localhost:3100" token="token_1" organizationId="org_1">
+      <RealtimeProvider
+        url="ws://localhost:3100"
+        organizationId="org_1"
+        fetchTicket={() => Promise.resolve('ticket_1')}
+      >
         <Subscriber />
         <Subscriber />
       </RealtimeProvider>
@@ -78,8 +94,20 @@ describe('RealtimeProvider under StrictMode', () => {
     expect(FakeWebSocket.instances).toHaveLength(1);
     const socket = FakeWebSocket.instances[0];
     expect(socket?.closed).toBe(false);
-    expect(socket?.url).toContain('token=token_1');
-    expect(socket?.url).toContain('organizationId=org_1');
+    expect(socket?.url).toBe('ws://localhost:3100');
+  });
+
+  it('sends the ticket as its first frame once the socket opens', async () => {
+    render(<Tree />);
+    await flush();
+    const socket = FakeWebSocket.instances[0];
+    act(() => {
+      socket?.open();
+    });
+
+    expect((socket?.sent ?? []).map((payload) => JSON.parse(payload))).toEqual([
+      { type: 'auth', ticket: 'ticket_1' },
+    ]);
   });
 
   it('subscribes to each scope once no matter how many consumers retain it', async () => {
@@ -88,6 +116,7 @@ describe('RealtimeProvider under StrictMode', () => {
     const socket = FakeWebSocket.instances[0];
     act(() => {
       socket?.open();
+      deliverReady(socket);
     });
 
     const subscribes = (socket?.sent ?? [])

--- a/packages/realtime-client/src/react.tsx
+++ b/packages/realtime-client/src/react.tsx
@@ -48,16 +48,16 @@ function mergePresence(current: PresenceByScope, messages: readonly PresenceMess
 
 export interface RealtimeProviderProps {
   url: string;
-  token: string;
   organizationId: string;
+  fetchTicket: () => Promise<string>;
   onTerminal?: (code: number) => void;
   children: ReactNode;
 }
 
 export function RealtimeProvider({
   url,
-  token,
   organizationId,
+  fetchTicket,
   onTerminal,
   children,
 }: RealtimeProviderProps) {
@@ -70,17 +70,22 @@ export function RealtimeProvider({
   const countsRef = useRef(new Map<string, number>());
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const onTerminalRef = useRef(onTerminal);
+  const fetchTicketRef = useRef(fetchTicket);
 
   useEffect(() => {
     onTerminalRef.current = onTerminal;
   }, [onTerminal]);
 
   useEffect(() => {
+    fetchTicketRef.current = fetchTicket;
+  }, [fetchTicket]);
+
+  useEffect(() => {
     if (closeTimerRef.current !== undefined) {
       clearTimeout(closeTimerRef.current);
       closeTimerRef.current = undefined;
     }
-    const config = `${url}${SCOPE_SEPARATOR}${token}${SCOPE_SEPARATOR}${organizationId}`;
+    const config = `${url}${SCOPE_SEPARATOR}${organizationId}`;
     if (clientRef.current !== null && configRef.current !== config) {
       clientRef.current.close();
       clientRef.current = null;
@@ -89,8 +94,7 @@ export function RealtimeProvider({
       configRef.current = config;
       clientRef.current = createRealtimeClient({
         url,
-        token,
-        organizationId,
+        fetchTicket: () => fetchTicketRef.current(),
         onStatus: (next) => {
           if (next !== 'open') setPresence(new Map());
           setStatus(next);
@@ -115,7 +119,7 @@ export function RealtimeProvider({
         clientRef.current = null;
       }, 0);
     };
-  }, [url, token, organizationId]);
+  }, [url, organizationId]);
 
   const retainScopes = useCallback((requested: readonly string[]) => {
     const counts = countsRef.current;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./events": "./src/events/index.ts",
+    "./events/ticket": "./src/events/ticket.ts",
     "./errors": "./src/errors/index.ts",
     "./policy": "./src/policy/index.ts",
     "./validators": "./src/validators/index.ts",

--- a/packages/shared/src/events/connection.ts
+++ b/packages/shared/src/events/connection.ts
@@ -1,10 +1,6 @@
-import { z } from 'zod';
-
 export const UNAUTHORIZED_CLOSE_CODE = 4001;
 export const SESSION_REVOKED_CLOSE_CODE = 4002;
 export const ORGANIZATION_FORBIDDEN_CLOSE_CODE = 4003;
-
-export const connectionOrganizationIdSchema = z.string().min(1).max(128);
 
 export const HEARTBEAT_INTERVAL_MS = 30_000;
 export const HEARTBEAT_TIMEOUT_MS = 75_000;

--- a/packages/shared/src/events/message.ts
+++ b/packages/shared/src/events/message.ts
@@ -2,6 +2,13 @@ import { z } from 'zod';
 import { presenceKindSchema, presenceMessageSchema } from './presence.ts';
 import { syncActionSchema, syncCursorSchema } from './sync.ts';
 
+export const authMessageSchema = z.object({
+  type: z.literal('auth'),
+  ticket: z.string().min(1),
+});
+
+export type AuthMessage = z.infer<typeof authMessageSchema>;
+
 export const clientMessageSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('subscribe'),

--- a/packages/shared/src/events/ticket.test.ts
+++ b/packages/shared/src/events/ticket.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  REALTIME_TICKET_TTL_MS,
+  type RealtimeTicketPayload,
+  signRealtimeTicket,
+  verifyRealtimeTicket,
+} from './ticket.ts';
+
+const SECRET = 'secret-value-that-is-long-enough';
+const NOW = 1_800_000_000_000;
+
+function payload(overrides: Partial<RealtimeTicketPayload> = {}): RealtimeTicketPayload {
+  return {
+    userId: 'user_1',
+    organizationId: 'org_1',
+    sessionId: 'session_1',
+    exp: NOW + REALTIME_TICKET_TTL_MS,
+    ...overrides,
+  };
+}
+
+describe('realtime ticket', () => {
+  it('round trips a signed payload', () => {
+    const ticket = signRealtimeTicket(payload(), SECRET);
+    expect(verifyRealtimeTicket(ticket, SECRET, NOW)).toEqual(payload());
+  });
+
+  it('rejects a ticket signed with a different secret', () => {
+    const ticket = signRealtimeTicket(payload(), SECRET);
+    expect(verifyRealtimeTicket(ticket, 'another-secret-entirely', NOW)).toBeNull();
+  });
+
+  it('rejects a ticket whose payload was tampered with after signing', () => {
+    const ticket = signRealtimeTicket(payload(), SECRET);
+    const forgedBody = Buffer.from(
+      JSON.stringify(payload({ organizationId: 'org_evil' })),
+    ).toString('base64url');
+    const tampered = `${forgedBody}.${ticket.slice(ticket.indexOf('.') + 1)}`;
+    expect(verifyRealtimeTicket(tampered, SECRET, NOW)).toBeNull();
+  });
+
+  it('rejects a ticket whose signature was tampered with', () => {
+    const ticket = signRealtimeTicket(payload(), SECRET);
+    const flipped = `${ticket.slice(0, -1)}${ticket.endsWith('A') ? 'B' : 'A'}`;
+    expect(verifyRealtimeTicket(flipped, SECRET, NOW)).toBeNull();
+  });
+
+  it('rejects a ticket that has expired', () => {
+    const ticket = signRealtimeTicket(payload({ exp: NOW - 1 }), SECRET);
+    expect(verifyRealtimeTicket(ticket, SECRET, NOW)).toBeNull();
+  });
+
+  it('accepts a ticket right up to its expiry boundary', () => {
+    const ticket = signRealtimeTicket(payload({ exp: NOW + 1 }), SECRET);
+    expect(verifyRealtimeTicket(ticket, SECRET, NOW)).not.toBeNull();
+    expect(verifyRealtimeTicket(ticket, SECRET, NOW + 1)).toBeNull();
+  });
+
+  it('rejects a structurally broken ticket', () => {
+    expect(verifyRealtimeTicket('', SECRET, NOW)).toBeNull();
+    expect(verifyRealtimeTicket('nodot', SECRET, NOW)).toBeNull();
+    expect(verifyRealtimeTicket('.onlysignature', SECRET, NOW)).toBeNull();
+    expect(verifyRealtimeTicket('onlybody.', SECRET, NOW)).toBeNull();
+  });
+
+  it('rejects a ticket whose body is valid base64 but not a valid payload', () => {
+    const body = Buffer.from(JSON.stringify({ userId: 'user_1' })).toString('base64url');
+    const secret = SECRET;
+    const forged = signRealtimeTicket(payload(), secret);
+    const signature = forged.slice(forged.indexOf('.') + 1);
+    expect(verifyRealtimeTicket(`${body}.${signature}`, secret, NOW)).toBeNull();
+  });
+});

--- a/packages/shared/src/events/ticket.ts
+++ b/packages/shared/src/events/ticket.ts
@@ -1,0 +1,54 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { z } from 'zod';
+
+export const REALTIME_TICKET_TTL_MS = 60_000;
+
+const identifier = z.string().min(1).max(128);
+
+export const realtimeTicketPayloadSchema = z.object({
+  userId: identifier,
+  organizationId: identifier,
+  sessionId: identifier,
+  exp: z.number().int().positive(),
+});
+
+export type RealtimeTicketPayload = z.infer<typeof realtimeTicketPayloadSchema>;
+
+export const realtimeTicketRequestSchema = z.object({
+  organizationId: identifier.optional(),
+});
+
+export type RealtimeTicketRequest = z.infer<typeof realtimeTicketRequestSchema>;
+
+function digest(body: string, secret: string): Buffer {
+  return createHmac('sha256', secret).update(body).digest();
+}
+
+export function signRealtimeTicket(payload: RealtimeTicketPayload, secret: string): string {
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${body}.${digest(body, secret).toString('base64url')}`;
+}
+
+export function verifyRealtimeTicket(
+  ticket: string,
+  secret: string,
+  now: number = Date.now(),
+): RealtimeTicketPayload | null {
+  const separator = ticket.indexOf('.');
+  if (separator <= 0 || separator === ticket.length - 1) return null;
+  const body = ticket.slice(0, separator);
+  const provided = Buffer.from(ticket.slice(separator + 1), 'base64url');
+  const expected = digest(body, secret);
+  if (provided.length !== expected.length) return null;
+  if (!timingSafeEqual(provided, expected)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+  const result = realtimeTicketPayloadSchema.safeParse(parsed);
+  if (!result.success) return null;
+  if (result.data.exp <= now) return null;
+  return result.data;
+}


### PR DESCRIPTION
Replace the raw session token in the realtime websocket URL with a short-lived HMAC-signed ticket sent in the connection's first frame.