### PR TITLE
feat(sidebar): collapsible sections and expandable team trees with smooth motion

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -302,6 +302,8 @@
   --animate-drawer-out: drawer-out var(--duration-fast) var(--ease-in);
   --animate-panel-in: panel-in var(--duration-base) var(--ease-out);
   --animate-panel-out: panel-out var(--duration-fast) var(--ease-in);
+  --animate-accordion-in: accordion-in var(--duration-fast) var(--ease-out);
+  --animate-accordion-out: accordion-out var(--duration-instant) var(--ease-in);
 }
 
 @keyframes panel-in {
@@ -337,6 +339,28 @@
   }
   to {
     transform: translateX(-100%);
+  }
+}
+
+@keyframes accordion-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes accordion-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.98);
   }
 }
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -302,8 +302,6 @@
   --animate-drawer-out: drawer-out var(--duration-fast) var(--ease-in);
   --animate-panel-in: panel-in var(--duration-base) var(--ease-out);
   --animate-panel-out: panel-out var(--duration-fast) var(--ease-in);
-  --animate-accordion-in: accordion-in var(--duration-fast) var(--ease-out);
-  --animate-accordion-out: accordion-out var(--duration-instant) var(--ease-in);
 }
 
 @keyframes panel-in {
@@ -339,28 +337,6 @@
   }
   to {
     transform: translateX(-100%);
-  }
-}
-
-@keyframes accordion-in {
-  from {
-    opacity: 0;
-    transform: translateY(-4px) scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-@keyframes accordion-out {
-  from {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-  to {
-    opacity: 0;
-    transform: translateY(-4px) scale(0.98);
   }
 }
 

--- a/apps/web/src/components/keyboard-hints.test.tsx
+++ b/apps/web/src/components/keyboard-hints.test.tsx
@@ -16,7 +16,7 @@ import {
   HotkeyProvider,
   useHotkeyList,
 } from '@/lib/keyboard/index.ts';
-import { buildNavigation } from '@/lib/navigation.ts';
+import { buildNavigation, buildSidebarNav } from '@/lib/navigation.ts';
 import type { Issue } from '@/lib/query/schemas.ts';
 import * as docsQuery from '@/lib/query/use-docs.ts';
 import * as issuesQuery from '@/lib/query/use-issues.ts';
@@ -92,7 +92,9 @@ const issue: Issue = {
   labelIds: [],
 };
 
-const sections = buildNavigation([{ id: 'team_1', key: 'ENG', name: 'Engineering' }], 3);
+const TEAMS = [{ id: 'team_1', key: 'ENG', name: 'Engineering' }];
+const sections = buildNavigation(TEAMS, 3);
+const sidebarNav = buildSidebarNav(TEAMS, 3);
 
 const noop = () => undefined;
 
@@ -113,7 +115,7 @@ function Surfaces({ extra }: { readonly extra?: ReactNode }) {
             workspace={{ id: 'org_1', name: 'Noveum', slug: 'noveum' }}
             workspaces={[]}
             user={{ name: 'Pulkit', email: 'pulkit@noveum.ai', image: null }}
-            sections={sections}
+            nav={sidebarNav}
             collapsed={false}
             onToggleCollapsed={noop}
             onOpenPalette={noop}

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/lib/cn.ts';
 import { useHotkey } from '@/lib/keyboard/index.ts';
 import {
   buildNavigation,
+  buildSidebarNav,
   type ShellTeam,
   type ShellUser,
   type ShellWorkspace,
@@ -52,6 +53,7 @@ export function AppShell({
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
   const sections = useMemo(() => buildNavigation(teams, inboxCount), [teams, inboxCount]);
+  const sidebarNav = useMemo(() => buildSidebarNav(teams, inboxCount), [teams, inboxCount]);
 
   useEffect(() => {
     if (isDesktop) setDrawerOpen(false);
@@ -81,7 +83,7 @@ export function AppShell({
       workspace={workspace}
       workspaces={workspaces}
       user={user}
-      sections={sections}
+      nav={sidebarNav}
       collapsed={!touch && collapsed}
       touch={touch}
       onToggleCollapsed={toggleSidebar}

--- a/apps/web/src/components/layout/sidebar-section.tsx
+++ b/apps/web/src/components/layout/sidebar-section.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { ChevronRight } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Collapsible } from '@/components/ui/collapsible.tsx';
+import { cn } from '@/lib/cn.ts';
+
+export interface SidebarSectionProps {
+  readonly title: string;
+  readonly open: boolean;
+  readonly onToggle: () => void;
+  readonly children: ReactNode;
+}
+
+export function SidebarSection({ title, open, onToggle, children }: SidebarSectionProps) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className={cn(
+          'group flex w-full items-center gap-1 rounded-md px-2 pt-1 pb-1',
+          'font-medium text-2xs text-faint uppercase tracking-wide',
+          'transition-colors duration-[var(--duration-fast)] hover:text-muted',
+        )}
+      >
+        <span className="min-w-0 flex-1 truncate text-left">{title}</span>
+        <ChevronRight
+          className={cn(
+            'size-3 shrink-0 text-faint transition-transform duration-[var(--duration-fast)]',
+            open && 'rotate-90',
+          )}
+          aria-hidden="true"
+        />
+      </button>
+      <Collapsible open={open} className="flex flex-col gap-0.5">
+        {children}
+      </Collapsible>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar-team.tsx
+++ b/apps/web/src/components/layout/sidebar-team.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { ChevronRight } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Collapsible } from '@/components/ui/collapsible.tsx';
+import { Tooltip } from '@/components/ui/tooltip.tsx';
+import { cn } from '@/lib/cn.ts';
+import type { NavLink, NavTeamNode } from '@/lib/navigation.ts';
+
+function initial(name: string): string {
+  return name.trim().slice(0, 1).toUpperCase() || '?';
+}
+
+function CountBadge({ count }: { readonly count: number }) {
+  return (
+    <span
+      data-numeric
+      className="shrink-0 rounded-xs bg-surface-3 px-1 text-2xs text-muted leading-4"
+    >
+      {count}
+    </span>
+  );
+}
+
+interface ChildItemProps {
+  readonly link: NavLink;
+  readonly touch: boolean;
+  readonly onNavigate: (() => void) | null;
+}
+
+function ChildItem({ link, touch, onNavigate }: ChildItemProps) {
+  const pathname = usePathname();
+  const active = pathname === link.href || pathname.startsWith(`${link.href}/`);
+  const Icon = link.icon;
+  return (
+    <Link
+      href={link.href}
+      aria-current={active ? 'page' : undefined}
+      {...(onNavigate === null ? {} : { onClick: onNavigate })}
+      className={cn(
+        'flex items-center gap-2 rounded-md px-2 text-dense',
+        'transition-colors duration-[var(--duration-fast)] ease-[var(--ease-out-orbit)]',
+        touch ? 'h-10' : 'h-7 3xl:h-8',
+        active
+          ? 'bg-surface-2 font-medium text-text'
+          : 'text-muted hover:bg-surface-2/70 hover:text-text',
+      )}
+    >
+      <Icon className="size-4 shrink-0" strokeWidth={1.75} aria-hidden="true" />
+      <span className="min-w-0 flex-1 truncate">{link.label}</span>
+      {typeof link.count === 'number' && link.count > 0 ? <CountBadge count={link.count} /> : null}
+    </Link>
+  );
+}
+
+export interface SidebarTeamProps {
+  readonly team: NavTeamNode;
+  readonly open: boolean;
+  readonly collapsed: boolean;
+  readonly touch: boolean;
+  readonly onToggle: () => void;
+  readonly onNavigate: (() => void) | null;
+}
+
+export function SidebarTeam({
+  team,
+  open,
+  collapsed,
+  touch,
+  onToggle,
+  onNavigate,
+}: SidebarTeamProps) {
+  const pathname = usePathname();
+  const base = `/team/${team.key.toLowerCase()}`;
+  const withinTeam = pathname === base || pathname.startsWith(`${base}/`);
+
+  const tile = (
+    <span
+      className="flex size-4 shrink-0 items-center justify-center rounded-sm font-semibold text-[9px] text-white"
+      style={{ backgroundColor: team.color }}
+      aria-hidden="true"
+    >
+      {initial(team.name)}
+    </span>
+  );
+
+  if (collapsed) {
+    const link = (
+      <Link
+        href={team.href}
+        aria-current={withinTeam ? 'page' : undefined}
+        {...(onNavigate === null ? {} : { onClick: onNavigate })}
+        className={cn(
+          'flex h-7 items-center justify-center rounded-md 3xl:h-8',
+          'transition-colors duration-[var(--duration-fast)]',
+          withinTeam ? 'bg-surface-2' : 'hover:bg-surface-2/70',
+        )}
+      >
+        {tile}
+      </Link>
+    );
+    return touch ? (
+      link
+    ) : (
+      <Tooltip label={team.name} side="right">
+        {link}
+      </Tooltip>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className={cn(
+          'group flex w-full items-center gap-2 rounded-md px-2 text-dense',
+          'transition-colors duration-[var(--duration-fast)] ease-[var(--ease-out-orbit)]',
+          touch ? 'h-11 gap-3 px-3' : 'h-7 3xl:h-8',
+          withinTeam && !open ? 'text-text' : 'text-muted',
+          'hover:bg-surface-2/70 hover:text-text',
+        )}
+      >
+        {tile}
+        <span className="min-w-0 flex-1 truncate text-left font-medium">{team.name}</span>
+        {!open && typeof team.count === 'number' && team.count > 0 ? (
+          <CountBadge count={team.count} />
+        ) : null}
+        <ChevronRight
+          className={cn(
+            'size-3.5 shrink-0 text-faint transition-transform duration-[var(--duration-fast)]',
+            open && 'rotate-90',
+          )}
+          aria-hidden="true"
+        />
+      </button>
+      <Collapsible open={open}>
+        <div className="relative mt-0.5 mb-1 flex flex-col gap-0.5 pl-6">
+          <div className="absolute top-0 bottom-1 left-[15px] w-px bg-border" aria-hidden="true" />
+          {team.children.map((child) => (
+            <ChildItem key={child.href} link={child} touch={touch} onNavigate={onNavigate} />
+          ))}
+        </div>
+      </Collapsible>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.test.tsx
+++ b/apps/web/src/components/layout/sidebar.test.tsx
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { TooltipProvider } from '@/components/ui/tooltip.tsx';
+import { buildSidebarNav, type ShellTeam } from '@/lib/navigation.ts';
+import { Sidebar } from './sidebar.tsx';
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ push: mock(), refresh: mock() }),
+  usePathname: () => '/team/eng/issues',
+}));
+
+mock.module('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'dark', setTheme: mock() }),
+}));
+
+mock.module('@/components/ui/toast.tsx', () => ({
+  useToast: () => ({ toast: mock(), dismiss: mock() }),
+}));
+
+mock.module('@/lib/auth/client.ts', () => ({
+  authClient: {
+    organization: { setActive: mock() },
+    signOut: mock(() => Promise.resolve()),
+  },
+}));
+
+const TEAMS: readonly ShellTeam[] = [
+  { id: 'team-eng', key: 'ENG', name: 'Engineering', color: '#5A63C8', openIssues: 4 },
+  { id: 'team-mkt', key: 'MKT', name: 'Marketing', color: '#22A06B' },
+];
+
+const noop = () => undefined;
+
+function renderSidebar() {
+  return render(
+    <TooltipProvider>
+      <Sidebar
+        workspace={{ id: 'org-1', name: 'Noveum', slug: 'noveum' }}
+        workspaces={[]}
+        user={{ name: 'Pulkit', email: 'pulkit@noveum.ai', image: null }}
+        nav={buildSidebarNav(TEAMS, 2)}
+        collapsed={false}
+        onToggleCollapsed={noop}
+        onOpenPalette={noop}
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('auto-expands the team matching the current route and collapses the others', () => {
+    renderSidebar();
+
+    expect(screen.getByRole('button', { name: /Engineering/ })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: /Marketing/ })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('reveals a team subtree when its row is clicked', () => {
+    renderSidebar();
+
+    expect(screen.getAllByRole('link', { name: 'Board' })).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /Marketing/ }));
+
+    expect(screen.getByRole('button', { name: /Marketing/ })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getAllByRole('link', { name: 'Board' })).toHaveLength(2);
+  });
+
+  it('collapses a section group from its header', () => {
+    renderSidebar();
+
+    const header = screen.getByRole('button', { name: 'Workspace' });
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('link', { name: /Projects/ })).toBeInTheDocument();
+
+    fireEvent.click(header);
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,19 +1,23 @@
 'use client';
 
 import { PanelLeft, Search, X } from 'lucide-react';
+import { usePathname } from 'next/navigation';
 import { Kbd } from '@/components/ui/kbd.tsx';
 import { ScrollArea } from '@/components/ui/scroll-area.tsx';
 import { Tooltip } from '@/components/ui/tooltip.tsx';
 import { cn } from '@/lib/cn.ts';
-import type { NavSection, ShellUser, ShellWorkspace } from '@/lib/navigation.ts';
+import type { NavLink, ShellUser, ShellWorkspace, SidebarNav } from '@/lib/navigation.ts';
+import { useSidebarDisclosure } from '@/lib/use-sidebar-disclosure.ts';
 import { NavItem } from './nav-item.tsx';
+import { SidebarSection } from './sidebar-section.tsx';
+import { SidebarTeam } from './sidebar-team.tsx';
 import { WorkspaceSwitcher } from './workspace-switcher.tsx';
 
 export interface SidebarProps {
   readonly workspace: ShellWorkspace;
   readonly workspaces: readonly ShellWorkspace[];
   readonly user: ShellUser;
-  readonly sections: readonly NavSection[];
+  readonly nav: SidebarNav;
   readonly collapsed: boolean;
   readonly touch?: boolean;
   readonly onToggleCollapsed: () => void;
@@ -21,17 +25,26 @@ export interface SidebarProps {
   readonly onNavigate?: (() => void) | null;
 }
 
+function activeTeamKey(pathname: string): string | null {
+  if (!pathname.startsWith('/team/')) return null;
+  return pathname.split('/')[2]?.toLowerCase() ?? null;
+}
+
 export function Sidebar({
   workspace,
   workspaces,
   user,
-  sections,
+  nav,
   collapsed,
   touch = false,
   onToggleCollapsed,
   onOpenPalette,
   onNavigate = null,
 }: SidebarProps) {
+  const pathname = usePathname();
+  const disclosure = useSidebarDisclosure();
+  const currentTeam = activeTeamKey(pathname);
+
   const toggle = (
     <button
       type="button"
@@ -50,6 +63,31 @@ export function Sidebar({
       )}
     </button>
   );
+
+  const renderLink = (link: NavLink) => (
+    <NavItem
+      key={link.href}
+      link={link}
+      collapsed={collapsed}
+      touch={touch}
+      onNavigate={onNavigate}
+    />
+  );
+
+  const teams = nav.teams.map((team) => {
+    const fallbackOpen = team.key.toLowerCase() === currentTeam;
+    return (
+      <SidebarTeam
+        key={team.id}
+        team={team}
+        collapsed={collapsed}
+        touch={touch}
+        open={disclosure.isOpen(`team:${team.id}`, fallbackOpen)}
+        onToggle={() => disclosure.toggle(`team:${team.id}`, fallbackOpen)}
+        onNavigate={onNavigate}
+      />
+    );
+  });
 
   return (
     <div className="flex h-full flex-col gap-1 border-border border-r bg-surface">
@@ -94,29 +132,47 @@ export function Sidebar({
       </div>
 
       <ScrollArea className="min-h-0 flex-1">
-        <nav
-          aria-label="Workspace"
-          className="flex flex-col gap-4 px-2 pb-4 3xl:gap-5 3xl:px-3 3xl:pb-6"
-        >
-          {sections.map((section) => (
-            <div key={section.id} className="flex flex-col gap-0.5">
-              {section.title !== undefined && !collapsed ? (
-                <p className="px-2 pt-1 pb-1 font-medium text-2xs text-faint uppercase tracking-wide">
-                  {section.title}
-                </p>
-              ) : null}
-              {section.links.map((link) => (
-                <NavItem
-                  key={link.href}
-                  link={link}
-                  collapsed={collapsed}
-                  touch={touch}
-                  onNavigate={onNavigate}
-                />
-              ))}
-            </div>
-          ))}
-        </nav>
+        {collapsed ? (
+          <nav
+            aria-label="Workspace"
+            className="flex flex-col items-stretch gap-0.5 px-2 pb-4 3xl:px-3 3xl:pb-6"
+          >
+            {nav.personal.map(renderLink)}
+            <div className="my-1 h-px bg-border" aria-hidden="true" />
+            {nav.workspace.links.map(renderLink)}
+            {teams.length > 0 ? (
+              <>
+                <div className="my-1 h-px bg-border" aria-hidden="true" />
+                {teams}
+              </>
+            ) : null}
+          </nav>
+        ) : (
+          <nav
+            aria-label="Workspace"
+            className="flex flex-col gap-3 px-2 pb-4 3xl:gap-4 3xl:px-3 3xl:pb-6"
+          >
+            <div className="flex flex-col gap-0.5">{nav.personal.map(renderLink)}</div>
+
+            <SidebarSection
+              title={nav.workspace.title}
+              open={disclosure.isOpen('section:workspace', true)}
+              onToggle={() => disclosure.toggle('section:workspace', true)}
+            >
+              {nav.workspace.links.map(renderLink)}
+            </SidebarSection>
+
+            {teams.length > 0 ? (
+              <SidebarSection
+                title="Teams"
+                open={disclosure.isOpen('section:teams', true)}
+                onToggle={() => disclosure.toggle('section:teams', true)}
+              >
+                {teams}
+              </SidebarSection>
+            ) : null}
+          </nav>
+        )}
       </ScrollArea>
     </div>
   );

--- a/apps/web/src/components/ui/collapsible.tsx
+++ b/apps/web/src/components/ui/collapsible.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/cn.ts';
+
+type Phase = 'idle' | 'in' | 'out';
+
+export interface CollapsibleProps {
+  readonly open: boolean;
+  readonly children: ReactNode;
+  readonly className?: string;
+}
+
+export function Collapsible({ open, children, className }: CollapsibleProps) {
+  const [rendered, setRendered] = useState(open);
+  const [phase, setPhase] = useState<Phase>('idle');
+  const first = useRef(true);
+
+  useEffect(() => {
+    if (first.current) {
+      first.current = false;
+      return;
+    }
+    if (open) {
+      setRendered(true);
+      setPhase('in');
+    } else {
+      setPhase('out');
+    }
+  }, [open]);
+
+  if (!rendered) return null;
+
+  return (
+    <div
+      className={cn(
+        'origin-top',
+        phase === 'in' && 'animate-accordion-in',
+        phase === 'out' && 'animate-accordion-out',
+        className,
+      )}
+      onAnimationEnd={(event) => {
+        if (event.target !== event.currentTarget) return;
+        if (phase === 'out') setRendered(false);
+        setPhase('idle');
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/collapsible.tsx
+++ b/apps/web/src/components/ui/collapsible.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { cn } from '@/lib/cn.ts';
-
-type Phase = 'idle' | 'in' | 'out';
 
 export interface CollapsibleProps {
   readonly open: boolean;
@@ -13,39 +11,35 @@ export interface CollapsibleProps {
 
 export function Collapsible({ open, children, className }: CollapsibleProps) {
   const [rendered, setRendered] = useState(open);
-  const [phase, setPhase] = useState<Phase>('idle');
-  const first = useRef(true);
+  const [expanded, setExpanded] = useState(open);
 
   useEffect(() => {
-    if (first.current) {
-      first.current = false;
-      return;
-    }
     if (open) {
       setRendered(true);
-      setPhase('in');
-    } else {
-      setPhase('out');
+      const frame = requestAnimationFrame(() => setExpanded(true));
+      return () => cancelAnimationFrame(frame);
     }
+    setExpanded(false);
+    return undefined;
   }, [open]);
 
   if (!rendered) return null;
 
   return (
     <div
+      data-state={expanded ? 'open' : 'closed'}
       className={cn(
-        'origin-top',
-        phase === 'in' && 'animate-accordion-in',
-        phase === 'out' && 'animate-accordion-out',
-        className,
+        'grid transition-[grid-template-rows,opacity] duration-[var(--duration-base)] ease-[var(--ease-out-orbit)]',
+        expanded ? 'opacity-100' : 'opacity-0',
       )}
-      onAnimationEnd={(event) => {
+      style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}
+      onTransitionEnd={(event) => {
         if (event.target !== event.currentTarget) return;
-        if (phase === 'out') setRendered(false);
-        setPhase('idle');
+        if (event.propertyName !== 'grid-template-rows') return;
+        if (!expanded) setRendered(false);
       }}
     >
-      {children}
+      <div className={cn('min-h-0 overflow-hidden', className)}>{children}</div>
     </div>
   );
 }

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -21,6 +21,7 @@ export interface ShellTeam {
   readonly id: string;
   readonly key: string;
   readonly name: string;
+  readonly color?: string | undefined;
   readonly openIssues?: number | undefined;
 }
 
@@ -92,6 +93,72 @@ export function buildNavigation(teams: readonly ShellTeam[], inboxCount = 0): Na
       ],
     })),
   ];
+}
+
+export interface NavGroup {
+  readonly id: string;
+  readonly title: string;
+  readonly links: readonly NavLink[];
+}
+
+export interface NavTeamNode {
+  readonly id: string;
+  readonly key: string;
+  readonly name: string;
+  readonly color: string;
+  readonly href: string;
+  readonly count?: number | undefined;
+  readonly children: readonly NavLink[];
+}
+
+export interface SidebarNav {
+  readonly personal: readonly NavLink[];
+  readonly workspace: NavGroup;
+  readonly teams: readonly NavTeamNode[];
+}
+
+const DEFAULT_TEAM_COLOR = '#5A63C8';
+
+export function buildSidebarNav(teams: readonly ShellTeam[], inboxCount = 0): SidebarNav {
+  return {
+    personal: [
+      { href: '/inbox', label: 'Inbox', icon: Inbox, binding: 'g i', count: inboxCount },
+      { href: '/my-issues', label: 'My issues', icon: CircleDot, binding: 'g m' },
+      { href: '/pulls', label: 'Pull requests', icon: GitPullRequest, binding: 'g r' },
+    ],
+    workspace: {
+      id: 'workspace',
+      title: 'Workspace',
+      links: [
+        { href: '/projects', label: 'Projects', icon: FolderKanban, binding: 'g p' },
+        { href: '/cycles', label: 'Cycles', icon: RefreshCcw },
+        { href: '/standup', label: 'Standup', icon: Users, binding: 'g s' },
+        { href: '/views', label: 'Views', icon: LayoutList, binding: 'g v' },
+        { href: '/docs', label: 'Docs', icon: FileText, binding: 'g d' },
+      ],
+    },
+    teams: teams.map((team) => {
+      const key = team.key.toLowerCase();
+      return {
+        id: team.id,
+        key: team.key,
+        name: team.name,
+        color: team.color ?? DEFAULT_TEAM_COLOR,
+        href: `/team/${key}/issues`,
+        count: team.openIssues,
+        children: [
+          {
+            href: `/team/${key}/issues`,
+            label: 'Issues',
+            icon: CircleDot,
+            count: team.openIssues,
+          },
+          { href: `/team/${key}/board`, label: 'Board', icon: Target },
+          { href: `/team/${key}/cycle/active`, label: 'Active cycle', icon: RefreshCcw },
+        ],
+      };
+    }),
+  };
 }
 
 export interface AppCommand {

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -136,6 +136,7 @@ export function buildSidebarNav(teams: readonly ShellTeam[], inboxCount = 0): Si
         { href: '/cycles', label: 'Cycles', icon: RefreshCcw },
         { href: '/standup', label: 'Standup', icon: Users, binding: 'g s' },
         { href: '/views', label: 'Views', icon: LayoutList, binding: 'g v' },
+        { href: '/analytics', label: 'Analytics', icon: BarChart3, binding: 'g a' },
         { href: '/docs', label: 'Docs', icon: FileText, binding: 'g d' },
       ],
     },

--- a/apps/web/src/lib/use-sidebar-disclosure.ts
+++ b/apps/web/src/lib/use-sidebar-disclosure.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'orbit:sidebar:disclosure';
+
+type OpenMap = Record<string, boolean>;
+
+function readStored(): OpenMap {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const result: OpenMap = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === 'boolean') result[key] = value;
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+export interface SidebarDisclosure {
+  readonly isOpen: (id: string, fallback: boolean) => boolean;
+  readonly toggle: (id: string, fallback: boolean) => void;
+}
+
+export function useSidebarDisclosure(): SidebarDisclosure {
+  const [map, setMap] = useState<OpenMap>({});
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    setMap(readStored());
+    setReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!ready) return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+    } catch {
+      setReady(true);
+    }
+  }, [map, ready]);
+
+  const isOpen = useCallback((id: string, fallback: boolean) => map[id] ?? fallback, [map]);
+
+  const toggle = useCallback((id: string, fallback: boolean) => {
+    setMap((prev) => ({ ...prev, [id]: !(prev[id] ?? fallback) }));
+  }, []);
+
+  return { isOpen, toggle };
+}

--- a/apps/web/src/lib/workspace.ts
+++ b/apps/web/src/lib/workspace.ts
@@ -22,7 +22,12 @@ export async function listTeamsForPrincipal(principal: Principal): Promise<Shell
     principal.role === 'admin' ? undefined : inArray(schema.team.id, [...principal.teamIds]);
 
   const rows = await db
-    .select({ id: schema.team.id, key: schema.team.key, name: schema.team.name })
+    .select({
+      id: schema.team.id,
+      key: schema.team.key,
+      name: schema.team.name,
+      color: schema.team.color,
+    })
     .from(schema.team)
     .where(
       and(


### PR DESCRIPTION
Restructures the sidebar into collapsible Workspace and Teams sections with expandable, smoothly animated per-team trees.

![Sidebar revamp demo](https://raw.githubusercontent.com/Noveum/orbit/pr-media/sidebar-revamp.gif)
