### PR TITLE
fix(integrations): replace a stale GitHub installation on reconnect

### DIFF
--- a/apps/web/src/features/settings/integrations-connect.ts
+++ b/apps/web/src/features/settings/integrations-connect.ts
@@ -1,7 +1,6 @@
-import { db, schema } from '@orbit/db';
-import { ensureSlackIntegration } from '@orbit/services';
+import { db } from '@orbit/db';
+import { ensureGithubInstallation, ensureSlackIntegration } from '@orbit/services';
 import { internal } from '@orbit/shared/errors';
-import { randomUUIDv7 } from 'bun';
 import { z } from 'zod';
 
 const SLACK_OAUTH_ACCESS_URL = 'https://slack.com/api/oauth.v2.access';
@@ -12,23 +11,11 @@ export async function persistGithubInstallation(input: {
   readonly userId: string;
   readonly installationId: string;
 }): Promise<void> {
-  await db
-    .insert(schema.integration)
-    .values({
-      id: randomUUIDv7(),
-      organizationId: input.organizationId,
-      provider: 'github',
-      externalId: input.installationId,
-      connectedById: input.userId,
-    })
-    .onConflictDoUpdate({
-      target: [
-        schema.integration.organizationId,
-        schema.integration.provider,
-        schema.integration.externalId,
-      ],
-      set: { connectedById: input.userId, updatedAt: new Date() },
-    });
+  await ensureGithubInstallation(db, {
+    organizationId: input.organizationId,
+    connectedById: input.userId,
+    installationId: input.installationId,
+  });
 }
 
 const oauthAccessSchema = z.object({

--- a/apps/web/src/features/settings/integrations-data.ts
+++ b/apps/web/src/features/settings/integrations-data.ts
@@ -114,7 +114,8 @@ export async function loadIntegrationSettings(principal: Principal): Promise<Int
         credentials: schema.integration.credentials,
       })
       .from(schema.integration)
-      .where(eq(schema.integration.organizationId, principal.organizationId)),
+      .where(eq(schema.integration.organizationId, principal.organizationId))
+      .orderBy(desc(schema.integration.createdAt)),
     db
       .select({
         id: schema.githubRepositorySync.id,

--- a/packages/services/src/github/index.ts
+++ b/packages/services/src/github/index.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 export * from './app.ts';
 export * from './apply.ts';
+export * from './install.ts';
 
 export function verifyGithubSignature(
   rawBody: string,

--- a/packages/services/src/github/install.test.ts
+++ b/packages/services/src/github/install.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'bun:test';
+import { integration, organization, user } from '@orbit/db/schema';
+import { randomUUIDv7 } from 'bun';
+import { and, eq } from 'drizzle-orm';
+import { type TestTransaction, withRollback } from '../test-database.ts';
+import { ensureGithubInstallation } from './install.ts';
+
+async function seed(tx: TestTransaction): Promise<{ organizationId: string; userId: string }> {
+  const suffix = randomUUIDv7();
+  const organizationId = `org_${suffix}`;
+  const userId = `usr_${suffix}`;
+  await tx
+    .insert(organization)
+    .values({ id: organizationId, name: 'Acme', slug: `acme-${suffix.toLowerCase()}` });
+  await tx.insert(user).values({
+    id: userId,
+    name: 'Ada',
+    email: `ada.${suffix}@orbit.local`,
+    handle: `ada-${suffix.toLowerCase()}`,
+  });
+  return { organizationId, userId };
+}
+
+function githubRows(tx: TestTransaction, organizationId: string) {
+  return tx
+    .select({ id: integration.id, externalId: integration.externalId })
+    .from(integration)
+    .where(and(eq(integration.organizationId, organizationId), eq(integration.provider, 'github')));
+}
+
+describe('ensureGithubInstallation', () => {
+  it('replaces a stale installation so only the latest remains', async () => {
+    await withRollback(async (tx) => {
+      const { organizationId, userId } = await seed(tx);
+      await ensureGithubInstallation(tx, {
+        organizationId,
+        connectedById: userId,
+        installationId: '148719427',
+      });
+      await ensureGithubInstallation(tx, {
+        organizationId,
+        connectedById: userId,
+        installationId: '148726691',
+      });
+
+      const rows = await githubRows(tx, organizationId);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.externalId).toBe('148726691');
+    });
+  });
+
+  it('reuses the row when the same installation reconnects', async () => {
+    await withRollback(async (tx) => {
+      const { organizationId, userId } = await seed(tx);
+      const first = await ensureGithubInstallation(tx, {
+        organizationId,
+        connectedById: userId,
+        installationId: '555',
+      });
+      const second = await ensureGithubInstallation(tx, {
+        organizationId,
+        connectedById: userId,
+        installationId: '555',
+      });
+
+      expect(second).toBe(first);
+      expect(await githubRows(tx, organizationId)).toHaveLength(1);
+    });
+  });
+
+  it('leaves other providers untouched', async () => {
+    await withRollback(async (tx) => {
+      const { organizationId, userId } = await seed(tx);
+      await tx.insert(integration).values({
+        id: randomUUIDv7(),
+        organizationId,
+        provider: 'slack',
+        externalId: 'T1',
+        connectedById: userId,
+        credentials: { botToken: 'x' },
+      });
+
+      await ensureGithubInstallation(tx, {
+        organizationId,
+        connectedById: userId,
+        installationId: '999',
+      });
+
+      const providers = await tx
+        .select({ provider: integration.provider })
+        .from(integration)
+        .where(eq(integration.organizationId, organizationId));
+      expect(providers.map((p) => p.provider).sort()).toEqual(['github', 'slack']);
+    });
+  });
+});

--- a/packages/services/src/github/install.ts
+++ b/packages/services/src/github/install.ts
@@ -1,0 +1,39 @@
+import { integration } from '@orbit/db/schema';
+import { randomUUIDv7 } from 'bun';
+import { and, eq, ne } from 'drizzle-orm';
+import type { GithubDatabase } from './apply.ts';
+
+export async function ensureGithubInstallation(
+  database: GithubDatabase,
+  input: {
+    readonly organizationId: string;
+    readonly connectedById: string;
+    readonly installationId: string;
+  },
+): Promise<string> {
+  await database
+    .delete(integration)
+    .where(
+      and(
+        eq(integration.organizationId, input.organizationId),
+        eq(integration.provider, 'github'),
+        ne(integration.externalId, input.installationId),
+      ),
+    );
+  const [row] = await database
+    .insert(integration)
+    .values({
+      id: randomUUIDv7(),
+      organizationId: input.organizationId,
+      provider: 'github',
+      externalId: input.installationId,
+      connectedById: input.connectedById,
+    })
+    .onConflictDoUpdate({
+      target: [integration.organizationId, integration.provider, integration.externalId],
+      set: { connectedById: input.connectedById, updatedAt: new Date() },
+    })
+    .returning({ id: integration.id });
+  if (row === undefined) throw new Error('Could not persist the GitHub installation.');
+  return row.id;
+}


### PR DESCRIPTION
Replace an org's stale GitHub installation on reconnect so repositories load without any manual database edit.

**Fix in action** (real Postgres, rolled-back tx reproducing the prod state):

```
prod today  -> github rows: [ "148719427" ]   (dead installation -> repos 404)
one Connect -> github rows: [ "148726691" ]   (live installation -> repos load)
```

`ensureGithubInstallation` removes the org's other github rows before upserting the current one; `loadIntegrationSettings` also reads newest-first as a fallback.
