### PR TITLE
Survive a multiplexing connection pooler

### DIFF
--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'bun:test';
+import { multiplexesConnections } from './client.ts';
+
+const HOST = 'aws-0-ap-northeast-1.pooler.supabase.com';
+
+describe('multiplexesConnections', () => {
+  it('detects the Supabase transaction pooler by port', () => {
+    expect(multiplexesConnections(`postgresql://user:pass@${HOST}:6543/postgres`)).toBe(true);
+  });
+
+  it('leaves the session pooler alone', () => {
+    expect(multiplexesConnections(`postgresql://user:pass@${HOST}:5432/postgres`)).toBe(false);
+  });
+
+  it('leaves a direct connection alone', () => {
+    expect(multiplexesConnections('postgresql://user:pass@db.ref.supabase.co:5432/postgres')).toBe(
+      false,
+    );
+  });
+
+  it('leaves local development alone', () => {
+    expect(multiplexesConnections('postgres://orbit:orbit@localhost:5434/orbit')).toBe(false);
+  });
+
+  it('ignores the port appearing elsewhere in the url', () => {
+    expect(multiplexesConnections(`postgresql://user:6543@${HOST}:5432/postgres`)).toBe(false);
+    expect(multiplexesConnections(`postgresql://user:pass@${HOST}:5432/db6543`)).toBe(false);
+  });
+
+  it('survives a query string and sslmode', () => {
+    expect(
+      multiplexesConnections(`postgresql://user:pass@${HOST}:6543/postgres?sslmode=require`),
+    ).toBe(true);
+  });
+
+  it('treats an unparseable connection string as not multiplexed', () => {
+    expect(multiplexesConnections('not a url')).toBe(false);
+    expect(multiplexesConnections('')).toBe(false);
+  });
+});

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'bun:test';
-import { multiplexesConnections } from './client.ts';
+import { multiplexesConnections, poolCacheKey } from './client.ts';
 
 const HOST = 'aws-0-ap-northeast-1.pooler.supabase.com';
+const SESSION = `postgresql://user:pass@${HOST}:5432/postgres`;
+const TRANSACTION = `postgresql://user:pass@${HOST}:6543/postgres`;
 
 describe('multiplexesConnections', () => {
   it('detects the Supabase transaction pooler by port', () => {
@@ -36,5 +38,27 @@ describe('multiplexesConnections', () => {
   it('treats an unparseable connection string as not multiplexed', () => {
     expect(multiplexesConnections('not a url')).toBe(false);
     expect(multiplexesConnections('')).toBe(false);
+  });
+});
+
+describe('poolCacheKey', () => {
+  it('matches when every connection option matches', () => {
+    expect(poolCacheKey(SESSION, 10, true)).toBe(poolCacheKey(SESSION, 10, true));
+  });
+
+  it('differs when the url changes', () => {
+    expect(poolCacheKey(SESSION, 10, true)).not.toBe(poolCacheKey(TRANSACTION, 10, true));
+  });
+
+  it('differs when the pool size changes', () => {
+    expect(poolCacheKey(SESSION, 10, true)).not.toBe(poolCacheKey(SESSION, 1, true));
+  });
+
+  it('differs when the prepare mode changes', () => {
+    expect(poolCacheKey(SESSION, 10, true)).not.toBe(poolCacheKey(SESSION, 10, false));
+  });
+
+  it('does not confuse a pool size with a url fragment', () => {
+    expect(poolCacheKey(`${SESSION}1`, 1, true)).not.toBe(poolCacheKey(SESSION, 11, true));
   });
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -19,6 +19,16 @@ if (!poolMax.success) {
   );
 }
 
+const TRANSACTION_POOLER_PORT = 6543;
+
+export function multiplexesConnections(url: string): boolean {
+  try {
+    return Number(new URL(url).port) === TRANSACTION_POOLER_PORT;
+  } catch {
+    return false;
+  }
+}
+
 const globalForDb = globalThis as unknown as { orbitPool?: SQL };
 
 export const pool =
@@ -26,11 +36,10 @@ export const pool =
   new SQL(connectionString, {
     max: poolMax.data,
     idleTimeout: 30,
+    prepare: !multiplexesConnections(connectionString),
   });
 
-if (process.env['NODE_ENV'] !== 'production') {
-  globalForDb.orbitPool = pool;
-}
+globalForDb.orbitPool = pool;
 
 export const db = drizzle({ client: pool, schema, casing: 'snake_case' });
 

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -29,17 +29,31 @@ export function multiplexesConnections(url: string): boolean {
   }
 }
 
-const globalForDb = globalThis as unknown as { orbitPool?: SQL };
+export function poolCacheKey(url: string, max: number, prepare: boolean): string {
+  return JSON.stringify([url, max, prepare]);
+}
+
+interface CachedPool {
+  readonly key: string;
+  readonly sql: SQL;
+}
+
+const globalForDb = globalThis as unknown as { orbitPool?: CachedPool };
+
+const prepareStatements = !multiplexesConnections(connectionString);
+const cacheKey = poolCacheKey(connectionString, poolMax.data, prepareStatements);
+const cached = globalForDb.orbitPool;
 
 export const pool =
-  globalForDb.orbitPool ??
-  new SQL(connectionString, {
-    max: poolMax.data,
-    idleTimeout: 30,
-    prepare: !multiplexesConnections(connectionString),
-  });
+  cached?.key === cacheKey
+    ? cached.sql
+    : new SQL(connectionString, {
+        max: poolMax.data,
+        idleTimeout: 30,
+        prepare: prepareStatements,
+      });
 
-globalForDb.orbitPool = pool;
+globalForDb.orbitPool = { key: cacheKey, sql: pool };
 
 export const db = drizzle({ client: pool, schema, casing: 'snake_case' });
 


### PR DESCRIPTION
Memoise the database pool in production and disable named prepared statements behind a transaction pooler.