### PR TITLE
fix(layout): make breadcrumb ancestors navigable

### DIFF
--- a/apps/web/src/components/layout/top-bar.tsx
+++ b/apps/web/src/components/layout/top-bar.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { Menu, PanelRight } from 'lucide-react';
+import Link from 'next/link';
 import { Fragment, type ReactNode } from 'react';
 import { ThemeToggle } from '@/components/theme-toggle.tsx';
 import { Button } from '@/components/ui/button.tsx';
 import { Tooltip } from '@/components/ui/tooltip.tsx';
 import { TopBarDisplayMenu } from '@/features/filters/view-controls.tsx';
 import { cn } from '@/lib/cn.ts';
+import { tabHover } from '@/lib/interaction.ts';
 
 export interface Breadcrumb {
   readonly label: string;
@@ -61,9 +63,18 @@ export function TopBar({
                     </li>
                   ) : null}
                   <li className={cn('min-w-0 truncate', last ? 'block' : 'hidden sm:block')}>
-                    <span className={last ? 'font-medium text-text' : 'text-muted'}>
-                      {crumb.label}
-                    </span>
+                    {crumb.href === undefined ? (
+                      <span className={last ? 'font-medium text-text' : 'text-muted'}>
+                        {crumb.label}
+                      </span>
+                    ) : (
+                      <Link
+                        href={crumb.href}
+                        className={cn('block truncate rounded-xs text-muted', tabHover)}
+                      >
+                        {crumb.label}
+                      </Link>
+                    )}
                   </li>
                 </Fragment>
               );

--- a/apps/web/src/components/layout/workspace-shell.tsx
+++ b/apps/web/src/components/layout/workspace-shell.tsx
@@ -2,24 +2,9 @@
 
 import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
+import { breadcrumbsFor } from '@/lib/breadcrumbs.ts';
 import type { ShellTeam, ShellUser, ShellWorkspace } from '@/lib/navigation.ts';
 import { AppShell } from './app-shell.tsx';
-import type { Breadcrumb } from './top-bar.tsx';
-
-const OPAQUE_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-function titleize(segment: string): string {
-  const words = segment.replace(/-/g, ' ');
-  return words.charAt(0).toUpperCase() + words.slice(1);
-}
-
-export function breadcrumbsFor(pathname: string, workspaceName: string): Breadcrumb[] {
-  const segments = pathname
-    .split('/')
-    .filter((segment) => segment.length > 0 && !OPAQUE_ID.test(segment));
-  if (segments.length === 0) return [{ label: workspaceName }];
-  return [{ label: workspaceName }, ...segments.map((segment) => ({ label: titleize(segment) }))];
-}
 
 export interface WorkspaceShellProps {
   readonly workspace: ShellWorkspace;

--- a/apps/web/src/lib/breadcrumbs.test.ts
+++ b/apps/web/src/lib/breadcrumbs.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import { breadcrumbsFor } from './breadcrumbs.ts';
+
+describe('breadcrumbsFor', () => {
+  test('a workspace-only path yields a single, non-navigable crumb', () => {
+    expect(breadcrumbsFor('/', 'Noveum')).toEqual([{ label: 'Noveum' }]);
+  });
+
+  test('the workspace crumb links home and the current page does not link', () => {
+    expect(breadcrumbsFor('/inbox', 'Noveum')).toEqual([
+      { label: 'Noveum', href: '/' },
+      { label: 'Inbox' },
+    ]);
+  });
+
+  test('a navigable ancestor links while the leaf stays plain text', () => {
+    expect(breadcrumbsFor('/docs/new', 'Noveum')).toEqual([
+      { label: 'Noveum', href: '/' },
+      { label: 'Docs', href: '/docs' },
+      { label: 'New' },
+    ]);
+  });
+
+  test('nested settings expose every navigable ancestor as a link', () => {
+    expect(breadcrumbsFor('/settings/account/passkeys', 'Noveum')).toEqual([
+      { label: 'Noveum', href: '/' },
+      { label: 'Settings', href: '/settings' },
+      { label: 'Account', href: '/settings/account' },
+      { label: 'Passkeys' },
+    ]);
+  });
+
+  test('ancestors without their own page never become links', () => {
+    expect(breadcrumbsFor('/team/eng/issues', 'Noveum')).toEqual([
+      { label: 'Noveum', href: '/' },
+      { label: 'Team' },
+      { label: 'Eng' },
+      { label: 'Issues' },
+    ]);
+  });
+
+  test('opaque id segments drop from labels but stay in ancestor hrefs', () => {
+    expect(breadcrumbsFor('/docs/1b3f6c2e-0a4d-4e2f-9c1a-7d5e8f0a1b2c', 'Noveum')).toEqual([
+      { label: 'Noveum', href: '/' },
+      { label: 'Docs' },
+    ]);
+  });
+
+  test('an unrouted parent stays text even with a real leaf', () => {
+    expect(breadcrumbsFor('/issue/ENG-123', 'Noveum')).toEqual([
+      { label: 'Noveum', href: '/' },
+      { label: 'Issue' },
+      { label: 'ENG 123' },
+    ]);
+  });
+
+  test('multi-word segments titleize on hyphen', () => {
+    expect(breadcrumbsFor('/my-issues', 'Noveum')).toEqual([
+      { label: 'Noveum', href: '/' },
+      { label: 'My issues' },
+    ]);
+  });
+});

--- a/apps/web/src/lib/breadcrumbs.ts
+++ b/apps/web/src/lib/breadcrumbs.ts
@@ -1,0 +1,61 @@
+import type { Breadcrumb } from '@/components/layout/top-bar.tsx';
+
+const OPAQUE_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const NAVIGABLE_ROUTES: readonly RegExp[] = [
+  /^\/$/,
+  /^\/inbox$/,
+  /^\/my-issues$/,
+  /^\/pulls$/,
+  /^\/projects$/,
+  /^\/projects\/[^/]+$/,
+  /^\/cycles$/,
+  /^\/views$/,
+  /^\/docs$/,
+  /^\/docs\/new$/,
+  /^\/docs\/[^/]+$/,
+  /^\/analytics$/,
+  /^\/issue\/[^/]+$/,
+  /^\/settings$/,
+  /^\/settings\/general$/,
+  /^\/settings\/members$/,
+  /^\/settings\/teams$/,
+  /^\/settings\/integrations$/,
+  /^\/settings\/notifications$/,
+  /^\/settings\/account$/,
+  /^\/settings\/account\/connections$/,
+  /^\/settings\/account\/passkeys$/,
+  /^\/settings\/account\/password$/,
+  /^\/settings\/account\/sessions$/,
+  /^\/team\/[^/]+\/issues$/,
+  /^\/team\/[^/]+\/board$/,
+  /^\/team\/[^/]+\/cycle\/active$/,
+  /^\/workspaces\/new$/,
+];
+
+function isNavigable(path: string): boolean {
+  return NAVIGABLE_ROUTES.some((route) => route.test(path));
+}
+
+function titleize(segment: string): string {
+  const words = segment.replace(/-/g, ' ');
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+export function breadcrumbsFor(pathname: string, workspaceName: string): Breadcrumb[] {
+  const trail: { readonly label: string; readonly href: string }[] = [
+    { label: workspaceName, href: '/' },
+  ];
+  let accumulated = '';
+  for (const segment of pathname.split('/')) {
+    if (segment.length === 0) continue;
+    accumulated += `/${segment}`;
+    if (OPAQUE_ID.test(segment)) continue;
+    trail.push({ label: titleize(segment), href: accumulated });
+  }
+  return trail.map((crumb, index) => {
+    const last = index === trail.length - 1;
+    if (last || !isNavigable(crumb.href)) return { label: crumb.label };
+    return { label: crumb.label, href: crumb.href };
+  });
+}


### PR DESCRIPTION
Make breadcrumb ancestors clickable links that navigate, instead of plain text.

**Evidence** (`bun test` in `apps/web`, the touched package):

```
apps/web/src/lib/breadcrumbs.test.ts:
 8 pass  0 fail  8 expect() calls

@orbit/web test: Ran 498 tests across 80 files. Exited with code 0
```

A crumb links only when its accumulated path resolves to a real route, so unrouted parents (`/team`, `/issue`) and the current page stay text and nothing links to a 404. Live dev-server screenshot skipped: `next dev` currently 500s on every route from an unrelated Turbopack + react-email/prettier module-externalization issue, present on `main`.
