### PR TITLE
fix(docs): fix hash/ID scroll by shipping heading ids from the server and make the sidebar a plain native scroller

### DIFF
--- a/apps/web/src/app/api/docs/[id]/route.ts
+++ b/apps/web/src/app/api/docs/[id]/route.ts
@@ -1,5 +1,5 @@
 import { archiveDoc, getDoc, updateDoc } from '@orbit/core';
-import { renderMarkdown } from '@orbit/services/markdown';
+import { renderMarkdownWithHeadingIds } from '@orbit/services/markdown';
 import { handle, publish, readJson } from '@/lib/api/handler.ts';
 
 interface RouteContext {
@@ -10,7 +10,7 @@ export async function GET(_request: Request, context: RouteContext): Promise<Res
   const { id } = await context.params;
   return await handle(async (principal) => {
     const detail = await getDoc(principal, id);
-    return { ...detail, contentHtml: renderMarkdown(detail.doc.content) };
+    return { ...detail, contentHtml: renderMarkdownWithHeadingIds(detail.doc.content) };
   });
 }
 
@@ -20,7 +20,7 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
   return await handle(async (principal) => {
     const saved = await updateDoc(principal, id, body);
     await publish(saved.actions);
-    return { doc: saved.doc, contentHtml: renderMarkdown(saved.doc.content) };
+    return { doc: saved.doc, contentHtml: renderMarkdownWithHeadingIds(saved.doc.content) };
   });
 }
 

--- a/apps/web/src/app/d/[token]/page.tsx
+++ b/apps/web/src/app/d/[token]/page.tsx
@@ -1,5 +1,5 @@
 import { getPublishedDoc } from '@orbit/core';
-import { renderMarkdown, summarize } from '@orbit/services/markdown';
+import { renderMarkdownWithHeadingIds, summarize } from '@orbit/services/markdown';
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import { DocReader } from '@/features/docs/doc-reader.tsx';
@@ -95,7 +95,7 @@ export default async function PublishedDocPage({ params }: PageProps) {
           archivedAt: null,
           publishToken: null,
         }}
-        contentHtml={renderMarkdown(detail.doc.content)}
+        contentHtml={renderMarkdownWithHeadingIds(detail.doc.content)}
         attachments={detail.attachments.map((attachment) => ({
           id: attachment.id,
           parentType: attachment.parentType,

--- a/apps/web/src/components/ui/scroll-area.tsx
+++ b/apps/web/src/components/ui/scroll-area.tsx
@@ -1,24 +1,21 @@
 'use client';
 
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
-import type { ComponentProps, Ref } from 'react';
+import type { ComponentProps } from 'react';
 import { cn } from '@/lib/cn.ts';
 
 export function ScrollArea({
   className,
   children,
-  viewportRef,
   ...props
-}: ComponentProps<typeof ScrollAreaPrimitive.Root> & {
-  readonly viewportRef?: Ref<HTMLDivElement>;
-}) {
+}: ComponentProps<typeof ScrollAreaPrimitive.Root>) {
   return (
     <ScrollAreaPrimitive.Root
       scrollHideDelay={400}
       className={cn('relative overflow-hidden', className)}
       {...props}
     >
-      <ScrollAreaPrimitive.Viewport ref={viewportRef} className="size-full [&>div]:!block">
+      <ScrollAreaPrimitive.Viewport className="size-full [&>div]:!block">
         {children}
       </ScrollAreaPrimitive.Viewport>
       <ScrollAreaPrimitive.Scrollbar

--- a/apps/web/src/features/docs/doc-body.tsx
+++ b/apps/web/src/features/docs/doc-body.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { cn } from '@/lib/cn.ts';
 import type { DocHeading } from './outline.ts';
-import { sameHeadings, withHeadingIds } from './outline.ts';
+import { extractHeadings, sameHeadings } from './outline.ts';
 
 export const docProseClassName = cn(
   'prose-orbit max-w-none text-base text-muted leading-7',
@@ -40,21 +40,21 @@ export function DocBody({ html, onHeadings, className }: DocBodyProps) {
   const previous = useRef<DocHeading[]>([]);
   notify.current = onHeadings;
 
-  const outlined = useMemo(() => withHeadingIds(html), [html]);
+  const headings = useMemo(() => extractHeadings(html), [html]);
 
   useEffect(() => {
     if (notify.current === undefined) return;
-    if (sameHeadings(outlined.headings, previous.current)) return;
-    previous.current = outlined.headings;
-    notify.current(outlined.headings);
-  }, [outlined]);
+    if (sameHeadings(headings, previous.current)) return;
+    previous.current = headings;
+    notify.current(headings);
+  }, [headings]);
 
   return (
     <div
       data-testid="doc-body"
       className={cn(docProseClassName, className)}
       // biome-ignore lint/security/noDangerouslySetInnerHtml: markdown is sanitized by @orbit/services/markdown
-      dangerouslySetInnerHTML={{ __html: outlined.html }}
+      dangerouslySetInnerHTML={{ __html: html }}
     />
   );
 }

--- a/apps/web/src/features/docs/doc-outline.tsx
+++ b/apps/web/src/features/docs/doc-outline.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { cn } from '@/lib/cn.ts';
-import { prefersReducedMotion, scrollHeadingIntoView } from './doc-scroll.ts';
+import { prefersReducedMotion } from './doc-scroll.ts';
 import type { DocHeading } from './outline.ts';
 
 export interface DocOutlineProps {
@@ -30,12 +30,6 @@ export function DocOutline({ headings, activeId }: DocOutlineProps) {
 
   if (headings.length < 2) return null;
 
-  const jumpTo = (heading: DocHeading) => {
-    if (document.getElementById(heading.id) === null) return;
-    scrollHeadingIntoView(heading.id);
-    window.history.replaceState(null, '', `#${heading.id}`);
-  };
-
   return (
     <nav
       ref={navRef}
@@ -53,11 +47,6 @@ export function DocOutline({ headings, activeId }: DocOutlineProps) {
               href={`#${heading.id}`}
               data-heading={heading.id}
               aria-current={activeId === heading.id ? 'location' : undefined}
-              onClick={(event) => {
-                if (event.metaKey || event.ctrlKey || event.shiftKey) return;
-                event.preventDefault();
-                jumpTo(heading);
-              }}
               className={cn(
                 'block border-l py-1 text-dense transition-colors duration-[var(--duration-fast)]',
                 heading.level === 1 && 'pl-3',

--- a/apps/web/src/features/docs/doc-reader.test.tsx
+++ b/apps/web/src/features/docs/doc-reader.test.tsx
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-import { renderMarkdown } from '@orbit/services/markdown';
+import { renderMarkdownWithHeadingIds } from '@orbit/services/markdown';
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import type { Doc } from '@/lib/query/schemas.ts';
 import { DocReader } from './doc-reader.tsx';
 
@@ -82,7 +81,7 @@ function renderReader() {
   return render(
     <DocReader
       doc={doc}
-      contentHtml={renderMarkdown(MARKDOWN)}
+      contentHtml={renderMarkdownWithHeadingIds(MARKDOWN)}
       attachments={[]}
       author={{ name: 'Pulkit', image: null }}
       followers={1}
@@ -157,36 +156,16 @@ describe('doc outline scroll spy', () => {
     expect(activeText()).not.toBe('Checklist');
   });
 
-  it('scrolls the clicked heading, not the one above it, and puts it in the url', async () => {
+  it('points each outline link at the anchor the body actually rendered', async () => {
     tops.set('intro', 200);
     tops.set('rules', 900);
     tops.set('checklist', 1600);
-    const scrolledTo: number[] = [];
-    const realScrollTo = window.scrollTo;
-    Object.defineProperty(window, 'scrollTo', {
-      writable: true,
-      configurable: true,
-      value: (options: ScrollToOptions) => {
-        if (typeof options?.top === 'number') scrolledTo.push(options.top);
-      },
-    });
-    const user = userEvent.setup();
     renderReader();
     await screen.findByTestId('doc-outline');
 
     const link = screen.getByTestId('doc-outline').querySelector('[data-heading="rules"]');
-    expect(link).not.toBeNull();
-    if (link !== null) await user.click(link);
-
-    expect(scrolledTo).toContain(900 - 96);
-    expect(scrolledTo).not.toContain(200 - 96);
-    expect(window.location.hash).toBe('#rules');
-
-    Object.defineProperty(window, 'scrollTo', {
-      writable: true,
-      configurable: true,
-      value: realScrollTo,
-    });
+    expect(link?.getAttribute('href')).toBe('#rules');
+    expect(screen.getByTestId('doc-body').querySelector('#rules')).not.toBeNull();
   });
 
   it('shows the docs that link here', async () => {

--- a/apps/web/src/features/docs/doc-scroll.test.ts
+++ b/apps/web/src/features/docs/doc-scroll.test.ts
@@ -1,12 +1,5 @@
 import { afterEach, describe, expect, it } from 'bun:test';
-import { scrollContainerOf, scrollHeadingIntoView } from './doc-scroll.ts';
-
-function fixedRect(el: Element, top: number): void {
-  Object.defineProperty(el, 'getBoundingClientRect', {
-    configurable: true,
-    value: () => ({ top, bottom: top + 24, left: 0, right: 0, width: 200, height: 24 }) as DOMRect,
-  });
-}
+import { scrollContainerOf } from './doc-scroll.ts';
 
 function scrollableContainer(scrollTop: number): HTMLDivElement {
   const container = document.createElement('div');
@@ -40,35 +33,5 @@ describe('scrollContainerOf', () => {
     document.body.appendChild(heading);
 
     expect(scrollContainerOf(heading)).toBeNull();
-  });
-});
-
-describe('scrollHeadingIntoView inside a nested scroll container', () => {
-  it('scrolls the container to the target measured against the container, not the viewport', () => {
-    const scrolls: number[] = [];
-    const container = scrollableContainer(120);
-    Object.defineProperty(container, 'scrollTo', {
-      configurable: true,
-      value: (options: ScrollToOptions) => {
-        if (typeof options?.top === 'number') scrolls.push(options.top);
-      },
-    });
-    fixedRect(container, 100);
-
-    const above = document.createElement('h2');
-    above.id = 'intro';
-    fixedRect(above, 300);
-    const target = document.createElement('h2');
-    target.id = 'rules';
-    fixedRect(target, 700);
-
-    container.appendChild(above);
-    container.appendChild(target);
-    document.body.appendChild(container);
-
-    scrollHeadingIntoView('rules');
-
-    expect(scrolls).toEqual([120 + (700 - 100) - 96]);
-    expect(scrolls).not.toContain(120 + (300 - 100) - 96);
   });
 });

--- a/apps/web/src/features/docs/doc-scroll.ts
+++ b/apps/web/src/features/docs/doc-scroll.ts
@@ -1,7 +1,5 @@
 'use client';
 
-export const HEADING_SCROLL_OFFSET = 96;
-
 export function prefersReducedMotion(): boolean {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -17,24 +15,4 @@ export function scrollContainerOf(element: HTMLElement): HTMLElement | null {
     node = node.parentElement;
   }
   return null;
-}
-
-export function headingOffsetWithin(target: HTMLElement, container: HTMLElement | null): number {
-  const targetTop = target.getBoundingClientRect().top;
-  if (container === null) return window.scrollY + targetTop;
-  return container.scrollTop + (targetTop - container.getBoundingClientRect().top);
-}
-
-export function scrollHeadingIntoView(id: string, offset: number = HEADING_SCROLL_OFFSET): void {
-  if (typeof document === 'undefined') return;
-  const target = document.getElementById(id);
-  if (target === null) return;
-  const container = scrollContainerOf(target);
-  const top = Math.max(0, headingOffsetWithin(target, container) - offset);
-  const behavior: ScrollBehavior = prefersReducedMotion() ? 'auto' : 'smooth';
-  if (container === null) {
-    window.scrollTo({ top, behavior });
-    return;
-  }
-  container.scrollTo({ top, behavior });
 }

--- a/apps/web/src/features/docs/doc-surface.tsx
+++ b/apps/web/src/features/docs/doc-surface.tsx
@@ -249,7 +249,7 @@ function LoadedDoc({
       {editing ? (
         <EditSession doc={detail.doc} save={update.mutateAsync} onStatusChange={setStatus} />
       ) : (
-        <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="min-h-0 flex-1 scroll-smooth overflow-y-auto motion-reduce:scroll-auto">
           <DocReader
             doc={detail.doc}
             contentHtml={detail.contentHtml}

--- a/apps/web/src/features/docs/doc-tree.test.tsx
+++ b/apps/web/src/features/docs/doc-tree.test.tsx
@@ -45,47 +45,33 @@ function tree(docs: readonly DocSummary[], collections: readonly DocCollection[]
   );
 }
 
-function viewportOf(): HTMLElement {
-  const viewport = document.querySelector<HTMLElement>('[data-radix-scroll-area-viewport]');
-  if (viewport === null) throw new Error('viewport not found');
-  return viewport;
+function scrollerOf(): HTMLElement {
+  const scroller = document.querySelector<HTMLElement>('[data-testid="doc-tree-scroll"]');
+  if (scroller === null) throw new Error('scroller not found');
+  return scroller;
 }
 
-describe('doc tree scroll preservation', () => {
-  it('keeps the scroll position when the docs data changes under the user', () => {
+describe('doc tree scroller', () => {
+  it('is a plain native overflow scroller, not a hijacked one', () => {
+    render(tree([summary('d0', 'Doc 0')], []));
+    expect(scrollerOf().className).toContain('overflow-y-auto');
+    expect(document.querySelector('[data-radix-scroll-area-viewport]')).toBeNull();
+  });
+
+  it('leaves the scroll position alone when the docs data changes under the user', () => {
     const docsA = Array.from({ length: 40 }, (_, index) => summary(`d${index}`, `Doc ${index}`));
     const view = render(tree(docsA, []));
 
-    const viewport = viewportOf();
+    const scroller = scrollerOf();
     act(() => {
-      viewport.scrollTop = 250;
-      viewport.dispatchEvent(new Event('scroll'));
+      scroller.scrollTop = 250;
     });
-    expect(viewport.scrollTop).toBe(250);
 
-    viewport.scrollTop = 0;
     const docsB = [summary('dNew', 'Doc New'), ...docsA];
     act(() => {
       view.rerender(tree(docsB, []));
     });
 
-    expect(viewportOf().scrollTop).toBe(250);
-  });
-
-  it('does not move the scroll on a re-render that keeps the same docs', () => {
-    const docs = Array.from({ length: 40 }, (_, index) => summary(`d${index}`, `Doc ${index}`));
-    const view = render(tree(docs, []));
-
-    const viewport = viewportOf();
-    act(() => {
-      viewport.scrollTop = 180;
-      viewport.dispatchEvent(new Event('scroll'));
-    });
-
-    act(() => {
-      view.rerender(tree(docs.slice(), []));
-    });
-
-    expect(viewportOf().scrollTop).toBe(180);
+    expect(scrollerOf().scrollTop).toBe(250);
   });
 });

--- a/apps/web/src/features/docs/doc-tree.tsx
+++ b/apps/web/src/features/docs/doc-tree.tsx
@@ -2,7 +2,7 @@
 
 import { FolderPlus, MoreHorizontal, Plus, Search } from 'lucide-react';
 import Link from 'next/link';
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import {
   DropdownMenu,
@@ -11,15 +11,12 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu.tsx';
 import { Input } from '@/components/ui/input.tsx';
-import { ScrollArea } from '@/components/ui/scroll-area.tsx';
 import { Tooltip } from '@/components/ui/tooltip.tsx';
 import { cn } from '@/lib/cn.ts';
 import { revealOnHover } from '@/lib/interaction.ts';
 import type { DocCollection, DocSummary } from '@/lib/query/schemas.ts';
 
 const RECENT_MS = 24 * 60 * 60 * 1000;
-
-const useStableLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
 export interface DocGroup {
   readonly id: string;
@@ -209,26 +206,6 @@ export function DocTree({
   const [renaming, setRenaming] = useState<{ id: string; name: string } | null>(null);
   const now = Date.now();
 
-  const viewportRef = useRef<HTMLDivElement>(null);
-  const lastScrollTop = useRef(0);
-  const treeSignature = docs.map((doc) => doc.id).join('|');
-
-  useEffect(() => {
-    const viewport = viewportRef.current;
-    if (viewport === null) return;
-    const remember = () => {
-      lastScrollTop.current = viewport.scrollTop;
-    };
-    viewport.addEventListener('scroll', remember, { passive: true });
-    return () => viewport.removeEventListener('scroll', remember);
-  }, []);
-
-  useStableLayoutEffect(() => {
-    const viewport = viewportRef.current;
-    if (viewport === null) return;
-    if (viewport.scrollTop !== lastScrollTop.current) viewport.scrollTop = lastScrollTop.current;
-  }, [treeSignature]);
-
   const submitDraft = () => {
     const name = (draftName ?? '').trim();
     setDraftName(null);
@@ -279,7 +256,7 @@ export function DocTree({
         ) : null}
       </div>
 
-      <ScrollArea className="min-h-0 flex-1" viewportRef={viewportRef}>
+      <div data-testid="doc-tree-scroll" className="min-h-0 flex-1 overflow-y-auto">
         <div className="flex flex-col gap-4 p-2">
           {draftName === null ? null : (
             <Input
@@ -347,7 +324,7 @@ export function DocTree({
             </section>
           ))}
         </div>
-      </ScrollArea>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/docs/docs.test.ts
+++ b/apps/web/src/features/docs/docs.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, jest, mock } from 'bun:test';
-import { renderMarkdown, summarize } from '@orbit/services/markdown';
+import { renderMarkdown, renderMarkdownWithHeadingIds, summarize } from '@orbit/services/markdown';
 import { act, renderHook } from '@testing-library/react';
 import { publicDocPath, publicDocUrl } from '@/lib/docs/paths.ts';
 import { descendantIds, matchParents } from './doc-surface.tsx';
@@ -12,7 +12,7 @@ import {
   SNIPPETS,
   wrapSelection,
 } from './markdown-input.ts';
-import { readTimeMinutes, sameHeadings, slugify, withHeadingIds } from './outline.ts';
+import { extractHeadings, readTimeMinutes, sameHeadings } from './outline.ts';
 import {
   canonicalDocUrl,
   isIndexable,
@@ -24,9 +24,9 @@ import { uploadContentType, uploadDocFile } from './upload.ts';
 import { AUTOSAVE_DELAY_MS, useAutosave } from './use-autosave.ts';
 import { activeHeadingId } from './use-scroll-spy.ts';
 
-describe('withHeadingIds', () => {
+describe('extractHeadings', () => {
   it('reads the headings the reader actually rendered, including indented and setext ones', () => {
-    const html = renderMarkdown(
+    const html = renderMarkdownWithHeadingIds(
       [
         '  # Realtime **protocol**',
         '',
@@ -43,7 +43,7 @@ describe('withHeadingIds', () => {
       ].join('\n'),
     );
 
-    expect(withHeadingIds(html).headings).toEqual([
+    expect(extractHeadings(html)).toEqual([
       { id: 'realtime-protocol', text: 'Realtime protocol', level: 1 },
       { id: 'action-shape', text: 'Action shape', level: 1 },
       { id: 'rules', text: 'Rules', level: 3 },
@@ -51,31 +51,32 @@ describe('withHeadingIds', () => {
   });
 
   it('survives an unbalanced fence rather than swallowing every heading after it', () => {
-    const html = renderMarkdown('## Setup\n\n```ts\nconst a = 1;\n\n## Teardown\n');
-    expect(withHeadingIds(html).headings.map((entry) => entry.text)).toEqual(['Setup']);
+    const html = renderMarkdownWithHeadingIds('## Setup\n\n```ts\nconst a = 1;\n\n## Teardown\n');
+    expect(extractHeadings(html).map((entry) => entry.text)).toEqual(['Setup']);
   });
 
-  it('bakes the ids into the html so a rerender cannot wipe them', () => {
-    const outlined = withHeadingIds(renderMarkdown('## Setup\n\n## Setup\n'));
-    expect(outlined.headings.map((entry) => entry.id)).toEqual(['setup', 'setup-1']);
-    expect(outlined.html).toBe('<h2 id="setup">Setup</h2>\n<h2 id="setup-1">Setup</h2>\n');
-    expect(withHeadingIds(outlined.html).html).toBe(outlined.html);
-    expect(slugify('   ')).toBe('section');
+  it('reads the same ids no matter how many times it runs over the html', () => {
+    const html = renderMarkdownWithHeadingIds('## Setup\n\n## Setup\n');
+    expect(extractHeadings(html).map((entry) => entry.id)).toEqual(['setup', 'setup-1']);
+    expect(extractHeadings(html).map((entry) => entry.id)).toEqual(['setup', 'setup-1']);
   });
 
   it('keeps ids unique when a later heading slugifies onto an earlier suffixed id', () => {
-    const outlined = withHeadingIds(renderMarkdown('## Setup\n\n## Setup\n\n## Setup 1\n'));
-    expect(outlined.headings.map((entry) => entry.id)).toEqual(['setup', 'setup-1', 'setup-1-1']);
+    const html = renderMarkdownWithHeadingIds('## Setup\n\n## Setup\n\n## Setup 1\n');
+    expect(extractHeadings(html).map((entry) => entry.id)).toEqual([
+      'setup',
+      'setup-1',
+      'setup-1-1',
+    ]);
   });
 
   it('reads through inline markup and entities to the heading text', () => {
-    const outlined = withHeadingIds(renderMarkdown('## Batch & `sync_id`\n'));
-    expect(outlined.headings[0]).toEqual({
+    const html = renderMarkdownWithHeadingIds('## Batch & `sync_id`\n');
+    expect(extractHeadings(html)[0]).toEqual({
       id: 'batch-sync-id',
       text: 'Batch & sync_id',
       level: 2,
     });
-    expect(outlined.html).toContain('id="batch-sync-id"');
   });
 
   it('compares heading lists by id so the reader does not loop on every render', () => {

--- a/apps/web/src/features/docs/outline.test.ts
+++ b/apps/web/src/features/docs/outline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
-import { renderMarkdown } from '@orbit/services/markdown';
-import { slugify, withHeadingIds } from './outline.ts';
+import { renderMarkdownWithHeadingIds } from '@orbit/services/markdown';
+import { extractHeadings } from './outline.ts';
 
 const MARKDOWN = [
   '# Global rules',
@@ -14,19 +14,28 @@ const MARKDOWN = [
   'body',
 ].join('\n');
 
-describe('heading ids', () => {
-  it('gives every heading the slug of its own text so anchors and hashes agree', () => {
-    const { html, headings } = withHeadingIds(renderMarkdown(MARKDOWN));
+describe('extractHeadings', () => {
+  it('reads the ids the server baked into the rendered html', () => {
+    const headings = extractHeadings(renderMarkdownWithHeadingIds(MARKDOWN));
 
-    expect(headings.map((heading) => heading.id)).toEqual([
-      'global-rules',
-      'delete-remote-branch-after-merging-a-pr',
-      'pr-descriptions-one-liner-only',
+    expect(headings).toEqual([
+      { id: 'global-rules', text: 'Global rules', level: 1 },
+      {
+        id: 'delete-remote-branch-after-merging-a-pr',
+        text: 'Delete remote branch after merging a PR',
+        level: 2,
+      },
+      { id: 'pr-descriptions-one-liner-only', text: 'PR descriptions: one-liner only', level: 2 },
     ]);
+  });
 
-    for (const heading of headings) {
-      expect(heading.id).toBe(slugify(heading.text));
-      expect(html).toContain(`id="${heading.id}"`);
-    }
+  it('reads through inline markup and entities to the heading text', () => {
+    expect(extractHeadings(renderMarkdownWithHeadingIds('## Batch & `sync_id`\n'))).toEqual([
+      { id: 'batch-sync-id', text: 'Batch & sync_id', level: 2 },
+    ]);
+  });
+
+  it('ignores headings without an id and returns nothing for plain html', () => {
+    expect(extractHeadings('<h2>No id here</h2>')).toEqual([]);
   });
 });

--- a/apps/web/src/features/docs/outline.ts
+++ b/apps/web/src/features/docs/outline.ts
@@ -1,5 +1,4 @@
 import { decodeEntities, htmlToText } from '@orbit/services/markdown';
-import { slugify as baseSlugify } from '@orbit/shared/utils';
 
 export interface DocHeading {
   readonly id: string;
@@ -7,49 +6,17 @@ export interface DocHeading {
   readonly level: number;
 }
 
-export interface OutlinedHtml {
-  readonly html: string;
-  readonly headings: DocHeading[];
-}
+const HEADING_WITH_ID = /<h([1-3])[^>]*?\sid="([^"]+)"[^>]*>([\s\S]*?)<\/h\1>/gi;
 
-const HEADING_TAG = /<h([1-3])((?:\s[^>]*)?)>([\s\S]*?)<\/h\1>/gi;
-const EXISTING_ID = /\sid="[^"]*"/gi;
-
-export function slugify(text: string): string {
-  const base = baseSlugify(text);
-  return base.length === 0 ? 'section' : base;
-}
-
-export function uniqueHeadingId(text: string, used: Map<string, number>): string {
-  const base = slugify(text);
-  let suffix = used.get(base) ?? 0;
-  let id = suffix === 0 ? base : `${base}-${suffix}`;
-  while (used.has(id)) {
-    suffix += 1;
-    id = `${base}-${suffix}`;
-  }
-  used.set(base, suffix + 1);
-  if (id !== base) used.set(id, 0);
-  return id;
-}
-
-export function withHeadingIds(html: string): OutlinedHtml {
-  const used = new Map<string, number>();
+export function extractHeadings(html: string): DocHeading[] {
   const headings: DocHeading[] = [];
-
-  const rewritten = html.replace(
-    HEADING_TAG,
-    (match, level: string, attrs: string, inner: string) => {
-      const text = decodeEntities(htmlToText(inner)).replace(/\s+/g, ' ').trim();
-      if (text.length === 0) return match;
-
-      const id = uniqueHeadingId(text, used);
-      headings.push({ id, text, level: Number.parseInt(level, 10) });
-      return `<h${level}${attrs.replace(EXISTING_ID, '')} id="${id}">${inner}</h${level}>`;
-    },
-  );
-
-  return { html: rewritten, headings };
+  for (const match of html.matchAll(HEADING_WITH_ID)) {
+    const [, level, id, inner] = match;
+    if (level === undefined || id === undefined || inner === undefined) continue;
+    const text = decodeEntities(htmlToText(inner)).replace(/\s+/g, ' ').trim();
+    headings.push({ id, text, level: Number.parseInt(level, 10) });
+  }
+  return headings;
 }
 
 export function sameHeadings(left: readonly DocHeading[], right: readonly DocHeading[]): boolean {

--- a/apps/web/src/features/docs/use-hash-scroll.test.tsx
+++ b/apps/web/src/features/docs/use-hash-scroll.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { renderMarkdown } from '@orbit/services/markdown';
+import { renderMarkdownWithHeadingIds } from '@orbit/services/markdown';
 import { render, waitFor } from '@testing-library/react';
 import type { Doc } from '@/lib/query/schemas.ts';
 import { DocReader } from './doc-reader.tsx';
@@ -8,12 +8,6 @@ import { hashTargetId } from './use-hash-scroll.ts';
 const MARKDOWN = ['## Intro', '', 'body', '', '## Rules', '', 'body', '', '## Checklist'].join(
   '\n',
 );
-
-const HEADING_TOP = new Map<string, number>([
-  ['intro', 200],
-  ['rules', 900],
-  ['checklist', 1600],
-]);
 
 const doc: Doc = {
   id: 'doc_1',
@@ -34,40 +28,26 @@ const doc: Doc = {
   archivedAt: null,
 };
 
-const scrolledTo: number[] = [];
-const realRect = Element.prototype.getBoundingClientRect;
-const realScrollTo = window.scrollTo;
+const scrolledIds: string[] = [];
+const realScrollIntoView = Element.prototype.scrollIntoView;
 
 beforeEach(() => {
-  scrolledTo.length = 0;
-  Object.defineProperty(window, 'scrollTo', {
-    writable: true,
-    configurable: true,
-    value: (options: ScrollToOptions) => {
-      if (typeof options?.top === 'number') scrolledTo.push(options.top);
-    },
-  });
-  Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+  scrolledIds.length = 0;
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
     writable: true,
     configurable: true,
     value(this: Element) {
-      const top = this.isConnected ? (HEADING_TOP.get(this.id) ?? 0) : 0;
-      return { top, bottom: top + 24, left: 0, right: 0, width: 200, height: 24 } as DOMRect;
+      scrolledIds.push(this.id);
     },
   });
 });
 
 afterEach(() => {
   window.location.hash = '';
-  Object.defineProperty(window, 'scrollTo', {
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
     writable: true,
     configurable: true,
-    value: realScrollTo,
-  });
-  Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
-    writable: true,
-    configurable: true,
-    value: realRect,
+    value: realScrollIntoView,
   });
 });
 
@@ -75,7 +55,7 @@ function reader(which: Doc) {
   return (
     <DocReader
       doc={which}
-      contentHtml={renderMarkdown(MARKDOWN)}
+      contentHtml={renderMarkdownWithHeadingIds(MARKDOWN)}
       attachments={[]}
       author={{ name: 'Pulkit', image: null }}
       followers={1}
@@ -83,10 +63,6 @@ function reader(which: Doc) {
       projectName={null}
     />
   );
-}
-
-function renderReader() {
-  return render(reader(doc));
 }
 
 describe('hash target id', () => {
@@ -99,26 +75,26 @@ describe('hash target id', () => {
 });
 
 describe('reader hash deep link', () => {
-  it('scrolls the heading that matches the url hash into view on mount', async () => {
+  it('brings the heading that matches the url hash into view on mount', async () => {
     window.location.hash = '#rules';
-    renderReader();
-    await waitFor(() => expect(scrolledTo).toContain(900 - 96));
+    render(reader(doc));
+    await waitFor(() => expect(scrolledIds).toContain('rules'));
   });
 
   it('does not scroll anywhere when there is no hash', async () => {
     window.location.hash = '';
-    renderReader();
+    render(reader(doc));
     await waitFor(() => expect(document.querySelector('#rules')).not.toBeNull());
-    expect(scrolledTo).toHaveLength(0);
+    expect(scrolledIds).toHaveLength(0);
   });
 
   it('scrolls again after switching to another doc that shares the heading id', async () => {
     window.location.hash = '#rules';
     const view = render(reader(doc));
-    await waitFor(() => expect(scrolledTo).toContain(900 - 96));
+    await waitFor(() => expect(scrolledIds).toContain('rules'));
 
-    scrolledTo.length = 0;
+    scrolledIds.length = 0;
     view.rerender(reader({ ...doc, id: 'doc_2' }));
-    await waitFor(() => expect(scrolledTo).toContain(900 - 96));
+    await waitFor(() => expect(scrolledIds).toContain('rules'));
   });
 });

--- a/apps/web/src/features/docs/use-hash-scroll.ts
+++ b/apps/web/src/features/docs/use-hash-scroll.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect } from 'react';
-import { scrollHeadingIntoView } from './doc-scroll.ts';
 
 export function hashTargetId(hash: string): string | null {
   if (hash.length <= 1) return null;
@@ -18,14 +17,12 @@ export function scrollToHash(): void {
   if (typeof window === 'undefined') return;
   const id = hashTargetId(window.location.hash);
   if (id === null) return;
-  scrollHeadingIntoView(id);
+  document.getElementById(id)?.scrollIntoView();
 }
 
 export function useHashScroll(readySignature: string): void {
-  // biome-ignore lint/correctness/useExhaustiveDependencies: readySignature is a readiness token, re-run the scroll once the rendered headings change so a deep link lands after the content mounts
+  // biome-ignore lint/correctness/useExhaustiveDependencies: readySignature is a readiness token, re-run the scroll once the rendered headings mount so a deep link opened on a client-loaded doc still lands on its target
   useEffect(() => {
     scrollToHash();
-    window.addEventListener('hashchange', scrollToHash);
-    return () => window.removeEventListener('hashchange', scrollToHash);
   }, [readySignature]);
 }

--- a/apps/web/src/features/docs/use-scroll-spy.ts
+++ b/apps/web/src/features/docs/use-scroll-spy.ts
@@ -1,10 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { HEADING_SCROLL_OFFSET, scrollContainerOf } from './doc-scroll.ts';
+import { scrollContainerOf } from './doc-scroll.ts';
 import type { DocHeading } from './outline.ts';
 
-export const SCROLL_SPY_OFFSET = HEADING_SCROLL_OFFSET;
+export const SCROLL_SPY_OFFSET = 96;
 
 export interface HeadingTop {
   readonly id: string;
@@ -47,7 +47,7 @@ export function useScrollSpy(headings: readonly DocHeading[]): string | null {
         id: node.id,
         top: node.getBoundingClientRect().top - containerTop,
       }));
-      setActiveId(activeHeadingId(tops, HEADING_SCROLL_OFFSET));
+      setActiveId(activeHeadingId(tops, SCROLL_SPY_OFFSET));
     };
 
     update();

--- a/apps/web/src/lib/query/docs-prefetch.ts
+++ b/apps/web/src/lib/query/docs-prefetch.ts
@@ -1,5 +1,5 @@
 import { getDoc } from '@orbit/core';
-import { renderMarkdown } from '@orbit/services/markdown';
+import { renderMarkdownWithHeadingIds } from '@orbit/services/markdown';
 import { isDomainError } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
@@ -21,7 +21,7 @@ async function docDetail(principal: Principal, docId: string): Promise<DocDetail
     const detail = await getDoc(principal, docId);
     return asWire(docDetailSchema, {
       ...detail,
-      contentHtml: renderMarkdown(detail.doc.content),
+      contentHtml: renderMarkdownWithHeadingIds(detail.doc.content),
     });
   } catch (error) {
     if (isDomainError(error) && error.code === 'not_found') return null;

--- a/packages/services/src/markdown/index.ts
+++ b/packages/services/src/markdown/index.ts
@@ -1,4 +1,4 @@
-import { truncate } from '@orbit/shared/utils';
+import { slugify, truncate } from '@orbit/shared/utils';
 import { Marked } from 'marked';
 import { decodeEntities, htmlToText, sanitizeHtml } from './sanitize.ts';
 
@@ -8,12 +8,45 @@ export { decodeEntities, htmlToText, sanitizeHtml } from './sanitize.ts';
 const UNSAFE_URL = /^\s*(javascript|vbscript|file|data):/i;
 const BLOCK_END = /<\/(p|h[1-6]|li|blockquote|pre|tr|table|ul|ol)>/gi;
 const IMAGE_KEYS = ['tokens', 'items', 'rows', 'header', 'cells'] as const;
+const HEADING_TAG = /<h([1-3])((?:\s[^>]*)?)>([\s\S]*?)<\/h\1>/gi;
+const EXISTING_ID = /\sid="[^"]*"/gi;
 
 const marked = new Marked({ gfm: true, breaks: false, pedantic: false, async: false });
 
 export function renderMarkdown(source: string): string {
   if (source.trim().length === 0) return '';
   return sanitizeHtml(marked.parse(source, { async: false }));
+}
+
+function headingSlug(text: string): string {
+  const base = slugify(text);
+  return base.length === 0 ? 'section' : base;
+}
+
+function uniqueHeadingId(text: string, used: Map<string, number>): string {
+  const base = headingSlug(text);
+  let suffix = used.get(base) ?? 0;
+  let id = suffix === 0 ? base : `${base}-${suffix}`;
+  while (used.has(id)) {
+    suffix += 1;
+    id = `${base}-${suffix}`;
+  }
+  used.set(base, suffix + 1);
+  if (id !== base) used.set(id, 0);
+  return id;
+}
+
+export function renderMarkdownWithHeadingIds(source: string): string {
+  const used = new Map<string, number>();
+  return renderMarkdown(source).replace(
+    HEADING_TAG,
+    (match: string, level: string, attrs: string, inner: string) => {
+      const text = decodeEntities(htmlToText(inner)).replace(/\s+/g, ' ').trim();
+      if (text.length === 0) return match;
+      const id = uniqueHeadingId(text, used);
+      return `<h${level}${attrs.replace(EXISTING_ID, '')} id="${id}">${inner}</h${level}>`;
+    },
+  );
 }
 
 export function renderPlainText(source: string): string {

--- a/packages/services/src/markdown/markdown.test.ts
+++ b/packages/services/src/markdown/markdown.test.ts
@@ -4,6 +4,7 @@ import {
   extractIssueIdentifiers,
   extractMentions,
   renderMarkdown,
+  renderMarkdownWithHeadingIds,
   renderPlainText,
   summarize,
 } from './index.ts';
@@ -105,6 +106,47 @@ describe('renderMarkdown xss', () => {
     const html = renderMarkdown('```\n<script>alert(1)</script>\n```');
     expect(html).not.toContain('<script>');
     expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('renderMarkdownWithHeadingIds', () => {
+  it('leaves renderMarkdown untouched so only the reader paths carry ids', () => {
+    expect(renderMarkdown('# Title')).toBe('<h1>Title</h1>\n');
+  });
+
+  it('gives each heading the slug of its own text so anchors and hashes agree', () => {
+    const html = renderMarkdownWithHeadingIds(
+      ['# Global rules', '', '## Delete a branch', '', 'body'].join('\n'),
+    );
+    expect(html).toContain('<h1 id="global-rules">Global rules</h1>');
+    expect(html).toContain('<h2 id="delete-a-branch">Delete a branch</h2>');
+  });
+
+  it('only tags h1 through h3', () => {
+    const html = renderMarkdownWithHeadingIds('### `Rules`\n\n#### Too deep');
+    expect(html).toContain('<h3 id="rules">');
+    expect(html).toContain('<h4>Too deep</h4>');
+  });
+
+  it('bakes stable, unique ids that survive a re-run', () => {
+    const html = renderMarkdownWithHeadingIds('## Setup\n\n## Setup\n');
+    expect(html).toBe('<h2 id="setup">Setup</h2>\n<h2 id="setup-1">Setup</h2>\n');
+    expect(renderMarkdownWithHeadingIds('## Setup\n\n## Setup\n')).toBe(html);
+  });
+
+  it('keeps ids unique when a later heading slugifies onto an earlier suffixed id', () => {
+    const html = renderMarkdownWithHeadingIds('## Setup\n\n## Setup\n\n## Setup 1\n');
+    expect(html).toContain('id="setup"');
+    expect(html).toContain('id="setup-1"');
+    expect(html).toContain('id="setup-1-1"');
+  });
+
+  it('reads through inline markup and entities to build the slug', () => {
+    expect(renderMarkdownWithHeadingIds('## Batch & `sync_id`\n')).toContain('id="batch-sync-id"');
+  });
+
+  it('falls back to a section slug when the heading slugifies to nothing', () => {
+    expect(renderMarkdownWithHeadingIds('## @@@\n')).toContain('id="section"');
   });
 });
 


### PR DESCRIPTION
Ship heading ids from the server so native anchor + hash scrolling works on the doc viewer and published page, and replace the sidebar's scroll-restore hijack with a plain native scroller.

Evidence: the shipped `renderMarkdownWithHeadingIds` on real seed doc content now emits ids that the client outline reads back, so `#hash` deep links and `<a href="#id">` anchors have real targets from first paint:

```
--- heading tags in server HTML ---
<h1 id="realtime-delta-protocol">Realtime delta protocol</h1>
<h2 id="action-shape">Action shape</h2>
<h2 id="rules">Rules</h2>
--- extractHeadings (client outline reads these) ---
[{"id":"realtime-delta-protocol",...,"level":1},{"id":"action-shape",...,"level":2},{"id":"rules",...,"level":2}]
```

lint, comment policy, typecheck and the docs + markdown suites (78 docs tests, 37 markdown tests) all pass.