### PR TITLE
perf(ci): install dependencies once in a shared orbit-deps base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,11 @@ jobs:
       - name: Build every service image
         run: |
           set -eu
+          docker build -f Dockerfile.deps -t orbit-deps:build .
           for target in web realtime mcp; do
-            docker build -f "apps/$target/Dockerfile" -t "orbit-$target:ci" .
+            docker build --build-arg DEPS_IMAGE=orbit-deps:build -f "apps/$target/Dockerfile" -t "orbit-$target:ci" .
           done
-          docker build -f packages/db/Dockerfile -t orbit-migrate:ci .
+          docker build --build-arg DEPS_IMAGE=orbit-deps:build -f packages/db/Dockerfile -t orbit-migrate:ci .
 
       - name: The web image must boot on Bun and serve its health endpoint
         run: |

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.7
+FROM oven/bun:1.3.14-alpine AS base
+ENV CI=1
+WORKDIR /app
+
+FROM base AS doppler
+RUN apk add --no-cache wget && \
+    wget -q -t3 'https://packages.doppler.com/public/cli/rsa.8004D9FF50437357.key' -O /etc/apk/keys/cli@doppler-8004D9FF50437357.rsa.pub && \
+    echo 'https://packages.doppler.com/public/cli/alpine/any-version/main' >> /etc/apk/repositories && \
+    apk add --no-cache doppler
+
+FROM base AS deps
+COPY --from=doppler /usr/bin/doppler /usr/bin/doppler
+COPY package.json bun.lock ./
+COPY apps/mcp/package.json apps/mcp/package.json
+COPY apps/realtime/package.json apps/realtime/package.json
+COPY apps/web/package.json apps/web/package.json
+COPY packages/core/package.json packages/core/package.json
+COPY packages/db/package.json packages/db/package.json
+COPY packages/realtime-client/package.json packages/realtime-client/package.json
+COPY packages/services/package.json packages/services/package.json
+COPY packages/shared/package.json packages/shared/package.json
+RUN test -s bun.lock || (echo "bun.lock is missing, refusing to build a floating dependency tree" >&2; exit 1)
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile

--- a/apps/mcp/Dockerfile
+++ b/apps/mcp/Dockerfile
@@ -1,26 +1,11 @@
 # syntax=docker/dockerfile:1.7
+ARG DEPS_IMAGE=orbit-deps:build
+
 FROM oven/bun:1.3.14-alpine AS base
 ENV CI=1
 WORKDIR /app
 
-FROM base AS doppler
-RUN apk add --no-cache wget && \
-    wget -q -t3 'https://packages.doppler.com/public/cli/rsa.8004D9FF50437357.key' -O /etc/apk/keys/cli@doppler-8004D9FF50437357.rsa.pub && \
-    echo 'https://packages.doppler.com/public/cli/alpine/any-version/main' >> /etc/apk/repositories && \
-    apk add --no-cache doppler
-
-FROM base AS deps
-COPY package.json bun.lock ./
-COPY apps/mcp/package.json apps/mcp/package.json
-COPY apps/realtime/package.json apps/realtime/package.json
-COPY apps/web/package.json apps/web/package.json
-COPY packages/core/package.json packages/core/package.json
-COPY packages/db/package.json packages/db/package.json
-COPY packages/realtime-client/package.json packages/realtime-client/package.json
-COPY packages/services/package.json packages/services/package.json
-COPY packages/shared/package.json packages/shared/package.json
-RUN test -s bun.lock || (echo "bun.lock is missing, refusing to build a floating dependency tree" >&2; exit 1)
-RUN bun install --frozen-lockfile
+FROM ${DEPS_IMAGE} AS deps
 
 FROM deps AS installer
 COPY tsconfig.base.json ./
@@ -32,7 +17,7 @@ FROM base AS runner
 ENV NODE_ENV=production
 ENV MCP_PORT=3200
 RUN addgroup -S orbit && adduser -S orbit -G orbit
-COPY --from=doppler /usr/bin/doppler /usr/bin/doppler
+COPY --from=deps /usr/bin/doppler /usr/bin/doppler
 COPY --from=installer --chown=orbit:orbit /app/apps/mcp/dist ./dist
 USER orbit
 EXPOSE 3200

--- a/apps/realtime/Dockerfile
+++ b/apps/realtime/Dockerfile
@@ -1,26 +1,11 @@
 # syntax=docker/dockerfile:1.7
+ARG DEPS_IMAGE=orbit-deps:build
+
 FROM oven/bun:1.3.14-alpine AS base
 ENV CI=1
 WORKDIR /app
 
-FROM base AS doppler
-RUN apk add --no-cache wget && \
-    wget -q -t3 'https://packages.doppler.com/public/cli/rsa.8004D9FF50437357.key' -O /etc/apk/keys/cli@doppler-8004D9FF50437357.rsa.pub && \
-    echo 'https://packages.doppler.com/public/cli/alpine/any-version/main' >> /etc/apk/repositories && \
-    apk add --no-cache doppler
-
-FROM base AS deps
-COPY package.json bun.lock ./
-COPY apps/mcp/package.json apps/mcp/package.json
-COPY apps/realtime/package.json apps/realtime/package.json
-COPY apps/web/package.json apps/web/package.json
-COPY packages/core/package.json packages/core/package.json
-COPY packages/db/package.json packages/db/package.json
-COPY packages/realtime-client/package.json packages/realtime-client/package.json
-COPY packages/services/package.json packages/services/package.json
-COPY packages/shared/package.json packages/shared/package.json
-RUN test -s bun.lock || (echo "bun.lock is missing, refusing to build a floating dependency tree" >&2; exit 1)
-RUN bun install --frozen-lockfile
+FROM ${DEPS_IMAGE} AS deps
 
 FROM deps AS installer
 COPY tsconfig.base.json ./
@@ -32,7 +17,7 @@ FROM base AS runner
 ENV NODE_ENV=production
 ENV REALTIME_PORT=3100
 RUN addgroup -S orbit && adduser -S orbit -G orbit
-COPY --from=doppler /usr/bin/doppler /usr/bin/doppler
+COPY --from=deps /usr/bin/doppler /usr/bin/doppler
 COPY --from=installer --chown=orbit:orbit /app/apps/realtime/dist ./dist
 USER orbit
 EXPOSE 3100

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,34 +1,19 @@
 # syntax=docker/dockerfile:1.7
+ARG DEPS_IMAGE=orbit-deps:build
+
 FROM oven/bun:1.3.14-alpine AS base
 ENV CI=1
 ENV NEXT_TELEMETRY_DISABLED=1
 WORKDIR /app
 
-FROM base AS doppler
-RUN apk add --no-cache wget && \
-    wget -q -t3 'https://packages.doppler.com/public/cli/rsa.8004D9FF50437357.key' -O /etc/apk/keys/cli@doppler-8004D9FF50437357.rsa.pub && \
-    echo 'https://packages.doppler.com/public/cli/alpine/any-version/main' >> /etc/apk/repositories && \
-    apk add --no-cache doppler
-
-FROM base AS deps
-COPY package.json bun.lock ./
-COPY apps/mcp/package.json apps/mcp/package.json
-COPY apps/realtime/package.json apps/realtime/package.json
-COPY apps/web/package.json apps/web/package.json
-COPY packages/core/package.json packages/core/package.json
-COPY packages/db/package.json packages/db/package.json
-COPY packages/realtime-client/package.json packages/realtime-client/package.json
-COPY packages/services/package.json packages/services/package.json
-COPY packages/shared/package.json packages/shared/package.json
-RUN test -s bun.lock || (echo "bun.lock is missing, refusing to build a floating dependency tree" >&2; exit 1)
-RUN bun install --frozen-lockfile
+FROM ${DEPS_IMAGE} AS deps
 
 FROM deps AS installer
 COPY tsconfig.base.json ./
 COPY packages packages
 COPY apps/web apps/web
-COPY --from=doppler /usr/bin/doppler /usr/bin/doppler
 RUN --mount=type=secret,id=DOPPLER_TOKEN,required=false \
+    --mount=type=cache,target=/app/apps/web/.next/cache \
     set -eu; \
     if [ -s /run/secrets/DOPPLER_TOKEN ]; then \
       export DOPPLER_INTERACTIVE=false; \
@@ -47,7 +32,7 @@ ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 RUN addgroup -S orbit && adduser -S orbit -G orbit
-COPY --from=doppler /usr/bin/doppler /usr/bin/doppler
+COPY --from=deps /usr/bin/doppler /usr/bin/doppler
 COPY --from=installer --chown=orbit:orbit /app/apps/web/.next/standalone ./
 COPY --from=installer --chown=orbit:orbit /app/apps/web/.next/static ./apps/web/.next/static
 COPY --from=installer --chown=orbit:orbit /app/apps/web/public ./apps/web/public

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -32,19 +32,30 @@ phases:
       - IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - 'if [ -z "$IMAGE_TAG" ]; then echo "ERROR: could not resolve the source commit"; exit 1; fi'
       - echo "Image tag is $IMAGE_TAG"
-      - for NAME in web realtime mcp migrate; do docker pull $ECR/orbit-$NAME:latest || true; done
+      - for NAME in deps web realtime mcp migrate; do docker pull $ECR/orbit-$NAME:latest || true; done
       - export ECR IMAGE_TAG
 
   build:
     commands:
       - |
         set -e
+        DEPS_IMAGE="orbit-deps:build"
+        docker build \
+          --cache-from "$ECR/orbit-deps:latest" \
+          --build-arg BUILDKIT_INLINE_CACHE=1 \
+          -t "$DEPS_IMAGE" \
+          -t "$ECR/orbit-deps:latest" \
+          -t "$ECR/orbit-deps:$IMAGE_TAG" \
+          -f Dockerfile.deps .
+        echo "deps image built"
+
         build_image() {
           NAME="$1"
           DOCKERFILE="$2"
           docker build \
             --cache-from "$ECR/orbit-$NAME:latest" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --build-arg DEPS_IMAGE="$DEPS_IMAGE" \
             --secret id=DOPPLER_TOKEN,env=DOPPLER_TOKEN_BUILD \
             -t "$ECR/orbit-$NAME:latest" \
             -t "$ECR/orbit-$NAME:$IMAGE_TAG" \
@@ -72,6 +83,9 @@ phases:
           docker push "$ECR/orbit-$1:latest"
           docker push "$ECR/orbit-$1:$IMAGE_TAG"
         }
+
+        push_image deps
+        echo "deps image pushed"
 
         push_image web & WEB_PID=$!
         push_image realtime & REALTIME_PID=$!

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -251,10 +251,17 @@ aws secretsmanager get-secret-value --region us-east-1 \
 
 ## Continuous deployment
 
-A CodeBuild project runs `buildspec.yml` on every push to `main`. It builds four
-images, pushes them to ECR tagged with the short commit, then `kubectl set
-image` on the three deployments and waits for the rollouts. It runs inside the
-VPC, which is the only reason it can reach the private EKS endpoint and RDS.
+A CodeBuild project runs `buildspec.yml` on every push to `main`. It first builds
+a shared `orbit-deps` image that runs `bun install` once, then builds the four
+service images (web, realtime, mcp, migrate) against it in parallel, pushes them
+to ECR tagged with the short commit, then `kubectl set image` on the three
+deployments and waits for the rollouts. It runs inside the VPC, which is the only
+reason it can reach the private EKS endpoint and RDS.
+
+The `orbit-deps` image is a build-and-cache artifact, never deployed. It carries
+the installed `node_modules` as a single layer that every service image shares,
+so the dependency install is built and pushed once instead of four times, and it
+gives the install step a cache that survives across fresh on-demand build hosts.
 
 CodeBuild never applies these manifests. The deployments must already exist, and
 the build fails loudly if they do not. Schema changes are never automatic: run

--- a/packages/db/Dockerfile
+++ b/packages/db/Dockerfile
@@ -1,31 +1,10 @@
 # syntax=docker/dockerfile:1.7
-FROM oven/bun:1.3.14-alpine AS base
-ENV CI=1
-WORKDIR /app
+ARG DEPS_IMAGE=orbit-deps:build
 
-FROM base AS doppler
-RUN apk add --no-cache wget && \
-    wget -q -t3 'https://packages.doppler.com/public/cli/rsa.8004D9FF50437357.key' -O /etc/apk/keys/cli@doppler-8004D9FF50437357.rsa.pub && \
-    echo 'https://packages.doppler.com/public/cli/alpine/any-version/main' >> /etc/apk/repositories && \
-    apk add --no-cache doppler
-
-FROM base AS runner
+FROM ${DEPS_IMAGE} AS runner
 RUN addgroup -S orbit && adduser -S orbit -G orbit
-COPY --from=doppler /usr/bin/doppler /usr/bin/doppler
-COPY --chown=orbit:orbit package.json bun.lock ./
-COPY --chown=orbit:orbit apps/mcp/package.json apps/mcp/package.json
-COPY --chown=orbit:orbit apps/realtime/package.json apps/realtime/package.json
-COPY --chown=orbit:orbit apps/web/package.json apps/web/package.json
-COPY --chown=orbit:orbit packages/core/package.json packages/core/package.json
-COPY --chown=orbit:orbit packages/db/package.json packages/db/package.json
-COPY --chown=orbit:orbit packages/realtime-client/package.json packages/realtime-client/package.json
-COPY --chown=orbit:orbit packages/services/package.json packages/services/package.json
-COPY --chown=orbit:orbit packages/shared/package.json packages/shared/package.json
-RUN test -s bun.lock || (echo "bun.lock is missing, refusing to build a floating dependency tree" >&2; exit 1)
-RUN bun install --frozen-lockfile
-COPY --chown=orbit:orbit tsconfig.base.json ./
-COPY --chown=orbit:orbit packages packages
-RUN chown -R orbit:orbit /app
+COPY tsconfig.base.json ./
+COPY packages packages
 USER orbit
 WORKDIR /app/packages/db
 CMD ["/usr/bin/doppler", "run", "--", "bun", "run", "push"]


### PR DESCRIPTION
Install workspace dependencies once in a shared `orbit-deps` base image so the four service images stop reinstalling in parallel and instead share one node_modules layer.

Prerequisite done: created the `orbit-deps` ECR repo (scanOnPush, AES256, MUTABLE), mirroring the others.

Evidence (local, arm64):
```
Layer sharing (deps -> migrate):
  deps layers=19  migrate layers=23  shared bottom layers=19
  node_modules layer shared: YES        # migrate push = only its 4 small deltas

migrate runs as non-root, resolves drizzle-kit from root-owned modules:
  uid=100(orbit) gid=101(orbit)
  drizzle-kit: v0.31.10   drizzle-orm: v0.45.2

Runtime artifacts intact:
  web       -> apps/web/server.js   doppler v3.76.1  user orbit
  realtime  -> dist/index.js        doppler v3.76.1  user orbit
  mcp       -> dist/index.js        doppler v3.76.1  user orbit

Local build (14 cores): deps 42s cold; then web 23s, realtime 9s, mcp 3s, migrate 7s
  (install runs once in deps, not four times in parallel)
```
