### PR TITLE
feat(integrations): searchable lazy-loaded repo and channel pickers

### DIFF
--- a/apps/web/src/app/api/integrations/github/repositories/route.ts
+++ b/apps/web/src/app/api/integrations/github/repositories/route.ts
@@ -1,0 +1,46 @@
+import { and, db, desc, eq, schema } from '@orbit/db';
+import { fetchInstalledRepositoryPage } from '@orbit/services';
+import { assertCan } from '@orbit/shared/policy';
+import { z } from 'zod';
+import { apiContext, handleRoute, searchParamsOf } from '@/lib/api/handler.ts';
+import { githubAppConfig, githubDiscoveryReady } from '@/lib/env.ts';
+
+const querySchema = z.object({ cursor: z.string().regex(/^\d+$/).optional() });
+
+export async function GET(request: Request): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    assertCan(principal, 'integration:manage');
+    const { cursor } = querySchema.parse(searchParamsOf(request));
+    const page = cursor === undefined ? 1 : Number(cursor);
+
+    const [row] = await db
+      .select({ externalId: schema.integration.externalId })
+      .from(schema.integration)
+      .where(
+        and(
+          eq(schema.integration.organizationId, principal.organizationId),
+          eq(schema.integration.provider, 'github'),
+        ),
+      )
+      .orderBy(desc(schema.integration.createdAt))
+      .limit(1);
+    const installationId =
+      row !== undefined && /^\d+$/.test(row.externalId) ? row.externalId : null;
+    if (installationId === null || !githubDiscoveryReady()) {
+      return { repositories: [], nextCursor: null };
+    }
+
+    const config = githubAppConfig();
+    const result = await fetchInstalledRepositoryPage({
+      appId: config.appId,
+      privateKey: config.privateKey,
+      installationId,
+      page,
+    });
+    return {
+      repositories: result.repositories.map((repository) => ({ ...repository, installationId })),
+      nextCursor: result.hasMore ? String(page + 1) : null,
+    };
+  });
+}

--- a/apps/web/src/app/api/integrations/slack/channels/route.ts
+++ b/apps/web/src/app/api/integrations/slack/channels/route.ts
@@ -1,0 +1,31 @@
+import { db } from '@orbit/db';
+import { resolveSlackContext, SlackClient } from '@orbit/services';
+import { assertCan } from '@orbit/shared/policy';
+import { z } from 'zod';
+import { apiContext, handleRoute, searchParamsOf } from '@/lib/api/handler.ts';
+
+const querySchema = z.object({ cursor: z.string().min(1).max(1024).optional() });
+
+export async function GET(request: Request): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    assertCan(principal, 'integration:manage');
+    const { cursor } = querySchema.parse(searchParamsOf(request));
+
+    const context = await resolveSlackContext(db, principal.organizationId);
+    if (context === null || context.token === null) {
+      return { channels: [], nextCursor: null };
+    }
+
+    const conversations = await new SlackClient({ token: context.token }).listConversations(
+      cursor === undefined ? {} : { cursor },
+    );
+    return {
+      channels: conversations.channels.map((channel) => ({
+        channelId: channel.id,
+        channelName: channel.name,
+      })),
+      nextCursor: conversations.nextCursor,
+    };
+  });
+}

--- a/apps/web/src/features/settings/integration-picker.test.tsx
+++ b/apps/web/src/features/settings/integration-picker.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  IntegrationPicker,
+  type IntegrationPickerProps,
+  type PickerItem,
+} from './integration-picker.tsx';
+
+const teams = [
+  { id: 'team-1', key: 'ENG', name: 'Engineering' },
+  { id: 'team-2', key: 'DES', name: 'Design' },
+];
+
+const items: PickerItem[] = [
+  { id: '1', label: 'acme/web', linked: false },
+  { id: '2', label: 'acme/api', linked: true },
+  { id: '3', label: 'acme/docs', linked: false },
+];
+
+function props(overrides: Partial<IntegrationPickerProps> = {}): IntegrationPickerProps {
+  return {
+    open: true,
+    onOpenChange: () => undefined,
+    title: 'Link a repository',
+    description: 'Search and map one to a team.',
+    searchPlaceholder: 'Search repositories…',
+    items,
+    isLoading: false,
+    isError: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    onLoadMore: () => undefined,
+    teams,
+    submitLabel: 'Link',
+    onSubmit: () => Promise.resolve(),
+    ...overrides,
+  };
+}
+
+describe('IntegrationPicker', () => {
+  it('filters the list by the search query', async () => {
+    const user = userEvent.setup();
+    render(<IntegrationPicker {...props()} />);
+    expect(screen.getByRole('button', { name: /acme\/web/ })).toBeInTheDocument();
+    await user.type(screen.getByLabelText('Search'), 'api');
+    expect(screen.queryByRole('button', { name: /acme\/web/ })).toBeNull();
+    expect(screen.getByRole('button', { name: /acme\/api/ })).toBeInTheDocument();
+  });
+
+  it('links the selected item to the chosen team', async () => {
+    const user = userEvent.setup();
+    const onSubmit = mock((_item: PickerItem, _teamId: string | null) => Promise.resolve());
+    render(<IntegrationPicker {...props({ onSubmit })} />);
+
+    await user.click(screen.getByRole('button', { name: /acme\/web/ }));
+    await user.selectOptions(screen.getByLabelText('Team'), 'team-2');
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const call = onSubmit.mock.calls[0];
+    expect(call?.[0]?.id).toBe('1');
+    expect(call?.[1]).toBe('team-2');
+  });
+
+  it('does not let an already linked item be selected', () => {
+    render(<IntegrationPicker {...props()} />);
+    expect(screen.getByRole('button', { name: /acme\/api/ })).toBeDisabled();
+  });
+
+  it('requests the next page from the load-more control', async () => {
+    const user = userEvent.setup();
+    const onLoadMore = mock();
+    render(<IntegrationPicker {...props({ hasNextPage: true, onLoadMore })} />);
+    await user.click(screen.getByRole('button', { name: 'Load more' }));
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+
+  it('passes a null team when workspace-wide is chosen', async () => {
+    const user = userEvent.setup();
+    const onSubmit = mock((_item: PickerItem, _teamId: string | null) => Promise.resolve());
+    render(
+      <IntegrationPicker {...props({ allowWorkspace: true, submitLabel: 'Connect', onSubmit })} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /acme\/web/ }));
+    await user.click(screen.getByRole('button', { name: 'Connect' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0]?.[1]).toBeNull();
+  });
+});

--- a/apps/web/src/features/settings/integration-picker.tsx
+++ b/apps/web/src/features/settings/integration-picker.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button.tsx';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog.tsx';
+import { Input } from '@/components/ui/input.tsx';
+import type { IntegrationTeam } from './integrations-data.ts';
+
+export interface PickerItem {
+  readonly id: string;
+  readonly label: string;
+  readonly linked: boolean;
+}
+
+export interface IntegrationPickerProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly title: string;
+  readonly description: string;
+  readonly searchPlaceholder: string;
+  readonly items: readonly PickerItem[];
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+  readonly hasNextPage: boolean;
+  readonly isFetchingNextPage: boolean;
+  readonly onLoadMore: () => void;
+  readonly teams: readonly IntegrationTeam[];
+  readonly allowWorkspace?: boolean;
+  readonly submitLabel: string;
+  readonly onSubmit: (item: PickerItem, teamId: string | null) => Promise<void>;
+}
+
+export function IntegrationPicker({
+  open,
+  onOpenChange,
+  title,
+  description,
+  searchPlaceholder,
+  items,
+  isLoading,
+  isError,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+  teams,
+  allowWorkspace = false,
+  submitLabel,
+  onSubmit,
+}: IntegrationPickerProps) {
+  const [search, setSearch] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [teamId, setTeamId] = useState(allowWorkspace ? '' : (teams[0]?.id ?? ''));
+  const [submitting, setSubmitting] = useState(false);
+  const sentinelRef = useRef<HTMLLIElement | null>(null);
+
+  useEffect(() => {
+    if (open) return;
+    setSearch('');
+    setSelectedId(null);
+    setSubmitting(false);
+  }, [open]);
+
+  const filtered = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    if (needle.length === 0) return items;
+    return items.filter((item) => item.label.toLowerCase().includes(needle));
+  }, [items, search]);
+
+  useEffect(() => {
+    const node = sentinelRef.current;
+    if (node === null || !open || typeof IntersectionObserver === 'undefined') return undefined;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting) && hasNextPage && !isFetchingNextPage) {
+        onLoadMore();
+      }
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [open, hasNextPage, isFetchingNextPage, onLoadMore]);
+
+  const selected = filtered.find((item) => item.id === selectedId) ?? null;
+
+  const renderBody = () => {
+    if (isError) {
+      return (
+        <li className="px-3 py-2.5 text-danger text-xs">
+          Could not load the list. Try again shortly.
+        </li>
+      );
+    }
+    if (isLoading) return <li className="px-3 py-2.5 text-faint text-xs">Loading…</li>;
+    if (filtered.length === 0) {
+      return <li className="px-3 py-2.5 text-faint text-xs">Nothing matches your search.</li>;
+    }
+    return filtered.map((item) => (
+      <li key={item.id}>
+        <button
+          type="button"
+          disabled={item.linked}
+          aria-pressed={selectedId === item.id}
+          onClick={() => setSelectedId(item.id)}
+          className={`flex w-full items-center justify-between gap-3 border-border border-b px-3 py-2 text-left last:border-b-0 ${
+            selectedId === item.id ? 'bg-surface-2' : ''
+          } ${item.linked ? 'cursor-default text-faint' : 'text-text hover:bg-surface-2'}`}
+        >
+          <span className="truncate text-dense">{item.label}</span>
+          {item.linked ? <span className="text-2xs text-faint">Linked</span> : null}
+        </button>
+      </li>
+    ));
+  };
+
+  const submit = async () => {
+    if (selected === null) return;
+    setSubmitting(true);
+    try {
+      await onSubmit(selected, allowWorkspace && teamId === '' ? null : teamId);
+      onOpenChange(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md" data-testid="integration-picker">
+        <DialogHeader>
+          <DialogTitle className="font-medium text-base text-text">{title}</DialogTitle>
+          <DialogDescription className="text-muted text-xs">{description}</DialogDescription>
+        </DialogHeader>
+
+        <Input
+          autoFocus
+          value={search}
+          placeholder={searchPlaceholder}
+          aria-label="Search"
+          onChange={(event) => setSearch(event.target.value)}
+        />
+
+        <ul
+          className="flex max-h-72 flex-col overflow-y-auto rounded-lg border border-border"
+          data-testid="integration-picker-list"
+        >
+          {renderBody()}
+          <li ref={sentinelRef} aria-hidden="true" />
+          {hasNextPage ? (
+            <li className="px-3 py-2">
+              <Button variant="ghost" size="sm" disabled={isFetchingNextPage} onClick={onLoadMore}>
+                {isFetchingNextPage ? 'Loading…' : 'Load more'}
+              </Button>
+            </li>
+          ) : null}
+        </ul>
+
+        <div className="flex items-center justify-between gap-2">
+          <span className="min-w-0 flex-1 truncate text-dense text-muted">
+            {selected === null ? 'Select an item above' : selected.label}
+          </span>
+          <select
+            aria-label="Team"
+            value={teamId}
+            onChange={(event) => setTeamId(event.target.value)}
+            className="h-8 rounded-md border border-border bg-surface px-2 text-dense text-text"
+          >
+            {allowWorkspace ? <option value="">Workspace-wide</option> : null}
+            {teams.map((team) => (
+              <option key={team.id} value={team.id}>
+                {team.name}
+              </option>
+            ))}
+          </select>
+          <Button
+            variant="primary"
+            size="sm"
+            disabled={selected === null || submitting || (!allowWorkspace && teamId === '')}
+            onClick={submit}
+          >
+            {submitLabel}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/settings/integration-picker.tsx
+++ b/apps/web/src/features/settings/integration-picker.tsx
@@ -105,9 +105,9 @@ export function IntegrationPicker({
           disabled={item.linked}
           aria-pressed={selectedId === item.id}
           onClick={() => setSelectedId(item.id)}
-          className={`flex w-full items-center justify-between gap-3 border-border border-b px-3 py-2 text-left last:border-b-0 ${
+          className={`flex w-full items-center justify-between gap-3 border-border border-b px-3 py-2 text-left last:border-b-0 disabled:cursor-not-allowed ${
             selectedId === item.id ? 'bg-surface-2' : ''
-          } ${item.linked ? 'cursor-default text-faint' : 'text-text hover:bg-surface-2'}`}
+          } ${item.linked ? 'text-faint' : 'text-text hover:bg-surface-2'}`}
         >
           <span className="truncate text-dense">{item.label}</span>
           {item.linked ? <span className="text-2xs text-faint">Linked</span> : null}

--- a/apps/web/src/features/settings/integrations-data.ts
+++ b/apps/web/src/features/settings/integrations-data.ts
@@ -1,12 +1,6 @@
 import { db, desc, eq, schema } from '@orbit/db';
-import { fetchInstalledRepositories, SlackClient } from '@orbit/services';
 import type { Principal } from '@orbit/shared/policy';
-import {
-  githubAppConfig,
-  githubConnectReady,
-  githubDiscoveryReady,
-  slackConnectReady,
-} from '@/lib/env.ts';
+import { githubConnectReady, slackConnectReady } from '@/lib/env.ts';
 import { listTeamsForPrincipal } from '@/lib/workspace.ts';
 
 export interface LinkedRepository {
@@ -17,23 +11,11 @@ export interface LinkedRepository {
   readonly enabled: boolean;
 }
 
-export interface AvailableRepository {
-  readonly repositoryId: string;
-  readonly repositoryName: string;
-  readonly defaultBranch: string;
-  readonly installationId: string;
-}
-
 export interface ConnectedChannel {
   readonly channelId: string;
   readonly channelName: string;
   readonly teamId: string | null;
   readonly enabled: boolean;
-}
-
-export interface AvailableChannel {
-  readonly channelId: string;
-  readonly channelName: string;
 }
 
 export interface IntegrationTeam {
@@ -46,14 +28,10 @@ export interface IntegrationSettings {
   readonly githubConnected: boolean;
   readonly githubConnectEnabled: boolean;
   readonly repositories: LinkedRepository[];
-  readonly availableRepositories: AvailableRepository[];
-  readonly githubReposError: boolean;
   readonly slackConnected: boolean;
   readonly slackHasToken: boolean;
   readonly slackConnectEnabled: boolean;
   readonly channels: ConnectedChannel[];
-  readonly availableChannels: AvailableChannel[];
-  readonly slackChannelsError: boolean;
   readonly teams: IntegrationTeam[];
 }
 
@@ -63,54 +41,11 @@ function slackBotTokenFrom(credentials: unknown): string | null {
   return typeof token === 'string' && token.length > 0 ? token : null;
 }
 
-async function discoverRepositories(
-  installationId: string | null,
-): Promise<{ repositories: AvailableRepository[]; error: boolean }> {
-  if (installationId === null || !githubDiscoveryReady()) {
-    return { repositories: [], error: false };
-  }
-  const config = githubAppConfig();
-  try {
-    const repositories = await fetchInstalledRepositories({
-      appId: config.appId,
-      privateKey: config.privateKey,
-      installationId,
-    });
-    return {
-      repositories: repositories.map((repository) => ({ ...repository, installationId })),
-      error: false,
-    };
-  } catch (error) {
-    console.error('Could not list GitHub repositories for the settings page.', error);
-    return { repositories: [], error: true };
-  }
-}
-
-async function discoverChannels(
-  token: string | null,
-): Promise<{ channels: AvailableChannel[]; error: boolean }> {
-  if (token === null) return { channels: [], error: false };
-  try {
-    const conversations = await new SlackClient({ token }).listConversations();
-    return {
-      channels: conversations.channels.map((channel) => ({
-        channelId: channel.id,
-        channelName: channel.name,
-      })),
-      error: false,
-    };
-  } catch (error) {
-    console.error('Could not list Slack channels for the settings page.', error);
-    return { channels: [], error: true };
-  }
-}
-
 export async function loadIntegrationSettings(principal: Principal): Promise<IntegrationSettings> {
   const [integrations, repositories, channels, teams] = await Promise.all([
     db
       .select({
         provider: schema.integration.provider,
-        externalId: schema.integration.externalId,
         credentials: schema.integration.credentials,
       })
       .from(schema.integration)
@@ -141,27 +76,15 @@ export async function loadIntegrationSettings(principal: Principal): Promise<Int
 
   const slackRow = integrations.find((row) => row.provider === 'slack');
   const slackToken = slackRow === undefined ? null : slackBotTokenFrom(slackRow.credentials);
-  const installationId =
-    integrations.find((row) => row.provider === 'github' && /^\d+$/.test(row.externalId))
-      ?.externalId ?? null;
-
-  const [repos, channelList] = await Promise.all([
-    discoverRepositories(installationId),
-    discoverChannels(slackToken),
-  ]);
 
   return {
     githubConnected: integrations.some((row) => row.provider === 'github'),
     githubConnectEnabled: githubConnectReady(),
     repositories,
-    availableRepositories: repos.repositories,
-    githubReposError: repos.error,
     slackConnected: slackRow !== undefined,
     slackHasToken: slackToken !== null,
     slackConnectEnabled: slackConnectReady(),
     channels,
-    availableChannels: channelList.channels,
-    slackChannelsError: channelList.error,
     teams,
   };
 }

--- a/apps/web/src/features/settings/integrations-panel.test.tsx
+++ b/apps/web/src/features/settings/integrations-panel.test.tsx
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
 import type { IntegrationSettings } from './integrations-data.ts';
-import { IntegrationsPanel } from './integrations-panel.tsx';
+import { IntegrationsPanel, type McpConnection } from './integrations-panel.tsx';
 
 const refresh = mock();
 
@@ -24,30 +26,10 @@ const CONNECTED: IntegrationSettings = {
       enabled: true,
     },
   ],
-  availableRepositories: [
-    {
-      repositoryId: '123456',
-      repositoryName: 'acme/web',
-      defaultBranch: 'main',
-      installationId: '77',
-    },
-    {
-      repositoryId: '654321',
-      repositoryName: 'acme/api',
-      defaultBranch: 'trunk',
-      installationId: '77',
-    },
-  ],
-  githubReposError: false,
   slackConnected: true,
   slackHasToken: true,
   slackConnectEnabled: true,
   channels: [{ channelId: 'C0123', channelName: 'engineering', teamId: 'team-1', enabled: true }],
-  availableChannels: [
-    { channelId: 'C0123', channelName: 'engineering' },
-    { channelId: 'C0999', channelName: 'design' },
-  ],
-  slackChannelsError: false,
   teams: [{ id: 'team-1', key: 'ENG', name: 'Engineering' }],
 };
 
@@ -55,14 +37,10 @@ const EMPTY: IntegrationSettings = {
   githubConnected: false,
   githubConnectEnabled: true,
   repositories: [],
-  availableRepositories: [],
-  githubReposError: false,
   slackConnected: false,
   slackHasToken: false,
   slackConnectEnabled: true,
   channels: [],
-  availableChannels: [],
-  slackChannelsError: false,
   teams: [{ id: 'team-1', key: 'ENG', name: 'Engineering' }],
 };
 
@@ -71,6 +49,28 @@ const UNCONFIGURED: IntegrationSettings = {
   githubConnectEnabled: false,
   slackConnectEnabled: false,
 };
+
+function Providers({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function renderPanel(
+  settings: IntegrationSettings,
+  canManage: boolean,
+  mcpConnections: readonly McpConnection[] = [],
+) {
+  return render(
+    <Providers>
+      <IntegrationsPanel
+        settings={settings}
+        canManage={canManage}
+        mcpUrl={MCP_URL}
+        mcpConnections={mcpConnections}
+      />
+    </Providers>,
+  );
+}
 
 const realFetch = globalThis.fetch;
 let lastRequest: { url: string; method: string; body: unknown } | null = null;
@@ -94,7 +94,7 @@ afterEach(() => {
 
 describe('IntegrationsPanel', () => {
   it('offers one-click connect actions as the primary path when nothing is connected', () => {
-    render(<IntegrationsPanel settings={EMPTY} canManage mcpUrl={MCP_URL} mcpConnections={[]} />);
+    renderPanel(EMPTY, true);
     const github = screen.getByRole('link', { name: 'Connect GitHub' });
     expect(github).toHaveAttribute('href', '/api/integrations/github/start');
     const slack = screen.getByRole('link', { name: 'Add to Slack' });
@@ -102,49 +102,36 @@ describe('IntegrationsPanel', () => {
   });
 
   it('never exposes a webhook secret or raw token entry', () => {
-    render(<IntegrationsPanel settings={EMPTY} canManage mcpUrl={MCP_URL} mcpConnections={[]} />);
+    renderPanel(EMPTY, true);
     expect(screen.queryByText(/GITHUB_WEBHOOK_SECRET/)).toBeNull();
     expect(screen.queryByLabelText('Bot token')).toBeNull();
     expect(screen.queryByLabelText('Repository id')).toBeNull();
   });
 
   it('hides connect actions and explains configuration is pending when the app is not set up', () => {
-    render(
-      <IntegrationsPanel settings={UNCONFIGURED} canManage mcpUrl={MCP_URL} mcpConnections={[]} />,
-    );
+    renderPanel(UNCONFIGURED, true);
     expect(screen.queryByRole('link', { name: 'Connect GitHub' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Add to Slack' })).toBeNull();
     expect(screen.getByText(/finish configuring the GitHub App/)).toBeInTheDocument();
   });
 
-  it('links a discovered repository with its API-provided id and installation', async () => {
+  it('opens a searchable repository picker to link a repo', async () => {
     const user = userEvent.setup();
-    render(
-      <IntegrationsPanel settings={CONNECTED} canManage mcpUrl={MCP_URL} mcpConnections={[]} />,
-    );
+    renderPanel(CONNECTED, true);
+    await user.click(screen.getByRole('button', { name: 'Link a repository' }));
+    expect(await screen.findByPlaceholderText('Search repositories…')).toBeInTheDocument();
+  });
 
-    expect(screen.getByText('acme/api')).toBeInTheDocument();
-    const linkButton = screen.getByRole('button', { name: 'Link' });
-    await user.click(linkButton);
-
-    await waitFor(() => {
-      expect(lastRequest?.url).toBe('/api/integrations/github');
-    });
-    expect(lastRequest?.method).toBe('POST');
-    expect(lastRequest?.body).toEqual({
-      repositoryId: '654321',
-      repositoryName: 'acme/api',
-      installationId: '77',
-      defaultBranch: 'trunk',
-      teamId: 'team-1',
-    });
+  it('opens a searchable channel picker to connect a channel', async () => {
+    const user = userEvent.setup();
+    renderPanel(CONNECTED, true);
+    await user.click(screen.getByRole('button', { name: 'Connect a channel' }));
+    expect(await screen.findByPlaceholderText('Search channels…')).toBeInTheDocument();
   });
 
   it('unlinks a linked repository through the github endpoint', async () => {
     const user = userEvent.setup();
-    render(
-      <IntegrationsPanel settings={CONNECTED} canManage mcpUrl={MCP_URL} mcpConnections={[]} />,
-    );
+    renderPanel(CONNECTED, true);
 
     await user.click(screen.getByRole('button', { name: 'Unlink' }));
 
@@ -154,24 +141,16 @@ describe('IntegrationsPanel', () => {
     expect(lastRequest?.url).toBe('/api/integrations/github?repositoryId=123456');
   });
 
-  it('maps a discovered Slack channel to a team without typing an id', async () => {
+  it('disconnects a connected Slack channel through the slack endpoint', async () => {
     const user = userEvent.setup();
-    render(
-      <IntegrationsPanel settings={CONNECTED} canManage mcpUrl={MCP_URL} mcpConnections={[]} />,
-    );
+    renderPanel(CONNECTED, true);
 
-    expect(screen.getByText('#design')).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'Connect' }));
+    await user.click(screen.getByRole('button', { name: 'Disconnect' }));
 
     await waitFor(() => {
       expect(lastRequest?.url).toBe('/api/integrations/slack');
     });
-    expect(lastRequest?.body).toEqual({
-      action: 'connect',
-      channelId: 'C0999',
-      channelName: 'design',
-      teamId: null,
-    });
+    expect(lastRequest?.body).toEqual({ action: 'disconnect', channelId: 'C0123' });
   });
 
   it('shows the MCP server URL and copies it to the clipboard', async () => {
@@ -181,9 +160,7 @@ describe('IntegrationsPanel', () => {
       configurable: true,
       value: { writeText },
     });
-    render(
-      <IntegrationsPanel settings={CONNECTED} canManage mcpUrl={MCP_URL} mcpConnections={[]} />,
-    );
+    renderPanel(CONNECTED, true);
 
     expect(screen.getByTestId('mcp-url')).toHaveTextContent(MCP_URL);
     await user.click(screen.getByRole('button', { name: 'Copy MCP server URL' }));
@@ -193,24 +170,16 @@ describe('IntegrationsPanel', () => {
   });
 
   it('hides management affordances when the viewer cannot manage integrations', () => {
-    render(
-      <IntegrationsPanel
-        settings={CONNECTED}
-        canManage={false}
-        mcpUrl={MCP_URL}
-        mcpConnections={[]}
-      />,
-    );
+    renderPanel(CONNECTED, false);
     expect(screen.queryByRole('button', { name: 'Unlink' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Link' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Link a repository' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Connect a channel' })).toBeNull();
     expect(screen.queryByRole('link', { name: /repositories on GitHub/ })).toBeNull();
     expect(screen.getByTestId('mcp-url')).toBeInTheDocument();
   });
 
   it('offers a one-click Claude Code command and drops the admin API key copy', () => {
-    render(
-      <IntegrationsPanel settings={CONNECTED} canManage mcpUrl={MCP_URL} mcpConnections={[]} />,
-    );
+    renderPanel(CONNECTED, true);
     expect(
       screen.getByRole('button', { name: 'Copy the Claude Code command' }),
     ).toBeInTheDocument();
@@ -220,21 +189,14 @@ describe('IntegrationsPanel', () => {
 
   it('lists connected clients and disconnects one through the mcp endpoint', async () => {
     const user = userEvent.setup();
-    render(
-      <IntegrationsPanel
-        settings={CONNECTED}
-        canManage
-        mcpUrl={MCP_URL}
-        mcpConnections={[
-          {
-            id: 'grant-1',
-            clientName: 'Claude Desktop',
-            organizationName: 'Nova',
-            lastUsedAt: null,
-          },
-        ]}
-      />,
-    );
+    renderPanel(CONNECTED, true, [
+      {
+        id: 'grant-1',
+        clientName: 'Claude Desktop',
+        organizationName: 'Nova',
+        lastUsedAt: null,
+      },
+    ]);
 
     expect(screen.getByText('Claude Desktop')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Disconnect Claude Desktop' }));

--- a/apps/web/src/features/settings/integrations-panel.tsx
+++ b/apps/web/src/features/settings/integrations-panel.tsx
@@ -5,6 +5,7 @@ import { type ReactNode, useState } from 'react';
 import { Badge } from '@/components/ui/badge.tsx';
 import { Button } from '@/components/ui/button.tsx';
 import { apiRequest, messageOf } from '@/lib/api/client.ts';
+import { IntegrationPicker, type PickerItem } from './integration-picker.tsx';
 import type {
   ConnectedChannel,
   IntegrationSettings,
@@ -12,6 +13,12 @@ import type {
   LinkedRepository,
 } from './integrations-data.ts';
 import { claudeCodeCommand, cursorInstallHref, vscodeInstallHref } from './mcp-install-links.ts';
+import {
+  type PickerChannel,
+  type PickerRepository,
+  useChannelSearch,
+  useRepositorySearch,
+} from './use-integration-lists.ts';
 
 function teamName(teams: readonly IntegrationTeam[], teamId: string | null): string {
   if (teamId === null) return 'Workspace-wide';
@@ -141,43 +148,95 @@ function ConnectCta({
   return <ConnectLink href={href} label={label} variant="primary" />;
 }
 
-function TeamSelect({
-  id,
+function LinkedRepoRow({
+  repo,
   teams,
-  value,
-  onChange,
-  allowWorkspace,
+  canManage,
+  onCall,
 }: {
-  id: string;
+  repo: LinkedRepository;
   teams: readonly IntegrationTeam[];
-  value: string;
-  onChange: (value: string) => void;
-  allowWorkspace?: boolean;
+  canManage: boolean;
+  onCall: CallFn;
 }) {
   return (
-    <select
-      id={id}
-      aria-label="Team"
-      value={value}
-      onChange={(event) => onChange(event.target.value)}
-      className="h-8 rounded-md border border-border bg-surface px-2 text-dense text-text"
-    >
-      {allowWorkspace === true ? <option value="">Workspace-wide</option> : null}
-      {teams.map((team) => (
-        <option key={team.id} value={team.id}>
-          {team.name}
-        </option>
-      ))}
-    </select>
+    <li className="flex items-center justify-between gap-3 border-border border-b px-3 py-2.5 last:border-b-0">
+      <span className="flex min-w-0 flex-col">
+        <span className="truncate font-mono text-dense text-text">{repo.repositoryName}</span>
+        <span className="text-2xs text-faint">{teamName(teams, repo.teamId)}</span>
+      </span>
+      {canManage ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() =>
+            onCall(
+              `/api/integrations/github?repositoryId=${encodeURIComponent(repo.repositoryId)}`,
+              'DELETE',
+              {},
+            )
+          }
+        >
+          Unlink
+        </Button>
+      ) : null}
+    </li>
   );
 }
 
-interface RepoRow {
-  readonly repositoryId: string;
-  readonly repositoryName: string;
-  readonly defaultBranch: string;
-  readonly installationId: string;
-  readonly linked: LinkedRepository | null;
+function RepoPicker({
+  open,
+  onOpenChange,
+  settings,
+  onCall,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  settings: IntegrationSettings;
+  onCall: CallFn;
+}) {
+  const query = useRepositorySearch(open);
+  const linkedIds = new Set(settings.repositories.map((repo) => repo.repositoryId));
+  const byId = new Map<string, PickerRepository>();
+  for (const page of query.data?.pages ?? []) {
+    for (const repo of page.repositories) {
+      if (!byId.has(repo.repositoryId)) byId.set(repo.repositoryId, repo);
+    }
+  }
+  const items: PickerItem[] = [...byId.values()].map((repo) => ({
+    id: repo.repositoryId,
+    label: repo.repositoryName,
+    linked: linkedIds.has(repo.repositoryId),
+  }));
+
+  return (
+    <IntegrationPicker
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Link a repository"
+      description="Search your installed repositories and map one to a team."
+      searchPlaceholder="Search repositories…"
+      items={items}
+      isLoading={query.isLoading}
+      isError={query.isError}
+      hasNextPage={query.hasNextPage}
+      isFetchingNextPage={query.isFetchingNextPage}
+      onLoadMore={() => query.fetchNextPage()}
+      teams={settings.teams}
+      submitLabel="Link"
+      onSubmit={async (item, teamId) => {
+        const repo = byId.get(item.id);
+        if (repo === undefined || teamId === null) return;
+        await onCall('/api/integrations/github', 'POST', {
+          repositoryId: repo.repositoryId,
+          repositoryName: repo.repositoryName,
+          installationId: repo.installationId,
+          defaultBranch: repo.defaultBranch,
+          teamId,
+        });
+      }}
+    />
+  );
 }
 
 function GithubSection({
@@ -189,26 +248,7 @@ function GithubSection({
   canManage: boolean;
   onCall: CallFn;
 }) {
-  const linkedById = new Map(settings.repositories.map((repo) => [repo.repositoryId, repo]));
-  const availableIds = new Set(settings.availableRepositories.map((repo) => repo.repositoryId));
-  const rows: RepoRow[] = [
-    ...settings.availableRepositories.map((repo) => ({
-      repositoryId: repo.repositoryId,
-      repositoryName: repo.repositoryName,
-      defaultBranch: repo.defaultBranch,
-      installationId: repo.installationId,
-      linked: linkedById.get(repo.repositoryId) ?? null,
-    })),
-    ...settings.repositories
-      .filter((repo) => !availableIds.has(repo.repositoryId))
-      .map((repo) => ({
-        repositoryId: repo.repositoryId,
-        repositoryName: repo.repositoryName,
-        defaultBranch: 'main',
-        installationId: '',
-        linked: repo,
-      })),
-  ];
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   return (
     <IntegrationCard
@@ -219,15 +259,11 @@ function GithubSection({
       {settings.githubConnected ? (
         <div className="flex flex-col gap-2.5">
           <ul className="flex flex-col overflow-hidden rounded-lg border border-border">
-            {rows.length === 0 ? (
-              <li className="px-3 py-2.5 text-faint text-xs">
-                {settings.githubReposError
-                  ? 'Could not load repositories from GitHub. Try again shortly.'
-                  : 'No repositories are shared with Orbit yet. Add some on GitHub.'}
-              </li>
+            {settings.repositories.length === 0 ? (
+              <li className="px-3 py-2.5 text-faint text-xs">No repositories linked yet.</li>
             ) : (
-              rows.map((repo) => (
-                <RepoMappingRow
+              settings.repositories.map((repo) => (
+                <LinkedRepoRow
                   key={repo.repositoryId}
                   repo={repo}
                   teams={settings.teams}
@@ -238,10 +274,23 @@ function GithubSection({
             )}
           </ul>
           {canManage ? (
-            <ConnectLink
-              href="/api/integrations/github/start"
-              label="Add or remove repositories on GitHub"
-              variant="secondary"
+            <div className="flex flex-wrap gap-2">
+              <Button variant="primary" size="sm" onClick={() => setPickerOpen(true)}>
+                Link a repository
+              </Button>
+              <ConnectLink
+                href="/api/integrations/github/start"
+                label="Add or remove repositories on GitHub"
+                variant="secondary"
+              />
+            </div>
+          ) : null}
+          {canManage ? (
+            <RepoPicker
+              open={pickerOpen}
+              onOpenChange={setPickerOpen}
+              settings={settings}
+              onCall={onCall}
             />
           ) : null}
         </div>
@@ -258,70 +307,13 @@ function GithubSection({
   );
 }
 
-function RepoAction({
-  repo,
-  teams,
-  onCall,
-}: {
-  repo: RepoRow;
-  teams: readonly IntegrationTeam[];
-  onCall: CallFn;
-}) {
-  const [teamId, setTeamId] = useState(teams[0]?.id ?? '');
-
-  if (repo.linked !== null) {
-    return (
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() =>
-          onCall(
-            `/api/integrations/github?repositoryId=${encodeURIComponent(repo.repositoryId)}`,
-            'DELETE',
-            {},
-          )
-        }
-      >
-        Unlink
-      </Button>
-    );
-  }
-
-  return (
-    <span className="flex items-center gap-2">
-      <TeamSelect
-        id={`gh-team-${repo.repositoryId}`}
-        teams={teams}
-        value={teamId}
-        onChange={setTeamId}
-      />
-      <Button
-        variant="primary"
-        size="sm"
-        disabled={teamId === ''}
-        onClick={() =>
-          onCall('/api/integrations/github', 'POST', {
-            repositoryId: repo.repositoryId,
-            repositoryName: repo.repositoryName,
-            installationId: repo.installationId,
-            defaultBranch: repo.defaultBranch,
-            teamId,
-          })
-        }
-      >
-        Link
-      </Button>
-    </span>
-  );
-}
-
-function RepoMappingRow({
-  repo,
+function LinkedChannelRow({
+  channel,
   teams,
   canManage,
   onCall,
 }: {
-  repo: RepoRow;
+  channel: ConnectedChannel;
   teams: readonly IntegrationTeam[];
   canManage: boolean;
   onCall: CallFn;
@@ -329,20 +321,80 @@ function RepoMappingRow({
   return (
     <li className="flex items-center justify-between gap-3 border-border border-b px-3 py-2.5 last:border-b-0">
       <span className="flex min-w-0 flex-col">
-        <span className="truncate font-mono text-dense text-text">{repo.repositoryName}</span>
-        <span className="text-2xs text-faint">
-          {repo.linked === null ? 'Not linked' : teamName(teams, repo.linked.teamId)}
-        </span>
+        <span className="truncate text-dense text-text">#{channel.channelName}</span>
+        <span className="text-2xs text-faint">{teamName(teams, channel.teamId)}</span>
       </span>
-      {canManage ? <RepoAction repo={repo} teams={teams} onCall={onCall} /> : null}
+      {canManage ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() =>
+            onCall('/api/integrations/slack', 'POST', {
+              action: 'disconnect',
+              channelId: channel.channelId,
+            })
+          }
+        >
+          Disconnect
+        </Button>
+      ) : null}
     </li>
   );
 }
 
-interface ChannelRow {
-  readonly channelId: string;
-  readonly channelName: string;
-  readonly connected: ConnectedChannel | null;
+function ChannelPicker({
+  open,
+  onOpenChange,
+  settings,
+  onCall,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  settings: IntegrationSettings;
+  onCall: CallFn;
+}) {
+  const query = useChannelSearch(open);
+  const connectedIds = new Set(settings.channels.map((channel) => channel.channelId));
+  const byId = new Map<string, PickerChannel>();
+  for (const page of query.data?.pages ?? []) {
+    for (const channel of page.channels) {
+      if (!byId.has(channel.channelId)) byId.set(channel.channelId, channel);
+    }
+  }
+  const items: PickerItem[] = [...byId.values()].map((channel) => ({
+    id: channel.channelId,
+    label: `#${channel.channelName}`,
+    linked: connectedIds.has(channel.channelId),
+  }));
+
+  return (
+    <IntegrationPicker
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Connect a channel"
+      description="Search channels Orbit can see and map one to a team, or the whole workspace."
+      searchPlaceholder="Search channels…"
+      items={items}
+      isLoading={query.isLoading}
+      isError={query.isError}
+      hasNextPage={query.hasNextPage}
+      isFetchingNextPage={query.isFetchingNextPage}
+      onLoadMore={() => query.fetchNextPage()}
+      teams={settings.teams}
+      allowWorkspace
+      submitLabel="Connect"
+      onSubmit={async (item, teamId) => {
+        const channel = byId.get(item.id);
+        if (channel === undefined) return;
+        await onCall('/api/integrations/slack', 'POST', {
+          action: 'connect',
+          channelId: channel.channelId,
+          channelName: channel.channelName,
+          teamId,
+        });
+      }}
+    />
+  );
 }
 
 function SlackSection({
@@ -354,22 +406,7 @@ function SlackSection({
   canManage: boolean;
   onCall: CallFn;
 }) {
-  const connectedById = new Map(settings.channels.map((channel) => [channel.channelId, channel]));
-  const availableIds = new Set(settings.availableChannels.map((channel) => channel.channelId));
-  const rows: ChannelRow[] = [
-    ...settings.availableChannels.map((channel) => ({
-      channelId: channel.channelId,
-      channelName: channel.channelName,
-      connected: connectedById.get(channel.channelId) ?? null,
-    })),
-    ...settings.channels
-      .filter((channel) => !availableIds.has(channel.channelId))
-      .map((channel) => ({
-        channelId: channel.channelId,
-        channelName: channel.channelName,
-        connected: channel,
-      })),
-  ];
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   return (
     <IntegrationCard
@@ -380,15 +417,11 @@ function SlackSection({
       {settings.slackHasToken ? (
         <div className="flex flex-col gap-2.5">
           <ul className="flex flex-col overflow-hidden rounded-lg border border-border">
-            {rows.length === 0 ? (
-              <li className="px-3 py-2.5 text-faint text-xs">
-                {settings.slackChannelsError
-                  ? 'Could not load channels from Slack. Try again shortly.'
-                  : 'No channels are visible to Orbit yet. Invite Orbit to a channel in Slack.'}
-              </li>
+            {settings.channels.length === 0 ? (
+              <li className="px-3 py-2.5 text-faint text-xs">No channels connected yet.</li>
             ) : (
-              rows.map((channel) => (
-                <ChannelMappingRow
+              settings.channels.map((channel) => (
+                <LinkedChannelRow
                   key={channel.channelId}
                   channel={channel}
                   teams={settings.teams}
@@ -399,10 +432,23 @@ function SlackSection({
             )}
           </ul>
           {canManage ? (
-            <ConnectLink
-              href="/api/integrations/slack/start"
-              label="Reconnect Slack"
-              variant="secondary"
+            <div className="flex flex-wrap gap-2">
+              <Button variant="primary" size="sm" onClick={() => setPickerOpen(true)}>
+                Connect a channel
+              </Button>
+              <ConnectLink
+                href="/api/integrations/slack/start"
+                label="Reconnect Slack"
+                variant="secondary"
+              />
+            </div>
+          ) : null}
+          {canManage ? (
+            <ChannelPicker
+              open={pickerOpen}
+              onOpenChange={setPickerOpen}
+              settings={settings}
+              onCall={onCall}
             />
           ) : null}
         </div>
@@ -416,85 +462,6 @@ function SlackSection({
         />
       )}
     </IntegrationCard>
-  );
-}
-
-function ChannelAction({
-  channel,
-  teams,
-  onCall,
-}: {
-  channel: ChannelRow;
-  teams: readonly IntegrationTeam[];
-  onCall: CallFn;
-}) {
-  const [teamId, setTeamId] = useState('');
-
-  if (channel.connected !== null) {
-    return (
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() =>
-          onCall('/api/integrations/slack', 'POST', {
-            action: 'disconnect',
-            channelId: channel.channelId,
-          })
-        }
-      >
-        Disconnect
-      </Button>
-    );
-  }
-
-  return (
-    <span className="flex items-center gap-2">
-      <TeamSelect
-        id={`slack-team-${channel.channelId}`}
-        teams={teams}
-        value={teamId}
-        onChange={setTeamId}
-        allowWorkspace
-      />
-      <Button
-        variant="primary"
-        size="sm"
-        onClick={() =>
-          onCall('/api/integrations/slack', 'POST', {
-            action: 'connect',
-            channelId: channel.channelId,
-            channelName: channel.channelName,
-            teamId: teamId === '' ? null : teamId,
-          })
-        }
-      >
-        Connect
-      </Button>
-    </span>
-  );
-}
-
-function ChannelMappingRow({
-  channel,
-  teams,
-  canManage,
-  onCall,
-}: {
-  channel: ChannelRow;
-  teams: readonly IntegrationTeam[];
-  canManage: boolean;
-  onCall: CallFn;
-}) {
-  return (
-    <li className="flex items-center justify-between gap-3 border-border border-b px-3 py-2.5 last:border-b-0">
-      <span className="flex min-w-0 flex-col">
-        <span className="truncate text-dense text-text">#{channel.channelName}</span>
-        <span className="text-2xs text-faint">
-          {channel.connected === null ? 'Not connected' : teamName(teams, channel.connected.teamId)}
-        </span>
-      </span>
-      {canManage ? <ChannelAction channel={channel} teams={teams} onCall={onCall} /> : null}
-    </li>
   );
 }
 

--- a/apps/web/src/features/settings/use-integration-lists.ts
+++ b/apps/web/src/features/settings/use-integration-lists.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+import { apiFetch } from '@/lib/query/fetcher.ts';
+
+const repositoryPageSchema = z.object({
+  repositories: z.array(
+    z.object({
+      repositoryId: z.string(),
+      repositoryName: z.string(),
+      defaultBranch: z.string(),
+      installationId: z.string(),
+    }),
+  ),
+  nextCursor: z.string().nullable(),
+});
+
+export type PickerRepository = z.infer<typeof repositoryPageSchema>['repositories'][number];
+
+const channelPageSchema = z.object({
+  channels: z.array(z.object({ channelId: z.string(), channelName: z.string() })),
+  nextCursor: z.string().nullable(),
+});
+
+export type PickerChannel = z.infer<typeof channelPageSchema>['channels'][number];
+
+function withCursor(path: string, cursor: string | null): string {
+  return cursor === null ? path : `${path}?cursor=${encodeURIComponent(cursor)}`;
+}
+
+export function useRepositorySearch(enabled: boolean) {
+  return useInfiniteQuery({
+    queryKey: ['integration', 'github', 'repositories'],
+    enabled,
+    initialPageParam: null as string | null,
+    queryFn: ({ pageParam, signal }) =>
+      apiFetch(
+        withCursor('/api/integrations/github/repositories', pageParam),
+        repositoryPageSchema,
+        {
+          signal,
+        },
+      ),
+    getNextPageParam: (last) => last.nextCursor,
+  });
+}
+
+export function useChannelSearch(enabled: boolean) {
+  return useInfiniteQuery({
+    queryKey: ['integration', 'slack', 'channels'],
+    enabled,
+    initialPageParam: null as string | null,
+    queryFn: ({ pageParam, signal }) =>
+      apiFetch(withCursor('/api/integrations/slack/channels', pageParam), channelPageSchema, {
+        signal,
+      }),
+    getNextPageParam: (last) => last.nextCursor,
+  });
+}

--- a/packages/services/src/github/app.test.ts
+++ b/packages/services/src/github/app.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { generateKeyPairSync } from 'node:crypto';
-import { fetchInstalledRepositories, githubAppJwt } from './app.ts';
+import { fetchInstalledRepositories, fetchInstalledRepositoryPage, githubAppJwt } from './app.ts';
 
 const { privateKey } = generateKeyPairSync('rsa', {
   modulusLength: 2048,
@@ -64,5 +64,60 @@ describe('fetchInstalledRepositories', () => {
     ]);
     expect(calls[0]).toContain('/app/installations/9001/access_tokens');
     expect(calls[1]).toContain('/installation/repositories');
+  });
+});
+
+function pagedFetch(totalCount: number): typeof globalThis.fetch {
+  return ((url: string) => {
+    if (url.includes('access_tokens')) {
+      return Promise.resolve(new Response(JSON.stringify({ token: 'ghs_x' }), { status: 201 }));
+    }
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          total_count: totalCount,
+          repositories: [{ id: 1, full_name: 'acme/a', default_branch: 'main' }],
+        }),
+        { status: 200 },
+      ),
+    );
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe('fetchInstalledRepositoryPage', () => {
+  it('requests the given page and reports more while the total exceeds it', async () => {
+    const calls: string[] = [];
+    const inner = pagedFetch(70);
+    const fetchImpl = ((url: string, init?: RequestInit) => {
+      calls.push(url);
+      return inner(url, init);
+    }) as unknown as typeof globalThis.fetch;
+
+    const page = await fetchInstalledRepositoryPage({
+      appId: '123456',
+      privateKey,
+      installationId: '99',
+      page: 2,
+      perPage: 30,
+      fetch: fetchImpl,
+    });
+
+    expect(page.repositories).toEqual([
+      { repositoryId: '1', repositoryName: 'acme/a', defaultBranch: 'main' },
+    ]);
+    expect(page.hasMore).toBe(true);
+    expect(calls.some((url) => url.includes('per_page=30&page=2'))).toBe(true);
+  });
+
+  it('reports no more once the page reaches the total', async () => {
+    const page = await fetchInstalledRepositoryPage({
+      appId: '123456',
+      privateKey,
+      installationId: '99',
+      page: 2,
+      perPage: 30,
+      fetch: pagedFetch(45),
+    });
+    expect(page.hasMore).toBe(false);
   });
 });

--- a/packages/services/src/github/app.ts
+++ b/packages/services/src/github/app.ts
@@ -45,7 +45,12 @@ const repositorySchema = z.object({
   default_branch: z.string().min(1).max(255).default('main'),
 });
 
-const repositoriesSchema = z.object({ repositories: z.array(repositorySchema).default([]) });
+const repositoriesSchema = z.object({
+  total_count: z.number().int().nonnegative().default(0),
+  repositories: z.array(repositorySchema).default([]),
+});
+
+const GITHUB_REPOSITORY_PAGE_SIZE = 30;
 
 export interface GithubInstalledRepository {
   readonly repositoryId: string;
@@ -120,6 +125,52 @@ export async function fetchInstalledRepositories(
   const token = await githubInstallationToken(input);
   return listInstallationRepositories({
     token,
+    ...(input.fetch === undefined ? {} : { fetch: input.fetch }),
+    ...(input.apiBase === undefined ? {} : { apiBase: input.apiBase }),
+  });
+}
+
+export interface GithubRepositoryPage {
+  readonly repositories: GithubInstalledRepository[];
+  readonly hasMore: boolean;
+}
+
+export async function listInstallationRepositoryPage(input: {
+  readonly token: string;
+  readonly page: number;
+  readonly perPage?: number;
+  readonly fetch?: typeof globalThis.fetch;
+  readonly apiBase?: string;
+}): Promise<GithubRepositoryPage> {
+  const fetchImpl = input.fetch ?? globalThis.fetch;
+  const base = input.apiBase ?? GITHUB_API_BASE;
+  const perPage = input.perPage ?? GITHUB_REPOSITORY_PAGE_SIZE;
+  const page = Math.max(1, input.page);
+  const body = await githubJson(
+    fetchImpl,
+    `${base}/installation/repositories?per_page=${perPage}&page=${page}`,
+    { headers: { authorization: `Bearer ${input.token}` } },
+    repositoriesSchema,
+    'installation repositories',
+  );
+  return {
+    repositories: body.repositories.map((repository) => ({
+      repositoryId: String(repository.id),
+      repositoryName: repository.full_name,
+      defaultBranch: repository.default_branch,
+    })),
+    hasMore: page * perPage < body.total_count,
+  };
+}
+
+export async function fetchInstalledRepositoryPage(
+  input: GithubAppRequest & { readonly page: number; readonly perPage?: number },
+): Promise<GithubRepositoryPage> {
+  const token = await githubInstallationToken(input);
+  return listInstallationRepositoryPage({
+    token,
+    page: input.page,
+    ...(input.perPage === undefined ? {} : { perPage: input.perPage }),
     ...(input.fetch === undefined ? {} : { fetch: input.fetch }),
     ...(input.apiBase === undefined ? {} : { apiBase: input.apiBase }),
   });


### PR DESCRIPTION
Replace the flat repo/channel lists with a searchable, lazy-loaded picker so GitHub repositories and Slack channels can be endless and mapped to a team from one place.

**Verification**

```
lint + comment policy         pass
typecheck (all 8 packages)    pass
web full suite                510 pass, 0 fail (+6 vs main, 0 regressions)
services GitHub pagination    pass
```

Backend adds cursor-paged GitHub repo listing plus GET /api/integrations/github/repositories and /api/integrations/slack/channels; the client uses TanStack Query infinite scroll and the settings loader no longer blocks on GitHub or Slack to render.
