### PR TITLE
fix(ui): wrap long unbreakable content so docs and issues stop overflowing

### DIFF
--- a/apps/web/src/features/comments/comment-thread.tsx
+++ b/apps/web/src/features/comments/comment-thread.tsx
@@ -100,7 +100,7 @@ export function CommentThread({ issueId, comments, activity, members }: CommentT
 }
 
 const bodyClassName =
-  'prose-orbit text-dense text-text leading-relaxed [&_a]:text-accent [&_code]:rounded-sm [&_code]:bg-surface-2 [&_code]:px-1 [&_p]:my-1';
+  'prose-orbit break-words text-dense text-text leading-relaxed [&_a]:text-accent [&_code]:rounded-sm [&_code]:bg-surface-2 [&_code]:px-1 [&_p]:my-1';
 
 export function CommentBody({ body, bodyHtml }: { body: string; bodyHtml: string }) {
   if (bodyHtml.length === 0) {

--- a/apps/web/src/features/docs/doc-body.tsx
+++ b/apps/web/src/features/docs/doc-body.tsx
@@ -6,7 +6,7 @@ import type { DocHeading } from './outline.ts';
 import { extractHeadings, sameHeadings } from './outline.ts';
 
 export const docProseClassName = cn(
-  'prose-orbit max-w-none text-base text-muted leading-7',
+  'prose-orbit max-w-none break-words text-base text-muted leading-7',
   '[&_h1]:mt-8 [&_h1]:mb-3 [&_h1]:scroll-mt-24 [&_h1]:font-semibold [&_h1]:text-text [&_h1]:text-xl',
   '[&_h2]:mt-8 [&_h2]:mb-3 [&_h2]:scroll-mt-24 [&_h2]:font-semibold [&_h2]:text-lg [&_h2]:text-text',
   '[&_h3]:mt-6 [&_h3]:mb-2 [&_h3]:scroll-mt-24 [&_h3]:font-medium [&_h3]:text-base [&_h3]:text-text',

--- a/apps/web/src/features/issues/issue-detail.tsx
+++ b/apps/web/src/features/issues/issue-detail.tsx
@@ -108,7 +108,7 @@ export function IssueDetailView({ identifier }: IssueDetailViewProps) {
 
   return (
     <div className="flex h-full min-h-0 flex-col lg:flex-row" data-testid="issue-detail">
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
         <header className="flex items-center gap-2 border-border border-b px-5 py-2.5">
           <span data-numeric className="text-2xs text-faint">
             {issue.identifier}

--- a/apps/web/src/features/issues/issue-detail.tsx
+++ b/apps/web/src/features/issues/issue-detail.tsx
@@ -27,7 +27,7 @@ export interface IssueDetailViewProps {
 }
 
 const descriptionClassName =
-  'prose-orbit w-full text-dense text-muted leading-relaxed [&_a]:text-accent [&_code]:rounded-sm [&_code]:bg-surface-2 [&_code]:px-1 [&_h2]:mt-4 [&_h2]:font-medium [&_h2]:text-text [&_li]:my-0.5 [&_p]:my-2 [&_ul]:list-disc [&_ul]:pl-5';
+  'prose-orbit w-full break-words text-dense text-muted leading-relaxed [&_a]:text-accent [&_code]:rounded-sm [&_code]:bg-surface-2 [&_code]:px-1 [&_h2]:mt-4 [&_h2]:font-medium [&_h2]:text-text [&_li]:my-0.5 [&_p]:my-2 [&_ul]:list-disc [&_ul]:pl-5';
 
 function Description({ body, html }: { body: string; html: string }) {
   if (html.length === 0) {


### PR DESCRIPTION
Add overflow-wrap to the shared doc prose, issue description, and comment body styles so long runs (arrow sequences, long inline code) wrap instead of spilling past the content column into the outline.