### PR TITLE
fix(mcp): one-click consent approval that never 500s

### DIFF
--- a/apps/web/src/app/(auth)/oauth/authorize/consent-form.tsx
+++ b/apps/web/src/app/(auth)/oauth/authorize/consent-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Check, Fingerprint, Loader2 } from 'lucide-react';
+import { Check, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import { useToast } from '@/components/ui/toast.tsx';
@@ -28,15 +28,17 @@ export interface ConsentFormProps {
   readonly userEmail: string;
 }
 
+type Pending = 'allow' | 'deny' | null;
+
+interface DecisionResponse {
+  readonly status?: string;
+  readonly redirectUri?: string;
+  readonly message?: string;
+}
+
 function messageOf(error: unknown): string {
   if (error instanceof Error && error.message.length > 0) return error.message;
   return 'Try again.';
-}
-
-function PasskeyIcon({ verifying, verified }: { verifying: boolean; verified: boolean }) {
-  if (verifying) return <Loader2 className="size-4 animate-spin" aria-hidden="true" />;
-  if (verified) return <Check className="size-4" aria-hidden="true" />;
-  return <Fingerprint className="size-4" aria-hidden="true" />;
 }
 
 export function ConsentForm({
@@ -51,30 +53,47 @@ export function ConsentForm({
 }: ConsentFormProps) {
   const { toast } = useToast();
   const [organizationId, setOrganizationId] = useState(organizations[0]?.id ?? '');
-  const [verified, setVerified] = useState(!requirePasskey);
-  const [verifying, setVerifying] = useState(false);
+  const [pending, setPending] = useState<Pending>(null);
 
   const permissions = scopes.filter((entry) => SCOPE_LABELS[entry] !== undefined);
 
-  async function verifyPasskey(): Promise<void> {
-    setVerifying(true);
-    try {
+  async function post(decision: 'allow' | 'deny'): Promise<DecisionResponse> {
+    const response = await fetch('/oauth/authorize/decision', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ decision, consentCode, clientId, scope, organizationId }),
+    });
+    const data = (await response.json().catch(() => ({}))) as DecisionResponse;
+    if (response.status === 200) return data;
+    throw new Error(data.message ?? 'Could not complete the connection.');
+  }
+
+  async function decide(decision: 'allow' | 'deny', alreadyVerified: boolean): Promise<void> {
+    const data = await post(decision);
+    if (data.status === 'passkey_required') {
+      if (alreadyVerified) throw new Error('Passkey verification did not complete.');
       const result = await authClient.signIn.passkey();
-      if (result?.error) throw new Error(result.error.message ?? 'No passkey available.');
-      setVerified(true);
-    } catch (error: unknown) {
-      toast({ title: 'Passkey check failed', description: messageOf(error), tone: 'danger' });
-    } finally {
-      setVerifying(false);
+      if (result?.error) throw new Error(result.error.message ?? 'Passkey verification failed.');
+      await decide(decision, true);
+      return;
     }
+    if (typeof data.redirectUri !== 'string') {
+      throw new Error(data.message ?? 'Could not complete the connection.');
+    }
+    window.location.assign(data.redirectUri);
+  }
+
+  function run(decision: 'allow' | 'deny'): void {
+    if (pending !== null) return;
+    setPending(decision);
+    decide(decision, false).catch((error: unknown) => {
+      toast({ title: 'Could not connect', description: messageOf(error), tone: 'danger' });
+      setPending(null);
+    });
   }
 
   return (
-    <form method="post" action="/oauth/authorize/decision" className="flex flex-col gap-5">
-      <input type="hidden" name="consent_code" value={consentCode} />
-      <input type="hidden" name="client_id" value={clientId} />
-      <input type="hidden" name="scope" value={scope} />
-
+    <div className="flex flex-col gap-5">
       <p className="text-center text-muted text-sm">
         <span className="font-medium text-text">{clientName}</span> wants to act in Orbit as{' '}
         <span className="font-medium text-text">{userEmail}</span>.
@@ -83,9 +102,9 @@ export function ConsentForm({
       <label className="flex flex-col gap-1.5 text-2xs text-faint">
         Workspace
         <select
-          name="organization_id"
           value={organizationId}
           onChange={(event) => setOrganizationId(event.target.value)}
+          disabled={pending !== null}
           className="h-9 rounded-md border border-border bg-surface px-2.5 text-dense text-text"
         >
           {organizations.map((organization) => (
@@ -110,42 +129,35 @@ export function ConsentForm({
         </div>
       ) : null}
 
-      {requirePasskey ? (
+      <div className="flex gap-2">
         <Button
           type="button"
-          variant="secondary"
+          variant="ghost"
           block
-          disabled={verified || verifying}
-          onClick={() => {
-            verifyPasskey();
-          }}
+          disabled={pending !== null}
+          onClick={() => run('deny')}
         >
-          <PasskeyIcon verifying={verifying} verified={verified} />
-          {verified ? 'Passkey verified' : 'Verify with your passkey'}
-        </Button>
-      ) : null}
-
-      <div className="flex gap-2">
-        <Button type="submit" name="decision" value="deny" variant="ghost" block>
           Deny
         </Button>
         <Button
-          type="submit"
-          name="decision"
-          value="allow"
+          type="button"
           variant="primary"
           block
-          disabled={!verified || organizationId === ''}
+          disabled={pending !== null || organizationId === ''}
+          onClick={() => run('allow')}
         >
+          {pending === 'allow' ? (
+            <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          ) : null}
           Approve
         </Button>
       </div>
 
-      {requirePasskey && !verified ? (
+      {requirePasskey ? (
         <p className="text-center text-2xs text-faint">
-          Verify with your passkey to approve this connection.
+          Approving prompts you to verify with your passkey.
         </p>
       ) : null}
-    </form>
+    </div>
   );
 }

--- a/apps/web/src/app/(auth)/oauth/authorize/decision/route.ts
+++ b/apps/web/src/app/(auth)/oauth/authorize/decision/route.ts
@@ -1,11 +1,12 @@
 import {
+  finalizeMcpConsent,
   listOrganizationsForUser,
   passkeyVerifiedWithin,
   recordMcpGrant,
   userHasPasskey,
 } from '@orbit/core';
-import { headers as nextHeaders } from 'next/headers';
-import { auth } from '@/lib/auth/server.ts';
+import { toDomainError } from '@orbit/shared/errors';
+import { z } from 'zod';
 import { getSession } from '@/lib/auth/session.ts';
 import { publicAppUrl } from '@/lib/env.ts';
 
@@ -14,56 +15,58 @@ export const dynamic = 'force-dynamic';
 
 const PASSKEY_STEP_UP_WINDOW_MS = 120_000;
 
-function redirectTo(url: string): Response {
-  return new Response(null, { status: 303, headers: { location: url } });
-}
-
-function consentError(reason: string): Response {
-  return redirectTo(`/oauth/authorize?consent_error=${encodeURIComponent(reason)}`);
-}
+const decisionSchema = z.object({
+  decision: z.enum(['allow', 'deny']),
+  consentCode: z.string().min(1),
+  clientId: z.string().min(1),
+  scope: z.string(),
+  organizationId: z.string().min(1),
+});
 
 export async function POST(request: Request): Promise<Response> {
   const origin = request.headers.get('origin');
   if (origin !== null && origin !== publicAppUrl()) {
-    return new Response('Invalid origin.', { status: 403 });
+    return Response.json({ error: 'invalid_origin' }, { status: 403 });
   }
 
   const session = await getSession();
-  if (session === null) return new Response('Sign in to continue.', { status: 401 });
+  if (session === null) return Response.json({ error: 'unauthorized' }, { status: 401 });
 
-  const form = await request.formData();
-  const decision = String(form.get('decision') ?? '');
-  const consentCode = String(form.get('consent_code') ?? '');
-  const clientId = String(form.get('client_id') ?? '');
-  const scope = String(form.get('scope') ?? '');
-  const organizationId = String(form.get('organization_id') ?? '');
-  if (consentCode.length === 0) return consentError('missing_consent_code');
-
-  const requestHeaders = await nextHeaders();
-
-  if (decision !== 'allow') {
-    const denied = await auth.api.oAuthConsent({
-      body: { accept: false, consent_code: consentCode },
-      headers: requestHeaders,
-    });
-    return redirectTo(denied.redirectURI);
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'invalid_request' }, { status: 400 });
   }
+  const parsed = decisionSchema.safeParse(body);
+  if (!parsed.success) return Response.json({ error: 'invalid_request' }, { status: 400 });
+  const { decision, consentCode, clientId, scope, organizationId } = parsed.data;
+  const userId = session.user.id;
 
-  if (await userHasPasskey(session.user.id)) {
-    const fresh = await passkeyVerifiedWithin(session.user.id, PASSKEY_STEP_UP_WINDOW_MS);
-    if (!fresh) return consentError('passkey_required');
+  try {
+    if (decision === 'deny') {
+      const denied = await finalizeMcpConsent({ userId, consentCode, accept: false });
+      return Response.json({ redirectUri: denied.redirectUri });
+    }
+
+    if (await userHasPasskey(userId)) {
+      const fresh = await passkeyVerifiedWithin(userId, PASSKEY_STEP_UP_WINDOW_MS);
+      if (!fresh) return Response.json({ status: 'passkey_required' });
+    }
+
+    const organizations = await listOrganizationsForUser(userId);
+    if (!organizations.some((entry) => entry.organization.id === organizationId)) {
+      return Response.json({ error: 'invalid_workspace' }, { status: 400 });
+    }
+
+    await recordMcpGrant({ clientId, userId, organizationId, scopes: scope });
+    const approved = await finalizeMcpConsent({ userId, consentCode, accept: true });
+    return Response.json({ redirectUri: approved.redirectUri });
+  } catch (error) {
+    const domain = toDomainError(error);
+    console.error('mcp consent decision failed', { code: domain.code, message: domain.message });
+    const message =
+      domain.status >= 500 ? 'Something went wrong. Try connecting again.' : domain.message;
+    return Response.json({ error: domain.code, message }, { status: domain.status });
   }
-
-  const organizations = await listOrganizationsForUser(session.user.id);
-  if (!organizations.some((entry) => entry.organization.id === organizationId)) {
-    return consentError('invalid_workspace');
-  }
-
-  await recordMcpGrant({ clientId, userId: session.user.id, organizationId, scopes: scope });
-
-  const approved = await auth.api.oAuthConsent({
-    body: { accept: true, consent_code: consentCode },
-    headers: requestHeaders,
-  });
-  return redirectTo(approved.redirectURI);
 }

--- a/packages/core/src/auth/mcp-token.test.ts
+++ b/packages/core/src/auth/mcp-token.test.ts
@@ -2,8 +2,9 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 import { randomUUID } from 'node:crypto';
 import { db, eq, schema } from '@orbit/db';
 import { createOrganization } from '../org/organization-service.ts';
-import { createWorkspace, resetDatabase, type Workspace } from '../test-support.ts';
+import { createUser, createWorkspace, resetDatabase, type Workspace } from '../test-support.ts';
 import {
+  finalizeMcpConsent,
   getMcpClient,
   listMcpGrants,
   passkeyVerifiedWithin,
@@ -177,3 +178,103 @@ async function createOrganizationFor(userId: string): Promise<string> {
   });
   return bootstrap.organization.id;
 }
+
+async function createConsentCode(
+  userId: string,
+  overrides: Partial<{
+    requireConsent: boolean;
+    expiresAt: Date;
+    redirectURI: string;
+    state: string;
+  }> = {},
+): Promise<string> {
+  const consentCode = randomUUID().replace(/-/g, '');
+  const clientId = await createClient();
+  await db.insert(schema.verification).values({
+    id: randomUUID(),
+    identifier: consentCode,
+    value: JSON.stringify({
+      clientId,
+      redirectURI: overrides.redirectURI ?? 'http://127.0.0.1:9876/callback',
+      scope: ['openid', 'orbit.read', 'orbit.write'],
+      userId,
+      requireConsent: overrides.requireConsent ?? true,
+      state: overrides.state ?? 'xyz',
+      codeChallenge: 'challenge',
+      codeChallengeMethod: 'S256',
+    }),
+    expiresAt: overrides.expiresAt ?? new Date(Date.now() + 600_000),
+  });
+  return consentCode;
+}
+
+describe('finalizeMcpConsent', () => {
+  it('mints a code, records consent, and preserves PKCE on accept', async () => {
+    const consentCode = await createConsentCode(workspace.adminUser.id);
+    const { redirectUri } = await finalizeMcpConsent({
+      userId: workspace.adminUser.id,
+      consentCode,
+      accept: true,
+    });
+
+    const url = new URL(redirectUri);
+    const code = url.searchParams.get('code');
+    expect(code).not.toBeNull();
+    expect(url.searchParams.get('state')).toBe('xyz');
+
+    const [old] = await db
+      .select()
+      .from(schema.verification)
+      .where(eq(schema.verification.identifier, consentCode));
+    expect(old).toBeUndefined();
+
+    const [minted] = await db
+      .select()
+      .from(schema.verification)
+      .where(eq(schema.verification.identifier, code ?? ''));
+    const value = JSON.parse(minted?.value ?? '{}');
+    expect(value.requireConsent).toBe(false);
+    expect(value.codeChallenge).toBe('challenge');
+
+    const [consent] = await db.select().from(schema.oauthConsent);
+    expect(consent?.consentGiven).toBe(true);
+  });
+
+  it('returns an access_denied redirect and clears the code on deny', async () => {
+    const consentCode = await createConsentCode(workspace.adminUser.id);
+    const { redirectUri } = await finalizeMcpConsent({
+      userId: workspace.adminUser.id,
+      consentCode,
+      accept: false,
+    });
+    expect(new URL(redirectUri).searchParams.get('error')).toBe('access_denied');
+    const rows = await db
+      .select()
+      .from(schema.verification)
+      .where(eq(schema.verification.identifier, consentCode));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('rejects an expired request', async () => {
+    const consentCode = await createConsentCode(workspace.adminUser.id, {
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    await expect(
+      finalizeMcpConsent({ userId: workspace.adminUser.id, consentCode, accept: true }),
+    ).rejects.toMatchObject({ code: 'unauthorized' });
+  });
+
+  it('refuses a request that belongs to another account', async () => {
+    const consentCode = await createConsentCode(workspace.adminUser.id);
+    const stranger = await createUser('Stranger');
+    await expect(
+      finalizeMcpConsent({ userId: stranger.id, consentCode, accept: true }),
+    ).rejects.toMatchObject({ code: 'forbidden' });
+  });
+
+  it('rejects an unknown consent code', async () => {
+    await expect(
+      finalizeMcpConsent({ userId: workspace.adminUser.id, consentCode: 'nope', accept: true }),
+    ).rejects.toMatchObject({ code: 'unauthorized' });
+  });
+});

--- a/packages/core/src/auth/mcp-token.ts
+++ b/packages/core/src/auth/mcp-token.ts
@@ -1,6 +1,8 @@
+import { randomBytes } from 'node:crypto';
 import { and, db, desc, eq, gt, isNull, schema } from '@orbit/db';
-import { notFound, unauthorized } from '@orbit/shared/errors';
+import { forbidden, notFound, unauthorized } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
+import { z } from 'zod';
 import { newId } from '../internal.ts';
 import { resolvePrincipal } from '../org/member-service.ts';
 
@@ -182,4 +184,84 @@ export async function revokeMcpGrant(
         eq(schema.oauthAccessToken.userId, userId),
       ),
     );
+}
+
+const CONSENT_CODE_TTL_MS = 600_000;
+
+const mcpConsentValueSchema = z.object({
+  clientId: z.string().min(1),
+  redirectURI: z.string().min(1),
+  scope: z.array(z.string()),
+  userId: z.string().min(1),
+  requireConsent: z.boolean().optional(),
+  state: z.string().nullable().optional(),
+});
+
+function authorizationCode(): string {
+  return randomBytes(24).toString('base64url');
+}
+
+export interface FinalizeMcpConsentInput {
+  readonly userId: string;
+  readonly consentCode: string;
+  readonly accept: boolean;
+}
+
+export async function finalizeMcpConsent(
+  input: FinalizeMcpConsentInput,
+  now: Date = new Date(),
+): Promise<{ redirectUri: string }> {
+  const invalid = unauthorized('This authorization request is invalid or has expired.');
+
+  const [record] = await db
+    .select()
+    .from(schema.verification)
+    .where(eq(schema.verification.identifier, input.consentCode))
+    .limit(1);
+  if (record === undefined) throw invalid;
+  if (record.expiresAt.getTime() <= now.getTime()) throw invalid;
+
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(record.value) as Record<string, unknown>;
+  } catch {
+    throw invalid;
+  }
+  const value = mcpConsentValueSchema.parse(raw);
+  if (value.userId !== input.userId) {
+    throw forbidden('This authorization request belongs to another account.');
+  }
+  if (value.requireConsent !== true) throw invalid;
+
+  const redirect = new URL(value.redirectURI);
+  if (!input.accept) {
+    await db
+      .delete(schema.verification)
+      .where(eq(schema.verification.identifier, input.consentCode));
+    redirect.searchParams.set('error', 'access_denied');
+    redirect.searchParams.set('error_description', 'User denied access');
+    if (value.state != null) redirect.searchParams.set('state', value.state);
+    return { redirectUri: redirect.toString() };
+  }
+
+  const code = authorizationCode();
+  await db
+    .update(schema.verification)
+    .set({
+      identifier: code,
+      value: JSON.stringify({ ...raw, requireConsent: false }),
+      expiresAt: new Date(now.getTime() + CONSENT_CODE_TTL_MS),
+    })
+    .where(eq(schema.verification.identifier, input.consentCode));
+  await db.insert(schema.oauthConsent).values({
+    id: newId(),
+    clientId: value.clientId,
+    userId: input.userId,
+    scopes: value.scope.join(' '),
+    consentGiven: true,
+  });
+
+  redirect.searchParams.set('code', code);
+  if (value.state != null) redirect.searchParams.set('state', value.state);
+  return { redirectUri: redirect.toString() };
 }


### PR DESCRIPTION
Approve now finalizes MCP consent in-process (fixing the unhandled 500 on approval) and is a single button that runs the passkey step-up inline when required.