### PR TITLE
perf: stream analytics, window the board with lazy-load, and server-prefetch data-first views

### DIFF
--- a/apps/web/src/app/(app)/analytics/page.tsx
+++ b/apps/web/src/app/(app)/analytics/page.tsx
@@ -1,14 +1,20 @@
 import type { Measure } from '@orbit/core';
-import { can } from '@orbit/shared/policy';
-import { Download } from 'lucide-react';
+import { assertCan, can } from '@orbit/shared/policy';
 import type { Metadata } from 'next';
-import { CyclePanel } from '@/features/analytics/cycle-panel.tsx';
-import { loadDashboard } from '@/features/analytics/data.ts';
-import { STATE_GROUP_ORDER, stateGroupLabel } from '@/features/analytics/labels.ts';
+import { Suspense } from 'react';
+import {
+  BreakdownCardSkeleton,
+  CycleSectionSkeleton,
+  DistributionGridSkeleton,
+  SavedViewBarSkeleton,
+  ScopeCardSkeleton,
+} from '@/features/analytics/analytics-skeleton.tsx';
+import { BreakdownSection } from '@/features/analytics/breakdown-section.tsx';
+import { CycleSection } from '@/features/analytics/cycle-section.tsx';
+import { DistributionSection } from '@/features/analytics/distribution-section.tsx';
 import { MeasureToggle } from '@/features/analytics/measure-toggle.tsx';
-import { SavedViewBar } from '@/features/analytics/saved-view-bar.tsx';
-import { BarChart } from '@/features/charts/bar-chart.tsx';
-import { LineChart } from '@/features/charts/line-chart.tsx';
+import { SavedViewSection } from '@/features/analytics/saved-view-section.tsx';
+import { ScopeSection } from '@/features/analytics/scope-section.tsx';
 import { pageContext } from '@/lib/api/handler.ts';
 
 export const metadata: Metadata = { title: 'Analytics' };
@@ -17,31 +23,12 @@ interface PageProps {
   readonly searchParams: Promise<{ measure?: string }>;
 }
 
-function Card({
-  title,
-  children,
-}: {
-  readonly title?: string;
-  readonly children: React.ReactNode;
-}) {
-  return (
-    <section className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
-      {title === undefined ? null : <h2 className="font-medium text-dense text-text">{title}</h2>}
-      {children}
-    </section>
-  );
-}
-
 export default async function AnalyticsPage({ searchParams }: PageProps) {
   const { measure: rawMeasure } = await searchParams;
   const measure: Measure = rawMeasure === 'points' ? 'points' : 'issues';
   const { principal } = await pageContext();
-  const dashboard = await loadDashboard(principal, measure);
+  assertCan(principal, 'project:read');
   const canManage = can(principal, 'view:manage');
-  const valueLabel = measure === 'points' ? 'Points' : 'Issues';
-
-  const scopeMax = Math.max(1, ...dashboard.series.map((point) => point.scope));
-  const segmentKeys = STATE_GROUP_ORDER.filter((key) => key in dashboard.breakdown.schema);
 
   return (
     <div className="flex flex-col gap-6 px-6 py-6">
@@ -55,130 +42,26 @@ export default async function AnalyticsPage({ searchParams }: PageProps) {
           </div>
           <MeasureToggle measure={measure} />
         </div>
-        <SavedViewBar views={dashboard.savedViews} measure={measure} canManage={canManage} />
+        <Suspense fallback={<SavedViewBarSkeleton />}>
+          <SavedViewSection principal={principal} measure={measure} canManage={canManage} />
+        </Suspense>
       </header>
 
-      <Card title="Scope and completed over time">
-        {dashboard.series.length === 0 ? (
-          <p className="py-6 text-center text-faint text-xs">
-            No issues yet, so there is nothing to plot.
-          </p>
-        ) : (
-          <LineChart
-            title=""
-            description={`Scope grew to ${dashboard.series.at(-1)?.scope ?? 0} ${valueLabel.toLowerCase()}, ${dashboard.series.at(-1)?.completed ?? 0} completed.`}
-            max={scopeMax}
-            labels={dashboard.series.map((point) => point.date)}
-            series={[
-              {
-                id: 'scope',
-                label: 'Scope',
-                tone: 'faint',
-                values: dashboard.series.map((point) => point.scope),
-              },
-              {
-                id: 'completed',
-                label: 'Completed',
-                tone: 'accent',
-                filled: true,
-                values: dashboard.series.map((point) => point.completed),
-              },
-            ]}
-          />
-        )}
-      </Card>
+      <Suspense fallback={<ScopeCardSkeleton />}>
+        <ScopeSection principal={principal} measure={measure} />
+      </Suspense>
 
-      <div className="grid gap-4 lg:grid-cols-2 4xl:grid-cols-4">
-        <Card>
-          <BarChart
-            title="By assignee"
-            description={`${valueLabel} per assignee.`}
-            valueLabel={valueLabel}
-            data={dashboard.byAssignee}
-          />
-        </Card>
-        <Card>
-          <BarChart
-            title="By project"
-            description={`${valueLabel} per project.`}
-            valueLabel={valueLabel}
-            data={dashboard.byProject}
-          />
-        </Card>
-        <Card>
-          <BarChart
-            title="By label"
-            description={`${valueLabel} per label. Issues with several labels count in each.`}
-            valueLabel={valueLabel}
-            data={dashboard.byLabel}
-          />
-        </Card>
-        <Card>
-          <BarChart
-            title="Estimate distribution"
-            description={`${valueLabel} per estimate.`}
-            valueLabel={valueLabel}
-            data={dashboard.byEstimate}
-          />
-        </Card>
-      </div>
+      <Suspense fallback={<DistributionGridSkeleton />}>
+        <DistributionSection principal={principal} measure={measure} />
+      </Suspense>
 
-      <Card>
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <h2 className="font-medium text-dense text-text">Assignee breakdown by state</h2>
-          <a
-            href={`/api/analytics/export?dimension=assignee&measure=${measure}`}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-2xs text-muted transition-colors duration-[var(--duration-fast)] hover:text-text"
-          >
-            <Download className="size-3.5" aria-hidden="true" />
-            Export CSV
-          </a>
-        </div>
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[40rem] border-collapse text-xs">
-            <thead>
-              <tr className="border-border border-b text-2xs text-faint uppercase">
-                <th scope="col" className="px-2 py-2 text-left font-medium">
-                  Assignee
-                </th>
-                {segmentKeys.map((key) => (
-                  <th key={key} scope="col" className="px-2 py-2 text-right font-medium">
-                    {stateGroupLabel(key)}
-                  </th>
-                ))}
-                <th scope="col" className="px-2 py-2 text-right font-medium">
-                  Total
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {dashboard.breakdown.data.length === 0 ? (
-                <tr>
-                  <td colSpan={segmentKeys.length + 2} className="px-2 py-4 text-center text-faint">
-                    No issues in range.
-                  </td>
-                </tr>
-              ) : (
-                dashboard.breakdown.data.map((row) => (
-                  <tr key={row.key} className="border-border border-b last:border-b-0">
-                    <td className="px-2 py-1.5 text-muted">{row.name}</td>
-                    {segmentKeys.map((key) => (
-                      <td key={key} className="px-2 py-1.5 text-right text-muted tabular">
-                        {row.values[key] ?? 0}
-                      </td>
-                    ))}
-                    <td className="px-2 py-1.5 text-right font-medium text-text tabular">
-                      {row.total}
-                    </td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
-      </Card>
+      <Suspense fallback={<BreakdownCardSkeleton />}>
+        <BreakdownSection principal={principal} measure={measure} />
+      </Suspense>
 
-      <CyclePanel cycles={dashboard.cycles} measure={measure} canManage={canManage} />
+      <Suspense fallback={<CycleSectionSkeleton />}>
+        <CycleSection principal={principal} measure={measure} canManage={canManage} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/my-issues/page.tsx
+++ b/apps/web/src/app/(app)/my-issues/page.tsx
@@ -1,8 +1,16 @@
+import { HydrationBoundary } from '@tanstack/react-query';
 import type { Metadata } from 'next';
 import { MyIssuesView } from '@/features/issues/my-issues-view.tsx';
+import { pageContext } from '@/lib/api/handler.ts';
+import { dehydratedAssignedIssues } from '@/lib/query/prefetch.ts';
 
 export const metadata: Metadata = { title: 'My issues' };
 
-export default function MyIssuesPage() {
-  return <MyIssuesView />;
+export default async function MyIssuesPage() {
+  const { principal } = await pageContext();
+  return (
+    <HydrationBoundary state={await dehydratedAssignedIssues(principal)}>
+      <MyIssuesView />
+    </HydrationBoundary>
+  );
 }

--- a/apps/web/src/app/(app)/settings/account/loading.tsx
+++ b/apps/web/src/app/(app)/settings/account/loading.tsx
@@ -1,0 +1,5 @@
+import { GeneralSettingsSkeleton } from '@/features/settings/settings-skeletons.tsx';
+
+export default function AccountSettingsLoading() {
+  return <GeneralSettingsSkeleton />;
+}

--- a/apps/web/src/app/(app)/standup/board/loading.tsx
+++ b/apps/web/src/app/(app)/standup/board/loading.tsx
@@ -1,5 +1,0 @@
-import { ListSkeleton } from '@/features/issues/list-skeleton.tsx';
-
-export default function StandupBoardLoading() {
-  return <ListSkeleton layout="board" />;
-}

--- a/apps/web/src/app/(app)/standup/board/loading.tsx
+++ b/apps/web/src/app/(app)/standup/board/loading.tsx
@@ -1,0 +1,5 @@
+import { ListSkeleton } from '@/features/issues/list-skeleton.tsx';
+
+export default function StandupBoardLoading() {
+  return <ListSkeleton layout="board" />;
+}

--- a/apps/web/src/app/(app)/standup/loading.tsx
+++ b/apps/web/src/app/(app)/standup/loading.tsx
@@ -1,0 +1,5 @@
+import { ListSkeleton } from '@/features/issues/list-skeleton.tsx';
+
+export default function StandupLoading() {
+  return <ListSkeleton layout="list" />;
+}

--- a/apps/web/src/components/command-palette.test.tsx
+++ b/apps/web/src/components/command-palette.test.tsx
@@ -91,6 +91,7 @@ describe('command palette', () => {
       /Go to Projects/,
       /Go to Cycles/,
       /Go to Views/,
+      /Go to Analytics/,
       /Go to Docs/,
       /Go to Engineering issues/,
       /Go to Engineering board/,

--- a/apps/web/src/features/analytics/analytics-card.tsx
+++ b/apps/web/src/features/analytics/analytics-card.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+export function AnalyticsCard({
+  title,
+  children,
+}: {
+  readonly title?: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
+      {title === undefined ? null : <h2 className="font-medium text-dense text-text">{title}</h2>}
+      {children}
+    </section>
+  );
+}

--- a/apps/web/src/features/analytics/analytics-skeleton.tsx
+++ b/apps/web/src/features/analytics/analytics-skeleton.tsx
@@ -28,6 +28,67 @@ function BarChartSkeleton() {
   );
 }
 
+export function SavedViewBarSkeleton() {
+  return <Skeleton className="h-8 w-full max-w-md rounded-md" />;
+}
+
+export function ScopeCardSkeleton() {
+  return (
+    <Card>
+      <Skeleton className="h-4 w-56" />
+      <Skeleton className="h-33 w-full" />
+      <div className="flex justify-between">
+        <Skeleton className="h-2.5 w-16" />
+        <Skeleton className="h-2.5 w-16" />
+      </div>
+    </Card>
+  );
+}
+
+export function DistributionGridSkeleton() {
+  return (
+    <div className="grid gap-4 lg:grid-cols-2 4xl:grid-cols-4">
+      {['assignee', 'project', 'label', 'estimate'].map((key) => (
+        <Card key={key}>
+          <BarChartSkeleton />
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export function BreakdownCardSkeleton() {
+  return (
+    <Card>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Skeleton className="h-4 w-48" />
+        <Skeleton className="h-7 w-24 rounded-md" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-3 w-full" />
+        {['r1', 'r2', 'r3', 'r4', 'r5'].map((key) => (
+          <Skeleton key={key} className="h-5 w-full" />
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+export function CycleSectionSkeleton() {
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-3 w-64" />
+        </div>
+        <Skeleton className="h-8 w-32 rounded-md" />
+      </div>
+      <Skeleton className="h-48 w-full rounded-lg" />
+    </section>
+  );
+}
+
 export function AnalyticsSkeleton() {
   return (
     <div className="flex flex-col gap-6 px-6 py-6" data-testid="analytics-skeleton">
@@ -39,49 +100,13 @@ export function AnalyticsSkeleton() {
           </div>
           <Skeleton className="h-8 w-40 rounded-md" />
         </div>
-        <Skeleton className="h-8 w-full max-w-md rounded-md" />
+        <SavedViewBarSkeleton />
       </header>
 
-      <Card>
-        <Skeleton className="h-4 w-56" />
-        <Skeleton className="h-33 w-full" />
-        <div className="flex justify-between">
-          <Skeleton className="h-2.5 w-16" />
-          <Skeleton className="h-2.5 w-16" />
-        </div>
-      </Card>
-
-      <div className="grid gap-4 lg:grid-cols-2">
-        {['assignee', 'project', 'label', 'estimate'].map((key) => (
-          <Card key={key}>
-            <BarChartSkeleton />
-          </Card>
-        ))}
-      </div>
-
-      <Card>
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <Skeleton className="h-4 w-48" />
-          <Skeleton className="h-7 w-24 rounded-md" />
-        </div>
-        <div className="flex flex-col gap-2">
-          <Skeleton className="h-3 w-full" />
-          {['r1', 'r2', 'r3', 'r4', 'r5'].map((key) => (
-            <Skeleton key={key} className="h-5 w-full" />
-          ))}
-        </div>
-      </Card>
-
-      <section className="flex flex-col gap-4">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex flex-col gap-1">
-            <Skeleton className="h-5 w-40" />
-            <Skeleton className="h-3 w-64" />
-          </div>
-          <Skeleton className="h-8 w-32 rounded-md" />
-        </div>
-        <Skeleton className="h-48 w-full rounded-lg" />
-      </section>
+      <ScopeCardSkeleton />
+      <DistributionGridSkeleton />
+      <BreakdownCardSkeleton />
+      <CycleSectionSkeleton />
     </div>
   );
 }

--- a/apps/web/src/features/analytics/breakdown-section.tsx
+++ b/apps/web/src/features/analytics/breakdown-section.tsx
@@ -1,0 +1,74 @@
+import type { Measure } from '@orbit/core';
+import type { Principal } from '@orbit/shared/policy';
+import { Download } from 'lucide-react';
+import { AnalyticsCard } from './analytics-card.tsx';
+import { loadBreakdown } from './data.ts';
+import { STATE_GROUP_ORDER, stateGroupLabel } from './labels.ts';
+
+export async function BreakdownSection({
+  principal,
+  measure,
+}: {
+  readonly principal: Principal;
+  readonly measure: Measure;
+}) {
+  const breakdown = await loadBreakdown(principal, measure);
+  const segmentKeys = STATE_GROUP_ORDER.filter((key) => key in breakdown.schema);
+
+  return (
+    <AnalyticsCard>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="font-medium text-dense text-text">Assignee breakdown by state</h2>
+        <a
+          href={`/api/analytics/export?dimension=assignee&measure=${measure}`}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-2xs text-muted transition-colors duration-[var(--duration-fast)] hover:text-text"
+        >
+          <Download className="size-3.5" aria-hidden="true" />
+          Export CSV
+        </a>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[40rem] border-collapse text-xs">
+          <thead>
+            <tr className="border-border border-b text-2xs text-faint uppercase">
+              <th scope="col" className="px-2 py-2 text-left font-medium">
+                Assignee
+              </th>
+              {segmentKeys.map((key) => (
+                <th key={key} scope="col" className="px-2 py-2 text-right font-medium">
+                  {stateGroupLabel(key)}
+                </th>
+              ))}
+              <th scope="col" className="px-2 py-2 text-right font-medium">
+                Total
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {breakdown.data.length === 0 ? (
+              <tr>
+                <td colSpan={segmentKeys.length + 2} className="px-2 py-4 text-center text-faint">
+                  No issues in range.
+                </td>
+              </tr>
+            ) : (
+              breakdown.data.map((row) => (
+                <tr key={row.key} className="border-border border-b last:border-b-0">
+                  <td className="px-2 py-1.5 text-muted">{row.name}</td>
+                  {segmentKeys.map((key) => (
+                    <td key={key} className="px-2 py-1.5 text-right text-muted tabular">
+                      {row.values[key] ?? 0}
+                    </td>
+                  ))}
+                  <td className="px-2 py-1.5 text-right font-medium text-text tabular">
+                    {row.total}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </AnalyticsCard>
+  );
+}

--- a/apps/web/src/features/analytics/cycle-section.tsx
+++ b/apps/web/src/features/analytics/cycle-section.tsx
@@ -1,0 +1,17 @@
+import type { Measure } from '@orbit/core';
+import type { Principal } from '@orbit/shared/policy';
+import { CyclePanel } from './cycle-panel.tsx';
+import { loadCycleOptions } from './data.ts';
+
+export async function CycleSection({
+  principal,
+  measure,
+  canManage,
+}: {
+  readonly principal: Principal;
+  readonly measure: Measure;
+  readonly canManage: boolean;
+}) {
+  const cycles = await loadCycleOptions(principal);
+  return <CyclePanel cycles={cycles} measure={measure} canManage={canManage} />;
+}

--- a/apps/web/src/features/analytics/data.ts
+++ b/apps/web/src/features/analytics/data.ts
@@ -40,7 +40,10 @@ function estimateName(key: string): string {
   return `${key} pt${key === '1' ? '' : 's'}`;
 }
 
-async function loadCycleOptions(principal: Principal, now: Date): Promise<CycleOption[]> {
+export async function loadCycleOptions(
+  principal: Principal,
+  now: Date = new Date(),
+): Promise<CycleOption[]> {
   const rows = await db
     .select({
       id: schema.cycle.id,
@@ -73,47 +76,42 @@ async function loadCycleOptions(principal: Principal, now: Date): Promise<CycleO
   }));
 }
 
-export interface DashboardData {
-  readonly measure: Measure;
-  readonly series: ScopePoint[];
+export function loadScopeSeries(principal: Principal, measure: Measure): Promise<ScopePoint[]> {
+  return scopeSeries(principal, WORKSPACE, measure, 'week');
+}
+
+export interface Distributions {
   readonly byAssignee: DistributionSlice[];
   readonly byProject: DistributionSlice[];
   readonly byLabel: DistributionSlice[];
   readonly byEstimate: DistributionSlice[];
-  readonly breakdown: ChartResult;
-  readonly cycles: CycleOption[];
-  readonly savedViews: SavedAnalyticsViewPayload[];
 }
 
-export async function loadDashboard(
+export async function loadDistributions(
   principal: Principal,
   measure: Measure,
-  now: Date = new Date(),
-): Promise<DashboardData> {
-  assertCan(principal, 'project:read');
-  const [series, byAssignee, byProject, byLabelRaw, byEstimateRaw, breakdown, cycles, savedRows] =
-    await Promise.all([
-      scopeSeries(principal, WORKSPACE, measure, 'week'),
-      workDistribution(principal, WORKSPACE, 'assignee', measure),
-      workDistribution(principal, WORKSPACE, 'project', measure),
-      workDistribution(principal, WORKSPACE, 'label', measure),
-      workDistribution(principal, WORKSPACE, 'estimate', measure),
-      stateGroupBreakdown(principal, WORKSPACE, 'assignee', measure),
-      loadCycleOptions(principal, now),
-      listSavedAnalyticsViews(principal),
-    ]);
-
+): Promise<Distributions> {
+  const [byAssignee, byProject, byLabel, byEstimateRaw] = await Promise.all([
+    workDistribution(principal, WORKSPACE, 'assignee', measure),
+    workDistribution(principal, WORKSPACE, 'project', measure),
+    workDistribution(principal, WORKSPACE, 'label', measure),
+    workDistribution(principal, WORKSPACE, 'estimate', measure),
+  ]);
   return {
-    measure,
-    series,
     byAssignee,
     byProject,
-    byLabel: byLabelRaw,
+    byLabel,
     byEstimate: byEstimateRaw.map((slice) => ({ ...slice, name: estimateName(slice.key) })),
-    breakdown,
-    cycles,
-    savedViews: savedRows.map(toSavedAnalyticsViewPayload),
   };
+}
+
+export function loadBreakdown(principal: Principal, measure: Measure): Promise<ChartResult> {
+  return stateGroupBreakdown(principal, WORKSPACE, 'assignee', measure);
+}
+
+export async function loadSavedViews(principal: Principal): Promise<SavedAnalyticsViewPayload[]> {
+  const rows = await listSavedAnalyticsViews(principal);
+  return rows.map(toSavedAnalyticsViewPayload);
 }
 
 export interface CycleBundle {

--- a/apps/web/src/features/analytics/distribution-section.tsx
+++ b/apps/web/src/features/analytics/distribution-section.tsx
@@ -1,0 +1,56 @@
+import type { Measure } from '@orbit/core';
+import type { Principal } from '@orbit/shared/policy';
+import { BarChart } from '@/features/charts/bar-chart.tsx';
+import { AnalyticsCard } from './analytics-card.tsx';
+import { loadDistributions } from './data.ts';
+
+export async function DistributionSection({
+  principal,
+  measure,
+}: {
+  readonly principal: Principal;
+  readonly measure: Measure;
+}) {
+  const { byAssignee, byProject, byLabel, byEstimate } = await loadDistributions(
+    principal,
+    measure,
+  );
+  const valueLabel = measure === 'points' ? 'Points' : 'Issues';
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2 4xl:grid-cols-4">
+      <AnalyticsCard>
+        <BarChart
+          title="By assignee"
+          description={`${valueLabel} per assignee.`}
+          valueLabel={valueLabel}
+          data={byAssignee}
+        />
+      </AnalyticsCard>
+      <AnalyticsCard>
+        <BarChart
+          title="By project"
+          description={`${valueLabel} per project.`}
+          valueLabel={valueLabel}
+          data={byProject}
+        />
+      </AnalyticsCard>
+      <AnalyticsCard>
+        <BarChart
+          title="By label"
+          description={`${valueLabel} per label. Issues with several labels count in each.`}
+          valueLabel={valueLabel}
+          data={byLabel}
+        />
+      </AnalyticsCard>
+      <AnalyticsCard>
+        <BarChart
+          title="Estimate distribution"
+          description={`${valueLabel} per estimate.`}
+          valueLabel={valueLabel}
+          data={byEstimate}
+        />
+      </AnalyticsCard>
+    </div>
+  );
+}

--- a/apps/web/src/features/analytics/saved-view-section.tsx
+++ b/apps/web/src/features/analytics/saved-view-section.tsx
@@ -1,0 +1,17 @@
+import type { Measure } from '@orbit/core';
+import type { Principal } from '@orbit/shared/policy';
+import { loadSavedViews } from './data.ts';
+import { SavedViewBar } from './saved-view-bar.tsx';
+
+export async function SavedViewSection({
+  principal,
+  measure,
+  canManage,
+}: {
+  readonly principal: Principal;
+  readonly measure: Measure;
+  readonly canManage: boolean;
+}) {
+  const savedViews = await loadSavedViews(principal);
+  return <SavedViewBar views={savedViews} measure={measure} canManage={canManage} />;
+}

--- a/apps/web/src/features/analytics/scope-section.tsx
+++ b/apps/web/src/features/analytics/scope-section.tsx
@@ -1,0 +1,49 @@
+import type { Measure } from '@orbit/core';
+import type { Principal } from '@orbit/shared/policy';
+import { LineChart } from '@/features/charts/line-chart.tsx';
+import { AnalyticsCard } from './analytics-card.tsx';
+import { loadScopeSeries } from './data.ts';
+
+export async function ScopeSection({
+  principal,
+  measure,
+}: {
+  readonly principal: Principal;
+  readonly measure: Measure;
+}) {
+  const series = await loadScopeSeries(principal, measure);
+  const valueLabel = measure === 'points' ? 'Points' : 'Issues';
+  const scopeMax = Math.max(1, ...series.map((point) => point.scope));
+
+  return (
+    <AnalyticsCard title="Scope and completed over time">
+      {series.length === 0 ? (
+        <p className="py-6 text-center text-faint text-xs">
+          No issues yet, so there is nothing to plot.
+        </p>
+      ) : (
+        <LineChart
+          title=""
+          description={`Scope grew to ${series.at(-1)?.scope ?? 0} ${valueLabel.toLowerCase()}, ${series.at(-1)?.completed ?? 0} completed.`}
+          max={scopeMax}
+          labels={series.map((point) => point.date)}
+          series={[
+            {
+              id: 'scope',
+              label: 'Scope',
+              tone: 'faint',
+              values: series.map((point) => point.scope),
+            },
+            {
+              id: 'completed',
+              label: 'Completed',
+              tone: 'accent',
+              filled: true,
+              values: series.map((point) => point.completed),
+            },
+          ]}
+        />
+      )}
+    </AnalyticsCard>
+  );
+}

--- a/apps/web/src/features/issues/board.test.tsx
+++ b/apps/web/src/features/issues/board.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { ToastProvider } from '@/components/ui/toast.tsx';
@@ -175,5 +175,104 @@ describe('Board peek', () => {
     });
 
     expect(screen.getByRole('button', { name: 'Resize panel' })).toBeInTheDocument();
+  });
+});
+
+type IntersectCallback = (entries: readonly { isIntersecting: boolean }[]) => void;
+const windowObservers: IntersectCallback[] = [];
+const realIntersectionObserver = globalThis.IntersectionObserver;
+
+class WindowStubObserver {
+  constructor(callback: IntersectCallback) {
+    windowObservers.push(callback);
+  }
+  observe = mock();
+  unobserve = mock();
+  disconnect = mock();
+  takeRecords = mock();
+}
+
+function manyIssues(count: number): Issue[] {
+  return Array.from({ length: count }, (_, index) =>
+    issue({
+      id: `issue_w${index}`,
+      number: index + 1,
+      identifier: `ENG-${index + 1}`,
+      title: `Windowed ${index + 1}`,
+      sortOrder: (index + 1) * 1024,
+    }),
+  );
+}
+
+function renderWindowedBoard(count: number, onLoadMore?: () => void) {
+  const groups = groupIssues(
+    manyIssues(count),
+    'state',
+    { states: [todo], members: [], projects: [], cycles: [], labels: [] },
+    { showEmptyGroups: false, ordering: 'manual' },
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <HotkeyProvider>
+          <Board
+            teamId="team_1"
+            groups={groups}
+            draggable={false}
+            hasMore={onLoadMore !== undefined}
+            onLoadMore={onLoadMore}
+          />
+        </HotkeyProvider>
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function fireIntersection() {
+  act(() => {
+    for (const notify of windowObservers) notify([{ isIntersecting: true }]);
+  });
+}
+
+describe('Board windowing', () => {
+  beforeEach(() => {
+    windowObservers.length = 0;
+    Object.defineProperty(globalThis, 'IntersectionObserver', {
+      writable: true,
+      configurable: true,
+      value: WindowStubObserver,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'IntersectionObserver', {
+      writable: true,
+      configurable: true,
+      value: realIntersectionObserver,
+    });
+  });
+
+  it('caps the initial window and reveals more when the column scrolls', () => {
+    renderWindowedBoard(20);
+    expect(screen.getAllByTestId(/^issue-card-/)).toHaveLength(15);
+
+    fireIntersection();
+
+    expect(screen.getAllByTestId(/^issue-card-/)).toHaveLength(20);
+  });
+
+  it('only fetches the next page after the column has been scrolled', () => {
+    const onLoadMore = mock();
+    renderWindowedBoard(10, onLoadMore);
+
+    fireIntersection();
+    expect(onLoadMore).not.toHaveBeenCalled();
+
+    fireEvent.scroll(screen.getByTestId('board-column-Todo').querySelector('ul') as HTMLElement);
+    fireIntersection();
+    expect(onLoadMore).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/issues/board.tsx
+++ b/apps/web/src/features/issues/board.tsx
@@ -23,7 +23,7 @@ import type { DisplayProperty } from '@orbit/shared/filters';
 import { DEFAULT_DISPLAY_PROPERTIES } from '@orbit/shared/filters';
 import { Plus } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { IssueGroup } from '@/features/filters/grouping.ts';
 import { cn } from '@/lib/cn.ts';
 import type { Cycle, Issue, Label, Member, Project, WorkflowState } from '@/lib/query/schemas.ts';
@@ -38,7 +38,13 @@ export interface BoardProps {
   readonly groups: readonly IssueGroup[];
   readonly draggable?: boolean;
   readonly properties?: readonly DisplayProperty[];
+  readonly hasMore?: boolean;
+  readonly loadingMore?: boolean;
+  readonly onLoadMore?: (() => void) | undefined;
 }
+
+const INITIAL_VISIBLE = 15;
+const VISIBLE_STEP = 15;
 
 interface CardLookups {
   readonly labelById: ReadonlyMap<string, Label>;
@@ -152,6 +158,9 @@ export function Board({
   groups,
   draggable = true,
   properties = DEFAULT_DISPLAY_PROPERTIES,
+  hasMore = false,
+  loadingMore = false,
+  onLoadMore,
 }: BoardProps) {
   const { labelById, memberById, stateById, projects, cycles, openQuickCreate } = useWorkspace();
   const router = useRouter();
@@ -206,6 +215,9 @@ export function Board({
           draggable={draggable}
           properties={properties}
           lookups={lookups}
+          hasMore={hasMore}
+          loadingMore={loadingMore}
+          onLoadMore={onLoadMore}
           onCreate={() => openQuickCreate()}
           onOpen={setPeekId}
         />
@@ -258,6 +270,9 @@ interface BoardColumnProps {
   readonly draggable: boolean;
   readonly properties: readonly DisplayProperty[];
   readonly lookups: CardLookups;
+  readonly hasMore: boolean;
+  readonly loadingMore: boolean;
+  readonly onLoadMore: (() => void) | undefined;
   readonly onCreate: () => void;
   readonly onOpen: (id: string) => void;
 }
@@ -267,12 +282,60 @@ function BoardColumn({
   draggable,
   properties,
   lookups,
+  hasMore,
+  loadingMore,
+  onLoadMore,
   onCreate,
   onOpen,
 }: BoardColumnProps) {
   const { setNodeRef } = useDroppable({ id: group.id, data: { isColumn: true } });
+  const scrollRef = useRef<HTMLUListElement | null>(null);
+  const sentinelRef = useRef<HTMLLIElement | null>(null);
+  const scrolledRef = useRef(false);
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE);
 
-  const cards = group.issues.map((issue) =>
+  const total = group.issues.length;
+  const hasHiddenLocal = visibleCount < total;
+  const visibleIssues = useMemo(
+    () => group.issues.slice(0, visibleCount),
+    [group.issues, visibleCount],
+  );
+
+  const canFetchMore = hasMore && onLoadMore !== undefined;
+  const wantsSentinel = hasHiddenLocal || canFetchMore;
+
+  useEffect(() => {
+    const node = sentinelRef.current;
+    const root = scrollRef.current;
+    if (node === null || root === null || !wantsSentinel) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        if (hasHiddenLocal) {
+          setVisibleCount((count) => Math.min(count + VISIBLE_STEP, total));
+        } else if (scrolledRef.current && canFetchMore) {
+          onLoadMore?.();
+        }
+      },
+      { root, rootMargin: '240px' },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [wantsSentinel, hasHiddenLocal, canFetchMore, total, onLoadMore]);
+
+  const markScrolled = useCallback(() => {
+    scrolledRef.current = true;
+  }, []);
+
+  const setScrollNode = useCallback(
+    (node: HTMLUListElement | null) => {
+      scrollRef.current = node;
+      if (draggable) setNodeRef(node);
+    },
+    [draggable, setNodeRef],
+  );
+
+  const cards = visibleIssues.map((issue) =>
     draggable ? (
       <SortableCard
         key={issue.id}
@@ -287,6 +350,19 @@ function BoardColumn({
       </li>
     ),
   );
+
+  const footer = (
+    <>
+      {loadingMore && !hasHiddenLocal ? (
+        <li className="h-[4.75rem] shrink-0 animate-pulse list-none rounded-lg bg-surface-3/50" />
+      ) : null}
+      {wantsSentinel ? (
+        <li ref={sentinelRef} className="h-px shrink-0 list-none" aria-hidden="true" />
+      ) : null}
+    </>
+  );
+
+  const listClass = 'flex min-h-24 flex-1 flex-col gap-2 overflow-y-auto p-2 pt-0';
 
   return (
     <section
@@ -316,18 +392,19 @@ function BoardColumn({
 
       {draggable ? (
         <SortableContext
-          items={group.issues.map((issue) => issue.id)}
+          items={visibleIssues.map((issue) => issue.id)}
           strategy={verticalListSortingStrategy}
         >
-          <ul
-            ref={setNodeRef}
-            className="flex min-h-24 flex-1 flex-col gap-2 overflow-y-auto p-2 pt-0"
-          >
+          <ul ref={setScrollNode} onScroll={markScrolled} className={listClass}>
             {cards}
+            {footer}
           </ul>
         </SortableContext>
       ) : (
-        <ul className="flex min-h-24 flex-1 flex-col gap-2 overflow-y-auto p-2 pt-0">{cards}</ul>
+        <ul ref={scrollRef} onScroll={markScrolled} className={listClass}>
+          {cards}
+          {footer}
+        </ul>
       )}
     </section>
   );

--- a/apps/web/src/features/issues/issue-list.tsx
+++ b/apps/web/src/features/issues/issue-list.tsx
@@ -49,6 +49,9 @@ export interface IssueListProps {
   readonly states: readonly WorkflowState[];
   readonly groups: readonly IssueGroup[];
   readonly properties?: readonly DisplayProperty[];
+  readonly hasMore?: boolean;
+  readonly loadingMore?: boolean;
+  readonly onLoadMore?: (() => void) | undefined;
 }
 
 export function IssueList({
@@ -56,6 +59,9 @@ export function IssueList({
   states,
   groups,
   properties = DEFAULT_DISPLAY_PROPERTIES,
+  hasMore = false,
+  loadingMore = false,
+  onLoadMore,
 }: IssueListProps) {
   const router = useRouter();
   const { labelById, memberById, stateById, projects, cycles } = useWorkspace();
@@ -90,6 +96,13 @@ export function IssueList({
     estimateSize: (index) => (rows[index]?.kind === 'issue' ? ROW_HEIGHT : HEADER_HEIGHT),
     overscan: 12,
   });
+
+  const virtualItems = virtualizer.getVirtualItems();
+  useEffect(() => {
+    if (!hasMore || onLoadMore === undefined || loadingMore) return;
+    const last = virtualItems.at(-1);
+    if (last !== undefined && last.index >= rows.length - 8) onLoadMore();
+  }, [hasMore, loadingMore, onLoadMore, virtualItems, rows.length]);
 
   const activeRow = rows[activeIndex];
   const activeIssue = activeRow?.kind === 'issue' ? activeRow.issue : undefined;
@@ -209,6 +222,11 @@ export function IssueList({
             );
           })}
         </div>
+        {loadingMore ? (
+          <div className="px-3 py-2" aria-hidden="true">
+            <div className="h-8 animate-pulse rounded-md bg-surface-2/60" />
+          </div>
+        ) : null}
       </div>
 
       {selected.length > 0 ? (

--- a/apps/web/src/features/issues/team-view.tsx
+++ b/apps/web/src/features/issues/team-view.tsx
@@ -189,6 +189,11 @@ export function TeamView({ teamKey, layout }: TeamViewProps) {
         layout={layout}
         empty={shown.issues.length === 0}
         loading={issues.isPending}
+        hasMore={issues.hasNextPage}
+        loadingMore={issues.isFetchingNextPage}
+        onLoadMore={() => {
+          issues.fetchNextPage().catch(() => undefined);
+        }}
         onClearLastFilter={() => setConfig({ ...config, filter: dropLastCondition(config.filter) })}
       />
 
@@ -225,6 +230,9 @@ interface TeamContentProps {
   readonly layout: ViewLayoutMode;
   readonly empty: boolean;
   readonly loading: boolean;
+  readonly hasMore: boolean;
+  readonly loadingMore: boolean;
+  readonly onLoadMore: () => void;
   readonly onClearLastFilter: () => void;
 }
 
@@ -236,6 +244,9 @@ function TeamContent({
   layout,
   empty,
   loading,
+  hasMore,
+  loadingMore,
+  onLoadMore,
   onClearLastFilter,
 }: TeamContentProps) {
   if (loading) return <ListSkeleton layout={layout} />;
@@ -274,6 +285,9 @@ function TeamContent({
         groups={groups}
         draggable={config.groupBy === 'state' && config.orderBy === 'manual'}
         properties={config.display.properties}
+        hasMore={hasMore}
+        loadingMore={loadingMore}
+        onLoadMore={onLoadMore}
       />
     );
   }
@@ -283,6 +297,9 @@ function TeamContent({
       states={states}
       groups={groups}
       properties={config.display.properties}
+      hasMore={hasMore}
+      loadingMore={loadingMore}
+      onLoadMore={onLoadMore}
     />
   );
 }

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -1,5 +1,6 @@
 import type { LucideIcon } from 'lucide-react';
 import {
+  BarChart3,
   CircleDot,
   FileText,
   FolderKanban,
@@ -70,6 +71,7 @@ export function buildNavigation(teams: readonly ShellTeam[], inboxCount = 0): Na
         { href: '/cycles', label: 'Cycles', icon: RefreshCcw },
         { href: '/standup', label: 'Standup', icon: Users, binding: 'g s' },
         { href: '/views', label: 'Views', icon: LayoutList, binding: 'g v' },
+        { href: '/analytics', label: 'Analytics', icon: BarChart3, binding: 'g a' },
         { href: '/docs', label: 'Docs', icon: FileText, binding: 'g d' },
       ],
     },

--- a/apps/web/src/lib/query/prefetch.ts
+++ b/apps/web/src/lib/query/prefetch.ts
@@ -3,7 +3,12 @@ import type { Principal } from '@orbit/shared/policy';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { bootstrapPayload } from '@/lib/api/bootstrap.ts';
 import { attachLabels } from '@/lib/api/issues.ts';
-import { DEFAULT_ISSUE_QUERY, ISSUE_PAGE_SIZE, issueSearch } from './issue-search.ts';
+import {
+  assignedSearch,
+  DEFAULT_ISSUE_QUERY,
+  ISSUE_PAGE_SIZE,
+  issueSearch,
+} from './issue-search.ts';
 import { queryKeys } from './keys.ts';
 import type { Bootstrap, IssuePage } from './schemas.ts';
 import { bootstrapSchema, issueListSchema } from './schemas.ts';
@@ -22,6 +27,28 @@ async function serverIssuePage(principal: Principal, teamId: string): Promise<Is
     issues: await attachLabels(page.issues),
     nextCursor: page.nextCursor,
   });
+}
+
+async function serverAssignedPage(principal: Principal): Promise<IssuePage> {
+  const page = await listIssues(principal, {
+    assigneeId: principal.userId,
+    orderBy: 'updated',
+    limit: ISSUE_PAGE_SIZE,
+  });
+  return asWire(issueListSchema, {
+    issues: await attachLabels(page.issues),
+    nextCursor: page.nextCursor,
+  });
+}
+
+export async function dehydratedAssignedIssues(principal: Principal) {
+  const client = new QueryClient();
+  const search = assignedSearch(principal.userId);
+  client.setQueryData(queryKeys.assignedIssues(principal.userId, search), {
+    pages: [await serverAssignedPage(principal)],
+    pageParams: [null],
+  });
+  return dehydrate(client);
 }
 
 export async function dehydratedWorkspace(principal: Principal) {

--- a/packages/db/src/schema/work.ts
+++ b/packages/db/src/schema/work.ts
@@ -359,6 +359,9 @@ export const issue = pgTable(
     index('issue_cycle_idx').on(table.cycleId),
     index('issue_parent_idx').on(table.parentId),
     index('issue_sync_idx').on(table.organizationId, table.syncId),
+    index('issue_org_active_idx')
+      .on(table.organizationId, table.completedAt)
+      .where(sql`${table.archivedAt} is null`),
     index('issue_team_order_idx')
       .on(table.teamId, table.sortOrder, table.id)
       .where(sql`${table.archivedAt} is null`),


### PR DESCRIPTION
Server-render and stream data-first pages: window board columns with fetch-on-scroll, split analytics into per-panel Suspense boundaries, index active issues by org, prefetch my-issues, add Analytics to the sidebar, and fill loading.tsx gaps.