### PR TITLE
Make the board fast and honest, rebuild standup, and close every security hole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ extras/
 
 next-env.d.ts
 .artifacts/
+.vercel
+.env*

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,7 @@ extras/
 
 .claude/worktrees/
 
+.vercel/
+
 next-env.d.ts
 .artifacts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,9 +74,13 @@ bun test             run one package's tests from inside that package
 ```
 
 Ports: web 3000, realtime 3100, postgres 5434, redis 6380, minio 9010. The realtime
-port is development only. In production the socket is served from the web app at
-`/api/ws`, and the client falls back to the same origin whenever
-`NEXT_PUBLIC_REALTIME_URL` is unset.
+port is development only. In production the socket is always served from the web app
+at `/api/ws` on the page's own origin: `configuredRealtimeUrl()` ignores
+`NEXT_PUBLIC_REALTIME_URL` whenever `NODE_ENV` is `production`, so the variable is a
+local development override and nothing else. Never set it on a deployed environment.
+A value left over from the standalone realtime host sends the browser to a dead
+origin, and because the ticket still comes from the app the failure looks like an
+endless "Reconnecting to live updates" banner rather than an error.
 
 Email goes out through Resend only. Set `RESEND_API_KEY` and an `EMAIL_FROM` on a
 domain verified in Resend, otherwise every send fails.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ bun install          install every workspace dependency
 bun run infra:up     start postgres, redis, minio
 bun run db:push      apply schema to the dev database
 bun run db:seed      load demo org, teams, members, issues, comments
+bun run db:test-setup create the per package test databases and push the schema
 bun run dev          run web, realtime, and mcp together
 bun run verify       lint + comment policy + typecheck + tests
 bun test             run one package's tests from inside that package
@@ -116,6 +117,7 @@ domain verified in Resend, otherwise every send fails.
 - Import test helpers from `bun:test`, never from `vitest`.
 - A package that needs environment or a DOM configures it in its own `bunfig.toml` with a `tests-preload.ts`. DOM tests register happy-dom in that preload.
 - Database tests run against the real Postgres from docker compose, in a transaction that rolls back. `scripts/test-env.ts` refuses to run against a database whose name does not contain `test`.
+- Each package owns an isolated database (`orbit_test_core`, `orbit_test_svc`, `orbit_test_rt`, `orbit_test_rts`, `orbit_test_mcp`, `orbit_test_web`). Run `bun run db:test-setup` once after `bun run infra:up`, otherwise `bun run verify` fails on a clean checkout with connection errors rather than test failures.
 - End to end: Playwright in `apps/web/e2e`.
 - A feature is not done until it has tests that would fail if the feature broke.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ bun install
 cp .env.example .env
 bun run infra:up
 bun run db:push
+bun run db:test-setup
 bun run db:seed
 bun run dev
 ```

--- a/apps/realtime/src/server.test.ts
+++ b/apps/realtime/src/server.test.ts
@@ -377,6 +377,26 @@ describe('authorization', () => {
     client.close();
   });
 
+  it('never carries a team issue to somebody who only holds the organization scope', async () => {
+    const listener = await connectClient(server.port, alice);
+    await listener.waitFor('ready');
+    listener.send({ type: 'subscribe', scopes: [scopes.organization(orgA)] });
+    await listener.waitFor('subscribed');
+
+    await publish(
+      syncAction({
+        organizationId: orgA,
+        scopes: [scopes.team(teamB), scopes.issue('issue_secret')],
+        modelId: 'issue_secret',
+        syncId: 9100,
+      }),
+    );
+    await delay(BATCH_WINDOW_MS * 4);
+
+    expect(listener.messages.filter((message) => message.type === 'delta')).toHaveLength(0);
+    listener.close();
+  });
+
   it('scopes an issue subscription to the teams a member can read, matching the read path', async () => {
     const issueId = await createIssue(orgA, teamB, bob.userId);
 

--- a/apps/web/src/app/(app)/projects/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[slug]/page.tsx
@@ -178,7 +178,7 @@ export default async function ProjectDetailPage({ params }: PageProps) {
         </div>
 
         <aside className="flex flex-col gap-4 rounded-lg border border-border p-4">
-          <div className="grid grid-cols-3 gap-2 text-center">
+          <div className="grid grid-cols-4 gap-2 text-center">
             <div className="flex flex-col">
               <span className="font-medium text-lg text-text tabular">{progress.scope}</span>
               <span className="text-2xs text-faint uppercase">Scope</span>
@@ -190,6 +190,10 @@ export default async function ProjectDetailPage({ params }: PageProps) {
             <div className="flex flex-col">
               <span className="font-medium text-lg text-text tabular">{progress.completed}</span>
               <span className="text-2xs text-faint uppercase">Done</span>
+            </div>
+            <div className="flex flex-col">
+              <span className="font-medium text-faint text-lg tabular">{progress.canceled}</span>
+              <span className="text-2xs text-faint uppercase">Cancelled</span>
             </div>
           </div>
           {series.length === 0 ? (

--- a/apps/web/src/app/(app)/standup/page.tsx
+++ b/apps/web/src/app/(app)/standup/page.tsx
@@ -1,8 +1,13 @@
 import type { Metadata } from 'next';
-import { StandupView } from '@/features/issues/standup-view.tsx';
+import { Suspense } from 'react';
+import { StandupPage } from '@/features/standup/standup-page.tsx';
 
 export const metadata: Metadata = { title: 'Standup' };
 
-export default function StandupPage() {
-  return <StandupView />;
+export default function Standup() {
+  return (
+    <Suspense fallback={null}>
+      <StandupPage />
+    </Suspense>
+  );
 }

--- a/apps/web/src/app/api/files/[...key]/route.ts
+++ b/apps/web/src/app/api/files/[...key]/route.ts
@@ -1,5 +1,9 @@
 import { db, eq, schema } from '@orbit/db';
-import { isPubliclyReadable, storageDriver } from '@orbit/services/storage';
+import {
+  assertAttachmentVisible,
+  isPubliclyReadable,
+  storageDriver,
+} from '@orbit/services/storage';
 import { notFound } from '@orbit/shared/errors';
 import { dispositionFor } from '@/lib/api/content-disposition.ts';
 import { apiContext, errorResponse } from '@/lib/api/handler.ts';
@@ -17,9 +21,7 @@ async function assertReadable(record: AttachmentRecord | undefined): Promise<Att
   if (record === undefined) throw notFound('That file does not exist.');
   if (await isPubliclyReadable(db, record)) return record;
   const { principal } = await apiContext();
-  if (record.organizationId !== principal.organizationId) {
-    throw notFound('That file does not exist.');
-  }
+  await assertAttachmentVisible(db, principal, record);
   return record;
 }
 

--- a/apps/web/src/app/api/files/[...key]/route.ts
+++ b/apps/web/src/app/api/files/[...key]/route.ts
@@ -5,37 +5,52 @@ import {
   storageDriver,
 } from '@orbit/services/storage';
 import { notFound } from '@orbit/shared/errors';
+import { z } from 'zod';
 import { dispositionFor } from '@/lib/api/content-disposition.ts';
 import { apiContext, errorResponse } from '@/lib/api/handler.ts';
+
+const storageKeySchema = z
+  .array(
+    z
+      .string()
+      .min(1)
+      .max(200)
+      .regex(/^[A-Za-z0-9._-]+$/, 'A storage key segment may only contain safe characters.'),
+  )
+  .min(1)
+  .max(8);
 
 interface RouteContext {
   readonly params: Promise<{ key: string[] }>;
 }
 
 const DOWNLOAD_URL_TTL_SECONDS = 300;
-const REDIRECT_CACHE_SECONDS = 280;
+const PUBLIC_REDIRECT_CACHE_SECONDS = 280;
 
 type AttachmentRecord = typeof schema.attachment.$inferSelect;
 
-async function assertReadable(record: AttachmentRecord | undefined): Promise<AttachmentRecord> {
+async function assertReadable(
+  record: AttachmentRecord | undefined,
+): Promise<{ record: AttachmentRecord; shared: boolean }> {
   if (record === undefined) throw notFound('That file does not exist.');
-  if (await isPubliclyReadable(db, record)) return record;
+  if (await isPubliclyReadable(db, record)) return { record, shared: true };
   const { principal } = await apiContext();
   await assertAttachmentVisible(db, principal, record);
-  return record;
+  return { record, shared: false };
 }
 
 export async function GET(_request: Request, context: RouteContext): Promise<Response> {
   try {
-    const { key } = await context.params;
-    const storageKey = key.join('/');
+    const parsed = storageKeySchema.safeParse((await context.params).key);
+    if (!parsed.success) throw notFound('That file does not exist.');
+    const storageKey = parsed.data.join('/');
 
     const [found] = await db
       .select()
       .from(schema.attachment)
       .where(eq(schema.attachment.storageKey, storageKey))
       .limit(1);
-    const record = await assertReadable(found);
+    const { record, shared } = await assertReadable(found);
 
     const url = await storageDriver().getUrl(storageKey, DOWNLOAD_URL_TTL_SECONDS, {
       contentType: record.contentType,
@@ -45,7 +60,9 @@ export async function GET(_request: Request, context: RouteContext): Promise<Res
       status: 302,
       headers: {
         location: url,
-        'cache-control': `private, max-age=${REDIRECT_CACHE_SECONDS}`,
+        'cache-control': shared
+          ? `private, max-age=${PUBLIC_REDIRECT_CACHE_SECONDS}`
+          : 'private, no-store',
       },
     });
   } catch (error: unknown) {

--- a/apps/web/src/app/api/issues/summary/route.ts
+++ b/apps/web/src/app/api/issues/summary/route.ts
@@ -1,0 +1,32 @@
+import { getIssueSummary } from '@orbit/core';
+import { GROUP_BY_FIELDS } from '@orbit/shared/filters';
+import { issueFilterSchema } from '@orbit/shared/validators';
+import { z } from 'zod';
+import { handle, searchParamsOf } from '@/lib/api/handler.ts';
+
+const FACET_GROUPS = new Set<string>([
+  'state',
+  'assignee',
+  'creator',
+  'priority',
+  'estimate',
+  'label',
+  'project',
+  'cycle',
+  'milestone',
+]);
+
+const summaryQuerySchema = issueFilterSchema.extend({
+  groupBy: z
+    .enum(GROUP_BY_FIELDS)
+    .optional()
+    .transform((value) => (value !== undefined && FACET_GROUPS.has(value) ? value : 'state')),
+});
+
+export async function GET(request: Request): Promise<Response> {
+  return await handle(async (principal) => {
+    const params = searchParamsOf(request);
+    const filter = summaryQuerySchema.parse(params);
+    return await getIssueSummary(principal, filter);
+  });
+}

--- a/apps/web/src/app/api/standups/[id]/advance/route.ts
+++ b/apps/web/src/app/api/standups/[id]/advance/route.ts
@@ -1,12 +1,12 @@
 import { advanceStandup } from '@orbit/core';
-import { handle, publish, readJson } from '@/lib/api/handler.ts';
+import { handle, publish, readJson, routeId } from '@/lib/api/handler.ts';
 
 interface RouteContext {
   readonly params: Promise<{ id: string }>;
 }
 
 export async function POST(request: Request, context: RouteContext): Promise<Response> {
-  const { id } = await context.params;
+  const id = routeId((await context.params).id, 'standup');
   const body = await readJson(request);
   return await handle(async (principal) => {
     const result = await advanceStandup(principal, id, body);

--- a/apps/web/src/app/api/standups/[id]/advance/route.ts
+++ b/apps/web/src/app/api/standups/[id]/advance/route.ts
@@ -1,0 +1,16 @@
+import { advanceStandup } from '@orbit/core';
+import { handle, publish, readJson } from '@/lib/api/handler.ts';
+
+interface RouteContext {
+  readonly params: Promise<{ id: string }>;
+}
+
+export async function POST(request: Request, context: RouteContext): Promise<Response> {
+  const { id } = await context.params;
+  const body = await readJson(request);
+  return await handle(async (principal) => {
+    const result = await advanceStandup(principal, id, body);
+    await publish(result.actions);
+    return result.detail;
+  });
+}

--- a/apps/web/src/app/api/standups/[id]/advance/route.ts
+++ b/apps/web/src/app/api/standups/[id]/advance/route.ts
@@ -6,9 +6,9 @@ interface RouteContext {
 }
 
 export async function POST(request: Request, context: RouteContext): Promise<Response> {
-  const id = routeId((await context.params).id, 'standup');
-  const body = await readJson(request);
   return await handle(async (principal) => {
+    const id = routeId((await context.params).id, 'standup');
+    const body = await readJson(request);
     const result = await advanceStandup(principal, id, body);
     await publish(result.actions);
     return result.detail;

--- a/apps/web/src/app/api/standups/[id]/focus/route.ts
+++ b/apps/web/src/app/api/standups/[id]/focus/route.ts
@@ -1,0 +1,16 @@
+import { focusTurn } from '@orbit/core';
+import { handle, publish, readJson } from '@/lib/api/handler.ts';
+
+interface RouteContext {
+  readonly params: Promise<{ id: string }>;
+}
+
+export async function POST(request: Request, context: RouteContext): Promise<Response> {
+  const { id } = await context.params;
+  const body = await readJson(request);
+  return await handle(async (principal) => {
+    const result = await focusTurn(principal, id, body);
+    await publish(result.actions);
+    return result.detail;
+  });
+}

--- a/apps/web/src/app/api/standups/[id]/focus/route.ts
+++ b/apps/web/src/app/api/standups/[id]/focus/route.ts
@@ -1,12 +1,12 @@
 import { focusTurn } from '@orbit/core';
-import { handle, publish, readJson } from '@/lib/api/handler.ts';
+import { handle, publish, readJson, routeId } from '@/lib/api/handler.ts';
 
 interface RouteContext {
   readonly params: Promise<{ id: string }>;
 }
 
 export async function POST(request: Request, context: RouteContext): Promise<Response> {
-  const { id } = await context.params;
+  const id = routeId((await context.params).id, 'standup');
   const body = await readJson(request);
   return await handle(async (principal) => {
     const result = await focusTurn(principal, id, body);

--- a/apps/web/src/app/api/standups/[id]/focus/route.ts
+++ b/apps/web/src/app/api/standups/[id]/focus/route.ts
@@ -6,9 +6,9 @@ interface RouteContext {
 }
 
 export async function POST(request: Request, context: RouteContext): Promise<Response> {
-  const id = routeId((await context.params).id, 'standup');
-  const body = await readJson(request);
   return await handle(async (principal) => {
+    const id = routeId((await context.params).id, 'standup');
+    const body = await readJson(request);
     const result = await focusTurn(principal, id, body);
     await publish(result.actions);
     return result.detail;

--- a/apps/web/src/app/api/standups/[id]/route.ts
+++ b/apps/web/src/app/api/standups/[id]/route.ts
@@ -6,14 +6,16 @@ interface RouteContext {
 }
 
 export async function GET(_request: Request, context: RouteContext): Promise<Response> {
-  const id = routeId((await context.params).id, 'standup');
-  return await handle(async (principal) => await getStandup(principal, id));
+  return await handle(async (principal) => {
+    const id = routeId((await context.params).id, 'standup');
+    return await getStandup(principal, id);
+  });
 }
 
 export async function PATCH(request: Request, context: RouteContext): Promise<Response> {
-  const id = routeId((await context.params).id, 'standup');
-  const body = await readJson(request);
   return await handle(async (principal) => {
+    const id = routeId((await context.params).id, 'standup');
+    const body = await readJson(request);
     const result = await updateStandup(principal, id, body);
     await publish(result.actions);
     return result.detail;

--- a/apps/web/src/app/api/standups/[id]/route.ts
+++ b/apps/web/src/app/api/standups/[id]/route.ts
@@ -1,17 +1,17 @@
 import { getStandup, updateStandup } from '@orbit/core';
-import { handle, publish, readJson } from '@/lib/api/handler.ts';
+import { handle, publish, readJson, routeId } from '@/lib/api/handler.ts';
 
 interface RouteContext {
   readonly params: Promise<{ id: string }>;
 }
 
 export async function GET(_request: Request, context: RouteContext): Promise<Response> {
-  const { id } = await context.params;
+  const id = routeId((await context.params).id, 'standup');
   return await handle(async (principal) => await getStandup(principal, id));
 }
 
 export async function PATCH(request: Request, context: RouteContext): Promise<Response> {
-  const { id } = await context.params;
+  const id = routeId((await context.params).id, 'standup');
   const body = await readJson(request);
   return await handle(async (principal) => {
     const result = await updateStandup(principal, id, body);

--- a/apps/web/src/app/api/standups/[id]/route.ts
+++ b/apps/web/src/app/api/standups/[id]/route.ts
@@ -1,0 +1,21 @@
+import { getStandup, updateStandup } from '@orbit/core';
+import { handle, publish, readJson } from '@/lib/api/handler.ts';
+
+interface RouteContext {
+  readonly params: Promise<{ id: string }>;
+}
+
+export async function GET(_request: Request, context: RouteContext): Promise<Response> {
+  const { id } = await context.params;
+  return await handle(async (principal) => await getStandup(principal, id));
+}
+
+export async function PATCH(request: Request, context: RouteContext): Promise<Response> {
+  const { id } = await context.params;
+  const body = await readJson(request);
+  return await handle(async (principal) => {
+    const result = await updateStandup(principal, id, body);
+    await publish(result.actions);
+    return result.detail;
+  });
+}

--- a/apps/web/src/app/api/standups/[id]/start/route.ts
+++ b/apps/web/src/app/api/standups/[id]/start/route.ts
@@ -1,12 +1,12 @@
 import { startStandup } from '@orbit/core';
-import { handle, publish } from '@/lib/api/handler.ts';
+import { handle, publish, routeId } from '@/lib/api/handler.ts';
 
 interface RouteContext {
   readonly params: Promise<{ id: string }>;
 }
 
 export async function POST(_request: Request, context: RouteContext): Promise<Response> {
-  const { id } = await context.params;
+  const id = routeId((await context.params).id, 'standup');
   return await handle(async (principal) => {
     const result = await startStandup(principal, id);
     await publish(result.actions);

--- a/apps/web/src/app/api/standups/[id]/start/route.ts
+++ b/apps/web/src/app/api/standups/[id]/start/route.ts
@@ -1,0 +1,15 @@
+import { startStandup } from '@orbit/core';
+import { handle, publish } from '@/lib/api/handler.ts';
+
+interface RouteContext {
+  readonly params: Promise<{ id: string }>;
+}
+
+export async function POST(_request: Request, context: RouteContext): Promise<Response> {
+  const { id } = await context.params;
+  return await handle(async (principal) => {
+    const result = await startStandup(principal, id);
+    await publish(result.actions);
+    return result.detail;
+  });
+}

--- a/apps/web/src/app/api/standups/[id]/start/route.ts
+++ b/apps/web/src/app/api/standups/[id]/start/route.ts
@@ -6,8 +6,8 @@ interface RouteContext {
 }
 
 export async function POST(_request: Request, context: RouteContext): Promise<Response> {
-  const id = routeId((await context.params).id, 'standup');
   return await handle(async (principal) => {
+    const id = routeId((await context.params).id, 'standup');
     const result = await startStandup(principal, id);
     await publish(result.actions);
     return result.detail;

--- a/apps/web/src/app/api/standups/[id]/turns/[turnId]/blockers/route.ts
+++ b/apps/web/src/app/api/standups/[id]/turns/[turnId]/blockers/route.ts
@@ -1,0 +1,16 @@
+import { addBlocker } from '@orbit/core';
+import { handle, publish, readJson } from '@/lib/api/handler.ts';
+
+interface RouteContext {
+  readonly params: Promise<{ id: string; turnId: string }>;
+}
+
+export async function POST(request: Request, context: RouteContext): Promise<Response> {
+  const { id, turnId } = await context.params;
+  const body = await readJson(request);
+  return await handle(async (principal) => {
+    const result = await addBlocker(principal, id, turnId, body);
+    await publish(result.actions);
+    return result.detail;
+  });
+}

--- a/apps/web/src/app/api/standups/[id]/turns/[turnId]/blockers/route.ts
+++ b/apps/web/src/app/api/standups/[id]/turns/[turnId]/blockers/route.ts
@@ -1,12 +1,14 @@
 import { addBlocker } from '@orbit/core';
-import { handle, publish, readJson } from '@/lib/api/handler.ts';
+import { handle, publish, readJson, routeId } from '@/lib/api/handler.ts';
 
 interface RouteContext {
   readonly params: Promise<{ id: string; turnId: string }>;
 }
 
 export async function POST(request: Request, context: RouteContext): Promise<Response> {
-  const { id, turnId } = await context.params;
+  const { id: rawId, turnId: rawTurnId } = await context.params;
+  const id = routeId(rawId, 'standup');
+  const turnId = routeId(rawTurnId, 'turn');
   const body = await readJson(request);
   return await handle(async (principal) => {
     const result = await addBlocker(principal, id, turnId, body);

--- a/apps/web/src/app/api/standups/[id]/turns/[turnId]/blockers/route.ts
+++ b/apps/web/src/app/api/standups/[id]/turns/[turnId]/blockers/route.ts
@@ -6,11 +6,11 @@ interface RouteContext {
 }
 
 export async function POST(request: Request, context: RouteContext): Promise<Response> {
-  const { id: rawId, turnId: rawTurnId } = await context.params;
-  const id = routeId(rawId, 'standup');
-  const turnId = routeId(rawTurnId, 'turn');
-  const body = await readJson(request);
   return await handle(async (principal) => {
+    const { id: rawId, turnId: rawTurnId } = await context.params;
+    const id = routeId(rawId, 'standup');
+    const turnId = routeId(rawTurnId, 'turn');
+    const body = await readJson(request);
     const result = await addBlocker(principal, id, turnId, body);
     await publish(result.actions);
     return result.detail;

--- a/apps/web/src/app/api/standups/[id]/turns/[turnId]/route.ts
+++ b/apps/web/src/app/api/standups/[id]/turns/[turnId]/route.ts
@@ -1,12 +1,14 @@
 import { updateTurn } from '@orbit/core';
-import { handle, publish, readJson } from '@/lib/api/handler.ts';
+import { handle, publish, readJson, routeId } from '@/lib/api/handler.ts';
 
 interface RouteContext {
   readonly params: Promise<{ id: string; turnId: string }>;
 }
 
 export async function PATCH(request: Request, context: RouteContext): Promise<Response> {
-  const { id, turnId } = await context.params;
+  const { id: rawId, turnId: rawTurnId } = await context.params;
+  const id = routeId(rawId, 'standup');
+  const turnId = routeId(rawTurnId, 'turn');
   const body = await readJson(request);
   return await handle(async (principal) => {
     const result = await updateTurn(principal, id, turnId, body);

--- a/apps/web/src/app/api/standups/[id]/turns/[turnId]/route.ts
+++ b/apps/web/src/app/api/standups/[id]/turns/[turnId]/route.ts
@@ -1,0 +1,16 @@
+import { updateTurn } from '@orbit/core';
+import { handle, publish, readJson } from '@/lib/api/handler.ts';
+
+interface RouteContext {
+  readonly params: Promise<{ id: string; turnId: string }>;
+}
+
+export async function PATCH(request: Request, context: RouteContext): Promise<Response> {
+  const { id, turnId } = await context.params;
+  const body = await readJson(request);
+  return await handle(async (principal) => {
+    const result = await updateTurn(principal, id, turnId, body);
+    await publish(result.actions);
+    return result.detail;
+  });
+}

--- a/apps/web/src/app/api/standups/[id]/turns/[turnId]/route.ts
+++ b/apps/web/src/app/api/standups/[id]/turns/[turnId]/route.ts
@@ -6,11 +6,11 @@ interface RouteContext {
 }
 
 export async function PATCH(request: Request, context: RouteContext): Promise<Response> {
-  const { id: rawId, turnId: rawTurnId } = await context.params;
-  const id = routeId(rawId, 'standup');
-  const turnId = routeId(rawTurnId, 'turn');
-  const body = await readJson(request);
   return await handle(async (principal) => {
+    const { id: rawId, turnId: rawTurnId } = await context.params;
+    const id = routeId(rawId, 'standup');
+    const turnId = routeId(rawTurnId, 'turn');
+    const body = await readJson(request);
     const result = await updateTurn(principal, id, turnId, body);
     await publish(result.actions);
     return result.detail;

--- a/apps/web/src/app/api/standups/blockers/[blockerId]/route.ts
+++ b/apps/web/src/app/api/standups/blockers/[blockerId]/route.ts
@@ -7,11 +7,11 @@ interface RouteContext {
 }
 
 export async function PATCH(request: Request, context: RouteContext): Promise<Response> {
-  const blockerId = routeId((await context.params).blockerId, 'blocker');
-  const standupId = searchParamsOf(request)['standupId'];
-  if (standupId === undefined) throw validationFailed('A standupId is required.');
-  const body = await readJson(request);
   return await handle(async (principal) => {
+    const blockerId = routeId((await context.params).blockerId, 'blocker');
+    const standupId = searchParamsOf(request)['standupId'];
+    if (standupId === undefined) throw validationFailed('A standupId is required.');
+    const body = await readJson(request);
     const result = await resolveBlocker(principal, standupId, blockerId, body);
     await publish(result.actions);
     return result.detail;

--- a/apps/web/src/app/api/standups/blockers/[blockerId]/route.ts
+++ b/apps/web/src/app/api/standups/blockers/[blockerId]/route.ts
@@ -1,13 +1,13 @@
 import { resolveBlocker } from '@orbit/core';
 import { validationFailed } from '@orbit/shared/errors';
-import { handle, publish, readJson, searchParamsOf } from '@/lib/api/handler.ts';
+import { handle, publish, readJson, routeId, searchParamsOf } from '@/lib/api/handler.ts';
 
 interface RouteContext {
   readonly params: Promise<{ blockerId: string }>;
 }
 
 export async function PATCH(request: Request, context: RouteContext): Promise<Response> {
-  const { blockerId } = await context.params;
+  const blockerId = routeId((await context.params).blockerId, 'blocker');
   const standupId = searchParamsOf(request)['standupId'];
   if (standupId === undefined) throw validationFailed('A standupId is required.');
   const body = await readJson(request);

--- a/apps/web/src/app/api/standups/blockers/[blockerId]/route.ts
+++ b/apps/web/src/app/api/standups/blockers/[blockerId]/route.ts
@@ -1,0 +1,19 @@
+import { resolveBlocker } from '@orbit/core';
+import { validationFailed } from '@orbit/shared/errors';
+import { handle, publish, readJson, searchParamsOf } from '@/lib/api/handler.ts';
+
+interface RouteContext {
+  readonly params: Promise<{ blockerId: string }>;
+}
+
+export async function PATCH(request: Request, context: RouteContext): Promise<Response> {
+  const { blockerId } = await context.params;
+  const standupId = searchParamsOf(request)['standupId'];
+  if (standupId === undefined) throw validationFailed('A standupId is required.');
+  const body = await readJson(request);
+  return await handle(async (principal) => {
+    const result = await resolveBlocker(principal, standupId, blockerId, body);
+    await publish(result.actions);
+    return result.detail;
+  });
+}

--- a/apps/web/src/app/api/standups/rotation/route.ts
+++ b/apps/web/src/app/api/standups/rotation/route.ts
@@ -1,0 +1,16 @@
+import { getRotation, setRotation } from '@orbit/core';
+import { validationFailed } from '@orbit/shared/errors';
+import { handle, readJson, searchParamsOf } from '@/lib/api/handler.ts';
+
+export async function GET(request: Request): Promise<Response> {
+  return await handle(async (principal) => {
+    const teamId = searchParamsOf(request)['teamId'];
+    if (teamId === undefined) throw validationFailed('A teamId is required.');
+    return { rotation: await getRotation(principal, teamId) };
+  });
+}
+
+export async function PUT(request: Request): Promise<Response> {
+  const body = await readJson(request);
+  return await handle(async (principal) => ({ rotation: await setRotation(principal, body) }));
+}

--- a/apps/web/src/app/api/standups/route.ts
+++ b/apps/web/src/app/api/standups/route.ts
@@ -1,0 +1,30 @@
+import { findStandup, listStandups, openStandup, standupWorkload, today } from '@orbit/core';
+import { handle, publish, readJson, searchParamsOf } from '@/lib/api/handler.ts';
+
+export async function GET(request: Request): Promise<Response> {
+  return await handle(async (principal) => {
+    const params = searchParamsOf(request);
+    const teamId = params['teamId'];
+    if (teamId !== undefined && params['heldOn'] !== undefined) {
+      return { standup: await findStandup(principal, teamId, params['heldOn']) };
+    }
+    if (teamId !== undefined && params['view'] === 'today') {
+      const since = new Date(Date.now() - 86_400_000);
+      const [standup, workload] = await Promise.all([
+        findStandup(principal, teamId, today()),
+        standupWorkload(principal, teamId, since),
+      ]);
+      return { standup, workload };
+    }
+    return { standups: await listStandups(principal, params) };
+  });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const body = await readJson(request);
+  return await handle(async (principal) => {
+    const result = await openStandup(principal, body);
+    await publish(result.actions);
+    return result.detail;
+  });
+}

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -2,7 +2,7 @@
 
 import { Command } from 'cmdk';
 import type { LucideIcon } from 'lucide-react';
-import { ArrowRight, CircleDot, Search, SlidersHorizontal, Terminal } from 'lucide-react';
+import { ArrowRight, CircleDot, Search, SlidersHorizontal, Terminal, Users } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useTheme } from 'next-themes';
 import { useMemo } from 'react';
@@ -25,6 +25,7 @@ const SECTION_ICONS: Record<HotkeySection, LucideIcon> = {
   Navigation: ArrowRight,
   Issues: CircleDot,
   View: SlidersHorizontal,
+  Standup: Users,
   General: Terminal,
 };
 

--- a/apps/web/src/features/analytics/data.ts
+++ b/apps/web/src/features/analytics/data.ts
@@ -21,7 +21,7 @@ import {
   type VelocityPoint,
   workDistribution,
 } from '@orbit/core';
-import { and, db, desc, eq, isNull, schema } from '@orbit/db';
+import { and, db, desc, eq, inArray, isNull, type SQL, schema, sql } from '@orbit/db';
 import { notFound } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan } from '@orbit/shared/policy';
@@ -38,6 +38,12 @@ export interface CycleOption {
 function estimateName(key: string): string {
   if (key === 'none' || key === '0') return 'No estimate';
   return `${key} pt${key === '1' ? '' : 's'}`;
+}
+
+function visibleCycleTeams(principal: Principal): SQL | undefined {
+  if (principal.role === 'admin') return undefined;
+  if (principal.teamIds.length === 0) return sql`false`;
+  return inArray(schema.cycle.teamId, [...principal.teamIds]);
 }
 
 export async function loadCycleOptions(
@@ -60,6 +66,7 @@ export async function loadCycleOptions(
       and(
         eq(schema.cycle.organizationId, principal.organizationId),
         isNull(schema.cycle.archivedAt),
+        visibleCycleTeams(principal),
       ),
     )
     .orderBy(desc(schema.cycle.startsAt))

--- a/apps/web/src/features/docs/doc-surface.tsx
+++ b/apps/web/src/features/docs/doc-surface.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useScopeSubscription } from '@orbit/realtime-client/react';
+import { scopes } from '@orbit/shared/events';
 import { Archive, Check, FolderInput, Indent, PanelLeft, Pencil, Search } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import {
@@ -98,6 +100,8 @@ function useDocList() {
 
 export function DocSurface(props: DocSurfaceProps) {
   const detail = useDoc(props.docId);
+  const docScopes = useMemo(() => [scopes.doc(props.docId)], [props.docId]);
+  useScopeSubscription(docScopes);
 
   if (detail.isPending) {
     return (

--- a/apps/web/src/features/docs/editor/extensions.ts
+++ b/apps/web/src/features/docs/editor/extensions.ts
@@ -90,7 +90,7 @@ export function editorExtensions(handler: MenuKeyHandlerRef, placeholder = '') {
     StarterKit.configure({
       codeBlock: false,
       link: { openOnClick: false, autolink: true },
-      heading: { levels: [1, 2, 3, 4] },
+      heading: { levels: [1, 2, 3, 4, 5, 6] },
     }),
     Highlight,
     CodeBlockLowlight.configure({ lowlight, defaultLanguage: 'ts' }),

--- a/apps/web/src/features/docs/editor/markdown.test.ts
+++ b/apps/web/src/features/docs/editor/markdown.test.ts
@@ -46,6 +46,24 @@ describe('a document survives being edited', () => {
     expect(docToMarkdown(doc)).toBe('One\n\nTwo\n');
   });
 
+  it('fences a block that itself contains a fence, so nothing leaks out', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'codeBlock',
+          attrs: { language: 'md' },
+          content: [{ type: 'text', text: 'Example:\n\n```\ninner\n```\n\n\ndone' }],
+        },
+      ],
+    };
+    const markdown = docToMarkdown(doc);
+    expect(markdown.startsWith('````md\n')).toBe(true);
+    expect(markdown).toContain('```\ninner\n```');
+    expect(markdown).toContain('\n\n\ndone');
+    expect(markdown.trimEnd().endsWith('````')).toBe(true);
+  });
+
   it('keeps every heading level the sanitizer allows', () => {
     for (const level of [1, 2, 3, 4, 5, 6]) {
       const doc: JSONContent = {

--- a/apps/web/src/features/docs/editor/markdown.test.ts
+++ b/apps/web/src/features/docs/editor/markdown.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'bun:test';
+import type { JSONContent } from '@tiptap/core';
+import { docToMarkdown } from './markdown.ts';
+
+describe('a document survives being edited', () => {
+  it('keeps blank lines inside a code fence, which are code', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'codeBlock',
+          attrs: { language: 'ts' },
+          content: [{ type: 'text', text: 'const a = 1;\n\n\n\nconst b = 2;' }],
+        },
+      ],
+    };
+    expect(docToMarkdown(doc)).toBe('```ts\nconst a = 1;\n\n\n\nconst b = 2;\n```\n');
+  });
+
+  it('keeps a fence intact when prose surrounds it', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'Before' }] },
+        {
+          type: 'codeBlock',
+          attrs: { language: null },
+          content: [{ type: 'text', text: 'a\n\n\nb' }],
+        },
+        { type: 'paragraph', content: [{ type: 'text', text: 'After' }] },
+      ],
+    };
+    expect(docToMarkdown(doc)).toBe('Before\n\n```\na\n\n\nb\n```\n\nAfter\n');
+  });
+
+  it('still collapses runs of blank lines between prose blocks', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'One' }] },
+        { type: 'paragraph' },
+        { type: 'paragraph' },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Two' }] },
+      ],
+    };
+    expect(docToMarkdown(doc)).toBe('One\n\nTwo\n');
+  });
+
+  it('keeps every heading level the sanitizer allows', () => {
+    for (const level of [1, 2, 3, 4, 5, 6]) {
+      const doc: JSONContent = {
+        type: 'doc',
+        content: [
+          { type: 'heading', attrs: { level }, content: [{ type: 'text', text: 'Title' }] },
+        ],
+      };
+      expect(docToMarkdown(doc)).toBe(`${'#'.repeat(level)} Title\n`);
+    }
+  });
+});

--- a/apps/web/src/features/docs/editor/markdown.ts
+++ b/apps/web/src/features/docs/editor/markdown.ts
@@ -198,6 +198,16 @@ function blocksOf(nodes: readonly JSONContent[] | undefined, separator: string):
     .join(separator);
 }
 
+const FENCE = /^```[^\n]*\n[\s\S]*?\n```$/;
+
+function collapseOutsideFences(markdown: string): string {
+  return markdown
+    .split(/(^```[^\n]*\n[\s\S]*?\n```$)/m)
+    .map((part) => (FENCE.test(part) ? part : part.replace(/\n{3,}/g, '\n\n')))
+    .join('');
+}
+
 export function docToMarkdown(doc: JSONContent): string {
-  return `${blocksOf(doc.content, '\n\n')}\n`.replace(/\n{3,}/g, '\n\n').replace(/^\n+/, '');
+  const body = `${blocksOf(doc.content, '\n\n')}\n`;
+  return collapseOutsideFences(body).replace(/^\n+/, '');
 }

--- a/apps/web/src/features/docs/editor/markdown.ts
+++ b/apps/web/src/features/docs/editor/markdown.ts
@@ -155,7 +155,8 @@ function blockOf(node: JSONContent): string {
         .map((child) => child.text ?? '')
         .join('')
         .replace(/\n+$/, '');
-      return `\`\`\`${language}\n${text}\n\`\`\``;
+      const fence = '`'.repeat(longestBacktickRun(text) + 1);
+      return `${fence}${language}\n${text}\n${fence}`;
     }
     case 'horizontalRule':
       return '---';
@@ -198,16 +199,19 @@ function blocksOf(nodes: readonly JSONContent[] | undefined, separator: string):
     .join(separator);
 }
 
-const FENCE = /^```[^\n]*\n[\s\S]*?\n```$/;
+function longestBacktickRun(text: string): number {
+  let longest = 2;
+  for (const run of text.match(/`+/g) ?? []) longest = Math.max(longest, run.length);
+  return longest;
+}
 
-function collapseOutsideFences(markdown: string): string {
-  return markdown
-    .split(/(^```[^\n]*\n[\s\S]*?\n```$)/m)
-    .map((part) => (FENCE.test(part) ? part : part.replace(/\n{3,}/g, '\n\n')))
-    .join('');
+function tidy(node: JSONContent, markdown: string): string {
+  return node.type === 'codeBlock' ? markdown : markdown.replace(/\n{3,}/g, '\n\n');
 }
 
 export function docToMarkdown(doc: JSONContent): string {
-  const body = `${blocksOf(doc.content, '\n\n')}\n`;
-  return collapseOutsideFences(body).replace(/^\n+/, '');
+  const blocks = (doc.content ?? [])
+    .map((node) => tidy(node, blockOf(node)))
+    .filter((block) => block.length > 0);
+  return `${blocks.join('\n\n')}\n`.replace(/^\n+/, '');
 }

--- a/apps/web/src/features/filters/filter-bar.tsx
+++ b/apps/web/src/features/filters/filter-bar.tsx
@@ -7,7 +7,7 @@ import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
 import { HOTKEY_PRIORITY, useHotkey } from '@/lib/keyboard/index.ts';
-import type { Issue, View } from '@/lib/query/schemas.ts';
+import type { IssueSummary, View } from '@/lib/query/schemas.ts';
 import { useUpdateView } from '@/lib/query/use-views.ts';
 import { DisplayMenu } from './display-menu.tsx';
 import type { FilterFieldDefinition } from './filter-fields.tsx';
@@ -27,7 +27,7 @@ export interface FilterBarProps {
   readonly config: ViewConfig;
   readonly onChange: (next: ViewConfig) => void;
   readonly controls: ViewControls;
-  readonly issues?: readonly Issue[];
+  readonly facets?: IssueSummary['facets'] | undefined;
   readonly savedView?: View | null;
   readonly dirty?: boolean;
   readonly showSaveView?: boolean;
@@ -40,7 +40,7 @@ export function FilterBar({
   config,
   onChange,
   controls,
-  issues = [],
+  facets,
   savedView = null,
   dirty = false,
   showSaveView = true,
@@ -111,7 +111,7 @@ export function FilterBar({
           onOpenChange={(open) => setTarget(open ? condition.property : null)}
           fields={fields}
           filter={config.filter}
-          issues={issues}
+          facets={facets}
           onChange={setFilter}
           onRemove={() => setFilter(removeCondition(config.filter, condition.property))}
         />
@@ -122,7 +122,7 @@ export function FilterBar({
         onOpenChange={(open) => setTarget(open ? 'new' : null)}
         fields={fields}
         filter={config.filter}
-        issues={issues}
+        facets={facets}
         onChange={setFilter}
         anchor={
           <Button
@@ -229,7 +229,7 @@ interface FilterChipProps {
   readonly onOpenChange: (open: boolean) => void;
   readonly fields: readonly FilterFieldDefinition[];
   readonly filter: FilterGroup;
-  readonly issues: readonly Issue[];
+  readonly facets: IssueSummary['facets'] | undefined;
   readonly onChange: (next: FilterGroup) => void;
   readonly onRemove: () => void;
 }
@@ -241,7 +241,7 @@ function FilterChip({
   onOpenChange,
   fields,
   filter,
-  issues,
+  facets,
   onChange,
   onRemove,
 }: FilterChipProps) {
@@ -259,7 +259,7 @@ function FilterChip({
         onOpenChange={onOpenChange}
         fields={fields}
         filter={filter}
-        issues={issues}
+        facets={facets}
         onChange={onChange}
         startProperty={condition.property}
         anchor={

--- a/apps/web/src/features/filters/filter-fields.test.tsx
+++ b/apps/web/src/features/filters/filter-fields.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import type { Issue } from '@/lib/query/schemas.ts';
+import { emptyFacets, type IssueSummary } from '@/lib/query/schemas.ts';
 import { countValues, type FilterFieldDefinition } from './filter-fields.tsx';
 
 const labelDef = {
@@ -7,23 +7,38 @@ const labelDef = {
   input: 'values',
   label: 'Label',
   options: [],
-  countOf: (issue: Issue) => (Array.isArray(issue.labelIds) ? issue.labelIds : []),
+  facet: 'label',
 } as unknown as FilterFieldDefinition;
 
+const uncountedDef = {
+  property: 'content',
+  input: 'text',
+  label: 'Content',
+  options: [],
+  facet: null,
+} as unknown as FilterFieldDefinition;
+
+function facetsWith(label: Record<string, number>): IssueSummary['facets'] {
+  return { ...emptyFacets(), label };
+}
+
 describe('countValues', () => {
-  it('never throws when the issues argument is not an array', () => {
-    const infiniteDataShape = { pages: [], pageParams: [] } as unknown as readonly Issue[];
-    expect(countValues(labelDef, infiniteDataShape).size).toBe(0);
-    expect(countValues(labelDef, undefined as unknown as readonly Issue[]).size).toBe(0);
+  it('reads the counts the server measured over the whole scope', () => {
+    const counts = countValues(labelDef, facetsWith({ bug: 412, perf: 97 }));
+    expect(counts.get('bug')).toBe(412);
+    expect(counts.get('perf')).toBe(97);
   });
 
-  it('counts values for a normal issue array', () => {
-    const rows = [
-      { labelIds: ['bug'] },
-      { labelIds: ['bug', 'perf'] },
-    ] as unknown as readonly Issue[];
-    const counts = countValues(labelDef, rows);
-    expect(counts.get('bug')).toBe(2);
-    expect(counts.get('perf')).toBe(1);
+  it('returns nothing before the summary has loaded', () => {
+    expect(countValues(labelDef, undefined).size).toBe(0);
+  });
+
+  it('returns nothing for a field the server does not count', () => {
+    expect(countValues(uncountedDef, facetsWith({ bug: 3 })).size).toBe(0);
+  });
+
+  it('survives a facet the server omitted', () => {
+    const partial = { ...emptyFacets() } as unknown as IssueSummary['facets'];
+    expect(countValues(labelDef, partial).size).toBe(0);
   });
 });

--- a/apps/web/src/features/filters/filter-fields.tsx
+++ b/apps/web/src/features/filters/filter-fields.tsx
@@ -35,7 +35,7 @@ import { Avatar } from '@/components/ui/avatar.tsx';
 import { PriorityGlyph } from '@/features/issues/priority-glyph.tsx';
 import { StateGlyph } from '@/features/issues/state-glyph.tsx';
 import { statesForTeam, type WorkspaceData } from '@/features/issues/workspace-provider.tsx';
-import type { Issue } from '@/lib/query/schemas.ts';
+import type { FacetProperty, IssueSummary } from '@/lib/query/schemas.ts';
 import { PRIORITY_ORDER } from './grouping.ts';
 
 export interface FilterOption {
@@ -52,7 +52,7 @@ export interface FilterFieldDefinition {
   readonly icon: LucideIcon;
   readonly input: FilterInputKind;
   readonly options: readonly FilterOption[];
-  readonly countOf: ((issue: Issue) => readonly string[]) | null;
+  readonly facet: FacetProperty | null;
 }
 
 const FIELD_ICONS: Record<FilterProperty, LucideIcon> = {
@@ -137,10 +137,6 @@ function dateOptions(): FilterOption[] {
   }));
 }
 
-function idsOf(value: string | null): readonly string[] {
-  return [value ?? UNSET_FILTER_VALUE];
-}
-
 export function buildFilterFields(
   workspace: WorkspaceData,
   teamId: string | null,
@@ -167,25 +163,25 @@ export function buildFilterFields(
         label: state.name,
         icon: <StateGlyph category={state.category} color={state.color} />,
       })),
-      countOf: (issue) => [issue.stateId],
+      facet: 'state',
     },
     {
       property: 'assignee',
       input: 'values',
       options: [...people, unsetOption('No assignee')],
-      countOf: (issue) => idsOf(issue.assigneeId),
+      facet: 'assignee',
     },
     {
       property: 'creator',
       input: 'values',
       options: people,
-      countOf: (issue) => [issue.creatorId],
+      facet: 'creator',
     },
     {
       property: 'subscriber',
       input: 'values',
       options: [...people, unsetOption('No subscribers')],
-      countOf: null,
+      facet: null,
     },
     {
       property: 'priority',
@@ -195,7 +191,7 @@ export function buildFilterFields(
         label: PRIORITY_LABELS[priority],
         icon: <PriorityGlyph priority={priority} />,
       })),
-      countOf: (issue) => [String(issue.priority)],
+      facet: 'priority',
     },
     {
       property: 'estimate',
@@ -208,7 +204,7 @@ export function buildFilterFields(
           icon: glyph(Gauge),
         })),
       ],
-      countOf: (issue) => [issue.estimate === null ? UNSET_FILTER_VALUE : String(issue.estimate)],
+      facet: 'estimate',
     },
     {
       property: 'label',
@@ -221,10 +217,7 @@ export function buildFilterFields(
         })),
         unsetOption('No label'),
       ],
-      countOf: (issue) => {
-        const ids = Array.isArray(issue.labelIds) ? issue.labelIds : [];
-        return ids.length === 0 ? [UNSET_FILTER_VALUE] : ids;
-      },
+      facet: 'label',
     },
     {
       property: 'project',
@@ -237,7 +230,7 @@ export function buildFilterFields(
         })),
         unsetOption('No project'),
       ],
-      countOf: (issue) => idsOf(issue.projectId),
+      facet: 'project',
     },
     {
       property: 'cycle',
@@ -250,7 +243,7 @@ export function buildFilterFields(
         })),
         unsetOption('No cycle'),
       ],
-      countOf: (issue) => idsOf(issue.cycleId),
+      facet: 'cycle',
     },
     {
       property: 'milestone',
@@ -259,7 +252,7 @@ export function buildFilterFields(
         { value: 'any', label: 'Has a milestone', icon: glyph(Flag) },
         unsetOption('No milestone'),
       ],
-      countOf: (issue) => [issue.milestoneId === null ? UNSET_FILTER_VALUE : 'any'],
+      facet: 'milestone',
     },
     {
       property: 'relation',
@@ -269,7 +262,7 @@ export function buildFilterFields(
         label: RELATION_FILTER_LABELS[value],
         icon: glyph(Network),
       })),
-      countOf: null,
+      facet: null,
     },
     {
       property: 'link',
@@ -279,15 +272,15 @@ export function buildFilterFields(
         label: LINK_FILTER_LABELS[value],
         icon: glyph(Link2),
       })),
-      countOf: null,
+      facet: null,
     },
-    { property: 'content', input: 'text', options: [], countOf: null },
-    { property: 'due', input: 'dates', options: dateOptions(), countOf: null },
-    { property: 'created', input: 'dates', options: dateOptions(), countOf: null },
-    { property: 'updated', input: 'dates', options: dateOptions(), countOf: null },
-    { property: 'started', input: 'dates', options: dateOptions(), countOf: null },
-    { property: 'completed', input: 'dates', options: dateOptions(), countOf: null },
-    { property: 'stateAge', input: 'dates', options: dateOptions(), countOf: null },
+    { property: 'content', input: 'text', options: [], facet: null },
+    { property: 'due', input: 'dates', options: dateOptions(), facet: null },
+    { property: 'created', input: 'dates', options: dateOptions(), facet: null },
+    { property: 'updated', input: 'dates', options: dateOptions(), facet: null },
+    { property: 'started', input: 'dates', options: dateOptions(), facet: null },
+    { property: 'completed', input: 'dates', options: dateOptions(), facet: null },
+    { property: 'stateAge', input: 'dates', options: dateOptions(), facet: null },
   ];
 
   return definitions
@@ -300,20 +293,15 @@ export function buildFilterFields(
     .filter((definition) => definition.input !== 'values' || definition.options.length > 0);
 }
 
+const EMPTY_COUNTS: ReadonlyMap<string, number> = new Map();
+
 export function countValues(
   definition: FilterFieldDefinition,
-  issues: readonly Issue[],
+  facets: IssueSummary['facets'] | undefined,
 ): ReadonlyMap<string, number> {
-  const counts = new Map<string, number>();
-  const read = definition.countOf;
-  if (read === null) return counts;
-  const list: readonly Issue[] = Array.isArray(issues) ? issues : [];
-  for (const issue of list) {
-    const keys = read(issue);
-    if (!Array.isArray(keys)) continue;
-    for (const key of keys) counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-  return counts;
+  const property = definition.facet;
+  if (property === null || facets === undefined) return EMPTY_COUNTS;
+  return new Map(Object.entries(facets[property] ?? {}));
 }
 
 export function operatorLabel(condition: FilterCondition): string {

--- a/apps/web/src/features/filters/filter-menu.tsx
+++ b/apps/web/src/features/filters/filter-menu.tsx
@@ -8,7 +8,7 @@ import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover.tsx';
 import { cn } from '@/lib/cn.ts';
-import type { Issue } from '@/lib/query/schemas.ts';
+import type { IssueSummary } from '@/lib/query/schemas.ts';
 import type { FilterFieldDefinition } from './filter-fields.tsx';
 import { countValues, RELATIVE_PRESETS } from './filter-fields.tsx';
 
@@ -24,7 +24,7 @@ export interface FilterMenuProps {
   readonly fields: readonly FilterFieldDefinition[];
   readonly filter: FilterGroup;
   readonly onChange: (next: FilterGroup) => void;
-  readonly issues: readonly Issue[];
+  readonly facets: IssueSummary['facets'] | undefined;
   readonly startProperty?: FilterProperty | null;
   readonly anchor: ReactNode;
 }
@@ -35,7 +35,7 @@ export function FilterMenu({
   fields,
   filter,
   onChange,
-  issues,
+  facets,
   startProperty = null,
   anchor,
 }: FilterMenuProps) {
@@ -111,7 +111,7 @@ export function FilterMenu({
               <FieldPicker
                 fields={fields}
                 filter={filter}
-                issues={issues}
+                facets={facets}
                 searching={search.trim().length > 0}
                 onPickField={(next) => {
                   setSearch('');
@@ -123,7 +123,7 @@ export function FilterMenu({
               <ValuePicker
                 definition={active}
                 condition={conditionFor(filter, active.property)}
-                issues={issues}
+                facets={facets}
                 search={search}
                 onToggleValue={(value) => toggleValue(active.property, value)}
                 onToggleNegate={() => toggleNegate(active.property)}
@@ -140,7 +140,7 @@ export function FilterMenu({
 interface FieldPickerProps {
   readonly fields: readonly FilterFieldDefinition[];
   readonly filter: FilterGroup;
-  readonly issues: readonly Issue[];
+  readonly facets: IssueSummary['facets'] | undefined;
   readonly searching: boolean;
   readonly onPickField: (property: FilterProperty) => void;
   readonly onPickValue: (property: FilterProperty, value: string) => void;
@@ -149,7 +149,7 @@ interface FieldPickerProps {
 function FieldPicker({
   fields,
   filter,
-  issues,
+  facets,
   searching,
   onPickField,
   onPickValue,
@@ -191,7 +191,7 @@ function FieldPicker({
                 >
                   {option.icon}
                   <span className="flex-1 truncate">{option.label}</span>
-                  <ValueCount count={countValues(definition, issues).get(option.value)} />
+                  <ValueCount count={countValues(definition, facets).get(option.value)} />
                   <Selected
                     on={selectedValues(filter, definition.property).includes(option.value)}
                   />
@@ -212,7 +212,7 @@ function selectedValues(filter: FilterGroup, property: FilterProperty): readonly
 interface ValuePickerProps {
   readonly definition: FilterFieldDefinition;
   readonly condition: FilterCondition | undefined;
-  readonly issues: readonly Issue[];
+  readonly facets: IssueSummary['facets'] | undefined;
   readonly search: string;
   readonly onToggleValue: (value: string) => void;
   readonly onToggleNegate: () => void;
@@ -222,14 +222,14 @@ interface ValuePickerProps {
 function ValuePicker({
   definition,
   condition,
-  issues,
+  facets,
   search,
   onToggleValue,
   onToggleNegate,
   onCommit,
 }: ValuePickerProps) {
   const negated = condition?.negate === true;
-  const counts = countValues(definition, issues);
+  const counts = countValues(definition, facets);
   const chosen = condition?.operator === 'in' ? condition.values : [];
 
   return (

--- a/apps/web/src/features/filters/grouping.ts
+++ b/apps/web/src/features/filters/grouping.ts
@@ -27,6 +27,7 @@ export interface IssueSubGroup extends GroupDefinition {
 export interface IssueGroup extends GroupDefinition {
   readonly issues: readonly Issue[];
   readonly subGroups: readonly IssueSubGroup[];
+  readonly total: number;
 }
 
 export const PRIORITY_ORDER: readonly Priority[] = [1, 2, 3, 4, 0];
@@ -144,21 +145,56 @@ export interface GroupOptions {
   readonly showEmptyGroups: boolean;
   readonly ordering: IssueOrdering;
   readonly subGroupBy?: GroupByField;
+  readonly totals?: Readonly<Record<string, number>> | undefined;
+  readonly remap?: ReadonlyMap<string, string> | undefined;
 }
 
 function bucket(
   issues: readonly Issue[],
   groupBy: GroupByField,
+  remap: ReadonlyMap<string, string> | undefined,
 ): ReadonlyMap<string, readonly Issue[]> {
   const buckets = new Map<string, Issue[]>();
   for (const issue of issues) {
-    for (const key of groupKeysOf(issue, groupBy)) {
+    for (const raw of groupKeysOf(issue, groupBy)) {
+      const key = remap?.get(raw) ?? raw;
       const current = buckets.get(key);
       if (current === undefined) buckets.set(key, [issue]);
       else current.push(issue);
     }
   }
   return buckets;
+}
+
+export interface MergedStates {
+  readonly states: readonly WorkflowState[];
+  readonly idMap: ReadonlyMap<string, string>;
+}
+
+export function mergeStatesByName(states: readonly WorkflowState[]): MergedStates {
+  const canonical = new Map<string, WorkflowState>();
+  const idMap = new Map<string, string>();
+  for (const state of states) {
+    const key = `${state.category}:${state.name.trim().toLowerCase()}`;
+    const existing = canonical.get(key);
+    if (existing === undefined) canonical.set(key, { ...state, id: key });
+    idMap.set(state.id, key);
+  }
+  const merged = [...canonical.values()].sort((left, right) => left.position - right.position);
+  return { states: merged, idMap };
+}
+
+export function remapTotals(
+  totals: Readonly<Record<string, number>> | undefined,
+  idMap: ReadonlyMap<string, string>,
+): Record<string, number> | undefined {
+  if (totals === undefined) return undefined;
+  const merged: Record<string, number> = {};
+  for (const [id, value] of Object.entries(totals)) {
+    const key = idMap.get(id) ?? id;
+    merged[key] = (merged[key] ?? 0) + value;
+  }
+  return merged;
 }
 
 function definitionsWithExtras(
@@ -184,18 +220,19 @@ export function groupIssues(
   context: GroupContext,
   options: GroupOptions,
 ): IssueGroup[] {
-  const buckets = bucket(issues, groupBy);
+  const buckets = bucket(issues, groupBy, options.remap);
   const subGroupBy = options.subGroupBy ?? 'none';
 
   return definitionsWithExtras(groupBy, context, buckets.keys()).flatMap((definition) => {
     const rows = buckets.get(definition.id) ?? [];
-    if (rows.length === 0 && !options.showEmptyGroups) return [];
+    const total = options.totals?.[definition.id] ?? rows.length;
+    if (total === 0 && !options.showEmptyGroups) return [];
     const sorted = ordered(rows, options.ordering);
     const subGroups =
       subGroupBy === 'none' || subGroupBy === groupBy
         ? []
         : subGroupsOf(sorted, subGroupBy, context, options);
-    return [{ ...definition, issues: sorted, subGroups }];
+    return [{ ...definition, issues: sorted, subGroups, total }];
   });
 }
 
@@ -205,7 +242,7 @@ function subGroupsOf(
   context: GroupContext,
   options: GroupOptions,
 ): IssueSubGroup[] {
-  const buckets = bucket(issues, subGroupBy);
+  const buckets = bucket(issues, subGroupBy, options.remap);
   return definitionsWithExtras(subGroupBy, context, buckets.keys()).flatMap((definition) => {
     const rows = buckets.get(definition.id) ?? [];
     if (rows.length === 0) return [];

--- a/apps/web/src/features/filters/grouping.ts
+++ b/apps/web/src/features/filters/grouping.ts
@@ -226,7 +226,7 @@ export function groupIssues(
   return definitionsWithExtras(groupBy, context, buckets.keys()).flatMap((definition) => {
     const rows = buckets.get(definition.id) ?? [];
     const total = options.totals?.[definition.id] ?? rows.length;
-    if (total === 0 && !options.showEmptyGroups) return [];
+    if (total === 0 && rows.length === 0 && !options.showEmptyGroups) return [];
     const sorted = ordered(rows, options.ordering);
     const subGroups =
       subGroupBy === 'none' || subGroupBy === groupBy

--- a/apps/web/src/features/filters/use-view-config.test.tsx
+++ b/apps/web/src/features/filters/use-view-config.test.tsx
@@ -1,25 +1,21 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import { act, render } from '@testing-library/react';
 
-const replaced: string[] = [];
 let search = '';
 
 mock.module('next/navigation', () => ({
-  useRouter: () => ({
-    replace: (url: string) => {
-      replaced.push(url);
-    },
-    push: () => undefined,
-  }),
+  useRouter: () => ({ replace: () => undefined, push: () => undefined }),
   usePathname: () => '/team/eng/issues',
   useSearchParams: () => new URLSearchParams(search),
 }));
 
 const { URL_SYNC_DELAY_MS, useViewConfig } = await import('./use-view-config.ts');
 
+type Ordering = 'manual' | 'priority' | 'created' | 'updated';
+
 interface Captured {
   readonly orderBy: string;
-  readonly setOrderBy: (value: 'manual' | 'priority' | 'created') => void;
+  readonly setOrderBy: (value: Ordering) => void;
 }
 
 let captured: Captured | null = null;
@@ -39,10 +35,19 @@ async function wait(ms: number): Promise<void> {
   });
 }
 
+function urlSearch(): string {
+  return window.location.search.replace(/^\?/, '');
+}
+
+function setUrl(next: string): void {
+  search = next;
+  const target = next === '' ? '/team/eng/issues' : `/team/eng/issues?${next}`;
+  window.history.replaceState(null, '', target);
+}
+
 describe('useViewConfig url sync', () => {
   beforeEach(() => {
-    replaced.length = 0;
-    search = '';
+    setUrl('');
     captured = null;
     window.localStorage.clear();
   });
@@ -54,43 +59,82 @@ describe('useViewConfig url sync', () => {
     act(() => captured?.setOrderBy('priority'));
 
     expect(captured?.orderBy).toBe('priority');
-    expect(replaced).toHaveLength(0);
+    expect(urlSearch()).toBe('');
   });
 
-  it('collapses a burst of changes into a single navigation', async () => {
+  it('collapses a burst of changes into a single url write', async () => {
     render(<Harness />);
 
     act(() => captured?.setOrderBy('priority'));
     act(() => captured?.setOrderBy('created'));
-    act(() => captured?.setOrderBy('manual'));
-    expect(replaced).toHaveLength(0);
+    act(() => captured?.setOrderBy('updated'));
+    expect(urlSearch()).toBe('');
 
-    await wait(URL_SYNC_DELAY_MS + 60);
+    await wait(URL_SYNC_DELAY_MS + 80);
 
-    expect(replaced).toHaveLength(1);
-    expect(captured?.orderBy).toBe('manual');
+    expect(urlSearch()).toContain('order=updated');
+    expect(captured?.orderBy).toBe('updated');
   });
 
-  it('writes the final state into the url so the view stays shareable', async () => {
-    render(<Harness />);
-
-    act(() => captured?.setOrderBy('priority'));
-    await wait(URL_SYNC_DELAY_MS + 60);
-
-    expect(replaced[0]).toContain('/team/eng/issues');
-    expect(replaced[0]).toContain('order=priority');
-  });
-
-  it('lets the url win when the browser navigates during the debounce', async () => {
+  it('keeps an edit made while the previous write is still in flight', async () => {
     const { rerender } = render(<Harness />);
 
     act(() => captured?.setOrderBy('priority'));
-    search = 'order=created';
-    act(() => rerender(<Harness />));
+    await wait(URL_SYNC_DELAY_MS + 80);
+    expect(urlSearch()).toContain('order=priority');
 
-    await wait(URL_SYNC_DELAY_MS + 60);
+    act(() => captured?.setOrderBy('created'));
+    search = 'order=priority';
+    act(() => rerender(<Harness />));
+    expect(captured?.orderBy).toBe('created');
+
+    await wait(URL_SYNC_DELAY_MS + 80);
 
     expect(captured?.orderBy).toBe('created');
-    expect(replaced).toHaveLength(0);
+    expect(urlSearch()).toContain('order=created');
+  });
+
+  it('flushes a pending edit when the view unmounts', () => {
+    const { unmount } = render(<Harness />);
+
+    act(() => captured?.setOrderBy('priority'));
+    expect(urlSearch()).toBe('');
+
+    act(() => unmount());
+
+    expect(urlSearch()).toContain('order=priority');
+  });
+
+  it('lets a url the hook did not request win and cancels the pending write', async () => {
+    const { rerender } = render(<Harness />);
+
+    act(() => captured?.setOrderBy('priority'));
+    setUrl('order=created');
+    act(() => rerender(<Harness />));
+
+    expect(captured?.orderBy).toBe('created');
+    await wait(URL_SYNC_DELAY_MS + 80);
+    expect(urlSearch()).toContain('order=created');
+  });
+
+  it('carries the saved view parameter through every write', async () => {
+    setUrl('view=view_1');
+    render(<Harness />);
+
+    act(() => captured?.setOrderBy('priority'));
+    await wait(URL_SYNC_DELAY_MS + 80);
+
+    expect(urlSearch()).toContain('view=view_1');
+    expect(urlSearch()).toContain('order=priority');
+  });
+
+  it('writes nothing when the config already matches the url', async () => {
+    setUrl('order=priority');
+    render(<Harness />);
+
+    act(() => captured?.setOrderBy('priority'));
+    await wait(URL_SYNC_DELAY_MS + 80);
+
+    expect(urlSearch()).toBe('order=priority');
   });
 });

--- a/apps/web/src/features/filters/use-view-config.test.tsx
+++ b/apps/web/src/features/filters/use-view-config.test.tsx
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { act, render } from '@testing-library/react';
+
+const replaced: string[] = [];
+let search = '';
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({
+    replace: (url: string) => {
+      replaced.push(url);
+    },
+    push: () => undefined,
+  }),
+  usePathname: () => '/team/eng/issues',
+  useSearchParams: () => new URLSearchParams(search),
+}));
+
+const { URL_SYNC_DELAY_MS, useViewConfig } = await import('./use-view-config.ts');
+
+interface Captured {
+  readonly orderBy: string;
+  readonly setOrderBy: (value: 'manual' | 'priority' | 'created') => void;
+}
+
+let captured: Captured | null = null;
+
+function Harness() {
+  const { config, setConfig } = useViewConfig('team_1', 'list', 'team');
+  captured = {
+    orderBy: config.orderBy,
+    setOrderBy: (value) => setConfig({ ...config, orderBy: value }),
+  };
+  return null;
+}
+
+async function wait(ms: number): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  });
+}
+
+describe('useViewConfig url sync', () => {
+  beforeEach(() => {
+    replaced.length = 0;
+    search = '';
+    captured = null;
+    window.localStorage.clear();
+  });
+
+  it('applies a change immediately without waiting for a navigation', () => {
+    render(<Harness />);
+    expect(captured?.orderBy).toBe('manual');
+
+    act(() => captured?.setOrderBy('priority'));
+
+    expect(captured?.orderBy).toBe('priority');
+    expect(replaced).toHaveLength(0);
+  });
+
+  it('collapses a burst of changes into a single navigation', async () => {
+    render(<Harness />);
+
+    act(() => captured?.setOrderBy('priority'));
+    act(() => captured?.setOrderBy('created'));
+    act(() => captured?.setOrderBy('manual'));
+    expect(replaced).toHaveLength(0);
+
+    await wait(URL_SYNC_DELAY_MS + 60);
+
+    expect(replaced).toHaveLength(1);
+    expect(captured?.orderBy).toBe('manual');
+  });
+
+  it('writes the final state into the url so the view stays shareable', async () => {
+    render(<Harness />);
+
+    act(() => captured?.setOrderBy('priority'));
+    await wait(URL_SYNC_DELAY_MS + 60);
+
+    expect(replaced[0]).toContain('/team/eng/issues');
+    expect(replaced[0]).toContain('order=priority');
+  });
+
+  it('lets the url win when the browser navigates during the debounce', async () => {
+    const { rerender } = render(<Harness />);
+
+    act(() => captured?.setOrderBy('priority'));
+    search = 'order=created';
+    act(() => rerender(<Harness />));
+
+    await wait(URL_SYNC_DELAY_MS + 60);
+
+    expect(captured?.orderBy).toBe('created');
+    expect(replaced).toHaveLength(0);
+  });
+});

--- a/apps/web/src/features/filters/use-view-config.ts
+++ b/apps/web/src/features/filters/use-view-config.ts
@@ -8,7 +8,7 @@ import {
   ISSUE_ORDERINGS,
 } from '@orbit/shared/filters';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { z } from 'zod';
 import type { ViewConfig, ViewLayoutMode, ViewPage } from './view-config.ts';
 import {
@@ -100,6 +100,8 @@ export interface ViewConfigController {
   readonly setFilter: (next: FilterGroup) => void;
 }
 
+export const URL_SYNC_DELAY_MS = 300;
+
 export function useViewConfig(
   teamId: string | null,
   layout: ViewLayoutMode,
@@ -109,17 +111,40 @@ export function useViewConfig(
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [stored, setStored] = useState<StoredDisplay | null>(null);
+  const [pending, setPending] = useState<ViewConfig | null>(null);
+  const requestedSearch = useRef<string | null>(null);
+  const syncTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
     setStored(readStoredDisplay(teamId, layout));
   }, [teamId, layout]);
 
-  const config = useMemo(() => {
+  const fromUrl = useMemo(() => {
     const base = withStored(defaultViewConfig(layout), stored);
     const parsed = parseViewConfig(new URLSearchParams(searchParams.toString()), layout, base);
     return applyCapabilities(parsed, page, layout);
   }, [searchParams, layout, stored, page]);
 
+  const current = searchParams.toString();
+
+  useEffect(() => {
+    const requested = requestedSearch.current;
+    if (requested !== null && requested !== current && syncTimer.current !== undefined) {
+      clearTimeout(syncTimer.current);
+      syncTimer.current = undefined;
+    }
+    requestedSearch.current = null;
+    setPending(null);
+  }, [current]);
+
+  useEffect(
+    () => () => {
+      if (syncTimer.current !== undefined) clearTimeout(syncTimer.current);
+    },
+    [],
+  );
+
+  const config = pending ?? fromUrl;
   const carried = searchParams.get(VIEW_PARAM);
 
   const setConfig = useCallback(
@@ -127,8 +152,15 @@ export function useViewConfig(
       const sanitized = applyCapabilities(next, page, layout);
       writeStoredDisplay(teamId, layout, sanitized);
       setStored(toStored(sanitized));
+      setPending(sanitized);
+
       const search = withViewParam(viewConfigSearch(sanitized, layout), carried);
-      router.replace(`${pathname}${search}`, { scroll: false });
+      requestedSearch.current = search.replace(/^\?/, '');
+      if (syncTimer.current !== undefined) clearTimeout(syncTimer.current);
+      syncTimer.current = setTimeout(() => {
+        syncTimer.current = undefined;
+        router.replace(`${pathname}${search}`, { scroll: false });
+      }, URL_SYNC_DELAY_MS);
     },
     [router, pathname, teamId, layout, page, carried],
   );

--- a/apps/web/src/features/filters/use-view-config.ts
+++ b/apps/web/src/features/filters/use-view-config.ts
@@ -7,7 +7,7 @@ import {
   GROUP_BY_FIELDS,
   ISSUE_ORDERINGS,
 } from '@orbit/shared/filters';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { z } from 'zod';
 import type { ViewConfig, ViewLayoutMode, ViewPage } from './view-config.ts';
@@ -107,12 +107,12 @@ export function useViewConfig(
   layout: ViewLayoutMode,
   page: ViewPage = 'team',
 ): ViewConfigController {
-  const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [stored, setStored] = useState<StoredDisplay | null>(null);
   const [pending, setPending] = useState<ViewConfig | null>(null);
-  const requestedSearch = useRef<string | null>(null);
+  const syncedSearch = useRef(searchParams.toString());
+  const nextWrite = useRef<string | null>(null);
   const syncTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
@@ -127,22 +127,45 @@ export function useViewConfig(
 
   const current = searchParams.toString();
 
+  const write = useCallback(
+    (search: string) => {
+      syncTimer.current = undefined;
+      nextWrite.current = null;
+      syncedSearch.current = search.replace(/^\?/, '');
+      window.history.replaceState(null, '', `${pathname}${search}`);
+    },
+    [pathname],
+  );
+
+  const flush = useCallback(() => {
+    const queued = nextWrite.current;
+    if (queued === null) return;
+    if (syncTimer.current !== undefined) clearTimeout(syncTimer.current);
+    if (window.location.pathname !== pathname) return;
+    write(queued);
+  }, [pathname, write]);
+
   useEffect(() => {
-    const requested = requestedSearch.current;
-    if (requested !== null && requested !== current && syncTimer.current !== undefined) {
+    if (current === syncedSearch.current) {
+      if (syncTimer.current === undefined) setPending(null);
+      return;
+    }
+    if (syncTimer.current !== undefined) {
       clearTimeout(syncTimer.current);
       syncTimer.current = undefined;
     }
-    requestedSearch.current = null;
+    nextWrite.current = null;
+    syncedSearch.current = current;
     setPending(null);
   }, [current]);
 
-  useEffect(
-    () => () => {
-      if (syncTimer.current !== undefined) clearTimeout(syncTimer.current);
-    },
-    [],
-  );
+  useEffect(() => {
+    window.addEventListener('pagehide', flush);
+    return () => {
+      window.removeEventListener('pagehide', flush);
+      flush();
+    };
+  }, [flush]);
 
   const config = pending ?? fromUrl;
   const carried = searchParams.get(VIEW_PARAM);
@@ -155,14 +178,12 @@ export function useViewConfig(
       setPending(sanitized);
 
       const search = withViewParam(viewConfigSearch(sanitized, layout), carried);
-      requestedSearch.current = search.replace(/^\?/, '');
+      if (search.replace(/^\?/, '') === syncedSearch.current) return;
+      nextWrite.current = search;
       if (syncTimer.current !== undefined) clearTimeout(syncTimer.current);
-      syncTimer.current = setTimeout(() => {
-        syncTimer.current = undefined;
-        router.replace(`${pathname}${search}`, { scroll: false });
-      }, URL_SYNC_DELAY_MS);
+      syncTimer.current = setTimeout(() => write(search), URL_SYNC_DELAY_MS);
     },
-    [router, pathname, teamId, layout, page, carried],
+    [write, teamId, layout, page, carried],
   );
 
   const setFilter = useCallback(

--- a/apps/web/src/features/filters/use-view-config.ts
+++ b/apps/web/src/features/filters/use-view-config.ts
@@ -131,6 +131,7 @@ export function useViewConfig(
     (search: string) => {
       syncTimer.current = undefined;
       nextWrite.current = null;
+      if (window.location.pathname !== pathname) return;
       syncedSearch.current = search.replace(/^\?/, '');
       window.history.replaceState(null, '', `${pathname}${search}`);
     },
@@ -178,7 +179,12 @@ export function useViewConfig(
       setPending(sanitized);
 
       const search = withViewParam(viewConfigSearch(sanitized, layout), carried);
-      if (search.replace(/^\?/, '') === syncedSearch.current) return;
+      if (search.replace(/^\?/, '') === syncedSearch.current) {
+        if (syncTimer.current !== undefined) clearTimeout(syncTimer.current);
+        syncTimer.current = undefined;
+        nextWrite.current = null;
+        return;
+      }
       nextWrite.current = search;
       if (syncTimer.current !== undefined) clearTimeout(syncTimer.current);
       syncTimer.current = setTimeout(() => write(search), URL_SYNC_DELAY_MS);

--- a/apps/web/src/features/issues/board.tsx
+++ b/apps/web/src/features/issues/board.tsx
@@ -20,18 +20,24 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { DisplayProperty } from '@orbit/shared/filters';
-import { DEFAULT_DISPLAY_PROPERTIES } from '@orbit/shared/filters';
+import { DEFAULT_DISPLAY_PROPERTIES, emptyFilterGroup } from '@orbit/shared/filters';
 import { Plus } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { IssueGroup } from '@/features/filters/grouping.ts';
 import { cn } from '@/lib/cn.ts';
 import type { Cycle, Issue, Label, Member, Project, WorkflowState } from '@/lib/query/schemas.ts';
-import { type MoveInput, useMoveIssue } from '@/lib/query/use-issues.ts';
+import type { IssueQuery } from '@/lib/query/use-issues.ts';
+import { type MoveInput, useColumnIssues, useMoveIssue } from '@/lib/query/use-issues.ts';
 import { GroupGlyph } from './group-glyph.tsx';
 import { IssueCard } from './issue-card.tsx';
 import { IssuePeek } from './issue-peek.tsx';
 import { useWorkspace } from './workspace-provider.tsx';
+
+export interface BoardColumnSource {
+  readonly teamId: string;
+  readonly query: IssueQuery;
+}
 
 export interface BoardProps {
   readonly teamId: string;
@@ -41,7 +47,10 @@ export interface BoardProps {
   readonly hasMore?: boolean;
   readonly loadingMore?: boolean;
   readonly onLoadMore?: (() => void) | undefined;
+  readonly columnSource?: BoardColumnSource | undefined;
 }
+
+const EMPTY_QUERY: IssueQuery = { filter: emptyFilterGroup(), orderBy: 'manual' };
 
 const INITIAL_VISIBLE = 15;
 const VISIBLE_STEP = 15;
@@ -161,6 +170,7 @@ export function Board({
   hasMore = false,
   loadingMore = false,
   onLoadMore,
+  columnSource,
 }: BoardProps) {
   const { labelById, memberById, stateById, projects, cycles, openQuickCreate } = useWorkspace();
   const router = useRouter();
@@ -218,6 +228,7 @@ export function Board({
           hasMore={hasMore}
           loadingMore={loadingMore}
           onLoadMore={onLoadMore}
+          columnSource={columnSource}
           onCreate={() => openQuickCreate()}
           onOpen={setPeekId}
         />
@@ -273,6 +284,7 @@ interface BoardColumnProps {
   readonly hasMore: boolean;
   readonly loadingMore: boolean;
   readonly onLoadMore: (() => void) | undefined;
+  readonly columnSource: BoardColumnSource | undefined;
   readonly onCreate: () => void;
   readonly onOpen: (id: string) => void;
 }
@@ -285,23 +297,37 @@ function BoardColumn({
   hasMore,
   loadingMore,
   onLoadMore,
+  columnSource,
   onCreate,
   onOpen,
 }: BoardColumnProps) {
+  const owned = useColumnIssues(
+    columnSource?.teamId ?? null,
+    columnSource?.query ?? EMPTY_QUERY,
+    group.id,
+    columnSource !== undefined,
+  );
+  const ownsData = columnSource !== undefined;
+  const issues = ownsData ? (owned.data ?? group.issues) : group.issues;
+  const columnHasMore = ownsData ? owned.hasNextPage : hasMore;
+  const columnLoadingMore = ownsData ? owned.isFetchingNextPage : loadingMore;
+  const loadMore = ownsData
+    ? () => {
+        owned.fetchNextPage().catch(() => undefined);
+      }
+    : onLoadMore;
+
   const { setNodeRef } = useDroppable({ id: group.id, data: { isColumn: true } });
   const scrollRef = useRef<HTMLUListElement | null>(null);
   const sentinelRef = useRef<HTMLLIElement | null>(null);
   const scrolledRef = useRef(false);
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE);
 
-  const total = group.issues.length;
-  const hasHiddenLocal = visibleCount < total;
-  const visibleIssues = useMemo(
-    () => group.issues.slice(0, visibleCount),
-    [group.issues, visibleCount],
-  );
+  const loaded = issues.length;
+  const hasHiddenLocal = visibleCount < loaded;
+  const visibleIssues = useMemo(() => issues.slice(0, visibleCount), [issues, visibleCount]);
 
-  const canFetchMore = hasMore && onLoadMore !== undefined;
+  const canFetchMore = columnHasMore && loadMore !== undefined;
   const wantsSentinel = hasHiddenLocal || canFetchMore;
 
   useEffect(() => {
@@ -312,16 +338,16 @@ function BoardColumn({
       (entries) => {
         if (!entries.some((entry) => entry.isIntersecting)) return;
         if (hasHiddenLocal) {
-          setVisibleCount((count) => Math.min(count + VISIBLE_STEP, total));
+          setVisibleCount((count) => Math.min(count + VISIBLE_STEP, loaded));
         } else if (scrolledRef.current && canFetchMore) {
-          onLoadMore?.();
+          loadMore?.();
         }
       },
       { root, rootMargin: '240px' },
     );
     observer.observe(node);
     return () => observer.disconnect();
-  }, [wantsSentinel, hasHiddenLocal, canFetchMore, total, onLoadMore]);
+  }, [wantsSentinel, hasHiddenLocal, canFetchMore, loaded, loadMore]);
 
   const markScrolled = useCallback(() => {
     scrolledRef.current = true;
@@ -353,7 +379,7 @@ function BoardColumn({
 
   const footer = (
     <>
-      {loadingMore && !hasHiddenLocal ? (
+      {columnLoadingMore && !hasHiddenLocal ? (
         <li className="h-[4.75rem] shrink-0 animate-pulse list-none rounded-lg bg-surface-3/50" />
       ) : null}
       {wantsSentinel ? (
@@ -373,7 +399,7 @@ function BoardColumn({
         <GroupGlyph group={group} />
         <h2 className="font-medium text-dense text-text">{group.title}</h2>
         <span data-numeric className="text-2xs text-faint">
-          {group.issues.length}
+          {group.total}
         </span>
         <button
           type="button"

--- a/apps/web/src/features/issues/board.tsx
+++ b/apps/web/src/features/issues/board.tsx
@@ -178,7 +178,23 @@ export function Board({
   const [activeId, setActiveId] = useState<string | null>(null);
   const [peekId, setPeekId] = useState<string | null>(null);
 
-  const issues = useMemo(() => groups.flatMap((group) => [...group.issues]), [groups]);
+  const [columnRows, setColumnRows] = useState<ReadonlyMap<string, readonly Issue[]>>(new Map());
+  const publishRows = useCallback((groupId: string, rows: readonly Issue[]) => {
+    setColumnRows((current) =>
+      current.get(groupId) === rows ? current : new Map(current).set(groupId, rows),
+    );
+  }, []);
+
+  const loadedGroups = useMemo(
+    () =>
+      groups.map((group) => {
+        const rows = columnRows.get(group.id);
+        return rows === undefined || rows === group.issues ? group : { ...group, issues: rows };
+      }),
+    [groups, columnRows],
+  );
+
+  const issues = useMemo(() => loadedGroups.flatMap((group) => [...group.issues]), [loadedGroups]);
   const projectById = useMemo(
     () => new Map(projects.map((project) => [project.id, project])),
     [projects],
@@ -212,7 +228,12 @@ export function Board({
   const onDragEnd = (event: DragEndEvent) => {
     setActiveId(null);
     if (event.over === null) return;
-    const placement = planDrop(groups, issues, String(event.active.id), String(event.over.id));
+    const placement = planDrop(
+      loadedGroups,
+      issues,
+      String(event.active.id),
+      String(event.over.id),
+    );
     if (placement !== null) move.mutate(placement);
   };
 
@@ -231,6 +252,7 @@ export function Board({
           columnSource={columnSource}
           onCreate={() => openQuickCreate()}
           onOpen={setPeekId}
+          onRows={publishRows}
         />
       ))}
     </div>
@@ -287,6 +309,7 @@ interface BoardColumnProps {
   readonly columnSource: BoardColumnSource | undefined;
   readonly onCreate: () => void;
   readonly onOpen: (id: string) => void;
+  readonly onRows: (groupId: string, issues: readonly Issue[]) => void;
 }
 
 function BoardColumn({
@@ -300,6 +323,7 @@ function BoardColumn({
   columnSource,
   onCreate,
   onOpen,
+  onRows,
 }: BoardColumnProps) {
   const owned = useColumnIssues(
     columnSource?.teamId ?? null,
@@ -309,6 +333,10 @@ function BoardColumn({
   );
   const ownsData = columnSource !== undefined;
   const issues = ownsData ? (owned.data ?? group.issues) : group.issues;
+
+  useEffect(() => {
+    onRows(group.id, issues);
+  }, [onRows, group.id, issues]);
   const columnHasMore = ownsData ? owned.hasNextPage : hasMore;
   const columnLoadingMore = ownsData ? owned.isFetchingNextPage : loadingMore;
   const loadMore = ownsData

--- a/apps/web/src/features/issues/card-controls.tsx
+++ b/apps/web/src/features/issues/card-controls.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { PRIORITIES, PRIORITY_LABELS } from '@orbit/shared/constants';
+import { useMemo } from 'react';
+import { Avatar } from '@/components/ui/avatar.tsx';
+import { cn } from '@/lib/cn.ts';
+import type { Issue, Member, WorkflowState } from '@/lib/query/schemas.ts';
+import { useUpdateIssue } from '@/lib/query/use-issues.ts';
+import { PriorityGlyph } from './priority-glyph.tsx';
+import { PropertyMenu, type PropertyOption } from './property-menu.tsx';
+import { StateGlyph } from './state-glyph.tsx';
+import { statesForTeam, useWorkspace } from './workspace-provider.tsx';
+
+function priorityLabel(priority: number): string {
+  const labels: Record<number, string> = PRIORITY_LABELS;
+  return labels[priority] ?? 'No priority';
+}
+
+const TRIGGER =
+  'relative z-10 -m-0.5 flex items-center rounded-sm p-0.5 transition-colors duration-[var(--duration-instant)] hover:bg-surface-3 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent motion-reduce:transition-none';
+
+export function StatusControl({
+  issue,
+  state,
+  disabled = false,
+}: {
+  readonly issue: Issue;
+  readonly state: WorkflowState | undefined;
+  readonly disabled?: boolean;
+}) {
+  const workspace = useWorkspace();
+  const update = useUpdateIssue(issue.teamId);
+
+  const options = useMemo<PropertyOption[]>(
+    () =>
+      statesForTeam(workspace.states, issue.teamId).map((entry) => ({
+        id: entry.id,
+        label: entry.name,
+        icon: <StateGlyph category={entry.category} color={entry.color} />,
+      })),
+    [workspace.states, issue.teamId],
+  );
+
+  const glyph =
+    state === undefined ? null : (
+      <StateGlyph category={state.category} color={state.color} title={state.name} />
+    );
+
+  if (disabled || state === undefined) return glyph;
+
+  return (
+    <PropertyMenu
+      title="Change status"
+      options={options}
+      selected={[issue.stateId]}
+      testId="card-status-menu"
+      onSelect={(stateId) => {
+        if (stateId !== issue.stateId) update.mutate({ issue, patch: { stateId } });
+      }}
+    >
+      <button
+        type="button"
+        aria-label={`Status: ${state.name}`}
+        data-testid={`card-status-${issue.identifier}`}
+        onClick={(event) => event.stopPropagation()}
+        className={cn(TRIGGER)}
+      >
+        {glyph}
+      </button>
+    </PropertyMenu>
+  );
+}
+
+export function PriorityControl({
+  issue,
+  disabled = false,
+}: {
+  readonly issue: Issue;
+  readonly disabled?: boolean;
+}) {
+  const update = useUpdateIssue(issue.teamId);
+
+  const options = useMemo<PropertyOption[]>(
+    () =>
+      PRIORITIES.map((priority) => ({
+        id: String(priority),
+        label: priorityLabel(priority),
+        icon: <PriorityGlyph priority={priority} />,
+      })),
+    [],
+  );
+
+  if (disabled) return <PriorityGlyph priority={issue.priority} />;
+
+  return (
+    <PropertyMenu
+      title="Set priority"
+      options={options}
+      selected={[String(issue.priority)]}
+      testId="card-priority-menu"
+      onSelect={(value) => {
+        const priority = Number(value);
+        if (Number.isInteger(priority) && priority !== issue.priority) {
+          update.mutate({ issue, patch: { priority } });
+        }
+      }}
+    >
+      <button
+        type="button"
+        aria-label={`Priority: ${priorityLabel(issue.priority)}`}
+        data-testid={`card-priority-${issue.identifier}`}
+        onClick={(event) => event.stopPropagation()}
+        className={cn(TRIGGER)}
+      >
+        <PriorityGlyph priority={issue.priority} />
+      </button>
+    </PropertyMenu>
+  );
+}
+
+export function AssigneeControl({
+  issue,
+  assignee,
+}: {
+  readonly issue: Issue;
+  readonly assignee: Member | undefined;
+}) {
+  const workspace = useWorkspace();
+  const update = useUpdateIssue(issue.teamId);
+
+  const options = useMemo<PropertyOption[]>(
+    () => [
+      { id: '', label: 'No assignee' },
+      ...workspace.members.map((member) => ({ id: member.id, label: member.name })),
+    ],
+    [workspace.members],
+  );
+
+  return (
+    <PropertyMenu
+      title="Assign to"
+      align="end"
+      options={options}
+      selected={[issue.assigneeId ?? '']}
+      testId="card-assignee-menu"
+      onSelect={(value) => {
+        const assigneeId = value === '' ? null : value;
+        if (assigneeId !== issue.assigneeId) update.mutate({ issue, patch: { assigneeId } });
+      }}
+    >
+      <button
+        type="button"
+        aria-label="Change assignee"
+        data-testid={`card-assignee-${issue.identifier}`}
+        onClick={(event) => event.stopPropagation()}
+        className={cn(TRIGGER, 'ml-auto')}
+      >
+        <AssigneeAvatar assignee={assignee} />
+      </button>
+    </PropertyMenu>
+  );
+}
+
+function AssigneeAvatar({ assignee }: { readonly assignee: Member | undefined }) {
+  if (assignee === undefined) {
+    return <span className="block size-5.5 rounded-full border border-border border-dashed" />;
+  }
+  return <Avatar name={assignee.name} src={assignee.image} size="sm" />;
+}

--- a/apps/web/src/features/issues/issue-card.test.tsx
+++ b/apps/web/src/features/issues/issue-card.test.tsx
@@ -1,11 +1,25 @@
 import { describe, expect, it } from 'bun:test';
 import type { DisplayProperty } from '@orbit/shared/filters';
-import { DISPLAY_PROPERTIES } from '@orbit/shared/filters';
-import { render, screen } from '@testing-library/react';
+import { DEFAULT_DISPLAY_PROPERTIES, DISPLAY_PROPERTIES } from '@orbit/shared/filters';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render as renderRaw, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { ToastProvider } from '@/components/ui/toast.tsx';
 import { groupIssues } from '@/features/filters/grouping.ts';
 import type { Issue, Label, Member, WorkflowState } from '@/lib/query/schemas.ts';
 import { planDrop } from './board.tsx';
 import { IssueCard } from './issue-card.tsx';
+
+function render(ui: ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrap = (node: ReactElement) => (
+    <QueryClientProvider client={client}>
+      <ToastProvider>{node}</ToastProvider>
+    </QueryClientProvider>
+  );
+  const result = renderRaw(wrap(ui));
+  return { ...result, rerender: (next: ReactElement) => result.rerender(wrap(next)) };
+}
 
 function issue(overrides: Partial<Issue> = {}): Issue {
   return {
@@ -209,5 +223,31 @@ describe('board placement', () => {
   it('ignores a drop on itself or on an unknown target', () => {
     expect(planDrop(columns, issues, 'a', 'a')).toBeNull();
     expect(planDrop(columns, issues, 'a', 'nowhere')).toBeNull();
+  });
+});
+
+describe('card controls', () => {
+  it('offers the priority and status as buttons a facilitator can press', () => {
+    render(<IssueCard issue={issue()} labels={[]} assignee={undefined} state={state} />);
+
+    const priority = screen.getByTestId('card-priority-ENG-4');
+    const status = screen.getByTestId('card-status-ENG-4');
+    expect(priority.tagName).toBe('BUTTON');
+    expect(status.tagName).toBe('BUTTON');
+    expect(priority).toHaveAttribute('aria-label', 'Priority: Urgent');
+    expect(status).toHaveAttribute('aria-label', 'Status: In progress');
+  });
+
+  it('falls back to a plain glyph while the card is being dragged', () => {
+    render(<IssueCard issue={issue()} labels={[]} assignee={undefined} state={state} dragging />);
+    expect(screen.queryByTestId('card-priority-ENG-4')).toBeNull();
+    expect(screen.queryByTestId('card-status-ENG-4')).toBeNull();
+    expect(screen.getByLabelText('Urgent')).toBeInTheDocument();
+  });
+
+  it('carries the properties a board reader expects by default', () => {
+    expect([...DEFAULT_DISPLAY_PROPERTIES]).toEqual(
+      expect.arrayContaining(['priority', 'status', 'labels', 'project', 'created', 'assignee']),
+    );
   });
 });

--- a/apps/web/src/features/issues/issue-card.tsx
+++ b/apps/web/src/features/issues/issue-card.tsx
@@ -7,9 +7,8 @@ import type { MouseEvent as ReactMouseEvent } from 'react';
 import { Avatar } from '@/components/ui/avatar.tsx';
 import { cn } from '@/lib/cn.ts';
 import type { Issue, Label, Member, WorkflowState } from '@/lib/query/schemas.ts';
+import { AssigneeControl, PriorityControl, StatusControl } from './card-controls.tsx';
 import { MetaChip, MetaDate } from './issue-meta.tsx';
-import { PriorityGlyph } from './priority-glyph.tsx';
-import { StateGlyph } from './state-glyph.tsx';
 
 export interface IssueCardProps {
   readonly issue: Issue;
@@ -65,10 +64,8 @@ export function IssueCard({
       )}
     >
       <div className="flex items-center gap-2 text-2xs text-faint">
-        {shows('priority') ? <PriorityGlyph priority={issue.priority} /> : null}
-        {shows('status') && state !== undefined ? (
-          <StateGlyph category={state.category} color={state.color} title={state.name} />
-        ) : null}
+        {shows('priority') ? <PriorityControl issue={issue} disabled={dragging} /> : null}
+        {shows('status') ? <StatusControl issue={issue} state={state} disabled={dragging} /> : null}
         {shows('identifier') ? (
           <span data-numeric className="truncate whitespace-nowrap font-medium">
             {issue.identifier}
@@ -103,7 +100,9 @@ export function IssueCard({
           subIssueCount={subIssueCount}
           properties={properties}
         />
-        {shows('assignee') ? <CardAssignee assignee={assignee} /> : null}
+        {shows('assignee') ? (
+          <CardAssigneeSlot issue={issue} assignee={assignee} dragging={dragging} />
+        ) : null}
       </div>
     </article>
   );
@@ -127,6 +126,19 @@ function CardLabels({ labels }: { labels: readonly Label[] }) {
       ))}
     </>
   );
+}
+
+function CardAssigneeSlot({
+  issue,
+  assignee,
+  dragging,
+}: {
+  issue: Issue;
+  assignee: Member | undefined;
+  dragging: boolean;
+}) {
+  if (dragging) return <CardAssignee assignee={assignee} />;
+  return <AssigneeControl issue={issue} assignee={assignee} />;
 }
 
 function CardAssignee({ assignee }: { assignee: Member | undefined }) {

--- a/apps/web/src/features/issues/my-issues-view.tsx
+++ b/apps/web/src/features/issues/my-issues-view.tsx
@@ -5,9 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
 import { Skeleton } from '@/components/ui/skeleton.tsx';
-import { applyDisplayFilters } from '@/features/filters/display-filter.ts';
 import { DisplayMenu } from '@/features/filters/display-menu.tsx';
-import { groupIssues } from '@/features/filters/grouping.ts';
 import { HiddenFooter } from '@/features/filters/hidden-footer.tsx';
 import { useViewConfig } from '@/features/filters/use-view-config.ts';
 import { useProvideViewControls } from '@/features/filters/view-controls.tsx';
@@ -17,6 +15,7 @@ import { useAssignedIssues } from '@/lib/query/use-issues.ts';
 import { GroupGlyph } from './group-glyph.tsx';
 import { IssuePeek } from './issue-peek.tsx';
 import { IssueRow } from './issue-row.tsx';
+import { useIssueViewModel } from './use-issue-view-model.ts';
 import { useWorkspace } from './workspace-provider.tsx';
 
 export function assignedTo(issues: readonly Issue[], userId: string | null): Issue[] {
@@ -48,31 +47,23 @@ export function MyIssuesView() {
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const loading = assigned.isPending;
-  const mine = assignedTo(assigned.data ?? [], workspace.userId);
-
-  const shown = applyDisplayFilters(mine, config.display, workspace.stateById);
-
-  const states = useMemo(
-    () => [...workspace.states].sort((left, right) => left.position - right.position),
-    [workspace.states],
+  const mine = useMemo(
+    () => assignedTo(assigned.data ?? [], workspace.userId),
+    [assigned.data, workspace.userId],
   );
 
-  const groups = groupIssues(
-    shown.issues,
-    config.groupBy,
-    {
-      states,
-      members: workspace.members,
-      projects: workspace.projects,
-      cycles: workspace.cycles,
-      labels: workspace.labels,
-    },
-    {
-      showEmptyGroups: config.display.showEmptyGroups,
-      ordering: config.orderBy,
-      subGroupBy: config.subGroupBy,
-    },
+  const scope = useMemo(
+    () => (workspace.userId === null ? {} : { assigneeId: workspace.userId }),
+    [workspace.userId],
   );
+  const model = useIssueViewModel({
+    teamId: null,
+    config,
+    issues: mine,
+    scopeToTeam: false,
+    scope,
+  });
+  const groups = model.groups;
 
   if (!workspace.ready) {
     return (
@@ -89,7 +80,7 @@ export function MyIssuesView() {
       <div className="flex items-center gap-2 border-border border-b px-3 py-2">
         <h1 className="font-medium text-dense text-text">My issues</h1>
         <span data-numeric className="text-2xs text-faint" data-testid="issue-count">
-          {shown.issues.length}
+          {model.total}
         </span>
         <div className="ml-auto">
           <DisplayMenu
@@ -101,7 +92,7 @@ export function MyIssuesView() {
         </div>
       </div>
 
-      {shown.issues.length === 0 ? (
+      {model.shownCount === 0 ? (
         <EmptyState
           icon={<CircleDot strokeWidth={1.75} aria-hidden="true" />}
           title={loading ? 'Loading your issues' : 'Nothing assigned to you'}
@@ -152,8 +143,8 @@ export function MyIssuesView() {
       )}
 
       <HiddenFooter
-        hiddenByFilters={0}
-        hiddenByDisplay={shown.hidden}
+        hiddenByFilters={model.hiddenByFilters}
+        hiddenByDisplay={model.hiddenByDisplay}
         onClearFilters={() => undefined}
         onRevealDisplay={() =>
           setConfig({

--- a/apps/web/src/features/issues/standup-view.tsx
+++ b/apps/web/src/features/issues/standup-view.tsx
@@ -207,7 +207,6 @@ export function StandupView() {
         config={config}
         onChange={setConfig}
         controls={controls}
-        issues={shown.issues}
         showSaveView={false}
       />
 

--- a/apps/web/src/features/issues/team-view.tsx
+++ b/apps/web/src/features/issues/team-view.tsx
@@ -6,17 +6,14 @@ import {
   isEmptyFilter,
   viewStateDirty,
 } from '@orbit/shared/filters';
-import { useQuery } from '@tanstack/react-query';
 import { Columns3, List, SearchX } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useMemo } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
-import { applyDisplayFilters } from '@/features/filters/display-filter.ts';
 import { FilterBar } from '@/features/filters/filter-bar.tsx';
 import type { IssueGroup } from '@/features/filters/grouping.ts';
-import { groupIssues } from '@/features/filters/grouping.ts';
 import { HiddenFooter } from '@/features/filters/hidden-footer.tsx';
 import { useViewConfig, VIEW_PARAM } from '@/features/filters/use-view-config.ts';
 import type { ViewConfig, ViewLayoutMode } from '@/features/filters/view-config.ts';
@@ -24,24 +21,15 @@ import { viewConfigToState } from '@/features/filters/view-config.ts';
 import { useProvideViewControls } from '@/features/filters/view-controls.tsx';
 import { cn } from '@/lib/cn.ts';
 import { useHotkey } from '@/lib/keyboard/index.ts';
-import type { Issue, View, WorkflowState } from '@/lib/query/schemas.ts';
-import type { IssuePages } from '@/lib/query/sync.ts';
-import { flattenIssuePages } from '@/lib/query/sync.ts';
-import { teamIssuesQuery, useIssues } from '@/lib/query/use-issues.ts';
+import type { View, WorkflowState } from '@/lib/query/schemas.ts';
+import { useIssues } from '@/lib/query/use-issues.ts';
 import { useViews } from '@/lib/query/use-views.ts';
-
-function toIssueArray(data: unknown, fallback: readonly Issue[]): readonly Issue[] {
-  if (Array.isArray(data)) return data as readonly Issue[];
-  if (data !== null && typeof data === 'object' && 'pages' in data) {
-    return flattenIssuePages(data as IssuePages);
-  }
-  return fallback;
-}
 
 import { Board } from './board.tsx';
 import { IssueList } from './issue-list.tsx';
 import { ListSkeleton } from './list-skeleton.tsx';
-import { statesForTeam, useWorkspace } from './workspace-provider.tsx';
+import { useIssueViewModel } from './use-issue-view-model.ts';
+import { useWorkspace } from './workspace-provider.tsx';
 
 export interface TeamViewProps {
   readonly teamKey: string;
@@ -65,61 +53,11 @@ export function TeamView({ teamKey, layout }: TeamViewProps) {
     orderBy: config.orderBy,
   });
 
-  const unfiltered = useQuery({
-    ...teamIssuesQuery(teamId ?? 'none'),
-    enabled: teamId !== null && filtered,
-  });
-
   const views = useViews();
   const savedView = useSavedView(views.data ?? [], searchParams.get(VIEW_PARAM));
 
-  const states = useMemo(() => statesForTeam(workspace.states, teamId), [workspace.states, teamId]);
   const rows = useMemo(() => issues.data ?? [], [issues.data]);
-
-  const shown = useMemo(
-    () => applyDisplayFilters(rows, config.display, workspace.stateById),
-    [rows, config.display, workspace.stateById],
-  );
-
-  const groups = useMemo(
-    () =>
-      groupIssues(
-        shown.issues,
-        config.groupBy,
-        {
-          states,
-          members: workspace.members,
-          projects: workspace.projects,
-          cycles: workspace.cycles.filter((cycle) => cycle.teamId === teamId),
-          labels: workspace.labels,
-        },
-        {
-          showEmptyGroups: config.display.showEmptyGroups,
-          ordering: config.orderBy,
-          subGroupBy: config.subGroupBy,
-        },
-      ),
-    [
-      shown.issues,
-      config.groupBy,
-      config.display.showEmptyGroups,
-      config.orderBy,
-      config.subGroupBy,
-      states,
-      workspace,
-      teamId,
-    ],
-  );
-
-  const unfilteredRows = useMemo(
-    () => toIssueArray(unfiltered.data, rows),
-    [unfiltered.data, rows],
-  );
-
-  const hiddenByFilters =
-    filtered && unfiltered.data !== undefined
-      ? Math.max(0, unfilteredRows.length - rows.length)
-      : 0;
+  const model = useIssueViewModel({ teamId, config, issues: rows });
 
   const other = layout === 'board' ? 'issues' : 'board';
   useHotkey(
@@ -154,7 +92,7 @@ export function TeamView({ teamKey, layout }: TeamViewProps) {
       <div className="flex items-center gap-2 border-border border-b px-3 py-2">
         <h1 className="font-medium text-dense text-text">{team.name}</h1>
         <span data-numeric className="text-2xs text-faint" data-testid="issue-count">
-          {shown.issues.length}
+          {model.total}
         </span>
         <div className="ml-auto flex items-center gap-1">
           <ViewToggle teamKey={teamKey} layout={layout} />
@@ -176,18 +114,18 @@ export function TeamView({ teamKey, layout }: TeamViewProps) {
         config={config}
         onChange={setConfig}
         controls={controls}
-        issues={unfilteredRows}
+        facets={model.facets}
         savedView={savedView}
         dirty={savedView !== null && isDirty(config, layout, savedView)}
       />
 
       <TeamContent
         teamId={teamId}
-        states={states}
-        groups={groups}
+        states={model.states}
+        groups={model.groups}
         config={config}
         layout={layout}
-        empty={shown.issues.length === 0}
+        empty={model.shownCount === 0}
         loading={issues.isPending}
         hasMore={issues.hasNextPage}
         loadingMore={issues.isFetchingNextPage}
@@ -198,8 +136,8 @@ export function TeamView({ teamKey, layout }: TeamViewProps) {
       />
 
       <HiddenFooter
-        hiddenByFilters={hiddenByFilters}
-        hiddenByDisplay={shown.hidden}
+        hiddenByFilters={model.hiddenByFilters}
+        hiddenByDisplay={model.hiddenByDisplay}
         onClearFilters={clearFilters}
         onRevealDisplay={revealDisplay}
       />
@@ -288,6 +226,11 @@ function TeamContent({
         hasMore={hasMore}
         loadingMore={loadingMore}
         onLoadMore={onLoadMore}
+        columnSource={
+          config.groupBy === 'state'
+            ? { teamId, query: { filter: config.filter, orderBy: config.orderBy } }
+            : undefined
+        }
       />
     );
   }

--- a/apps/web/src/features/issues/use-issue-view-model.ts
+++ b/apps/web/src/features/issues/use-issue-view-model.ts
@@ -1,0 +1,140 @@
+'use client';
+
+import { isEmptyFilter } from '@orbit/shared/filters';
+import { useMemo } from 'react';
+import { applyDisplayFilters } from '@/features/filters/display-filter.ts';
+import type { IssueGroup } from '@/features/filters/grouping.ts';
+import { groupIssues, mergeStatesByName, remapTotals } from '@/features/filters/grouping.ts';
+import type { ViewConfig } from '@/features/filters/view-config.ts';
+import { summarySearch } from '@/lib/query/issue-search.ts';
+import type { Issue, IssueSummary, WorkflowState } from '@/lib/query/schemas.ts';
+import { useIssueSummary } from '@/lib/query/use-issues.ts';
+import { statesForTeam, useWorkspace } from './workspace-provider.tsx';
+
+export interface IssueViewModel {
+  readonly groups: readonly IssueGroup[];
+  readonly states: readonly WorkflowState[];
+  readonly shownCount: number;
+  readonly total: number;
+  readonly hiddenByFilters: number;
+  readonly hiddenByDisplay: number;
+  readonly filtered: boolean;
+  readonly facets: IssueSummary['facets'] | undefined;
+}
+
+export interface IssueViewModelInput {
+  readonly teamId: string | null;
+  readonly config: ViewConfig;
+  readonly issues: readonly Issue[];
+  readonly scopeToTeam?: boolean;
+  readonly scope?: Readonly<Record<string, string>>;
+}
+
+export function useIssueViewModel({
+  teamId,
+  config,
+  issues,
+  scopeToTeam = true,
+  scope,
+}: IssueViewModelInput): IssueViewModel {
+  const workspace = useWorkspace();
+  const filtered = !isEmptyFilter(config.filter);
+
+  const search = summarySearch(
+    scopeToTeam ? teamId : null,
+    { filter: config.filter, orderBy: config.orderBy },
+    config.groupBy,
+    scope,
+  );
+  const summary = useIssueSummary(search, !scopeToTeam || teamId !== null);
+
+  const merged = useMemo(
+    () =>
+      scopeToTeam
+        ? null
+        : mergeStatesByName(
+            [...workspace.states].sort((left, right) => left.position - right.position),
+          ),
+    [workspace.states, scopeToTeam],
+  );
+
+  const states = useMemo(
+    () => merged?.states ?? statesForTeam(workspace.states, teamId),
+    [merged, workspace.states, teamId],
+  );
+
+  const shown = useMemo(
+    () => applyDisplayFilters(issues, config.display, workspace.stateById),
+    [issues, config.display, workspace.stateById],
+  );
+
+  const cycles = useMemo(
+    () =>
+      scopeToTeam && teamId !== null
+        ? workspace.cycles.filter((cycle) => cycle.teamId === teamId)
+        : workspace.cycles,
+    [workspace.cycles, teamId, scopeToTeam],
+  );
+
+  const remap = merged !== null && config.groupBy === 'state' ? merged.idMap : undefined;
+
+  const groupTotals = useMemo(
+    () =>
+      remap === undefined
+        ? summary.data?.groupTotals
+        : remapTotals(summary.data?.groupTotals, remap),
+    [summary.data?.groupTotals, remap],
+  );
+
+  const groups = useMemo(
+    () =>
+      groupIssues(
+        shown.issues,
+        config.groupBy,
+        {
+          states,
+          members: workspace.members,
+          projects: workspace.projects,
+          cycles,
+          labels: workspace.labels,
+        },
+        {
+          showEmptyGroups: config.display.showEmptyGroups,
+          ordering: config.orderBy,
+          subGroupBy: config.subGroupBy,
+          totals: groupTotals,
+          remap: config.groupBy === 'state' ? remap : undefined,
+        },
+      ),
+    [
+      shown.issues,
+      config.groupBy,
+      config.display.showEmptyGroups,
+      config.orderBy,
+      config.subGroupBy,
+      states,
+      cycles,
+      workspace.members,
+      workspace.projects,
+      workspace.labels,
+      groupTotals,
+      remap,
+    ],
+  );
+
+  const total = summary.data?.total ?? shown.issues.length;
+
+  return {
+    groups,
+    states,
+    shownCount: shown.issues.length,
+    total,
+    hiddenByFilters:
+      filtered && summary.data !== undefined
+        ? Math.max(0, summary.data.scopeTotal - summary.data.total)
+        : 0,
+    hiddenByDisplay: shown.hidden,
+    filtered,
+    facets: summary.data?.facets,
+  };
+}

--- a/apps/web/src/features/standup/roster.tsx
+++ b/apps/web/src/features/standup/roster.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { CircleCheck, UserMinus } from 'lucide-react';
+import { Avatar } from '@/components/ui/avatar.tsx';
+import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
+import { cn } from '@/lib/cn.ts';
+import type { StandupTurn, StandupWorkload } from '@/lib/query/schemas.ts';
+
+export interface RosterProps {
+  readonly turns: readonly StandupTurn[];
+  readonly currentTurnId: string | null;
+  readonly workloadByUser: ReadonlyMap<string, StandupWorkload>;
+  readonly presenting: boolean;
+  readonly onFocus: (turnId: string) => void;
+}
+
+function TurnMarker({
+  turn,
+  workload,
+}: {
+  readonly turn: StandupTurn;
+  readonly workload: StandupWorkload | undefined;
+}) {
+  if (turn.attendance === 'absent') {
+    return <UserMinus className="size-3.5 text-faint" aria-label="Absent" />;
+  }
+  if (turn.status === 'done') {
+    return <CircleCheck className="size-3.5 text-success" aria-label="Spoken" />;
+  }
+  if (turn.status === 'speaking') {
+    return <span className="size-1.5 rounded-full bg-accent" role="img" aria-label="Speaking" />;
+  }
+  if (workload === undefined) return null;
+  return (
+    <span data-numeric className="text-2xs text-faint">
+      {workload.inProgress}
+    </span>
+  );
+}
+
+export function Roster({ turns, currentTurnId, workloadByUser, presenting, onFocus }: RosterProps) {
+  const workspace = useWorkspace();
+
+  return (
+    <ol
+      className={cn(
+        'flex shrink-0 flex-col gap-0.5 overflow-y-auto border-border border-r p-2',
+        presenting ? 'w-64' : 'w-72',
+      )}
+      data-testid="standup-roster"
+    >
+      {turns.map((turn) => {
+        const member = workspace.memberById.get(turn.userId);
+        const active = turn.id === currentTurnId;
+        return (
+          <li key={turn.id}>
+            <button
+              type="button"
+              data-testid={`roster-${turn.userId}`}
+              onClick={() => onFocus(turn.id)}
+              className={cn(
+                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left',
+                'transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)] motion-reduce:transition-none',
+                active ? 'bg-accent/12 text-text' : 'text-muted hover:bg-surface-2',
+                turn.attendance === 'absent' && 'opacity-50',
+              )}
+            >
+              <Avatar name={member?.name ?? 'Unknown'} src={member?.image ?? null} size="xs" />
+              <span className="min-w-0 flex-1 truncate text-dense">
+                {member?.name ?? 'Unknown member'}
+              </span>
+              <TurnMarker turn={turn} workload={workloadByUser.get(turn.userId)} />
+            </button>
+          </li>
+        );
+      })}
+      {turns.length === 0 ? (
+        <li className="px-2 py-3 text-2xs text-faint">Nobody is in this team's rotation yet.</li>
+      ) : null}
+    </ol>
+  );
+}

--- a/apps/web/src/features/standup/standup-page.tsx
+++ b/apps/web/src/features/standup/standup-page.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useMemo } from 'react';
+import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
+import { cn } from '@/lib/cn.ts';
+import { useStandupToday } from '@/lib/query/use-standup.ts';
+import { StandupRoom } from './standup-room.tsx';
+
+const TEAM_PARAM = 'team';
+
+export function StandupPage() {
+  const workspace = useWorkspace();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const requested = searchParams.get(TEAM_PARAM);
+  const team = useMemo(() => {
+    const match = workspace.teams.find(
+      (entry) => entry.key.toLowerCase() === (requested ?? '').toLowerCase(),
+    );
+    return match ?? workspace.teams[0];
+  }, [workspace.teams, requested]);
+
+  const teamId = team?.id ?? null;
+  const today = useStandupToday(teamId);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {workspace.teams.length > 1 ? (
+        <nav
+          className="flex shrink-0 items-center gap-1 border-border border-b px-3 py-1.5"
+          aria-label="Standup team"
+        >
+          {workspace.teams.map((entry) => (
+            <button
+              key={entry.id}
+              type="button"
+              data-testid={`standup-team-${entry.key.toLowerCase()}`}
+              onClick={() => router.replace(`/standup?${TEAM_PARAM}=${entry.key.toLowerCase()}`)}
+              className={cn(
+                'rounded-md px-2 py-1 text-2xs',
+                'transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)] motion-reduce:transition-none',
+                entry.id === teamId ? 'bg-surface-2 text-text' : 'text-faint hover:text-muted',
+              )}
+            >
+              {entry.name}
+            </button>
+          ))}
+        </nav>
+      ) : null}
+
+      <StandupRoom
+        teamId={teamId}
+        teamName={team?.name ?? 'Team'}
+        detail={today.data?.standup ?? null}
+        workload={today.data?.workload ?? []}
+        loading={!workspace.ready || today.isPending}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/standup/standup-room.tsx
+++ b/apps/web/src/features/standup/standup-room.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import { ChevronLeft, ChevronRight, CircleSlash, Flag, Play } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import { Avatar } from '@/components/ui/avatar.tsx';
+import { Button } from '@/components/ui/button.tsx';
+import { EmptyState } from '@/components/ui/empty-state.tsx';
+import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
+import { useHotkey } from '@/lib/keyboard/index.ts';
+import type { StandupDetail, StandupWorkload } from '@/lib/query/schemas.ts';
+import {
+  useAddBlocker,
+  useAdvanceStandup,
+  useFinishStandup,
+  useFocusTurn,
+  useOpenStandup,
+  useResolveBlocker,
+  useStartStandup,
+  useUpdateTurn,
+} from '@/lib/query/use-standup.ts';
+import { Roster } from './roster.tsx';
+import { TurnPanel } from './turn-panel.tsx';
+
+export interface StandupRoomProps {
+  readonly teamId: string | null;
+  readonly teamName: string;
+  readonly detail: StandupDetail | null;
+  readonly workload: readonly StandupWorkload[];
+  readonly loading: boolean;
+}
+
+export function StandupRoom(props: StandupRoomProps) {
+  const { teamId, teamName, detail, loading } = props;
+  const open = useOpenStandup(teamId);
+
+  if (teamId === null) {
+    return (
+      <EmptyState
+        icon={<Flag strokeWidth={1.75} aria-hidden="true" />}
+        title="Pick a team"
+        description="Standup runs per team. Choose one above to begin."
+        className="flex-1"
+      />
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-3 p-6">
+        <div className="h-8 w-64 animate-pulse rounded-md bg-surface-2" />
+        <div className="h-40 w-full animate-pulse rounded-lg bg-surface-2" />
+      </div>
+    );
+  }
+
+  if (detail === null) {
+    return (
+      <EmptyState
+        icon={<Play strokeWidth={1.75} aria-hidden="true" />}
+        title={`No standup for ${teamName} today`}
+        description="Open the room to seat everyone in the rotation and pick today's facilitator."
+        className="flex-1"
+        action={
+          <Button
+            size="sm"
+            variant="primary"
+            data-testid="open-standup"
+            onClick={() => open.mutate(undefined)}
+            disabled={open.isPending}
+          >
+            {open.isPending ? 'Opening' : 'Open standup'}
+          </Button>
+        }
+      />
+    );
+  }
+
+  return <RunningRoom {...props} teamId={teamId} detail={detail} />;
+}
+
+interface RunningRoomProps extends StandupRoomProps {
+  readonly teamId: string;
+  readonly detail: StandupDetail;
+}
+
+function RunningRoom({ teamId, teamName, detail, workload }: RunningRoomProps) {
+  const workspace = useWorkspace();
+  const start = useStartStandup(teamId);
+  const advance = useAdvanceStandup(teamId);
+  const focus = useFocusTurn(teamId);
+  const updateTurn = useUpdateTurn(teamId);
+  const addBlocker = useAddBlocker(teamId);
+  const resolveBlocker = useResolveBlocker(teamId);
+  const finish = useFinishStandup(teamId);
+  const [presenting, setPresenting] = useState(false);
+
+  const { standup, turns } = detail;
+  const running = standup.status === 'running';
+
+  const current = useMemo(
+    () => turns.find((turn) => turn.id === standup.currentTurnId) ?? null,
+    [turns, standup.currentTurnId],
+  );
+
+  const workloadByUser = useMemo(
+    () => new Map(workload.map((entry) => [entry.userId, entry])),
+    [workload],
+  );
+
+  const move = useCallback(
+    (direction: 'next' | 'previous') => {
+      if (!running) return;
+      advance.mutate({ standupId: standup.id, direction });
+    },
+    [standup.id, running, advance],
+  );
+
+  useHotkey('right', () => move('next'), {
+    label: 'Next person',
+    section: 'Standup',
+    scope: 'standup',
+    enabled: running,
+  });
+  useHotkey('left', () => move('previous'), {
+    label: 'Previous person',
+    section: 'Standup',
+    scope: 'standup',
+    enabled: running,
+  });
+  useHotkey('p', () => setPresenting((value) => !value), {
+    label: 'Toggle presenter mode',
+    section: 'Standup',
+    scope: 'standup',
+  });
+
+  const facilitator =
+    standup.facilitatorId === null ? undefined : workspace.memberById.get(standup.facilitatorId);
+  const spoken = turns.filter((turn) => turn.status === 'done').length;
+  const expected = turns.filter((turn) => turn.attendance !== 'absent').length;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-testid="standup-room">
+      <header className="flex flex-wrap items-center gap-3 border-border border-b px-4 py-2.5">
+        <div className="flex items-baseline gap-2">
+          <h1 className="font-medium text-dense text-text">{teamName} standup</h1>
+          <span data-numeric className="text-2xs text-faint">
+            {standup.heldOn}
+          </span>
+        </div>
+
+        {facilitator === undefined ? null : (
+          <span
+            className="flex items-center gap-1.5 rounded-full bg-surface-2 py-0.5 pr-2.5 pl-1"
+            data-testid="facilitator"
+          >
+            <Avatar name={facilitator.name} src={facilitator.image} size="xs" />
+            <span className="text-2xs text-muted">{facilitator.name} is facilitating</span>
+          </span>
+        )}
+
+        <span data-numeric className="text-2xs text-faint" data-testid="standup-progress">
+          {spoken} of {expected} spoken
+        </span>
+
+        <div className="ml-auto flex items-center gap-1.5">
+          <Button size="sm" variant="ghost" onClick={() => setPresenting((value) => !value)}>
+            {presenting ? 'Exit presenter' : 'Presenter'}
+          </Button>
+          {standup.status === 'scheduled' ? (
+            <Button
+              size="sm"
+              variant="primary"
+              data-testid="start-standup"
+              onClick={() => start.mutate(standup.id)}
+              disabled={start.isPending}
+            >
+              Start
+            </Button>
+          ) : null}
+          {running ? (
+            <RoomControls
+              onPrevious={() => move('previous')}
+              onNext={() => move('next')}
+              onFinish={() => finish.mutate(standup.id)}
+            />
+          ) : null}
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        <Roster
+          turns={turns}
+          currentTurnId={standup.currentTurnId}
+          workloadByUser={workloadByUser}
+          presenting={presenting}
+          onFocus={(turnId) => focus.mutate({ standupId: standup.id, turnId })}
+        />
+
+        <div className="min-w-0 flex-1 overflow-y-auto">
+          {current === null ? (
+            <EmptyState
+              icon={<CircleSlash strokeWidth={1.75} aria-hidden="true" />}
+              title={standup.status === 'finished' ? 'Standup finished' : 'Nobody is speaking'}
+              description={
+                standup.status === 'finished'
+                  ? 'Every blocker raised today stays on the team board until it is resolved.'
+                  : 'Press Start, or pick someone from the list to begin.'
+              }
+              className="flex-1"
+            />
+          ) : (
+            <TurnPanel
+              standupId={standup.id}
+              teamId={teamId}
+              turn={current}
+              member={workspace.memberById.get(current.userId)}
+              workload={workloadByUser.get(current.userId)}
+              blockers={detail.blockers}
+              presenting={presenting}
+              onSaveNotes={(notes) =>
+                updateTurn.mutate({ standupId: standup.id, turnId: current.id, notes })
+              }
+              onAttendance={(attendance) =>
+                updateTurn.mutate({ standupId: standup.id, turnId: current.id, attendance })
+              }
+              onAddBlocker={(summary, issueId) =>
+                addBlocker.mutate({ standupId: standup.id, turnId: current.id, summary, issueId })
+              }
+              onResolveBlocker={(blockerId, resolved) =>
+                resolveBlocker.mutate({ standupId: standup.id, blockerId, resolved })
+              }
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RoomControls({
+  onPrevious,
+  onNext,
+  onFinish,
+}: {
+  readonly onPrevious: () => void;
+  readonly onNext: () => void;
+  readonly onFinish: () => void;
+}) {
+  return (
+    <>
+      <Button size="sm" variant="secondary" aria-label="Previous person" onClick={onPrevious}>
+        <ChevronLeft className="size-3.5" aria-hidden="true" />
+      </Button>
+      <Button size="sm" variant="primary" data-testid="next-person" onClick={onNext}>
+        Next
+        <ChevronRight className="size-3.5" aria-hidden="true" />
+      </Button>
+      <Button size="sm" variant="ghost" onClick={onFinish}>
+        Finish
+      </Button>
+    </>
+  );
+}

--- a/apps/web/src/features/standup/standup-room.tsx
+++ b/apps/web/src/features/standup/standup-room.tsx
@@ -109,7 +109,7 @@ function RunningRoom({ teamId, teamName, detail, workload }: RunningRoomProps) {
 
   const move = useCallback(
     (direction: 'next' | 'previous') => {
-      if (!running) return;
+      if (!running || advance.isPending) return;
       advance.mutate({ standupId: standup.id, direction });
     },
     [standup.id, running, advance],
@@ -210,6 +210,7 @@ function RunningRoom({ teamId, teamName, detail, workload }: RunningRoomProps) {
             />
           ) : (
             <TurnPanel
+              key={current.id}
               standupId={standup.id}
               teamId={teamId}
               turn={current}

--- a/apps/web/src/features/standup/turn-panel.tsx
+++ b/apps/web/src/features/standup/turn-panel.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import { AlertTriangle, Check, Plus } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Avatar } from '@/components/ui/avatar.tsx';
+import { Button } from '@/components/ui/button.tsx';
+import { StateGlyph } from '@/features/issues/state-glyph.tsx';
+import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
+import { cn } from '@/lib/cn.ts';
+import type {
+  Issue,
+  Member,
+  StandupBlocker,
+  StandupTurn,
+  StandupWorkload,
+} from '@/lib/query/schemas.ts';
+import { useTeamMemberIssues } from '@/lib/query/use-issues.ts';
+
+export interface TurnPanelProps {
+  readonly standupId: string;
+  readonly teamId: string;
+  readonly turn: StandupTurn;
+  readonly member: Member | undefined;
+  readonly workload: StandupWorkload | undefined;
+  readonly blockers: readonly StandupBlocker[];
+  readonly presenting: boolean;
+  readonly onSaveNotes: (notes: string) => void;
+  readonly onAttendance: (attendance: 'present' | 'absent') => void;
+  readonly onAddBlocker: (summary: string, issueId: string | null) => void;
+  readonly onResolveBlocker: (blockerId: string, resolved: boolean) => void;
+}
+
+const YESTERDAY_WINDOW_MS = 36 * 60 * 60 * 1000;
+
+function isRecent(value: string | null, now: number): boolean {
+  if (value === null) return false;
+  const at = Date.parse(value);
+  return Number.isFinite(at) && now - at <= YESTERDAY_WINDOW_MS;
+}
+
+export function TurnPanel({
+  teamId,
+  turn,
+  member,
+  workload,
+  blockers,
+  presenting,
+  onSaveNotes,
+  onAttendance,
+  onAddBlocker,
+  onResolveBlocker,
+}: TurnPanelProps) {
+  const workspace = useWorkspace();
+  const [notes, setNotes] = useState(turn.notes);
+  const [blocker, setBlocker] = useState('');
+
+  useEffect(() => {
+    setNotes(turn.notes);
+    setBlocker('');
+  }, [turn.notes]);
+
+  const now = Date.now();
+  const owned = useTeamMemberIssues(teamId, turn.userId);
+  const mine = useMemo(() => owned.data ?? [], [owned.data]);
+
+  const finished = useMemo(
+    () => mine.filter((issue) => isRecent(issue.completedAt, now)),
+    [mine, now],
+  );
+
+  const inFlight = useMemo(
+    () =>
+      mine.filter((issue) => {
+        const category = workspace.stateById.get(issue.stateId)?.category;
+        return category === 'started' || category === 'review';
+      }),
+    [mine, workspace.stateById],
+  );
+
+  const upNext = useMemo(
+    () =>
+      mine.filter((issue) => {
+        const category = workspace.stateById.get(issue.stateId)?.category;
+        return category === 'unstarted' || category === 'triage';
+      }),
+    [mine, workspace.stateById],
+  );
+
+  const turnBlockers = blockers.filter((entry) => entry.turnId === turn.id);
+  const heading = presenting ? 'text-2xl' : 'text-lg';
+  const columnTitle = 'font-medium text-2xs text-faint uppercase tracking-[0.08em]';
+
+  return (
+    <div className={cn('flex flex-col gap-5', presenting ? 'p-8' : 'p-5')} data-testid="turn-panel">
+      <div className="flex items-center gap-3">
+        <Avatar
+          name={member?.name ?? 'Unknown'}
+          src={member?.image ?? null}
+          size={presenting ? 'md' : 'sm'}
+        />
+        <div className="min-w-0 flex-1">
+          <h2 className={cn('font-medium text-text', heading)}>
+            {member?.name ?? 'Unknown member'}
+          </h2>
+          {workload === undefined ? null : (
+            <p data-numeric className="text-2xs text-faint">
+              {workload.inProgress} in progress, {workload.assigned} assigned
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Button
+            size="sm"
+            variant={turn.attendance === 'present' ? 'primary' : 'ghost'}
+            data-testid="mark-present"
+            onClick={() => onAttendance('present')}
+          >
+            Present
+          </Button>
+          <Button
+            size="sm"
+            variant={turn.attendance === 'absent' ? 'secondary' : 'ghost'}
+            data-testid="mark-absent"
+            onClick={() => onAttendance('absent')}
+          >
+            Absent
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <IssueColumn
+          title="Since yesterday"
+          titleClass={columnTitle}
+          issues={finished}
+          presenting={presenting}
+          empty="Nothing closed yet."
+        />
+        <IssueColumn
+          title="Working on today"
+          titleClass={columnTitle}
+          issues={inFlight}
+          presenting={presenting}
+          empty="Nothing in progress."
+        />
+        <IssueColumn
+          title="Up next"
+          titleClass={columnTitle}
+          issues={upNext.slice(0, 6)}
+          presenting={presenting}
+          empty="Nothing queued."
+        />
+      </div>
+
+      <section className="flex flex-col gap-2">
+        <h3 className={columnTitle}>Blockers</h3>
+        <ul className="flex flex-col gap-1.5">
+          {turnBlockers.map((entry) => (
+            <li
+              key={entry.id}
+              className="flex items-center gap-2 rounded-md border border-border px-2.5 py-1.5"
+            >
+              <AlertTriangle
+                className={cn(
+                  'size-3.5',
+                  entry.resolvedAt === null ? 'text-warning' : 'text-faint',
+                )}
+                aria-hidden="true"
+              />
+              <span
+                className={cn(
+                  'min-w-0 flex-1 text-dense',
+                  entry.resolvedAt === null ? 'text-text' : 'text-faint line-through',
+                )}
+              >
+                {entry.summary}
+              </span>
+              <Button
+                size="sm"
+                variant="ghost"
+                aria-label={entry.resolvedAt === null ? 'Resolve blocker' : 'Reopen blocker'}
+                onClick={() => onResolveBlocker(entry.id, entry.resolvedAt === null)}
+              >
+                <Check className="size-3.5" aria-hidden="true" />
+              </Button>
+            </li>
+          ))}
+          {turnBlockers.length === 0 ? (
+            <li className="text-2xs text-faint">Nothing blocking.</li>
+          ) : null}
+        </ul>
+
+        <form
+          className="flex gap-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const summary = blocker.trim();
+            if (summary.length === 0) return;
+            onAddBlocker(summary, null);
+            setBlocker('');
+          }}
+        >
+          <input
+            value={blocker}
+            onChange={(event) => setBlocker(event.target.value)}
+            placeholder="What is in the way?"
+            data-testid="blocker-input"
+            className="flex-1 rounded-md border border-border bg-surface-1 px-2.5 py-1.5 text-dense text-text placeholder:text-faint focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+          />
+          <Button size="sm" variant="secondary" type="submit" data-testid="add-blocker">
+            <Plus className="size-3.5" aria-hidden="true" />
+            Add
+          </Button>
+        </form>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h3 className={columnTitle}>Notes</h3>
+        <textarea
+          value={notes}
+          onChange={(event) => setNotes(event.target.value)}
+          onBlur={() => {
+            if (notes !== turn.notes) onSaveNotes(notes);
+          }}
+          rows={presenting ? 3 : 4}
+          data-testid="turn-notes"
+          placeholder="What the team should remember from this update."
+          className="w-full resize-y rounded-md border border-border bg-surface-1 px-2.5 py-2 text-dense text-text placeholder:text-faint focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+        />
+      </section>
+    </div>
+  );
+}
+
+interface IssueColumnProps {
+  readonly title: string;
+  readonly titleClass: string;
+  readonly issues: readonly Issue[];
+  readonly presenting: boolean;
+  readonly empty: string;
+}
+
+function IssueColumn({ title, titleClass, issues, presenting, empty }: IssueColumnProps) {
+  const workspace = useWorkspace();
+  return (
+    <section className="flex min-w-0 flex-col gap-1.5">
+      <h3 className={titleClass}>
+        {title}
+        <span data-numeric className="ml-1.5 text-faint">
+          {issues.length}
+        </span>
+      </h3>
+      <ul className="flex flex-col gap-1">
+        {issues.map((issue) => {
+          const state = workspace.stateById.get(issue.stateId);
+          return (
+            <li key={issue.id} className="flex items-center gap-2 rounded-md px-1.5 py-1">
+              {state === undefined ? null : (
+                <StateGlyph category={state.category} color={state.color} />
+              )}
+              <span data-numeric className="shrink-0 text-2xs text-faint">
+                {issue.identifier}
+              </span>
+              <span
+                className={cn(
+                  'min-w-0 flex-1 truncate text-text',
+                  presenting ? 'text-dense' : 'text-2xs',
+                )}
+              >
+                {issue.title}
+              </span>
+            </li>
+          );
+        })}
+        {issues.length === 0 ? <li className="px-1.5 text-2xs text-faint">{empty}</li> : null}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/features/standup/turn-panel.tsx
+++ b/apps/web/src/features/standup/turn-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AlertTriangle, Check, Plus } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Avatar } from '@/components/ui/avatar.tsx';
 import { Button } from '@/components/ui/button.tsx';
 import { StateGlyph } from '@/features/issues/state-glyph.tsx';
@@ -53,11 +53,6 @@ export function TurnPanel({
   const workspace = useWorkspace();
   const [notes, setNotes] = useState(turn.notes);
   const [blocker, setBlocker] = useState('');
-
-  useEffect(() => {
-    setNotes(turn.notes);
-    setBlocker('');
-  }, [turn.notes]);
 
   const now = Date.now();
   const owned = useTeamMemberIssues(teamId, turn.userId);

--- a/apps/web/src/lib/api/handler.ts
+++ b/apps/web/src/lib/api/handler.ts
@@ -1,8 +1,9 @@
 import { publishDeltas } from '@orbit/core';
-import { toDomainError, unauthorized } from '@orbit/shared/errors';
+import { notFound, toDomainError, unauthorized } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
 import { ORIGIN_CLIENT_ID_HEADER, originClientIdSchema } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
+import { idSchema } from '@orbit/shared/validators';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { ZodError } from 'zod';
@@ -115,6 +116,12 @@ export async function readJson(request: Request): Promise<unknown> {
   } catch {
     return {};
   }
+}
+
+export function routeId(value: string, what = 'record'): string {
+  const parsed = idSchema.safeParse(value);
+  if (!parsed.success) throw notFound(`That ${what} does not exist.`);
+  return parsed.data;
 }
 
 export function searchParamsOf(request: Request): Record<string, string> {

--- a/apps/web/src/lib/api/issues.ts
+++ b/apps/web/src/lib/api/issues.ts
@@ -1,11 +1,10 @@
-import type { IssueRow } from '@orbit/core';
 import { db, inArray, schema } from '@orbit/db';
 
-export interface IssueWithLabels extends IssueRow {
-  readonly labelIds: string[];
-}
+export type WithLabels<T> = T & { readonly labelIds: string[] };
 
-export async function attachLabels(issues: readonly IssueRow[]): Promise<IssueWithLabels[]> {
+export async function attachLabels<T extends { id: string }>(
+  issues: readonly T[],
+): Promise<WithLabels<T>[]> {
   if (issues.length === 0) return [];
   const links = await db
     .select({ issueId: schema.issueLabel.issueId, labelId: schema.issueLabel.labelId })

--- a/apps/web/src/lib/keyboard/registry.ts
+++ b/apps/web/src/lib/keyboard/registry.ts
@@ -1,8 +1,8 @@
 import { type BufferedStep, bufferMatches, type HotkeyStep, parseBinding } from './binding.ts';
 
-export type HotkeySection = 'Navigation' | 'General' | 'Issues' | 'View';
+export type HotkeySection = 'Navigation' | 'General' | 'Issues' | 'View' | 'Standup';
 
-export type HotkeyScope = 'global' | 'issues' | 'docs' | 'inbox' | 'filters';
+export type HotkeyScope = 'global' | 'issues' | 'docs' | 'inbox' | 'filters' | 'standup';
 
 export const HOTKEY_PRIORITY = {
   global: 0,

--- a/apps/web/src/lib/query/issue-search.ts
+++ b/apps/web/src/lib/query/issue-search.ts
@@ -26,6 +26,26 @@ export function issueSearch(teamId: string, query: IssueQuery): string {
   return params.toString();
 }
 
+export function columnSearch(teamId: string, query: IssueQuery, stateId: string): string {
+  const params = searchParams(query);
+  params.set('teamId', teamId);
+  params.set('stateId', stateId);
+  return params.toString();
+}
+
+export function summarySearch(
+  teamId: string | null,
+  query: IssueQuery,
+  groupBy: string,
+  scope: Readonly<Record<string, string>> = {},
+): string {
+  const params = searchParams(query);
+  if (teamId !== null) params.set('teamId', teamId);
+  for (const [key, value] of Object.entries(scope)) params.set(key, value);
+  params.set('groupBy', groupBy);
+  return params.toString();
+}
+
 export function assignedSearch(userId: string): string {
   const params = searchParams({ ...DEFAULT_ISSUE_QUERY, orderBy: 'updated' });
   params.set('assigneeId', userId);

--- a/apps/web/src/lib/query/issue-search.ts
+++ b/apps/web/src/lib/query/issue-search.ts
@@ -26,6 +26,13 @@ export function issueSearch(teamId: string, query: IssueQuery): string {
   return params.toString();
 }
 
+export function assigneeInTeamSearch(teamId: string, userId: string): string {
+  const params = searchParams({ ...DEFAULT_ISSUE_QUERY, orderBy: 'updated' });
+  params.set('teamId', teamId);
+  params.set('assigneeId', userId);
+  return params.toString();
+}
+
 export function columnSearch(teamId: string, query: IssueQuery, stateId: string): string {
   const params = searchParams(query);
   params.set('teamId', teamId);

--- a/apps/web/src/lib/query/keys.ts
+++ b/apps/web/src/lib/query/keys.ts
@@ -9,6 +9,7 @@ export const queryKeys = {
     ['issues', ASSIGNED_SCOPE, userId, filter] as const,
   allIssues: (filter = '') => ['issues', ALL_SCOPE, filter] as const,
   issueCounts: (filter: string) => ['issue-counts', filter] as const,
+  issueSummary: (search: string) => ['issue-summary', search] as const,
   issue: (identifier: string) => ['issue', identifier] as const,
   comments: (issueId: string) => ['comments', issueId] as const,
   docComments: (docId: string) => ['doc-comments', docId] as const,
@@ -19,6 +20,7 @@ export const queryKeys = {
 } as const;
 
 export const ISSUES_ROOT = 'issues';
+export const ISSUE_SUMMARY_ROOT = 'issue-summary';
 export const ISSUE_ROOT = 'issue';
 export const COMMENTS_ROOT = 'comments';
 export const DOC_COMMENTS_ROOT = 'doc-comments';

--- a/apps/web/src/lib/query/keys.ts
+++ b/apps/web/src/lib/query/keys.ts
@@ -17,6 +17,8 @@ export const queryKeys = {
   doc: (docId: string) => ['doc', docId] as const,
   docVersions: (docId: string) => ['doc', docId, 'versions'] as const,
   views: () => ['views'] as const,
+  standupToday: (teamId: string) => ['standup', 'today', teamId] as const,
+  standupHistory: (teamId: string) => ['standup', 'history', teamId] as const,
 } as const;
 
 export const ISSUES_ROOT = 'issues';
@@ -28,3 +30,4 @@ export const BOOTSTRAP_ROOT = 'bootstrap';
 export const DOCS_ROOT = 'docs';
 export const DOC_ROOT = 'doc';
 export const VIEWS_ROOT = 'views';
+export const STANDUP_ROOT = 'standup';

--- a/apps/web/src/lib/query/schemas.ts
+++ b/apps/web/src/lib/query/schemas.ts
@@ -11,12 +11,12 @@ const nullableTimestamp = z.string().nullable();
 
 export const issueSchema = z.object({
   id: z.string(),
-  organizationId: z.string(),
+  organizationId: z.string().default(''),
   teamId: z.string(),
   number: z.number(),
   identifier: z.string(),
   title: z.string(),
-  description: z.string(),
+  description: z.string().default(''),
   stateId: z.string(),
   priority: z.number(),
   creatorId: z.string(),
@@ -31,7 +31,7 @@ export const issueSchema = z.object({
   startedAt: nullableTimestamp,
   completedAt: nullableTimestamp,
   canceledAt: nullableTimestamp,
-  stateEnteredAt: timestamp,
+  stateEnteredAt: timestamp.default(''),
   syncId: z.number(),
   createdAt: timestamp,
   updatedAt: timestamp,
@@ -191,6 +191,58 @@ export const issueCountsSchema = z.object({
 });
 
 export type IssueCounts = z.infer<typeof issueCountsSchema>;
+
+export const FACET_PROPERTIES = [
+  'state',
+  'assignee',
+  'creator',
+  'priority',
+  'estimate',
+  'label',
+  'project',
+  'cycle',
+  'milestone',
+] as const;
+
+export type FacetProperty = (typeof FACET_PROPERTIES)[number];
+
+const facetCounts = z.record(z.string(), z.number()).catch({}).default({});
+
+export const issueSummarySchema = z.object({
+  total: z.number(),
+  scopeTotal: z.number(),
+  byState: z.record(z.string(), z.number()).catch({}).default({}),
+  groupTotals: z.record(z.string(), z.number()).catch({}).default({}),
+  facets: z
+    .object({
+      state: facetCounts,
+      assignee: facetCounts,
+      creator: facetCounts,
+      priority: facetCounts,
+      estimate: facetCounts,
+      label: facetCounts,
+      project: facetCounts,
+      cycle: facetCounts,
+      milestone: facetCounts,
+    })
+    .catch(() => emptyFacets()),
+});
+
+export type IssueSummary = z.infer<typeof issueSummarySchema>;
+
+export function emptyFacets(): IssueSummary['facets'] {
+  return {
+    state: {},
+    assignee: {},
+    creator: {},
+    priority: {},
+    estimate: {},
+    label: {},
+    project: {},
+    cycle: {},
+    milestone: {},
+  };
+}
 
 export const issueEnvelopeSchema = z.object({ issue: issueSchema });
 

--- a/apps/web/src/lib/query/schemas.ts
+++ b/apps/web/src/lib/query/schemas.ts
@@ -379,3 +379,70 @@ export const docCommentEnvelopeSchema = z.object({ comment: docCommentSchema });
 export const reactionResultSchema = z.object({ emoji: z.string(), active: z.boolean() });
 export const deletedSchema = z.object({ deleted: z.boolean() });
 export const subscribedSchema = z.object({ subscribed: z.boolean() });
+
+export const standupTurnSchema = z.object({
+  id: z.string(),
+  standupId: z.string(),
+  userId: z.string(),
+  position: z.number(),
+  attendance: z.enum(['unknown', 'present', 'absent']).catch('unknown'),
+  status: z.enum(['waiting', 'speaking', 'done', 'skipped']).catch('waiting'),
+  notes: z.string().default(''),
+  blockers: z.string().default(''),
+  spokeAt: nullableTimestamp,
+  durationSeconds: z.number().nullable(),
+});
+
+export type StandupTurn = z.infer<typeof standupTurnSchema>;
+
+export const standupBlockerSchema = z.object({
+  id: z.string(),
+  turnId: z.string(),
+  issueId: z.string().nullable(),
+  summary: z.string(),
+  ownerId: z.string().nullable(),
+  resolvedAt: nullableTimestamp,
+  createdAt: timestamp,
+});
+
+export type StandupBlocker = z.infer<typeof standupBlockerSchema>;
+
+export const standupSchema = z.object({
+  id: z.string(),
+  teamId: z.string(),
+  cycleId: z.string().nullable(),
+  heldOn: z.string(),
+  facilitatorId: z.string().nullable(),
+  status: z.enum(['scheduled', 'running', 'finished']).catch('scheduled'),
+  currentTurnId: z.string().nullable(),
+  startedAt: nullableTimestamp,
+  endedAt: nullableTimestamp,
+});
+
+export type Standup = z.infer<typeof standupSchema>;
+
+export const standupDetailSchema = z.object({
+  standup: standupSchema,
+  turns: z.array(standupTurnSchema).default([]),
+  blockers: z.array(standupBlockerSchema).default([]),
+});
+
+export type StandupDetail = z.infer<typeof standupDetailSchema>;
+
+export const standupWorkloadSchema = z.object({
+  userId: z.string(),
+  assigned: z.number(),
+  inProgress: z.number(),
+  completedSinceLast: z.number(),
+});
+
+export type StandupWorkload = z.infer<typeof standupWorkloadSchema>;
+
+export const standupTodaySchema = z.object({
+  standup: standupDetailSchema.nullable(),
+  workload: z.array(standupWorkloadSchema).default([]),
+});
+
+export type StandupToday = z.infer<typeof standupTodaySchema>;
+
+export const standupListSchema = z.object({ standups: z.array(standupSchema).default([]) });

--- a/apps/web/src/lib/query/sync.test.ts
+++ b/apps/web/src/lib/query/sync.test.ts
@@ -8,8 +8,10 @@ import {
   applyIssueDeltaToPages,
   applyIssueDetailDelta,
   applyReactionDelta,
+  belongsInList,
   flattenIssuePages,
   mapIssuePages,
+  searchOf,
   summarizeReactions,
 } from './sync.ts';
 
@@ -381,5 +383,35 @@ describe('issue pages', () => {
       TEAM,
     );
     expect(next?.pages[1]?.issues[0]?.title).toBe('Renamed');
+  });
+});
+
+describe('belongsInList', () => {
+  const base = issue({ id: 'issue_1', teamId: 'team_eng', stateId: 'state_todo' });
+
+  it('accepts anything when the search carries no scope', () => {
+    expect(belongsInList('limit=100&orderBy=manual', base)).toBe(true);
+  });
+
+  it('keeps a board column to its own status', () => {
+    expect(belongsInList('teamId=team_eng&stateId=state_todo', base)).toBe(true);
+    expect(belongsInList('teamId=team_eng&stateId=state_done', base)).toBe(false);
+  });
+
+  it('keeps a team list to its own team', () => {
+    expect(belongsInList('teamId=team_design', base)).toBe(false);
+  });
+
+  it('matches an unassigned issue only when no assignee is required', () => {
+    const unassigned = issue({ id: 'issue_2', assigneeId: null });
+    expect(belongsInList('limit=100', unassigned)).toBe(true);
+    expect(belongsInList('assigneeId=user_1', unassigned)).toBe(false);
+  });
+
+  it('reads the scope out of a query key', () => {
+    expect(searchOf(['issues', 'team_eng', 'teamId=team_eng&stateId=state_todo'])).toBe(
+      'teamId=team_eng&stateId=state_todo',
+    );
+    expect(searchOf(['issues'])).toBe('');
   });
 });

--- a/apps/web/src/lib/query/sync.test.ts
+++ b/apps/web/src/lib/query/sync.test.ts
@@ -2,16 +2,20 @@ import { describe, expect, it } from 'bun:test';
 import type { SyncAction } from '@orbit/shared/events';
 import type { Comment, DocComment, Issue } from './schemas.ts';
 import {
+  admitsNewRows,
   applyCommentDelta,
   applyDocCommentDelta,
   applyIssueDelta,
   applyIssueDeltaToPages,
   applyIssueDetailDelta,
   applyReactionDelta,
+  awaitsServerRefresh,
   belongsInList,
   flattenIssuePages,
   mapIssuePages,
+  orderingOf,
   searchOf,
+  sortForSearch,
   summarizeReactions,
 } from './sync.ts';
 
@@ -413,5 +417,77 @@ describe('belongsInList', () => {
       'teamId=team_eng&stateId=state_todo',
     );
     expect(searchOf(['issues'])).toBe('');
+  });
+});
+
+describe('a cached list keeps the order the server would return', () => {
+  it('orders by the query ordering, not by manual sortOrder', () => {
+    const older = issue({ id: 'issue_a', sortOrder: 10, updatedAt: '2026-01-01T00:00:00.000Z' });
+    const newer = issue({ id: 'issue_b', sortOrder: 90, updatedAt: '2026-06-01T00:00:00.000Z' });
+    const byUpdated = sortForSearch('orderBy=updated', [older, newer]);
+    expect(byUpdated.map((entry) => entry.id)).toEqual(['issue_b', 'issue_a']);
+
+    const byManual = sortForSearch('orderBy=manual', [newer, older]);
+    expect(byManual.map((entry) => entry.id)).toEqual(['issue_a', 'issue_b']);
+  });
+
+  it('treats an unknown or missing ordering as manual', () => {
+    expect(orderingOf('')).toBe('manual');
+    expect(orderingOf('orderBy=nonsense')).toBe('manual');
+    expect(orderingOf('orderBy=priority')).toBe('priority');
+  });
+
+  it('sorts a title ordering as text and an estimate ordering as a number', () => {
+    const b = issue({ id: 'i_b', title: 'beta', estimate: 8 });
+    const a = issue({ id: 'i_a', title: 'alpha', estimate: 21 });
+    expect(sortForSearch('orderBy=title', [b, a]).map((entry) => entry.id)).toEqual(['i_a', 'i_b']);
+    expect(sortForSearch('orderBy=estimate', [a, b]).map((entry) => entry.id)).toEqual([
+      'i_b',
+      'i_a',
+    ]);
+  });
+});
+
+describe('a filtered list never invents a row the server did not return', () => {
+  const filtered = 'teamId=team_eng&filter=cHJpb3JpdHk6dXJnZW50';
+
+  it('refuses to admit an insert it cannot check against the encoded filter', () => {
+    const incoming = issue({ id: 'issue_2', identifier: 'ENG-4' });
+    const list = [issue()];
+    expect(
+      applyIssueDelta(list, action({ action: 'insert', data: incoming }), TEAM, filtered),
+    ).toBe(list);
+  });
+
+  it('admits the same insert into a list carrying no encoded filter', () => {
+    const incoming = issue({ id: 'issue_2', identifier: 'ENG-4' });
+    const next = applyIssueDelta(
+      [issue()],
+      action({ action: 'insert', data: incoming }),
+      TEAM,
+      'teamId=team_eng',
+    );
+    expect(next).toHaveLength(2);
+  });
+
+  it('asks the server to settle the filtered list instead', () => {
+    const incoming = issue({ id: 'issue_2', identifier: 'ENG-4' });
+    const insert = action({ action: 'insert', data: incoming });
+    expect(awaitsServerRefresh([issue()], insert, TEAM, filtered)).toBe(true);
+    expect(awaitsServerRefresh([issue()], insert, TEAM, 'teamId=team_eng')).toBe(false);
+    expect(awaitsServerRefresh([issue(), incoming], insert, TEAM, filtered)).toBe(false);
+  });
+
+  it('still drops a delete from a filtered list without waiting for the server', () => {
+    const remove = action({ action: 'delete', data: { id: 'issue_1' } });
+    expect(applyIssueDelta([issue()], remove, TEAM, filtered)).toEqual([]);
+    expect(awaitsServerRefresh([issue()], remove, TEAM, filtered)).toBe(false);
+  });
+
+  it('reads the filter param, not merely any query string', () => {
+    expect(admitsNewRows('')).toBe(true);
+    expect(admitsNewRows('teamId=team_eng&orderBy=updated')).toBe(true);
+    expect(admitsNewRows('filter=')).toBe(true);
+    expect(admitsNewRows(filtered)).toBe(false);
   });
 });

--- a/apps/web/src/lib/query/sync.test.ts
+++ b/apps/web/src/lib/query/sync.test.ts
@@ -491,3 +491,12 @@ describe('a filtered list never invents a row the server did not return', () => 
     expect(admitsNewRows(filtered)).toBe(false);
   });
 });
+
+describe('an ordering name from the URL cannot reach the prototype', () => {
+  it('treats an inherited property name as manual rather than crashing', () => {
+    for (const name of ['__proto__', 'toString', 'constructor', 'hasOwnProperty']) {
+      expect(orderingOf(`orderBy=${encodeURIComponent(name)}`)).toBe('manual');
+      expect(() => sortForSearch(`orderBy=${encodeURIComponent(name)}`, [issue()])).not.toThrow();
+    }
+  });
+});

--- a/apps/web/src/lib/query/sync.ts
+++ b/apps/web/src/lib/query/sync.ts
@@ -51,6 +51,30 @@ function definedFields(value: Record<string, unknown>): IssueDelta {
 
 export type IssueBelongs = (issue: Issue) => boolean;
 
+const SCOPED_PARAMS = ['teamId', 'stateId', 'assigneeId', 'projectId', 'cycleId'] as const;
+
+const ISSUE_FIELD_OF: Record<(typeof SCOPED_PARAMS)[number], keyof Issue> = {
+  teamId: 'teamId',
+  stateId: 'stateId',
+  assigneeId: 'assigneeId',
+  projectId: 'projectId',
+  cycleId: 'cycleId',
+};
+
+export function belongsInList(search: string, issue: Issue): boolean {
+  const params = new URLSearchParams(search);
+  return SCOPED_PARAMS.every((name) => {
+    const expected = params.get(name);
+    return expected === null || issue[ISSUE_FIELD_OF[name]] === expected;
+  });
+}
+
+export function searchOf(key: readonly unknown[]): string {
+  if (key.length < 3) return '';
+  const last = key.at(-1);
+  return typeof last === 'string' ? last : '';
+}
+
 export function applyIssueDelta(
   issues: readonly Issue[],
   action: SyncAction,

--- a/apps/web/src/lib/query/sync.ts
+++ b/apps/web/src/lib/query/sync.ts
@@ -1,4 +1,5 @@
 import type { SyncAction } from '@orbit/shared/events';
+import type { IssueOrdering } from '@orbit/shared/filters';
 import type { InfiniteData } from '@tanstack/react-query';
 import { z } from 'zod';
 import type { Comment, DocComment, Issue, IssuePage, Reaction } from './schemas.ts';
@@ -75,10 +76,29 @@ export function searchOf(key: readonly unknown[]): string {
   return typeof last === 'string' ? last : '';
 }
 
+export function admitsNewRows(search: string): boolean {
+  return (new URLSearchParams(search).get('filter') ?? '') === '';
+}
+
+export function awaitsServerRefresh(
+  issues: readonly Issue[],
+  action: SyncAction,
+  belongs: IssueBelongs,
+  search: string,
+): boolean {
+  if (action.action === 'delete' || action.action === 'archive') return false;
+  if (admitsNewRows(search)) return false;
+  const full = issueSchema.safeParse(action.data);
+  if (!full.success || full.data.archivedAt !== null) return false;
+  if (!belongs(full.data)) return false;
+  return !issues.some((issue) => issue.id === full.data.id);
+}
+
 export function applyIssueDelta(
   issues: readonly Issue[],
   action: SyncAction,
   belongs: IssueBelongs,
+  search = '',
 ): readonly Issue[] {
   const parsed = partialIssueSchema.safeParse(action.data);
   if (!parsed.success) return issues;
@@ -94,7 +114,8 @@ export function applyIssueDelta(
     if (!full.success) return issues;
     if (!belongs(full.data)) return issues;
     if (full.data.archivedAt !== null) return issues;
-    return [...issues, full.data];
+    if (!admitsNewRows(search)) return issues;
+    return sortForSearch(search, [...issues, full.data]);
   }
 
   const existing = issues[index];
@@ -143,9 +164,10 @@ export function applyIssueDeltaToPages(
   data: IssuePages | undefined,
   action: SyncAction,
   belongs: IssueBelongs,
+  search = '',
 ): IssuePages | undefined {
   if (data === undefined) return data;
-  return mapIssuePages(data, (issues) => applyIssueDelta(issues, action, belongs));
+  return mapIssuePages(data, (issues) => applyIssueDelta(issues, action, belongs, search));
 }
 
 export function applyIssueDetailDelta<T extends { issue: Issue; descriptionHtml?: string }>(
@@ -270,5 +292,38 @@ export function sortIssues(issues: readonly Issue[]): Issue[] {
   return [...issues].sort((left, right) => {
     if (left.sortOrder !== right.sortOrder) return left.sortOrder - right.sortOrder;
     return left.identifier.localeCompare(right.identifier);
+  });
+}
+
+const ORDER_READERS: Record<
+  IssueOrdering,
+  { readonly descending: boolean; readonly read: (issue: Issue) => string | number }
+> = {
+  manual: { descending: false, read: (issue) => issue.sortOrder },
+  priority: { descending: false, read: (issue) => (issue.priority === 0 ? 5 : issue.priority) },
+  created: { descending: true, read: (issue) => issue.createdAt },
+  updated: { descending: true, read: (issue) => issue.updatedAt },
+  due: { descending: false, read: (issue) => issue.dueDate ?? '9999-12-31' },
+  estimate: { descending: false, read: (issue) => issue.estimate ?? 9999 },
+  title: { descending: false, read: (issue) => issue.title.toLowerCase() },
+};
+
+function compareValues(left: string | number, right: string | number): number {
+  if (typeof left === 'number' && typeof right === 'number') return left - right;
+  return String(left).localeCompare(String(right));
+}
+
+export function orderingOf(search: string): IssueOrdering {
+  const requested = new URLSearchParams(search).get('orderBy');
+  return requested !== null && requested in ORDER_READERS ? (requested as IssueOrdering) : 'manual';
+}
+
+export function sortForSearch(search: string, issues: readonly Issue[]): Issue[] {
+  const ordering = ORDER_READERS[orderingOf(search)];
+  const sign = ordering.descending ? -1 : 1;
+  return [...issues].sort((left, right) => {
+    const primary = compareValues(ordering.read(left), ordering.read(right));
+    if (primary !== 0) return primary * sign;
+    return left.id.localeCompare(right.id) * sign;
   });
 }

--- a/apps/web/src/lib/query/sync.ts
+++ b/apps/web/src/lib/query/sync.ts
@@ -315,7 +315,9 @@ function compareValues(left: string | number, right: string | number): number {
 
 export function orderingOf(search: string): IssueOrdering {
   const requested = new URLSearchParams(search).get('orderBy');
-  return requested !== null && requested in ORDER_READERS ? (requested as IssueOrdering) : 'manual';
+  return requested !== null && Object.hasOwn(ORDER_READERS, requested)
+    ? (requested as IssueOrdering)
+    : 'manual';
 }
 
 export function sortForSearch(search: string, issues: readonly Issue[]): Issue[] {

--- a/apps/web/src/lib/query/use-issues.ts
+++ b/apps/web/src/lib/query/use-issues.ts
@@ -41,7 +41,13 @@ import {
   issueSummarySchema,
 } from './schemas.ts';
 import type { IssuePages } from './sync.ts';
-import { belongsInList, flattenIssuePages, mapIssuePages, searchOf, sortIssues } from './sync.ts';
+import {
+  belongsInList,
+  flattenIssuePages,
+  mapIssuePages,
+  searchOf,
+  sortForSearch,
+} from './sync.ts';
 
 export type { IssueQuery };
 export {
@@ -234,7 +240,7 @@ function reconcile(
   if (!belongsInList(search, next)) {
     return index === -1 ? issues : issues.filter((issue) => issue.id !== next.id);
   }
-  if (index === -1) return admit ? sortIssues([...issues, next]) : issues;
+  if (index === -1) return admit ? sortForSearch(search, [...issues, next]) : issues;
   const copy = [...issues];
   copy[index] = next;
   return copy;
@@ -270,7 +276,7 @@ function placeIssues(client: QueryClient, moved: readonly Issue[]): void {
   eachIssueList(client, { queryKey: [ISSUES_ROOT] }, (issues, search) => {
     let next = issues;
     for (const issue of moved) next = reconcile(search, next, issue, false);
-    return sortIssues(next);
+    return sortForSearch(search, next);
   });
 }
 
@@ -284,12 +290,10 @@ function refreshCounts(client: QueryClient): void {
   client.invalidateQueries({ queryKey: [ISSUE_SUMMARY_ROOT] }).catch(() => undefined);
 }
 
-function patchTeamIssueLists(
-  client: QueryClient,
-  teamId: string,
-  update: (issues: readonly Issue[]) => readonly Issue[],
-): void {
-  eachIssueList(client, { queryKey: queryKeys.issueTeam(teamId) }, (issues) => update(issues));
+function resortTeamIssueLists(client: QueryClient, teamId: string): void {
+  eachIssueList(client, { queryKey: queryKeys.issueTeam(teamId) }, (issues, search) =>
+    sortForSearch(search, issues),
+  );
 }
 
 export function useUpdateIssue(_teamId: string) {
@@ -386,7 +390,7 @@ export function useMoveIssue(teamId: string) {
       placeIssues(client, moved);
     },
     onSettled: () => {
-      patchTeamIssueLists(client, teamId, sortIssues);
+      resortTeamIssueLists(client, teamId);
       refreshCounts(client);
     },
   });

--- a/apps/web/src/lib/query/use-issues.ts
+++ b/apps/web/src/lib/query/use-issues.ts
@@ -22,7 +22,7 @@ import {
   type IssueQuery,
   issueSearch,
 } from './issue-search.ts';
-import { ISSUES_ROOT, queryKeys } from './keys.ts';
+import { ISSUE_SUMMARY_ROOT, ISSUES_ROOT, queryKeys } from './keys.ts';
 import type {
   Bootstrap,
   Issue,
@@ -224,12 +224,17 @@ function restoreIssueLists(client: QueryClient, snapshot: IssueListSnapshot): vo
   for (const [key, pages] of snapshot) client.setQueryData(key, pages);
 }
 
-function reconcile(search: string, issues: readonly Issue[], next: Issue): readonly Issue[] {
+function reconcile(
+  search: string,
+  issues: readonly Issue[],
+  next: Issue,
+  admit: boolean,
+): readonly Issue[] {
   const index = issues.findIndex((issue) => issue.id === next.id);
   if (!belongsInList(search, next)) {
     return index === -1 ? issues : issues.filter((issue) => issue.id !== next.id);
   }
-  if (index === -1) return sortIssues([...issues, next]);
+  if (index === -1) return admit ? sortIssues([...issues, next]) : issues;
   const copy = [...issues];
   copy[index] = next;
   return copy;
@@ -257,22 +262,26 @@ function patchIssueLists(
 
 function placeIssue(client: QueryClient, next: Issue): void {
   eachIssueList(client, { queryKey: [ISSUES_ROOT] }, (issues, search) =>
-    reconcile(search, issues, next),
+    reconcile(search, issues, next, false),
   );
 }
 
 function placeIssues(client: QueryClient, moved: readonly Issue[]): void {
   eachIssueList(client, { queryKey: [ISSUES_ROOT] }, (issues, search) => {
     let next = issues;
-    for (const issue of moved) next = reconcile(search, next, issue);
+    for (const issue of moved) next = reconcile(search, next, issue, false);
     return sortIssues(next);
   });
 }
 
 function addToTeamLists(client: QueryClient, teamId: string, next: Issue): void {
   eachIssueList(client, { queryKey: queryKeys.issueTeam(teamId) }, (issues, search) =>
-    reconcile(search, issues, next),
+    reconcile(search, issues, next, true),
   );
+}
+
+function refreshCounts(client: QueryClient): void {
+  client.invalidateQueries({ queryKey: [ISSUE_SUMMARY_ROOT] }).catch(() => undefined);
 }
 
 function patchTeamIssueLists(
@@ -329,6 +338,7 @@ export function useUpdateIssue(_teamId: string) {
     },
     onSuccess: (issue) => {
       placeIssue(client, issue);
+      refreshCounts(client);
       client.setQueryData<IssueDetail>(queryKeys.issue(issue.identifier), (current) =>
         current === undefined ? current : { ...current, issue },
       );
@@ -377,6 +387,7 @@ export function useMoveIssue(teamId: string) {
     },
     onSettled: () => {
       patchTeamIssueLists(client, teamId, sortIssues);
+      refreshCounts(client);
     },
   });
 }
@@ -415,6 +426,7 @@ export function useCreateIssue(teamId: string) {
     },
     onSuccess: (issue) => {
       addToTeamLists(client, teamId, issue);
+      refreshCounts(client);
     },
   });
 }
@@ -441,6 +453,7 @@ export function useDeleteIssue(_teamId: string) {
     },
     onSettled: (_data, _error, issue) => {
       client.removeQueries({ queryKey: queryKeys.issue(issue.identifier) });
+      refreshCounts(client);
     },
   });
 }

--- a/apps/web/src/lib/query/use-issues.ts
+++ b/apps/web/src/lib/query/use-issues.ts
@@ -15,13 +15,21 @@ import {
   ALL_ISSUES_QUERY,
   allIssuesSearch,
   assignedSearch,
+  columnSearch,
   DEFAULT_ISSUE_QUERY,
   ISSUE_PAGE_SIZE,
   type IssueQuery,
   issueSearch,
 } from './issue-search.ts';
 import { ISSUES_ROOT, queryKeys } from './keys.ts';
-import type { Bootstrap, Issue, IssueCounts, IssueDetail, IssuePage } from './schemas.ts';
+import type {
+  Bootstrap,
+  Issue,
+  IssueCounts,
+  IssueDetail,
+  IssuePage,
+  IssueSummary,
+} from './schemas.ts';
 import {
   bootstrapSchema,
   issueCountsSchema,
@@ -29,6 +37,7 @@ import {
   issueEnvelopeSchema,
   issueListSchema,
   issueMoveResultSchema,
+  issueSummarySchema,
 } from './schemas.ts';
 import type { IssuePages } from './sync.ts';
 import { flattenIssuePages, mapIssuePages, sortIssues } from './sync.ts';
@@ -38,6 +47,7 @@ export {
   ALL_ISSUES_QUERY,
   allIssuesSearch,
   assignedSearch,
+  columnSearch,
   DEFAULT_ISSUE_QUERY,
   ISSUE_PAGE_SIZE,
   issueSearch,
@@ -92,27 +102,18 @@ export function issuesQueryOptions(teamId: string, query: IssueQuery = DEFAULT_I
   return pagedIssueOptions(queryKeys.issues(teamId, search), search);
 }
 
-const MAX_PAGES = 40;
-
-async function fetchAllIssues(search: string, signal: AbortSignal): Promise<readonly Issue[]> {
-  const issues: Issue[] = [];
-  let cursor: string | null = null;
-  for (let page = 0; page < MAX_PAGES; page += 1) {
-    const result = await fetchIssuePage(search, cursor, signal);
-    issues.push(...result.issues);
-    if (result.nextCursor === null) break;
-    cursor = result.nextCursor;
-  }
-  return issues;
+export function issueSummaryQueryOptions(search: string, enabled = true) {
+  return {
+    queryKey: queryKeys.issueSummary(search),
+    enabled,
+    placeholderData: keepPreviousData,
+    queryFn: async ({ signal }: { signal: AbortSignal }): Promise<IssueSummary> =>
+      await apiFetch(`/api/issues/summary?${search}`, issueSummarySchema, { signal }),
+  };
 }
 
-export function teamIssuesQuery(teamId: string) {
-  const search = issueSearch(teamId, DEFAULT_ISSUE_QUERY);
-  return {
-    queryKey: queryKeys.issues(teamId, search),
-    queryFn: async ({ signal }: { signal: AbortSignal }): Promise<readonly Issue[]> =>
-      await fetchAllIssues(search, signal),
-  };
+export function useIssueSummary(search: string, enabled = true) {
+  return useQuery(issueSummaryQueryOptions(search, enabled));
 }
 
 function seedPages(seed: readonly Issue[] | undefined): IssuePages | undefined {
@@ -131,6 +132,21 @@ export function useIssues(
     enabled: teamId !== null,
     select: flattenIssuePages,
     placeholderData: seedPages(seed) ?? keepPreviousData,
+  });
+}
+
+export function useColumnIssues(
+  teamId: string | null,
+  query: IssueQuery,
+  stateId: string,
+  enabled: boolean,
+) {
+  const search = teamId === null ? '' : columnSearch(teamId, query, stateId);
+  return useInfiniteQuery({
+    ...pagedIssueOptions(queryKeys.issues(teamId ?? 'none', search), search),
+    enabled: enabled && teamId !== null,
+    select: flattenIssuePages,
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/apps/web/src/lib/query/use-issues.ts
+++ b/apps/web/src/lib/query/use-issues.ts
@@ -41,7 +41,7 @@ import {
   issueSummarySchema,
 } from './schemas.ts';
 import type { IssuePages } from './sync.ts';
-import { flattenIssuePages, mapIssuePages, sortIssues } from './sync.ts';
+import { belongsInList, flattenIssuePages, mapIssuePages, searchOf, sortIssues } from './sync.ts';
 
 export type { IssueQuery };
 export {
@@ -214,22 +214,6 @@ export interface IssuePatch {
   readonly labelIds?: readonly string[];
 }
 
-function replaceIssue(issues: readonly Issue[], next: Issue): readonly Issue[] {
-  const index = issues.findIndex((issue) => issue.id === next.id);
-  if (index === -1) return issues;
-  const copy = [...issues];
-  copy[index] = next;
-  return copy;
-}
-
-function addIssue(issues: readonly Issue[], next: Issue): readonly Issue[] {
-  const index = issues.findIndex((issue) => issue.id === next.id);
-  if (index === -1) return [...issues, next];
-  const copy = [...issues];
-  copy[index] = next;
-  return copy;
-}
-
 type IssueListSnapshot = readonly [QueryKey, IssuePages | undefined][];
 
 function snapshotIssueLists(client: QueryClient): IssueListSnapshot {
@@ -240,12 +224,54 @@ function restoreIssueLists(client: QueryClient, snapshot: IssueListSnapshot): vo
   for (const [key, pages] of snapshot) client.setQueryData(key, pages);
 }
 
+function reconcile(search: string, issues: readonly Issue[], next: Issue): readonly Issue[] {
+  const index = issues.findIndex((issue) => issue.id === next.id);
+  if (!belongsInList(search, next)) {
+    return index === -1 ? issues : issues.filter((issue) => issue.id !== next.id);
+  }
+  if (index === -1) return sortIssues([...issues, next]);
+  const copy = [...issues];
+  copy[index] = next;
+  return copy;
+}
+
+function eachIssueList(
+  client: QueryClient,
+  filters: { queryKey: QueryKey },
+  update: (issues: readonly Issue[], search: string) => readonly Issue[],
+): void {
+  for (const [key] of client.getQueriesData<IssuePages>(filters)) {
+    const search = searchOf(key);
+    client.setQueryData<IssuePages>(key, (current) =>
+      current === undefined ? current : mapIssuePages(current, (issues) => update(issues, search)),
+    );
+  }
+}
+
 function patchIssueLists(
   client: QueryClient,
   update: (issues: readonly Issue[]) => readonly Issue[],
 ): void {
-  client.setQueriesData<IssuePages>({ queryKey: [ISSUES_ROOT] }, (current) =>
-    current === undefined ? current : mapIssuePages(current, update),
+  eachIssueList(client, { queryKey: [ISSUES_ROOT] }, (issues) => update(issues));
+}
+
+function placeIssue(client: QueryClient, next: Issue): void {
+  eachIssueList(client, { queryKey: [ISSUES_ROOT] }, (issues, search) =>
+    reconcile(search, issues, next),
+  );
+}
+
+function placeIssues(client: QueryClient, moved: readonly Issue[]): void {
+  eachIssueList(client, { queryKey: [ISSUES_ROOT] }, (issues, search) => {
+    let next = issues;
+    for (const issue of moved) next = reconcile(search, next, issue);
+    return sortIssues(next);
+  });
+}
+
+function addToTeamLists(client: QueryClient, teamId: string, next: Issue): void {
+  eachIssueList(client, { queryKey: queryKeys.issueTeam(teamId) }, (issues, search) =>
+    reconcile(search, issues, next),
   );
 }
 
@@ -254,9 +280,7 @@ function patchTeamIssueLists(
   teamId: string,
   update: (issues: readonly Issue[]) => readonly Issue[],
 ): void {
-  client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(teamId) }, (current) =>
-    current === undefined ? current : mapIssuePages(current, update),
-  );
+  eachIssueList(client, { queryKey: queryKeys.issueTeam(teamId) }, (issues) => update(issues));
 }
 
 export function useUpdateIssue(_teamId: string) {
@@ -284,7 +308,7 @@ export function useUpdateIssue(_teamId: string) {
         labelIds:
           input.patch.labelIds === undefined ? input.issue.labelIds : [...input.patch.labelIds],
       };
-      patchIssueLists(client, (issues) => replaceIssue(issues, optimistic));
+      placeIssue(client, optimistic);
       if (previousDetail !== undefined) {
         client.setQueryData(queryKeys.issue(input.issue.identifier), {
           ...previousDetail,
@@ -304,7 +328,7 @@ export function useUpdateIssue(_teamId: string) {
       toast({ title: 'Could not save', description: messageOf(error), tone: 'danger' });
     },
     onSuccess: (issue) => {
-      patchIssueLists(client, (issues) => replaceIssue(issues, issue));
+      placeIssue(client, issue);
       client.setQueryData<IssueDetail>(queryKeys.issue(issue.identifier), (current) =>
         current === undefined ? current : { ...current, issue },
       );
@@ -341,7 +365,7 @@ export function useMoveIssue(teamId: string) {
         stateId: input.stateId,
         sortOrder: sortOrderBetween(input.beforeOrder, input.afterOrder),
       };
-      patchIssueLists(client, (issues) => replaceIssue(issues, optimistic));
+      placeIssue(client, optimistic);
       return { previous };
     },
     onError: (error, _input, context) => {
@@ -349,11 +373,7 @@ export function useMoveIssue(teamId: string) {
       toast({ title: 'Could not move that issue', description: messageOf(error), tone: 'danger' });
     },
     onSuccess: (moved) => {
-      patchIssueLists(client, (current) => {
-        let next = current;
-        for (const issue of moved) next = replaceIssue(next, issue);
-        return sortIssues(next);
-      });
+      placeIssues(client, moved);
     },
     onSettled: () => {
       patchTeamIssueLists(client, teamId, sortIssues);
@@ -394,7 +414,7 @@ export function useCreateIssue(teamId: string) {
       });
     },
     onSuccess: (issue) => {
-      patchTeamIssueLists(client, teamId, (issues) => sortIssues(addIssue(issues, issue)));
+      addToTeamLists(client, teamId, issue);
     },
   });
 }

--- a/apps/web/src/lib/query/use-issues.ts
+++ b/apps/web/src/lib/query/use-issues.ts
@@ -15,6 +15,7 @@ import {
   ALL_ISSUES_QUERY,
   allIssuesSearch,
   assignedSearch,
+  assigneeInTeamSearch,
   columnSearch,
   DEFAULT_ISSUE_QUERY,
   ISSUE_PAGE_SIZE,
@@ -47,6 +48,7 @@ export {
   ALL_ISSUES_QUERY,
   allIssuesSearch,
   assignedSearch,
+  assigneeInTeamSearch,
   columnSearch,
   DEFAULT_ISSUE_QUERY,
   ISSUE_PAGE_SIZE,
@@ -145,6 +147,16 @@ export function useColumnIssues(
   return useInfiniteQuery({
     ...pagedIssueOptions(queryKeys.issues(teamId ?? 'none', search), search),
     enabled: enabled && teamId !== null,
+    select: flattenIssuePages,
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useTeamMemberIssues(teamId: string | null, userId: string | null) {
+  const search = teamId === null || userId === null ? '' : assigneeInTeamSearch(teamId, userId);
+  return useInfiniteQuery({
+    ...pagedIssueOptions(queryKeys.issues(teamId ?? 'none', search), search),
+    enabled: teamId !== null && userId !== null,
     select: flattenIssuePages,
     placeholderData: keepPreviousData,
   });

--- a/apps/web/src/lib/query/use-standup.ts
+++ b/apps/web/src/lib/query/use-standup.ts
@@ -1,0 +1,185 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useToast } from '@/components/ui/toast.tsx';
+import { apiFetch, messageOf } from './fetcher.ts';
+import { queryKeys } from './keys.ts';
+import type { StandupDetail, StandupToday } from './schemas.ts';
+import { standupDetailSchema, standupListSchema, standupTodaySchema } from './schemas.ts';
+
+export function useStandupToday(teamId: string | null) {
+  return useQuery({
+    queryKey: queryKeys.standupToday(teamId ?? 'none'),
+    enabled: teamId !== null,
+    queryFn: async ({ signal }): Promise<StandupToday> =>
+      await apiFetch(
+        `/api/standups?view=today&teamId=${encodeURIComponent(teamId ?? '')}`,
+        standupTodaySchema,
+        { signal },
+      ),
+  });
+}
+
+export function useStandupHistory(teamId: string | null, limit = 20) {
+  return useQuery({
+    queryKey: queryKeys.standupHistory(teamId ?? 'none'),
+    enabled: teamId !== null,
+    queryFn: async ({ signal }) =>
+      await apiFetch(
+        `/api/standups?teamId=${encodeURIComponent(teamId ?? '')}&limit=${limit}`,
+        standupListSchema,
+        { signal },
+      ),
+  });
+}
+
+function useStandupMutation<TInput>(
+  teamId: string | null,
+  request: (input: TInput) => Promise<StandupDetail>,
+  failure: string,
+) {
+  const client = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: request,
+    onSuccess: (detail) => {
+      client.setQueryData<StandupToday>(queryKeys.standupToday(teamId ?? 'none'), (current) =>
+        current === undefined ? current : { ...current, standup: detail },
+      );
+    },
+    onError: (error) => {
+      toast({ title: failure, description: messageOf(error), tone: 'danger' });
+    },
+    onSettled: () => {
+      client
+        .invalidateQueries({ queryKey: queryKeys.standupToday(teamId ?? 'none') })
+        .catch(() => undefined);
+    },
+  });
+}
+
+export function useOpenStandup(teamId: string | null) {
+  return useStandupMutation(
+    teamId,
+    async () =>
+      await apiFetch('/api/standups', standupDetailSchema, {
+        method: 'POST',
+        body: { teamId },
+      }),
+    'Could not open the standup',
+  );
+}
+
+export function useStartStandup(teamId: string | null) {
+  return useStandupMutation(
+    teamId,
+    async (standupId: string) =>
+      await apiFetch(`/api/standups/${standupId}/start`, standupDetailSchema, { method: 'POST' }),
+    'Could not start the standup',
+  );
+}
+
+export interface AdvanceInput {
+  readonly standupId: string;
+  readonly direction: 'next' | 'previous';
+}
+
+export function useAdvanceStandup(teamId: string | null) {
+  return useStandupMutation(
+    teamId,
+    async ({ standupId, direction }: AdvanceInput) =>
+      await apiFetch(`/api/standups/${standupId}/advance`, standupDetailSchema, {
+        method: 'POST',
+        body: { direction, markDone: true },
+      }),
+    'Could not move to the next person',
+  );
+}
+
+export interface FocusInput {
+  readonly standupId: string;
+  readonly turnId: string;
+}
+
+export function useFocusTurn(teamId: string | null) {
+  return useStandupMutation(
+    teamId,
+    async ({ standupId, turnId }: FocusInput) =>
+      await apiFetch(`/api/standups/${standupId}/focus`, standupDetailSchema, {
+        method: 'POST',
+        body: { turnId },
+      }),
+    'Could not switch to that person',
+  );
+}
+
+export interface TurnPatch {
+  readonly standupId: string;
+  readonly turnId: string;
+  readonly attendance?: 'unknown' | 'present' | 'absent';
+  readonly notes?: string;
+  readonly blockers?: string;
+}
+
+export function useUpdateTurn(teamId: string | null) {
+  return useStandupMutation(
+    teamId,
+    async ({ standupId, turnId, ...patch }: TurnPatch) =>
+      await apiFetch(`/api/standups/${standupId}/turns/${turnId}`, standupDetailSchema, {
+        method: 'PATCH',
+        body: patch,
+      }),
+    'Could not save that turn',
+  );
+}
+
+export interface BlockerInput {
+  readonly standupId: string;
+  readonly turnId: string;
+  readonly summary: string;
+  readonly issueId?: string | null;
+}
+
+export function useAddBlocker(teamId: string | null) {
+  return useStandupMutation(
+    teamId,
+    async ({ standupId, turnId, summary, issueId }: BlockerInput) =>
+      await apiFetch(`/api/standups/${standupId}/turns/${turnId}/blockers`, standupDetailSchema, {
+        method: 'POST',
+        body: { summary, issueId: issueId ?? null },
+      }),
+    'Could not record that blocker',
+  );
+}
+
+export interface ResolveBlockerInput {
+  readonly standupId: string;
+  readonly blockerId: string;
+  readonly resolved: boolean;
+}
+
+export function useResolveBlocker(teamId: string | null) {
+  return useStandupMutation(
+    teamId,
+    async ({ standupId, blockerId, resolved }: ResolveBlockerInput) =>
+      await apiFetch(
+        `/api/standups/blockers/${blockerId}?standupId=${encodeURIComponent(standupId)}`,
+        standupDetailSchema,
+        { method: 'PATCH', body: { resolved } },
+      ),
+    'Could not update that blocker',
+  );
+}
+
+export function useFinishStandup(teamId: string | null) {
+  return useStandupMutation(
+    teamId,
+    async (standupId: string) =>
+      await apiFetch(`/api/standups/${standupId}`, standupDetailSchema, {
+        method: 'PATCH',
+        body: { status: 'finished' },
+      }),
+    'Could not finish the standup',
+  );
+}

--- a/apps/web/src/lib/realtime/connection-banner.test.tsx
+++ b/apps/web/src/lib/realtime/connection-banner.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test';
+import type { RealtimeStatus } from '@orbit/realtime-client';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { ConnectionBannerView, RECONNECT_GRACE_MS } from './connection-banner.tsx';
+
+function renderAt(status: RealtimeStatus): void {
+  render(<ConnectionBannerView status={status} />);
+}
+
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  });
+}
+
+describe('ConnectionBannerView', () => {
+  it('stays hidden while the connection is healthy', () => {
+    renderAt('open');
+    expect(screen.queryByTestId('realtime-connection-banner')).toBeNull();
+    cleanup();
+  });
+
+  it('does not flash during a reconnect that resolves inside the grace window', async () => {
+    renderAt('reconnecting');
+    expect(screen.queryByTestId('realtime-connection-banner')).toBeNull();
+    await advance(RECONNECT_GRACE_MS / 2);
+    expect(screen.queryByTestId('realtime-connection-banner')).toBeNull();
+    cleanup();
+  });
+
+  it('surfaces a reconnect that outlasts the grace window', async () => {
+    renderAt('reconnecting');
+    await advance(RECONNECT_GRACE_MS + 50);
+    expect(screen.getByTestId('realtime-connection-banner').textContent).toContain('Reconnecting');
+    cleanup();
+  });
+
+  it('reports a terminal close immediately, with no grace period', () => {
+    renderAt('closed');
+    expect(screen.getByTestId('realtime-connection-banner').textContent).toContain(
+      'no longer valid',
+    );
+    cleanup();
+  });
+});

--- a/apps/web/src/lib/realtime/connection-banner.tsx
+++ b/apps/web/src/lib/realtime/connection-banner.tsx
@@ -1,13 +1,32 @@
 'use client';
 
+import type { RealtimeStatus } from '@orbit/realtime-client';
 import { useRealtimeStatus } from '@orbit/realtime-client/react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 
-export function ConnectionBanner() {
-  const status = useRealtimeStatus();
-  if (status !== 'closed' && status !== 'reconnecting') return null;
+export const RECONNECT_GRACE_MS = 4_000;
 
+export function ConnectionBanner() {
+  return <ConnectionBannerView status={useRealtimeStatus()} />;
+}
+
+export function ConnectionBannerView({ status }: { readonly status: RealtimeStatus }) {
   const closed = status === 'closed';
+  const reconnecting = status === 'reconnecting';
+  const [graceElapsed, setGraceElapsed] = useState(false);
+
+  useEffect(() => {
+    if (!reconnecting) {
+      setGraceElapsed(false);
+      return;
+    }
+    const timer = setTimeout(() => setGraceElapsed(true), RECONNECT_GRACE_MS);
+    return () => clearTimeout(timer);
+  }, [reconnecting]);
+
+  if (!(closed || (reconnecting && graceElapsed))) return null;
+
   return (
     <div
       role="status"

--- a/apps/web/src/lib/realtime/delta-bridge.test.tsx
+++ b/apps/web/src/lib/realtime/delta-bridge.test.tsx
@@ -12,6 +12,7 @@ let capturedResume: ((since: number) => void) | null = null;
 const observed: number[] = [];
 
 mock.module('@orbit/realtime-client/react', () => ({
+  useRealtimeStatus: () => 'open',
   useScopeSubscription: () => undefined,
   useDeltaHandler: (handler: (actions: SyncAction[]) => void) => {
     capturedHandler = handler;

--- a/apps/web/src/lib/realtime/delta-bridge.test.tsx
+++ b/apps/web/src/lib/realtime/delta-bridge.test.tsx
@@ -3,7 +3,14 @@ import type { SyncAction } from '@orbit/shared/events';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, render } from '@testing-library/react';
 import { clientId } from '@/lib/query/client-id.ts';
-import { BOOTSTRAP_ROOT, DOC_ROOT, DOCS_ROOT, queryKeys, VIEWS_ROOT } from '@/lib/query/keys.ts';
+import {
+  BOOTSTRAP_ROOT,
+  DOC_ROOT,
+  DOCS_ROOT,
+  ISSUE_SUMMARY_ROOT,
+  queryKeys,
+  VIEWS_ROOT,
+} from '@/lib/query/keys.ts';
 import type { Issue } from '@/lib/query/schemas.ts';
 import type { IssuePages } from '@/lib/query/sync.ts';
 
@@ -190,11 +197,11 @@ describe('DeltaBridge root invalidation', () => {
     expect(seen).toEqual([[DOCS_ROOT], [DOC_ROOT, 'doc_1']]);
   });
 
-  it('leaves every root alone for a delta the bridge patches in place', () => {
+  it('refreshes only the counts for an issue delta it patches in place', () => {
     const client = mount();
     const seen = trackInvalidations(client);
     act(() => capturedHandler?.([action()]));
-    expect(seen).toEqual([]);
+    expect(seen).toEqual([[ISSUE_SUMMARY_ROOT]]);
   });
 });
 
@@ -264,6 +271,6 @@ describe('DeltaBridge reconnect backfill', () => {
     expect(requested).toEqual(['/api/sync?since=17']);
     expect(titleIn(client)).toBe('Caught up');
     expect(observed).toContain(42);
-    expect(seen).toEqual([]);
+    expect(seen).toEqual([[ISSUE_SUMMARY_ROOT]]);
   });
 });

--- a/apps/web/src/lib/realtime/delta-bridge.test.tsx
+++ b/apps/web/src/lib/realtime/delta-bridge.test.tsx
@@ -9,6 +9,7 @@ import {
   DOCS_ROOT,
   ISSUE_SUMMARY_ROOT,
   queryKeys,
+  STANDUP_ROOT,
   VIEWS_ROOT,
 } from '@/lib/query/keys.ts';
 import type { Issue } from '@/lib/query/schemas.ts';
@@ -272,5 +273,18 @@ describe('DeltaBridge reconnect backfill', () => {
     expect(titleIn(client)).toBe('Caught up');
     expect(observed).toContain(42);
     expect(seen).toEqual([[ISSUE_SUMMARY_ROOT]]);
+  });
+});
+
+describe('DeltaBridge standup', () => {
+  it('refreshes the room when somebody else advances the standup', () => {
+    const client = mount();
+    const seen = trackInvalidations(client);
+    act(() =>
+      capturedHandler?.([
+        action({ model: 'standup', modelId: 'standup_1', data: { id: 'standup_1' } }),
+      ]),
+    );
+    expect(seen).toEqual([[STANDUP_ROOT]]);
   });
 });

--- a/apps/web/src/lib/realtime/delta-bridge.tsx
+++ b/apps/web/src/lib/realtime/delta-bridge.tsx
@@ -34,7 +34,9 @@ import {
   applyIssueDeltaToPages,
   applyIssueDetailDelta,
   applyReactionDelta,
+  awaitsServerRefresh,
   belongsInList,
+  flattenIssuePages,
   searchOf,
 } from '@/lib/query/sync.ts';
 import { useCurrentUserId } from './session.tsx';
@@ -86,8 +88,12 @@ function patchIssueCaches(client: QueryClient, action: SyncAction): void {
     if (belongs === null) continue;
     const current = query.state.data as IssuePages | undefined;
     if (current === undefined) continue;
-    const next = applyIssueDeltaToPages(current, action, belongs);
+    const search = searchOf(query.queryKey);
+    const next = applyIssueDeltaToPages(current, action, belongs, search);
     if (next !== current) client.setQueryData(query.queryKey, next);
+    if (awaitsServerRefresh(flattenIssuePages(current), action, belongs, search)) {
+      client.invalidateQueries({ queryKey: query.queryKey }).catch(() => undefined);
+    }
   }
 
   for (const query of client.getQueryCache().findAll({ queryKey: [ISSUE_ROOT] })) {

--- a/apps/web/src/lib/realtime/delta-bridge.tsx
+++ b/apps/web/src/lib/realtime/delta-bridge.tsx
@@ -13,6 +13,7 @@ import { useCallback, useMemo } from 'react';
 import { clientId } from '@/lib/query/client-id.ts';
 import { apiFetch } from '@/lib/query/fetcher.ts';
 import {
+  ALL_SCOPE,
   ASSIGNED_SCOPE,
   BOOTSTRAP_ROOT,
   COMMENTS_ROOT,
@@ -31,6 +32,8 @@ import {
   applyIssueDeltaToPages,
   applyIssueDetailDelta,
   applyReactionDelta,
+  belongsInList,
+  searchOf,
 } from '@/lib/query/sync.ts';
 import { useCurrentUserId } from './session.tsx';
 
@@ -63,12 +66,14 @@ interface RootInvalidations {
 function membershipOf(key: QueryKey): IssueBelongs | null {
   const scope = key[1];
   if (typeof scope !== 'string') return null;
+  const search = searchOf(key);
   if (scope === ASSIGNED_SCOPE) {
     const userId = key[2];
     if (typeof userId !== 'string') return null;
-    return (issue: Issue) => issue.assigneeId === userId;
+    return (issue: Issue) => issue.assigneeId === userId && belongsInList(search, issue);
   }
-  return (issue: Issue) => issue.teamId === scope;
+  if (scope === ALL_SCOPE) return (issue: Issue) => belongsInList(search, issue);
+  return (issue: Issue) => issue.teamId === scope && belongsInList(search, issue);
 }
 
 function patchIssueCaches(client: QueryClient, action: SyncAction): void {

--- a/apps/web/src/lib/realtime/delta-bridge.tsx
+++ b/apps/web/src/lib/realtime/delta-bridge.tsx
@@ -23,6 +23,7 @@ import {
   ISSUE_ROOT,
   ISSUE_SUMMARY_ROOT,
   ISSUES_ROOT,
+  STANDUP_ROOT,
   VIEWS_ROOT,
 } from '@/lib/query/keys.ts';
 import type { Comment, DocComment, Issue, IssueDetail } from '@/lib/query/schemas.ts';
@@ -59,6 +60,7 @@ function noop(): undefined {
 
 interface RootInvalidations {
   counts: boolean;
+  standup: boolean;
   bootstrap: boolean;
   views: boolean;
   docs: boolean;
@@ -168,6 +170,10 @@ function routeAction(
     patchSubscription(client, action, currentUserId);
     return;
   }
+  if (action.model === 'standup') {
+    roots.standup = true;
+    return;
+  }
   if (DOC_MODELS.has(action.model)) {
     roots.docs = true;
     if (action.model === 'doc') roots.docIds.add(action.modelId);
@@ -182,6 +188,7 @@ function routeAction(
 
 function flushRoots(client: QueryClient, roots: RootInvalidations): void {
   if (roots.counts) client.invalidateQueries({ queryKey: [ISSUE_SUMMARY_ROOT] }).catch(noop);
+  if (roots.standup) client.invalidateQueries({ queryKey: [STANDUP_ROOT] }).catch(noop);
   if (roots.bootstrap) client.invalidateQueries({ queryKey: [BOOTSTRAP_ROOT] }).catch(noop);
   if (roots.views) client.invalidateQueries({ queryKey: [VIEWS_ROOT] }).catch(noop);
   if (roots.docs) client.invalidateQueries({ queryKey: [DOCS_ROOT] }).catch(noop);
@@ -211,6 +218,7 @@ export function DeltaBridge({ organizationId, teamIds }: DeltaBridgeProps) {
       const tabClientId = clientId();
       const roots: RootInvalidations = {
         counts: false,
+        standup: false,
         bootstrap: false,
         views: false,
         docs: false,

--- a/apps/web/src/lib/realtime/delta-bridge.tsx
+++ b/apps/web/src/lib/realtime/delta-bridge.tsx
@@ -21,6 +21,7 @@ import {
   DOC_ROOT,
   DOCS_ROOT,
   ISSUE_ROOT,
+  ISSUE_SUMMARY_ROOT,
   ISSUES_ROOT,
   VIEWS_ROOT,
 } from '@/lib/query/keys.ts';
@@ -57,6 +58,7 @@ function noop(): undefined {
 }
 
 interface RootInvalidations {
+  counts: boolean;
   bootstrap: boolean;
   views: boolean;
   docs: boolean;
@@ -147,6 +149,7 @@ function routeAction(
 ): void {
   if (action.model === 'issue') {
     patchIssueCaches(client, action);
+    roots.counts = true;
     return;
   }
   if (action.model === 'comment') {
@@ -178,6 +181,7 @@ function routeAction(
 }
 
 function flushRoots(client: QueryClient, roots: RootInvalidations): void {
+  if (roots.counts) client.invalidateQueries({ queryKey: [ISSUE_SUMMARY_ROOT] }).catch(noop);
   if (roots.bootstrap) client.invalidateQueries({ queryKey: [BOOTSTRAP_ROOT] }).catch(noop);
   if (roots.views) client.invalidateQueries({ queryKey: [VIEWS_ROOT] }).catch(noop);
   if (roots.docs) client.invalidateQueries({ queryKey: [DOCS_ROOT] }).catch(noop);
@@ -206,6 +210,7 @@ export function DeltaBridge({ organizationId, teamIds }: DeltaBridgeProps) {
     (actions: readonly SyncAction[]) => {
       const tabClientId = clientId();
       const roots: RootInvalidations = {
+        counts: false,
         bootstrap: false,
         views: false,
         docs: false,

--- a/apps/web/src/lib/realtime/url.test.ts
+++ b/apps/web/src/lib/realtime/url.test.ts
@@ -30,15 +30,24 @@ describe('resolveRealtimeUrl', () => {
 describe('configuredRealtimeUrl', () => {
   const key = 'NEXT_PUBLIC_REALTIME_URL';
   const saved = process.env[key];
+  const env = process.env as Record<string, string | undefined>;
+  const savedMode = env['NODE_ENV'];
 
   afterEach(() => {
     if (saved === undefined) delete process.env[key];
     else process.env[key] = saved;
+    env['NODE_ENV'] = savedMode;
   });
 
   it('keeps a websocket url', () => {
     process.env[key] = 'wss://orbit.example/api/ws';
     expect(configuredRealtimeUrl()).toBe('wss://orbit.example/api/ws');
+  });
+
+  it('ignores a configured url in production so the socket always follows the app origin', () => {
+    env['NODE_ENV'] = 'production';
+    process.env[key] = 'wss://realtime.orbit.example';
+    expect(configuredRealtimeUrl()).toBe('');
   });
 
   it('falls back to the same origin when the url is not a websocket', () => {

--- a/apps/web/src/lib/realtime/url.ts
+++ b/apps/web/src/lib/realtime/url.ts
@@ -8,6 +8,7 @@ const socketUrlSchema = z
   .catch('');
 
 export function configuredRealtimeUrl(): string {
+  if (process.env['NODE_ENV'] === 'production') return '';
   const configured = process.env['NEXT_PUBLIC_REALTIME_URL'] ?? '';
   if (configured.length === 0) return '';
   return socketUrlSchema.parse(configured);

--- a/biome.json
+++ b/biome.json
@@ -235,6 +235,7 @@
       "includes": [
         "scripts/**",
         "**/seed/**",
+        "packages/db/src/ensure-*.ts",
         "**/*.config.ts",
         "**/*.config.mjs",
         "**/*.config.js"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "db:migrate": "bun run --filter '@orbit/db' migrate",
     "db:push": "bun run --filter '@orbit/db' push",
     "db:seed": "bun run --filter '@orbit/db' seed",
+    "db:test-setup": "bun run --filter '@orbit/db' test-setup",
     "db:studio": "bun run --filter '@orbit/db' studio",
     "db:import-plane": "bun run --filter '@orbit/db' import:plane",
     "db:verify-plane": "bun run --filter '@orbit/db' import:verify",

--- a/packages/core/bunfig.toml
+++ b/packages/core/bunfig.toml
@@ -1,3 +1,4 @@
 [test]
 preload = ["./tests-preload.ts"]
 root = "src"
+timeout = 20000

--- a/packages/core/src/analytics/burndown.ts
+++ b/packages/core/src/analytics/burndown.ts
@@ -1,8 +1,9 @@
 import { and, asc, db, eq, schema, sql } from '@orbit/db';
 import type { Principal } from '@orbit/shared/policy';
-import { assertCan } from '@orbit/shared/policy';
+import { assertCan, assertInTeam, teamScope } from '@orbit/shared/policy';
 import type { SQL } from 'drizzle-orm';
 import { requireRow, startOfUtcDay } from '../internal.ts';
+import { requireTeam } from '../org/team-service.ts';
 import { churnFromScopeSeries, type Distribution, distributionOf, idealRemaining } from './math.ts';
 import type { Measure } from './schemas.ts';
 
@@ -49,7 +50,9 @@ async function loadCycle(principal: Principal, cycleId: string) {
       and(eq(schema.cycle.id, cycleId), eq(schema.cycle.organizationId, principal.organizationId)),
     )
     .limit(1);
-  return requireRow(row, 'That cycle does not exist.');
+  const cycle = requireRow(row, 'That cycle does not exist.');
+  assertInTeam(principal, teamScope(cycle));
+  return cycle;
 }
 
 export async function cycleBurndown(
@@ -262,6 +265,7 @@ export async function teamVelocity(
   limit = 8,
 ): Promise<VelocityPoint[]> {
   assertCan(principal, 'project:read');
+  await requireTeam(principal, teamId);
   const weight = weightSql(measure);
 
   const rows = await db.execute<VelocityRow>(sql`

--- a/packages/core/src/analytics/distribution.test.ts
+++ b/packages/core/src/analytics/distribution.test.ts
@@ -177,3 +177,33 @@ describe('scopeSeries and projectProgressSeries', () => {
     expect(series.at(-1)?.scope).toBe(3);
   });
 });
+
+describe('analytics never reaches past the teams you are on', () => {
+  it('leaves another team’s work out of the workspace numbers', async () => {
+    const engineering = await workDistribution(workspace.admin, WORKSPACE, 'assignee', 'issues');
+    const engineeringTotal = engineering.reduce((sum, row) => sum + row.value, 0);
+    expect(engineeringTotal).toBeGreaterThan(0);
+
+    const { principal: outsider } = await addMember(workspace, 'member', {
+      name: 'Des Designer',
+      teamIds: [],
+    });
+    const outside = await workDistribution(outsider, WORKSPACE, 'assignee', 'issues');
+    expect(outside.reduce((sum, row) => sum + row.value, 0)).toBe(0);
+  });
+
+  it('refuses to answer for a team the caller is not on, even when named directly', async () => {
+    const { principal: outsider } = await addMember(workspace, 'member', {
+      name: 'Des Designer',
+      teamIds: [],
+    });
+    const scoped: AnalyticsScope = { type: 'team', id: workspace.teamId };
+    const rows = await workDistribution(outsider, scoped, 'assignee', 'issues');
+    expect(rows.reduce((sum, row) => sum + row.value, 0)).toBe(0);
+  });
+
+  it('still answers in full for an admin', async () => {
+    const chart = await stateGroupBreakdown(workspace.admin, WORKSPACE, 'assignee', 'issues');
+    expect(chart.data.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/analytics/distribution.ts
+++ b/packages/core/src/analytics/distribution.ts
@@ -86,8 +86,18 @@ function joinClause(dimensions: readonly (ChartDimension | undefined)[]): SQL {
   return fragments.length === 0 ? sql`` : sql.join(fragments, sql` `);
 }
 
+function visibleTeamsClause(principal: Principal): SQL {
+  if (principal.role === 'admin') return sql``;
+  if (principal.teamIds.length === 0) return sql` and false`;
+  const ids = sql.join(
+    principal.teamIds.map((id) => sql`${id}`),
+    sql`, `,
+  );
+  return sql` and i.team_id in (${ids})`;
+}
+
 function scopeClause(principal: Principal, scope: AnalyticsScope): SQL {
-  const base = sql`i.organization_id = ${principal.organizationId} and i.archived_at is null`;
+  const base = sql`i.organization_id = ${principal.organizationId} and i.archived_at is null${visibleTeamsClause(principal)}`;
   switch (scope.type) {
     case 'team':
       return sql`${base} and i.team_id = ${scope.id}`;

--- a/packages/core/src/content/comment-service.ts
+++ b/packages/core/src/content/comment-service.ts
@@ -43,11 +43,7 @@ async function loadIssueForComment(executor: Executor, principal: Principal, iss
 }
 
 function commentScopes(issue: { organizationId: string; teamId: string; id: string }): string[] {
-  return [
-    scopes.organization(issue.organizationId),
-    scopes.team(issue.teamId),
-    scopes.issue(issue.id),
-  ];
+  return [scopes.team(issue.teamId), scopes.issue(issue.id)];
 }
 
 async function loadComment(

--- a/packages/core/src/content/doc-comment-service.test.ts
+++ b/packages/core/src/content/doc-comment-service.test.ts
@@ -7,7 +7,7 @@ import {
   listDocComments,
   updateDocComment,
 } from './doc-comment-service.ts';
-import { createDoc } from './doc-service.ts';
+import { createDoc, setDocAccess } from './doc-service.ts';
 
 let workspace: Workspace;
 let docId: string;
@@ -132,5 +132,57 @@ describe('doc comment policy', () => {
     const actions = await deleteDocComment(workspace.admin, comment.id);
     expect(actions[0]?.action).toBe('delete');
     expect(actions[0]?.model).toBe('doc_comment');
+  });
+});
+
+describe('a private doc keeps its conversation private', () => {
+  it('hides the thread from somebody the doc was never shared with', async () => {
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Compensation review',
+      content: 'Bob gets a raise.',
+      visibility: 'private',
+    });
+    await createDocComment(workspace.admin, doc.id, { body: 'Approved by finance.' });
+    const { principal: outsider } = await addMember(workspace, 'member');
+
+    await expect(listDocComments(outsider, doc.id)).rejects.toMatchObject({ code: 'not_found' });
+    await expect(
+      createDocComment(outsider, doc.id, { body: 'Who else is on this list?' }),
+    ).rejects.toMatchObject({ code: 'not_found' });
+  });
+
+  it('lets somebody the doc was shared with join the thread', async () => {
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Compensation review',
+      content: 'Bob gets a raise.',
+      visibility: 'private',
+    });
+    const { principal: invited, user } = await addMember(workspace, 'member');
+    await setDocAccess(workspace.admin, doc.id, [
+      { subjectType: 'user', subjectId: user.id, level: 'read' },
+    ]);
+
+    const { comment } = await createDocComment(invited, doc.id, { body: 'Looks right to me.' });
+    expect(comment.body).toBe('Looks right to me.');
+    expect(await listDocComments(invited, doc.id)).toMatchObject({
+      comments: [{ id: comment.id }],
+    });
+  });
+
+  it('never announces a private doc comment on the workspace channel', async () => {
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Compensation review',
+      content: 'Bob gets a raise.',
+      visibility: 'private',
+    });
+    const { actions } = await createDocComment(workspace.admin, doc.id, { body: 'Approved.' });
+
+    expect(actions[0]?.scopes).toContain(scopes.doc(doc.id));
+    expect(actions[0]?.scopes).not.toContain(scopes.organization(workspace.organizationId));
+  });
+
+  it('still announces a workspace doc comment to the workspace', async () => {
+    const { actions } = await createDocComment(workspace.admin, docId, { body: 'Ship it.' });
+    expect(actions[0]?.scopes).toContain(scopes.organization(workspace.organizationId));
   });
 });

--- a/packages/core/src/content/doc-comment-service.ts
+++ b/packages/core/src/content/doc-comment-service.ts
@@ -1,4 +1,5 @@
 import { and, asc, db, eq, isNull, schema, sql } from '@orbit/db';
+import { isRestricted } from '@orbit/shared/constants';
 import { forbidden, validationFailed } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
@@ -13,28 +14,22 @@ import { principalActor } from '../activity/activity-service.ts';
 import { type Executor, newId, requireRow } from '../internal.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
+import { type DocRow, loadReadableDoc } from './doc-service.ts';
 
 export type DocCommentRow = typeof schema.docComment.$inferSelect;
 
-interface DocRef {
-  readonly id: string;
-  readonly organizationId: string;
-}
+type DocRef = DocRow;
 
 async function loadDocForComment(
   executor: Executor,
   principal: Principal,
   docId: string,
 ): Promise<DocRef> {
-  const [row] = await executor
-    .select({ id: schema.doc.id, organizationId: schema.doc.organizationId })
-    .from(schema.doc)
-    .where(and(eq(schema.doc.id, docId), eq(schema.doc.organizationId, principal.organizationId)))
-    .limit(1);
-  return requireRow(row, 'That doc does not exist.');
+  return await loadReadableDoc(executor, principal, docId);
 }
 
 function docCommentScopes(doc: DocRef): string[] {
+  if (isRestricted(doc.visibility)) return [scopes.user(doc.authorId), scopes.doc(doc.id)];
   return [scopes.organization(doc.organizationId), scopes.doc(doc.id)];
 }
 

--- a/packages/core/src/content/doc-service.test.ts
+++ b/packages/core/src/content/doc-service.test.ts
@@ -561,3 +561,42 @@ describe('a read grant does not become a write grant', () => {
     expect(saved.doc.title).toBe('Handbook v2');
   });
 });
+
+describe('backlinks respect who may read the linking doc', () => {
+  it('hides a private doc that links to one you can read', async () => {
+    const { doc: target } = await createDoc(workspace.admin, {
+      title: 'Deploy runbook',
+      content: 'How we ship.',
+      visibility: 'workspace',
+    });
+    await createDoc(workspace.admin, {
+      title: 'Layoff plan',
+      content: `See /docs/${target.id} before the announcement.`,
+      visibility: 'private',
+    });
+    const { principal: member } = await addMember(workspace, 'member');
+
+    const seen = await getDoc(member, target.id);
+    expect(seen.backlinks.map((link) => link.title)).not.toContain('Layoff plan');
+
+    const asAdmin = await getDoc(workspace.admin, target.id);
+    expect(asAdmin.backlinks.map((link) => link.title)).toContain('Layoff plan');
+  });
+
+  it('still shows a workspace doc that links to it', async () => {
+    const { doc: target } = await createDoc(workspace.admin, {
+      title: 'Deploy runbook',
+      content: 'How we ship.',
+      visibility: 'workspace',
+    });
+    await createDoc(workspace.admin, {
+      title: 'Onboarding',
+      content: `Read /docs/${target.id} on day one.`,
+      visibility: 'workspace',
+    });
+    const { principal: member } = await addMember(workspace, 'member');
+
+    const seen = await getDoc(member, target.id);
+    expect(seen.backlinks.map((link) => link.title)).toContain('Onboarding');
+  });
+});

--- a/packages/core/src/content/doc-service.test.ts
+++ b/packages/core/src/content/doc-service.test.ts
@@ -515,3 +515,49 @@ describe('a doc body never travels on the wire', () => {
     ).rejects.toThrow();
   });
 });
+
+describe('a read grant does not become a write grant', () => {
+  it('refuses an edit from somebody granted read only', async () => {
+    const { principal: reader, user: readerUser } = await addMember(workspace, 'member');
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Board pack',
+      content: 'Read this, do not change it.',
+      visibility: 'private',
+    });
+    await setDocAccess(workspace.admin, doc.id, [
+      { subjectType: 'user', subjectId: readerUser.id, level: 'read' },
+    ]);
+
+    expect((await getDoc(reader, doc.id)).doc.id).toBe(doc.id);
+    await expect(updateDoc(reader, doc.id, { title: 'Hijacked' })).rejects.toMatchObject({
+      code: 'forbidden',
+    });
+    await expect(archiveDoc(reader, doc.id)).rejects.toMatchObject({ code: 'forbidden' });
+  });
+
+  it('allows an edit from somebody granted write', async () => {
+    const { principal: editor, user: editorUser } = await addMember(workspace, 'member');
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Shared draft',
+      content: 'Edit away.',
+      visibility: 'private',
+    });
+    await setDocAccess(workspace.admin, doc.id, [
+      { subjectType: 'user', subjectId: editorUser.id, level: 'write' },
+    ]);
+
+    const saved = await updateDoc(editor, doc.id, { title: 'Edited' });
+    expect(saved.doc.title).toBe('Edited');
+  });
+
+  it('leaves a workspace doc editable by anyone who may write docs', async () => {
+    const { principal: member } = await addMember(workspace, 'member');
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Handbook',
+      content: 'Everyone edits this.',
+      visibility: 'workspace',
+    });
+    const saved = await updateDoc(member, doc.id, { title: 'Handbook v2' });
+    expect(saved.doc.title).toBe('Handbook v2');
+  });
+});

--- a/packages/core/src/content/doc-service.test.ts
+++ b/packages/core/src/content/doc-service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { scopes } from '@orbit/shared/events';
+import { DOC_CONTENT_LIMIT } from '@orbit/shared/validators';
 import { createTeam } from '../org/team-service.ts';
 import { addMember, createWorkspace, resetDatabase, type Workspace } from '../test-support.ts';
 import {
@@ -475,5 +476,42 @@ describe('doc access', () => {
     });
     expect(doc.authorId).toBe(authorUser.id);
     expect((await getDoc(workspace.admin, doc.id)).doc.id).toBe(doc.id);
+  });
+});
+
+describe('a doc body never travels on the wire', () => {
+  it('announces a change without the content', async () => {
+    const secret = 'A body that should never appear in a delta payload.';
+    const { actions } = await createDoc(workspace.admin, {
+      title: 'Long doc',
+      content: secret,
+      visibility: 'workspace',
+    });
+
+    const payload = JSON.stringify(actions);
+    expect(actions.length).toBeGreaterThan(0);
+    expect(payload).not.toContain(secret);
+    expect(payload).toContain('Long doc');
+  });
+
+  it('accepts a document far larger than the old hundred kilobyte cap', async () => {
+    const long = 'x'.repeat(200_000);
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Very long',
+      content: long,
+      visibility: 'workspace',
+    });
+    const read = await getDoc(workspace.admin, doc.id);
+    expect(read.doc.content.length).toBe(200_000);
+  });
+
+  it('refuses a document past the doc limit with an explanation', async () => {
+    await expect(
+      createDoc(workspace.admin, {
+        title: 'Too long',
+        content: 'x'.repeat(DOC_CONTENT_LIMIT + 1),
+        visibility: 'workspace',
+      }),
+    ).rejects.toThrow();
   });
 });

--- a/packages/core/src/content/doc-service.test.ts
+++ b/packages/core/src/content/doc-service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { scopes } from '@orbit/shared/events';
+import { createTeam } from '../org/team-service.ts';
 import { addMember, createWorkspace, resetDatabase, type Workspace } from '../test-support.ts';
 import {
   archiveDoc,
@@ -15,6 +16,7 @@ import {
   listPublicDocs,
   publishedDocToken,
   restoreDocVersion,
+  setDocAccess,
   shareDoc,
   updateDoc,
   updateDocCollection,
@@ -398,5 +400,80 @@ describe('backlinks', () => {
     const detail = await getDoc(workspace.admin, target.id);
     expect(detail.backlinks.map((entry) => entry.id)).toEqual([linking.id]);
     expect((await getDoc(workspace.admin, linking.id)).backlinks).toEqual([]);
+  });
+});
+
+describe('doc access', () => {
+  it('keeps a private doc away from everyone but its author', async () => {
+    const { principal: other } = await addMember(workspace, 'member');
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Compensation review',
+      content: 'Numbers nobody else should read.',
+      visibility: 'private',
+    });
+
+    await expect(getDoc(other, doc.id)).rejects.toMatchObject({ code: 'not_found' });
+    const listed = await listDocs(other, {});
+    expect(listed.some((row) => row.id === doc.id)).toBe(false);
+
+    const asAuthor = await getDoc(workspace.admin, doc.id);
+    expect(asAuthor.doc.id).toBe(doc.id);
+  });
+
+  it('shares a private doc with exactly the people it was shared with', async () => {
+    const { principal: invited, user: invitedUser } = await addMember(workspace, 'member');
+    const { principal: stranger } = await addMember(workspace, 'member');
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Shared plan',
+      content: 'For a named few.',
+      visibility: 'private',
+    });
+
+    await setDocAccess(workspace.admin, doc.id, [
+      { subjectType: 'user', subjectId: invitedUser.id, level: 'read' },
+    ]);
+
+    expect((await getDoc(invited, doc.id)).doc.id).toBe(doc.id);
+    expect((await listDocs(invited, {})).some((row) => row.id === doc.id)).toBe(true);
+    await expect(getDoc(stranger, doc.id)).rejects.toMatchObject({ code: 'not_found' });
+  });
+
+  it('shares with a whole team when the grant names one', async () => {
+    const team = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const { principal: designer } = await addMember(workspace, 'member', {
+      teamIds: [team.team.id],
+    });
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Design brief',
+      content: 'For the design team.',
+      visibility: 'private',
+    });
+
+    await expect(getDoc(designer, doc.id)).rejects.toMatchObject({ code: 'not_found' });
+    await setDocAccess(workspace.admin, doc.id, [
+      { subjectType: 'team', subjectId: team.team.id, level: 'read' },
+    ]);
+    expect((await getDoc(designer, doc.id)).doc.id).toBe(doc.id);
+  });
+
+  it('leaves workspace docs readable by everyone, as before', async () => {
+    const { principal: guest } = await addMember(workspace, 'guest');
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Handbook',
+      content: 'Everybody reads this.',
+      visibility: 'workspace',
+    });
+    expect((await getDoc(guest, doc.id)).doc.id).toBe(doc.id);
+  });
+
+  it('lets an admin reach a private doc they do not own', async () => {
+    const { principal: author, user: authorUser } = await addMember(workspace, 'member');
+    const { doc } = await createDoc(author, {
+      title: 'Personal notes',
+      content: 'Mine.',
+      visibility: 'private',
+    });
+    expect(doc.authorId).toBe(authorUser.id);
+    expect((await getDoc(workspace.admin, doc.id)).doc.id).toBe(doc.id);
   });
 });

--- a/packages/core/src/content/doc-service.ts
+++ b/packages/core/src/content/doc-service.ts
@@ -106,9 +106,14 @@ function docAction(
     action,
     model: 'doc',
     modelId: row.id,
-    data: { ...row, publishToken: row.publishToken === null ? null : 'redacted' },
+    data: docAnnouncement(row),
     actor,
   });
+}
+
+function docAnnouncement(row: DocRow): Record<string, unknown> {
+  const { content: _body, publishToken, ...rest } = row;
+  return { ...rest, publishToken: publishToken === null ? null : 'redacted' };
 }
 
 function tokenFor(visibility: string, current: string | null): string | null {

--- a/packages/core/src/content/doc-service.ts
+++ b/packages/core/src/content/doc-service.ts
@@ -217,7 +217,7 @@ async function writeGrantedDocIds(
   return rows.length > 0;
 }
 
-async function assertDocWritable(
+export async function assertDocWritable(
   executor: Executor,
   principal: Principal,
   doc: DocRow,
@@ -229,7 +229,11 @@ async function assertDocWritable(
   throw forbidden('You only have read access to that doc.');
 }
 
-async function loadDoc(executor: Executor, principal: Principal, docId: string): Promise<DocRow> {
+export async function loadReadableDoc(
+  executor: Executor,
+  principal: Principal,
+  docId: string,
+): Promise<DocRow> {
   const [row] = await executor
     .select()
     .from(schema.doc)
@@ -376,7 +380,11 @@ async function attachmentsFor(docId: string): Promise<AttachmentRow[]> {
     .orderBy(asc(schema.attachment.createdAt));
 }
 
-export async function listDocBacklinks(doc: DocRow): Promise<DocBacklink[]> {
+export async function listDocBacklinks(
+  doc: DocRow,
+  principal: Principal | null,
+): Promise<DocBacklink[]> {
+  if (principal === null) return [];
   return await db
     .select({ id: schema.doc.id, title: schema.doc.title })
     .from(schema.doc)
@@ -386,13 +394,14 @@ export async function listDocBacklinks(doc: DocRow): Promise<DocBacklink[]> {
         isNull(schema.doc.archivedAt),
         ne(schema.doc.id, doc.id),
         ilike(schema.doc.content, `%/docs/${doc.id}%`),
+        docReadFilter(principal),
       ),
     )
     .orderBy(asc(schema.doc.title))
     .limit(DOC_BACKLINK_LIMIT);
 }
 
-async function detailFor(doc: DocRow): Promise<DocDetail> {
+async function detailFor(doc: DocRow, principal: Principal | null): Promise<DocDetail> {
   const [author] = await db
     .select({ id: schema.user.id, name: schema.user.name, image: schema.user.image })
     .from(schema.user)
@@ -408,13 +417,13 @@ async function detailFor(doc: DocRow): Promise<DocDetail> {
     attachments: await attachmentsFor(doc.id),
     author: author ?? { id: doc.authorId, name: 'Someone', image: null },
     followers: followers?.total ?? 0,
-    backlinks: await listDocBacklinks(doc),
+    backlinks: await listDocBacklinks(doc, principal),
   };
 }
 
 export async function getDoc(principal: Principal, docId: string): Promise<DocDetail> {
   assertCan(principal, 'doc:read');
-  return await detailFor(await loadDoc(db, principal, docId));
+  return await detailFor(await loadReadableDoc(db, principal, docId), principal);
 }
 
 export async function getPublishedDoc(pathSegment: string): Promise<DocDetail | null> {
@@ -427,7 +436,7 @@ export async function getPublishedDoc(pathSegment: string): Promise<DocDetail | 
     .limit(1);
   if (doc === undefined) return null;
   if (!isExternallyShared(doc.visibility)) return null;
-  return await detailFor(doc);
+  return await detailFor(doc, null);
 }
 
 export async function listPublicDocs(): Promise<DocRow[]> {
@@ -547,7 +556,7 @@ export async function updateDoc(
   }
 
   return await db.transaction(async (tx) => {
-    const current = await loadDoc(tx, principal, docId);
+    const current = await loadReadableDoc(tx, principal, docId);
     await assertDocWritable(tx, principal, current);
     if (current.archivedAt !== null) throw conflict('That doc is archived.');
     await assertPlacement(tx, principal, parsed, docId);
@@ -581,7 +590,7 @@ export async function listDocVersions(
   docId: string,
 ): Promise<DocVersionRow[]> {
   assertCan(principal, 'doc:read');
-  await loadDoc(db, principal, docId);
+  await loadReadableDoc(db, principal, docId);
   return await db
     .select()
     .from(schema.docVersion)
@@ -598,7 +607,7 @@ export async function restoreDocVersion(
   assertCan(principal, 'doc:write');
 
   return await db.transaction(async (tx) => {
-    const current = await loadDoc(tx, principal, docId);
+    const current = await loadReadableDoc(tx, principal, docId);
     await assertDocWritable(tx, principal, current);
     if (current.archivedAt !== null) throw conflict('That doc is archived.');
 
@@ -636,7 +645,7 @@ export async function archiveDoc(
   assertCan(principal, 'doc:write');
 
   return await db.transaction(async (tx) => {
-    await assertDocWritable(tx, principal, await loadDoc(tx, principal, docId));
+    await assertDocWritable(tx, principal, await loadReadableDoc(tx, principal, docId));
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
     const [saved] = await tx
@@ -663,7 +672,7 @@ export async function shareDoc(
   const { visibility, rotateToken } = docShareSchema.parse(input);
 
   return await db.transaction(async (tx) => {
-    const current = await loadDoc(tx, principal, docId);
+    const current = await loadReadableDoc(tx, principal, docId);
     await assertDocWritable(tx, principal, current);
     if (current.archivedAt !== null) throw conflict('That doc is archived.');
 
@@ -794,7 +803,7 @@ export async function listDocAccess(
   docId: string,
 ): Promise<(typeof schema.docAccess.$inferSelect)[]> {
   assertCan(principal, 'doc:read');
-  await loadDoc(db, principal, docId);
+  await loadReadableDoc(db, principal, docId);
   return await db
     .select()
     .from(schema.docAccess)
@@ -808,7 +817,7 @@ export async function setDocAccess(
   grants: readonly DocAccessGrant[],
 ): Promise<(typeof schema.docAccess.$inferSelect)[]> {
   assertCan(principal, 'doc:write');
-  const doc = await loadDoc(db, principal, docId);
+  const doc = await loadReadableDoc(db, principal, docId);
   if (principal.role !== 'admin' && doc.authorId !== principal.userId) {
     throw notFound('That doc does not exist.');
   }

--- a/packages/core/src/content/doc-service.ts
+++ b/packages/core/src/content/doc-service.ts
@@ -1,4 +1,19 @@
-import { and, asc, count, db, desc, eq, ilike, isNull, ne, or, schema, sql } from '@orbit/db';
+import {
+  and,
+  asc,
+  count,
+  db,
+  desc,
+  eq,
+  ilike,
+  inArray,
+  isNull,
+  ne,
+  or,
+  schema,
+  sql,
+} from '@orbit/db';
+import { isRestricted } from '@orbit/shared/constants';
 import { conflict, notFound, validationFailed } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
@@ -13,7 +28,7 @@ import {
   docShareSchema,
   docUpdateSchema,
 } from '@orbit/shared/validators';
-import { getTableColumns } from 'drizzle-orm';
+import { getTableColumns, type SQL } from 'drizzle-orm';
 import { principalActor } from '../activity/activity-service.ts';
 import { type Executor, newId, newToken, requireRow } from '../internal.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
@@ -100,13 +115,82 @@ function tokenFor(visibility: string, current: string | null): string | null {
   return current ?? newToken();
 }
 
+export function docReadFilter(principal: Principal): SQL {
+  if (principal.role === 'admin') return sql`true`;
+  const open = inArray(schema.doc.visibility, ['workspace', 'link', 'public']);
+
+  const grants = db
+    .select({ docId: schema.docAccess.docId })
+    .from(schema.docAccess)
+    .where(
+      or(
+        and(
+          eq(schema.docAccess.subjectType, 'user'),
+          eq(schema.docAccess.subjectId, principal.userId),
+        ),
+        principal.teamIds.length === 0
+          ? sql`false`
+          : and(
+              eq(schema.docAccess.subjectType, 'team'),
+              inArray(schema.docAccess.subjectId, [...principal.teamIds]),
+            ),
+      ),
+    );
+
+  const clause = or(
+    open,
+    eq(schema.doc.authorId, principal.userId),
+    inArray(schema.doc.id, grants),
+  );
+  return clause ?? sql`false`;
+}
+
+export function canReadDoc(principal: Principal, doc: DocRow, grants: readonly string[]): boolean {
+  if (principal.role === 'admin') return true;
+  if (doc.authorId === principal.userId) return true;
+  if (!isRestricted(doc.visibility)) return true;
+  return grants.includes(doc.id);
+}
+
+async function grantedDocIds(
+  executor: Executor,
+  principal: Principal,
+  docIds: readonly string[],
+): Promise<string[]> {
+  if (docIds.length === 0) return [];
+  const rows = await executor
+    .select({ docId: schema.docAccess.docId })
+    .from(schema.docAccess)
+    .where(
+      and(
+        inArray(schema.docAccess.docId, [...docIds]),
+        or(
+          and(
+            eq(schema.docAccess.subjectType, 'user'),
+            eq(schema.docAccess.subjectId, principal.userId),
+          ),
+          principal.teamIds.length === 0
+            ? sql`false`
+            : and(
+                eq(schema.docAccess.subjectType, 'team'),
+                inArray(schema.docAccess.subjectId, [...principal.teamIds]),
+              ),
+        ),
+      ),
+    );
+  return rows.map((row) => row.docId);
+}
+
 async function loadDoc(executor: Executor, principal: Principal, docId: string): Promise<DocRow> {
   const [row] = await executor
     .select()
     .from(schema.doc)
     .where(and(eq(schema.doc.id, docId), eq(schema.doc.organizationId, principal.organizationId)))
     .limit(1);
-  return requireRow(row, 'That doc does not exist.');
+  const doc = requireRow(row, 'That doc does not exist.');
+  const grants = await grantedDocIds(executor, principal, [doc.id]);
+  if (!canReadDoc(principal, doc, grants)) throw notFound('That doc does not exist.');
+  return doc;
 }
 
 async function assertParent(
@@ -204,7 +288,10 @@ export async function listDocs(principal: Principal, input: unknown = {}): Promi
   assertCan(principal, 'doc:read');
   const filter = docFilterSchema.parse(input);
 
-  const conditions = [eq(schema.doc.organizationId, principal.organizationId)];
+  const conditions = [
+    eq(schema.doc.organizationId, principal.organizationId),
+    docReadFilter(principal),
+  ];
   if (!filter.includeArchived) conditions.push(isNull(schema.doc.archivedAt));
   if (filter.collectionId !== undefined) {
     conditions.push(eq(schema.doc.collectionId, filter.collectionId));
@@ -642,5 +729,57 @@ export async function deleteDocCollection(
     const collection = requireRow(removed, 'That collection does not exist.');
 
     return [collectionAction(collection, syncId, actor, 'delete')];
+  });
+}
+
+export interface DocAccessGrant {
+  readonly subjectType: 'user' | 'team';
+  readonly subjectId: string;
+  readonly level: 'read' | 'write';
+}
+
+export async function listDocAccess(
+  principal: Principal,
+  docId: string,
+): Promise<(typeof schema.docAccess.$inferSelect)[]> {
+  assertCan(principal, 'doc:read');
+  await loadDoc(db, principal, docId);
+  return await db
+    .select()
+    .from(schema.docAccess)
+    .where(eq(schema.docAccess.docId, docId))
+    .orderBy(asc(schema.docAccess.createdAt));
+}
+
+export async function setDocAccess(
+  principal: Principal,
+  docId: string,
+  grants: readonly DocAccessGrant[],
+): Promise<(typeof schema.docAccess.$inferSelect)[]> {
+  assertCan(principal, 'doc:write');
+  const doc = await loadDoc(db, principal, docId);
+  if (principal.role !== 'admin' && doc.authorId !== principal.userId) {
+    throw notFound('That doc does not exist.');
+  }
+
+  return await db.transaction(async (tx) => {
+    await tx.delete(schema.docAccess).where(eq(schema.docAccess.docId, docId));
+    if (grants.length === 0) return [];
+    const syncId = await nextSyncId(tx);
+    return await tx
+      .insert(schema.docAccess)
+      .values(
+        grants.map((grant) => ({
+          id: newId(),
+          organizationId: principal.organizationId,
+          docId,
+          subjectType: grant.subjectType,
+          subjectId: grant.subjectId,
+          level: grant.level,
+          grantedById: principal.userId,
+          syncId,
+        })),
+      )
+      .returning();
   });
 }

--- a/packages/core/src/content/doc-service.ts
+++ b/packages/core/src/content/doc-service.ts
@@ -13,7 +13,7 @@ import {
   schema,
   sql,
 } from '@orbit/db';
-import { isRestricted } from '@orbit/shared/constants';
+import { isExternallyShared, isRestricted } from '@orbit/shared/constants';
 import { conflict, notFound, validationFailed } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
@@ -87,6 +87,7 @@ export interface SavedDocCollection {
 }
 
 function docScopes(row: DocRow): string[] {
+  if (isRestricted(row.visibility)) return [scopes.user(row.authorId), scopes.doc(row.id)];
   const list = [scopes.organization(row.organizationId), scopes.doc(row.id)];
   if (row.projectId !== null) list.push(scopes.project(row.projectId));
   return list;
@@ -111,7 +112,7 @@ function docAction(
 }
 
 function tokenFor(visibility: string, current: string | null): string | null {
-  if (visibility === 'workspace') return null;
+  if (!isExternallyShared(visibility)) return null;
   return current ?? newToken();
 }
 
@@ -378,7 +379,7 @@ export async function getPublishedDoc(pathSegment: string): Promise<DocDetail | 
     .where(and(eq(schema.doc.publishToken, token), isNull(schema.doc.archivedAt)))
     .limit(1);
   if (doc === undefined) return null;
-  if (doc.visibility === 'workspace') return null;
+  if (!isExternallyShared(doc.visibility)) return null;
   return await detailFor(doc);
 }
 
@@ -403,13 +404,13 @@ export async function isPublishedDoc(docId: string): Promise<boolean> {
     .from(schema.doc)
     .where(eq(schema.doc.id, docId))
     .limit(1);
-  return row !== undefined && row.archivedAt === null && row.visibility !== 'workspace';
+  return row !== undefined && row.archivedAt === null && isExternallyShared(row.visibility);
 }
 
 export async function createDoc(principal: Principal, input: unknown): Promise<SavedDoc> {
   assertCan(principal, 'doc:write');
   const parsed = docCreateSchema.parse(input);
-  if (parsed.visibility !== 'workspace') assertCan(principal, 'doc:publish');
+  if (isExternallyShared(parsed.visibility)) assertCan(principal, 'doc:publish');
 
   return await db.transaction(async (tx) => {
     await assertPlacement(tx, principal, parsed);
@@ -494,7 +495,7 @@ export async function updateDoc(
 ): Promise<SavedDoc> {
   assertCan(principal, 'doc:write');
   const parsed = docUpdateSchema.parse(input);
-  if (parsed.visibility !== undefined && parsed.visibility !== 'workspace') {
+  if (parsed.visibility !== undefined && isExternallyShared(parsed.visibility)) {
     assertCan(principal, 'doc:publish');
   }
 

--- a/packages/core/src/content/doc-service.ts
+++ b/packages/core/src/content/doc-service.ts
@@ -14,7 +14,7 @@ import {
   sql,
 } from '@orbit/db';
 import { isExternallyShared, isRestricted } from '@orbit/shared/constants';
-import { conflict, notFound, validationFailed } from '@orbit/shared/errors';
+import { conflict, forbidden, notFound, validationFailed } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
@@ -185,6 +185,48 @@ async function grantedDocIds(
       ),
     );
   return rows.map((row) => row.docId);
+}
+
+async function writeGrantedDocIds(
+  executor: Executor,
+  principal: Principal,
+  docId: string,
+): Promise<boolean> {
+  const rows = await executor
+    .select({ docId: schema.docAccess.docId })
+    .from(schema.docAccess)
+    .where(
+      and(
+        eq(schema.docAccess.docId, docId),
+        eq(schema.docAccess.level, 'write'),
+        or(
+          and(
+            eq(schema.docAccess.subjectType, 'user'),
+            eq(schema.docAccess.subjectId, principal.userId),
+          ),
+          principal.teamIds.length === 0
+            ? sql`false`
+            : and(
+                eq(schema.docAccess.subjectType, 'team'),
+                inArray(schema.docAccess.subjectId, [...principal.teamIds]),
+              ),
+        ),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+async function assertDocWritable(
+  executor: Executor,
+  principal: Principal,
+  doc: DocRow,
+): Promise<void> {
+  if (principal.role === 'admin') return;
+  if (doc.authorId === principal.userId) return;
+  if (!isRestricted(doc.visibility)) return;
+  if (await writeGrantedDocIds(executor, principal, doc.id)) return;
+  throw forbidden('You only have read access to that doc.');
 }
 
 async function loadDoc(executor: Executor, principal: Principal, docId: string): Promise<DocRow> {
@@ -506,6 +548,7 @@ export async function updateDoc(
 
   return await db.transaction(async (tx) => {
     const current = await loadDoc(tx, principal, docId);
+    await assertDocWritable(tx, principal, current);
     if (current.archivedAt !== null) throw conflict('That doc is archived.');
     await assertPlacement(tx, principal, parsed, docId);
 
@@ -556,6 +599,7 @@ export async function restoreDocVersion(
 
   return await db.transaction(async (tx) => {
     const current = await loadDoc(tx, principal, docId);
+    await assertDocWritable(tx, principal, current);
     if (current.archivedAt !== null) throw conflict('That doc is archived.');
 
     const [found] = await tx
@@ -592,7 +636,7 @@ export async function archiveDoc(
   assertCan(principal, 'doc:write');
 
   return await db.transaction(async (tx) => {
-    await loadDoc(tx, principal, docId);
+    await assertDocWritable(tx, principal, await loadDoc(tx, principal, docId));
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
     const [saved] = await tx
@@ -620,6 +664,7 @@ export async function shareDoc(
 
   return await db.transaction(async (tx) => {
     const current = await loadDoc(tx, principal, docId);
+    await assertDocWritable(tx, principal, current);
     if (current.archivedAt !== null) throw conflict('That doc is archived.');
 
     const publishToken = tokenFor(visibility, rotateToken ? null : current.publishToken);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,5 +23,6 @@ export * from './work/issue-service.ts';
 export * from './work/label-service.ts';
 export * from './work/milestone-service.ts';
 export * from './work/project-service.ts';
+export * from './work/standup-service.ts';
 export * from './work/view-service.ts';
 export * from './work/workflow-state-service.ts';

--- a/packages/core/src/realtime/backfill.test.ts
+++ b/packages/core/src/realtime/backfill.test.ts
@@ -4,7 +4,7 @@ import { SYNC_MODELS } from '@orbit/shared/events';
 import { createDoc, createDocCollection } from '../content/doc-service.ts';
 import { newId } from '../internal.ts';
 import { createInvite } from '../org/invite-service.ts';
-import { addTeamMember } from '../org/team-service.ts';
+import { addTeamMember, createTeam } from '../org/team-service.ts';
 import {
   addMember,
   createUser,
@@ -14,6 +14,13 @@ import {
 } from '../test-support.ts';
 import { createIssue, subscribe, updateIssue } from '../work/issue-service.ts';
 import { catchUp, SYNC_CATCHUP_MODELS } from './backfill.ts';
+
+function teamKey(): string {
+  return `D${newId()
+    .replace(/[^a-z0-9]/gi, '')
+    .slice(0, 4)
+    .toUpperCase()}`;
+}
 
 let workspace: Workspace;
 
@@ -166,5 +173,72 @@ describe('catchUp', () => {
         ),
       ).toBe(true);
     }
+  });
+});
+
+describe('catch up never crosses a team boundary', () => {
+  it('hides another team and its issues from a member', async () => {
+    const outsider = await createTeam(workspace.admin, {
+      name: 'Design',
+      key: teamKey(),
+    });
+    const { principal: member } = await addMember(workspace, 'member', {
+      teamIds: [workspace.teamId],
+    });
+
+    const mine = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Visible to the member',
+    });
+    const theirs = await createIssue(workspace.admin, {
+      teamId: outsider.team.id,
+      title: 'Confidential to Design',
+    });
+
+    const result = await catchUp(member, 0);
+    const ids = new Set(result.actions.map((action) => action.modelId));
+
+    expect(ids.has(mine.issue.id)).toBe(true);
+    expect(ids.has(theirs.issue.id)).toBe(false);
+
+    const bodies = JSON.stringify(result.actions);
+    expect(bodies).toContain('Visible to the member');
+    expect(bodies).not.toContain('Confidential to Design');
+  });
+
+  it('still gives an admin the whole workspace', async () => {
+    const outsider = await createTeam(workspace.admin, {
+      name: 'Design',
+      key: teamKey(),
+    });
+    const theirs = await createIssue(workspace.admin, {
+      teamId: outsider.team.id,
+      title: 'Admin can see this',
+    });
+
+    const result = await catchUp(workspace.admin, 0);
+    expect(result.actions.some((action) => action.modelId === theirs.issue.id)).toBe(true);
+  });
+
+  it('gives a guest on no teams none of the workspace issues', async () => {
+    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Not for guests' });
+    const { principal: guest } = await addMember(workspace, 'guest', { teamIds: [] });
+
+    const result = await catchUp(guest, 0);
+    expect(JSON.stringify(result.actions)).not.toContain('Not for guests');
+  });
+
+  it('keeps pending invitations away from anyone who cannot invite', async () => {
+    await createInvite(workspace.admin, {
+      email: `secret.${newId().slice(0, 8)}@example.com`,
+      role: 'admin',
+    });
+    const { principal: contributor } = await addMember(workspace, 'contributor');
+
+    const asContributor = await catchUp(contributor, 0);
+    expect(asContributor.actions.some((action) => action.model === 'invitation')).toBe(false);
+
+    const asAdmin = await catchUp(workspace.admin, 0);
+    expect(asAdmin.actions.some((action) => action.model === 'invitation')).toBe(true);
   });
 });

--- a/packages/core/src/realtime/backfill.test.ts
+++ b/packages/core/src/realtime/backfill.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { db, schema } from '@orbit/db';
 import { SYNC_MODELS } from '@orbit/shared/events';
-import { createDoc, createDocCollection } from '../content/doc-service.ts';
+import { createDoc, createDocCollection, setDocAccess } from '../content/doc-service.ts';
 import { newId } from '../internal.ts';
 import { createInvite } from '../org/invite-service.ts';
 import { addTeamMember, createTeam } from '../org/team-service.ts';
@@ -240,5 +240,47 @@ describe('catch up never crosses a team boundary', () => {
 
     const asAdmin = await catchUp(workspace.admin, 0);
     expect(asAdmin.actions.some((action) => action.model === 'invitation')).toBe(true);
+  });
+});
+
+describe('catch up respects document access', () => {
+  it('never returns a private doc body to somebody it was not shared with', async () => {
+    const { principal: other } = await addMember(workspace, 'member');
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Compensation review',
+      content: 'Numbers nobody else should read.',
+      visibility: 'private',
+    });
+
+    const result = await catchUp(other, 0);
+    const payload = JSON.stringify(result.actions);
+    expect(payload).not.toContain('Numbers nobody else should read.');
+    expect(result.actions.some((action) => action.modelId === doc.id)).toBe(false);
+  });
+
+  it('returns a private doc once it is shared', async () => {
+    const { principal: invited, user: invitedUser } = await addMember(workspace, 'member');
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Shared plan',
+      content: 'For a named few.',
+      visibility: 'private',
+    });
+    await setDocAccess(workspace.admin, doc.id, [
+      { subjectType: 'user', subjectId: invitedUser.id, level: 'read' },
+    ]);
+
+    const result = await catchUp(invited, 0);
+    expect(result.actions.some((action) => action.modelId === doc.id)).toBe(true);
+  });
+
+  it('keeps workspace docs reaching everyone', async () => {
+    const { principal: guest } = await addMember(workspace, 'guest', { teamIds: [] });
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Handbook',
+      content: 'Everybody reads this.',
+      visibility: 'workspace',
+    });
+    const result = await catchUp(guest, 0);
+    expect(result.actions.some((action) => action.modelId === doc.id)).toBe(true);
   });
 });

--- a/packages/core/src/realtime/backfill.ts
+++ b/packages/core/src/realtime/backfill.ts
@@ -510,6 +510,26 @@ const LOADERS: Record<SyncModel, Loader> = {
       ],
       data: row,
     })),
+
+  standup: async (principal, since, limit) =>
+    (
+      await db
+        .select()
+        .from(schema.standup)
+        .where(
+          and(
+            eq(schema.standup.organizationId, principal.organizationId),
+            gt(schema.standup.syncId, since),
+          ),
+        )
+        .orderBy(asc(schema.standup.syncId))
+        .limit(limit)
+    ).map((row) => ({
+      modelId: row.id,
+      syncId: row.syncId,
+      scopes: [scopes.organization(row.organizationId), scopes.team(row.teamId)],
+      data: row,
+    })),
 };
 
 export const SYNC_CATCHUP_MODELS = Object.keys(LOADERS) as SyncModel[];

--- a/packages/core/src/realtime/backfill.ts
+++ b/packages/core/src/realtime/backfill.ts
@@ -1,7 +1,7 @@
-import { and, asc, db, eq, gt, or, schema } from '@orbit/db';
+import { and, asc, db, eq, gt, inArray, or, schema } from '@orbit/db';
 import type { SyncAction, SyncModel } from '@orbit/shared/events';
 import { CATCHUP_LIMIT, scopes } from '@orbit/shared/events';
-import { assertCan, type Principal } from '@orbit/shared/policy';
+import { assertCan, can, type Principal } from '@orbit/shared/policy';
 import { buildSyncAction } from './publisher.ts';
 
 export interface SyncCatchupResult {
@@ -20,6 +20,81 @@ interface BackfilledRow {
 type Loader = (principal: Principal, since: number, limit: number) => Promise<BackfilledRow[]>;
 
 const CATCHUP_ACTOR = { type: 'system', id: 'sync', name: 'Catch up' } as const;
+
+type AttachmentParent = {
+  readonly id: string;
+  readonly parentType: string;
+  readonly parentId: string;
+};
+
+async function issueTeamsById(issueIds: readonly string[]): Promise<Map<string, string>> {
+  const ids = [...new Set(issueIds)];
+  if (ids.length === 0) return new Map();
+  const rows = await db
+    .select({ id: schema.issue.id, teamId: schema.issue.teamId })
+    .from(schema.issue)
+    .where(inArray(schema.issue.id, ids));
+  return new Map(rows.map((row) => [row.id, row.teamId]));
+}
+
+async function commentTeamsById(commentIds: readonly string[]): Promise<Map<string, string>> {
+  const ids = [...new Set(commentIds)];
+  if (ids.length === 0) return new Map();
+  const rows = await db
+    .select({ id: schema.comment.id, teamId: schema.issue.teamId })
+    .from(schema.comment)
+    .innerJoin(schema.issue, eq(schema.issue.id, schema.comment.issueId))
+    .where(inArray(schema.comment.id, ids));
+  return new Map(rows.map((row) => [row.id, row.teamId]));
+}
+
+async function teamsByAttachmentParent(
+  rows: readonly AttachmentParent[],
+): Promise<Map<string, string[]>> {
+  const of = (type: string) => rows.filter((row) => row.parentType === type);
+  const issueParents = of('issue');
+  const commentParents = of('comment');
+  const projectParents = of('project');
+
+  const [issueTeams, commentTeams, projectTeams] = await Promise.all([
+    issueTeamsById(issueParents.map((row) => row.parentId)),
+    commentTeamsById(commentParents.map((row) => row.parentId)),
+    teamsByProject(projectParents.map((row) => row.parentId)),
+  ]);
+
+  const byAttachment = new Map<string, string[]>();
+  for (const row of issueParents) {
+    const teamId = issueTeams.get(row.parentId);
+    if (teamId !== undefined) byAttachment.set(row.id, [teamId]);
+  }
+  for (const row of commentParents) {
+    const teamId = commentTeams.get(row.parentId);
+    if (teamId !== undefined) byAttachment.set(row.id, [teamId]);
+  }
+  for (const row of projectParents) {
+    const found = projectTeams.get(row.parentId) ?? [];
+    if (found.length > 0) byAttachment.set(row.id, found);
+  }
+  return byAttachment;
+}
+
+async function teamsByProject(
+  projectIds: readonly (string | null)[],
+): Promise<Map<string, string[]>> {
+  const ids = [...new Set(projectIds.filter((id): id is string => id !== null))];
+  const byProject = new Map<string, string[]>();
+  if (ids.length === 0) return byProject;
+  const rows = await db
+    .select({ projectId: schema.projectTeam.projectId, teamId: schema.projectTeam.teamId })
+    .from(schema.projectTeam)
+    .where(inArray(schema.projectTeam.projectId, ids));
+  for (const row of rows) {
+    const bucket = byProject.get(row.projectId) ?? [];
+    bucket.push(row.teamId);
+    byProject.set(row.projectId, bucket);
+  }
+  return byProject;
+}
 
 const LOADERS: Record<SyncModel, Loader> = {
   organization: async (principal, since, limit) =>
@@ -63,24 +138,26 @@ const LOADERS: Record<SyncModel, Loader> = {
     })),
 
   invitation: async (principal, since, limit) =>
-    (
-      await db
-        .select()
-        .from(schema.invitation)
-        .where(
-          and(
-            eq(schema.invitation.organizationId, principal.organizationId),
-            gt(schema.invitation.syncId, since),
-          ),
-        )
-        .orderBy(asc(schema.invitation.syncId))
-        .limit(limit)
-    ).map((row) => ({
-      modelId: row.id,
-      syncId: row.syncId,
-      scopes: [scopes.organization(row.organizationId)],
-      data: row,
-    })),
+    can(principal, 'member:invite')
+      ? (
+          await db
+            .select()
+            .from(schema.invitation)
+            .where(
+              and(
+                eq(schema.invitation.organizationId, principal.organizationId),
+                gt(schema.invitation.syncId, since),
+              ),
+            )
+            .orderBy(asc(schema.invitation.syncId))
+            .limit(limit)
+        ).map((row) => ({
+          modelId: row.id,
+          syncId: row.syncId,
+          scopes: [scopes.organization(row.organizationId)],
+          data: row,
+        }))
+      : [],
 
   team: async (principal, since, limit) =>
     (
@@ -166,45 +243,55 @@ const LOADERS: Record<SyncModel, Loader> = {
       data: row,
     })),
 
-  project: async (principal, since, limit) =>
-    (
-      await db
-        .select()
-        .from(schema.project)
-        .where(
-          and(
-            eq(schema.project.organizationId, principal.organizationId),
-            gt(schema.project.syncId, since),
-          ),
-        )
-        .orderBy(asc(schema.project.syncId))
-        .limit(limit)
-    ).map((row) => ({
+  project: async (principal, since, limit) => {
+    const rows = await db
+      .select()
+      .from(schema.project)
+      .where(
+        and(
+          eq(schema.project.organizationId, principal.organizationId),
+          gt(schema.project.syncId, since),
+        ),
+      )
+      .orderBy(asc(schema.project.syncId))
+      .limit(limit);
+    const teams = await teamsByProject(rows.map((row) => row.id));
+    return rows.map((row) => ({
       modelId: row.id,
       syncId: row.syncId,
-      scopes: [scopes.organization(row.organizationId), scopes.project(row.id)],
+      scopes: [
+        scopes.organization(row.organizationId),
+        scopes.project(row.id),
+        ...(teams.get(row.id) ?? []).map(scopes.team),
+      ],
       data: row,
-    })),
+    }));
+  },
 
-  milestone: async (principal, since, limit) =>
-    (
-      await db
-        .select()
-        .from(schema.milestone)
-        .where(
-          and(
-            eq(schema.milestone.organizationId, principal.organizationId),
-            gt(schema.milestone.syncId, since),
-          ),
-        )
-        .orderBy(asc(schema.milestone.syncId))
-        .limit(limit)
-    ).map((row) => ({
+  milestone: async (principal, since, limit) => {
+    const rows = await db
+      .select()
+      .from(schema.milestone)
+      .where(
+        and(
+          eq(schema.milestone.organizationId, principal.organizationId),
+          gt(schema.milestone.syncId, since),
+        ),
+      )
+      .orderBy(asc(schema.milestone.syncId))
+      .limit(limit);
+    const teams = await teamsByProject(rows.map((row) => row.projectId));
+    return rows.map((row) => ({
       modelId: row.id,
       syncId: row.syncId,
-      scopes: [scopes.organization(row.organizationId), scopes.project(row.projectId)],
+      scopes: [
+        scopes.organization(row.organizationId),
+        scopes.project(row.projectId),
+        ...(teams.get(row.projectId) ?? []).map(scopes.team),
+      ],
       data: row,
-    })),
+    }));
+  },
 
   cycle: async (principal, since, limit) =>
     (
@@ -257,8 +344,9 @@ const LOADERS: Record<SyncModel, Loader> = {
   issue_relation: async (principal, since, limit) =>
     (
       await db
-        .select()
+        .select({ row: schema.issueRelation, teamId: schema.issue.teamId })
         .from(schema.issueRelation)
+        .innerJoin(schema.issue, eq(schema.issue.id, schema.issueRelation.issueId))
         .where(
           and(
             eq(schema.issueRelation.organizationId, principal.organizationId),
@@ -267,11 +355,12 @@ const LOADERS: Record<SyncModel, Loader> = {
         )
         .orderBy(asc(schema.issueRelation.syncId))
         .limit(limit)
-    ).map((row) => ({
+    ).map(({ row, teamId }) => ({
       modelId: row.id,
       syncId: row.syncId,
       scopes: [
         scopes.organization(row.organizationId),
+        scopes.team(teamId),
         scopes.issue(row.issueId),
         scopes.issue(row.relatedIssueId),
       ],
@@ -368,28 +457,33 @@ const LOADERS: Record<SyncModel, Loader> = {
       data: row,
     })),
 
-  attachment: async (principal, since, limit) =>
-    (
-      await db
-        .select()
-        .from(schema.attachment)
-        .where(
-          and(
-            eq(schema.attachment.organizationId, principal.organizationId),
-            gt(schema.attachment.syncId, since),
-          ),
-        )
-        .orderBy(asc(schema.attachment.syncId))
-        .limit(limit)
-    ).map((row) => ({
+  attachment: async (principal, since, limit) => {
+    const rows = await db
+      .select()
+      .from(schema.attachment)
+      .where(
+        and(
+          eq(schema.attachment.organizationId, principal.organizationId),
+          gt(schema.attachment.syncId, since),
+        ),
+      )
+      .orderBy(asc(schema.attachment.syncId))
+      .limit(limit);
+    const teams = await teamsByAttachmentParent(rows);
+    return rows.map((row) => ({
       modelId: row.id,
       syncId: row.syncId,
       scopes:
         row.parentType === 'doc'
           ? [scopes.organization(row.organizationId), scopes.doc(row.parentId)]
-          : [scopes.organization(row.organizationId), scopes.issue(row.parentId)],
+          : [
+              scopes.organization(row.organizationId),
+              scopes.issue(row.parentId),
+              ...(teams.get(row.id) ?? []).map(scopes.team),
+            ],
       data: row,
-    })),
+    }));
+  },
 
   doc: async (principal, since, limit) =>
     (
@@ -534,6 +628,17 @@ const LOADERS: Record<SyncModel, Loader> = {
 
 export const SYNC_CATCHUP_MODELS = Object.keys(LOADERS) as SyncModel[];
 
+const TEAM_SCOPE_PREFIX = 'team:';
+
+export function visibleToPrincipal(principal: Principal, rowScopes: readonly string[]): boolean {
+  if (principal.role === 'admin') return true;
+  const teamScopes = rowScopes.filter((scope) => scope.startsWith(TEAM_SCOPE_PREFIX));
+  if (teamScopes.length === 0) return true;
+  return teamScopes.some((scope) =>
+    principal.teamIds.includes(scope.slice(TEAM_SCOPE_PREFIX.length)),
+  );
+}
+
 export async function catchUp(
   principal: Principal,
   since: number,
@@ -551,6 +656,7 @@ export async function catchUp(
   for (const { model, rows } of loaded) {
     if (rows.length > perModel) saturated = true;
     for (const row of rows.slice(0, perModel)) {
+      if (!visibleToPrincipal(principal, row.scopes)) continue;
       all.push(
         buildSyncAction({
           syncId: row.syncId,

--- a/packages/core/src/realtime/backfill.ts
+++ b/packages/core/src/realtime/backfill.ts
@@ -28,6 +28,11 @@ type AttachmentParent = {
   readonly parentId: string;
 };
 
+function withoutBody<T extends { content: string }>(row: T): Omit<T, 'content'> {
+  const { content: _body, ...rest } = row;
+  return rest;
+}
+
 async function readableDocIds(
   principal: Principal,
   docIds: readonly string[],
@@ -532,7 +537,7 @@ const LOADERS: Record<SyncModel, Loader> = {
               scopes.doc(row.id),
               scopes.project(row.projectId),
             ],
-      data: { ...row, publishToken: row.publishToken === null ? null : 'redacted' },
+      data: { ...withoutBody(row), publishToken: row.publishToken === null ? null : 'redacted' },
     })),
 
   doc_collection: async (principal, since, limit) =>

--- a/packages/core/src/realtime/backfill.ts
+++ b/packages/core/src/realtime/backfill.ts
@@ -2,6 +2,7 @@ import { and, asc, db, eq, gt, inArray, or, schema } from '@orbit/db';
 import type { SyncAction, SyncModel } from '@orbit/shared/events';
 import { CATCHUP_LIMIT, scopes } from '@orbit/shared/events';
 import { assertCan, can, type Principal } from '@orbit/shared/policy';
+import { docReadFilter } from '../content/doc-service.ts';
 import { buildSyncAction } from './publisher.ts';
 
 export interface SyncCatchupResult {
@@ -26,6 +27,19 @@ type AttachmentParent = {
   readonly parentType: string;
   readonly parentId: string;
 };
+
+async function readableDocIds(
+  principal: Principal,
+  docIds: readonly string[],
+): Promise<Set<string>> {
+  const ids = [...new Set(docIds)];
+  if (ids.length === 0) return new Set();
+  const rows = await db
+    .select({ id: schema.doc.id })
+    .from(schema.doc)
+    .where(and(inArray(schema.doc.id, ids), docReadFilter(principal)));
+  return new Set(rows.map((row) => row.id));
+}
 
 async function issueTeamsById(issueIds: readonly string[]): Promise<Map<string, string>> {
   const ids = [...new Set(issueIds)];
@@ -417,20 +431,22 @@ const LOADERS: Record<SyncModel, Loader> = {
   doc_comment: async (principal, since, limit) =>
     (
       await db
-        .select()
+        .select({ row: schema.docComment })
         .from(schema.docComment)
+        .innerJoin(schema.doc, eq(schema.doc.id, schema.docComment.docId))
         .where(
           and(
             eq(schema.docComment.organizationId, principal.organizationId),
+            docReadFilter(principal),
             gt(schema.docComment.syncId, since),
           ),
         )
         .orderBy(asc(schema.docComment.syncId))
         .limit(limit)
-    ).map((row) => ({
+    ).map(({ row }) => ({
       modelId: row.id,
       syncId: row.syncId,
-      scopes: [scopes.organization(row.organizationId), scopes.doc(row.docId)],
+      scopes: [scopes.doc(row.docId)],
       data: row,
     })),
 
@@ -470,19 +486,25 @@ const LOADERS: Record<SyncModel, Loader> = {
       .orderBy(asc(schema.attachment.syncId))
       .limit(limit);
     const teams = await teamsByAttachmentParent(rows);
-    return rows.map((row) => ({
-      modelId: row.id,
-      syncId: row.syncId,
-      scopes:
-        row.parentType === 'doc'
-          ? [scopes.organization(row.organizationId), scopes.doc(row.parentId)]
-          : [
-              scopes.organization(row.organizationId),
-              scopes.issue(row.parentId),
-              ...(teams.get(row.id) ?? []).map(scopes.team),
-            ],
-      data: row,
-    }));
+    const readableDocs = await readableDocIds(
+      principal,
+      rows.filter((row) => row.parentType === 'doc').map((row) => row.parentId),
+    );
+    return rows
+      .filter((row) => row.parentType !== 'doc' || readableDocs.has(row.parentId))
+      .map((row) => ({
+        modelId: row.id,
+        syncId: row.syncId,
+        scopes:
+          row.parentType === 'doc'
+            ? [scopes.organization(row.organizationId), scopes.doc(row.parentId)]
+            : [
+                scopes.organization(row.organizationId),
+                scopes.issue(row.parentId),
+                ...(teams.get(row.id) ?? []).map(scopes.team),
+              ],
+        data: row,
+      }));
   },
 
   doc: async (principal, since, limit) =>
@@ -493,6 +515,7 @@ const LOADERS: Record<SyncModel, Loader> = {
         .where(
           and(
             eq(schema.doc.organizationId, principal.organizationId),
+            docReadFilter(principal),
             gt(schema.doc.syncId, since),
           ),
         )

--- a/packages/core/src/work/cycle-service.test.ts
+++ b/packages/core/src/work/cycle-service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { db, eq, schema } from '@orbit/db';
 import { scopes } from '@orbit/shared/events';
+import { cycleBurndown, teamVelocity } from '../analytics/burndown.ts';
 import { createTeam } from '../org/team-service.ts';
 import {
   addMember,
@@ -14,6 +15,7 @@ import {
   completeCycle,
   createCycle,
   cycleProgress,
+  deleteCycle,
   getCycle,
   listCycles,
   upcomingCycles,
@@ -248,6 +250,70 @@ describe('cycle reads are team scoped', () => {
     if (foreign === undefined) throw new Error('missing seeded cycle');
     await expect(getCycle(workspace.admin, foreign.id)).rejects.toMatchObject({
       code: 'not_found',
+    });
+  });
+});
+
+describe('cycle writes are team scoped', () => {
+  it('refuses a member of another team renaming or deleting a sprint', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const { principal: outsider } = await addMember(workspace, 'member', {
+      teamIds: [other.team.id],
+    });
+    const { cycle } = await createCycle(workspace.admin, {
+      teamId: workspace.teamId,
+      startsAt: new Date('2030-01-06T00:00:00.000Z'),
+      endsAt: new Date('2030-01-20T00:00:00.000Z'),
+    });
+
+    await expect(updateCycle(outsider, cycle.id, { name: 'Hijacked' })).rejects.toMatchObject({
+      code: 'forbidden',
+    });
+    await expect(deleteCycle(outsider, cycle.id)).rejects.toMatchObject({ code: 'forbidden' });
+
+    const still = await getCycle(workspace.admin, cycle.id);
+    expect(still.name).not.toBe('Hijacked');
+  });
+
+  it('refuses putting an issue into another team sprint', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const { cycle: theirs } = await createCycle(workspace.admin, {
+      teamId: other.team.id,
+      startsAt: new Date('2030-01-06T00:00:00.000Z'),
+      endsAt: new Date('2030-01-20T00:00:00.000Z'),
+    });
+    const { issue } = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Mine',
+    });
+
+    await expect(
+      updateIssue(workspace.admin, issue.id, { cycleId: theirs.id }),
+    ).rejects.toMatchObject({ code: 'validation_failed' });
+
+    await expect(
+      createIssue(workspace.admin, {
+        teamId: workspace.teamId,
+        title: 'Also mine',
+        cycleId: theirs.id,
+      }),
+    ).rejects.toMatchObject({ code: 'validation_failed' });
+  });
+
+  it('keeps burndown and velocity inside the team', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const { principal: outsider } = await addMember(workspace, 'member', {
+      teamIds: [other.team.id],
+    });
+    const { cycle } = await createCycle(workspace.admin, {
+      teamId: workspace.teamId,
+      startsAt: new Date('2030-01-06T00:00:00.000Z'),
+      endsAt: new Date('2030-01-20T00:00:00.000Z'),
+    });
+
+    await expect(cycleBurndown(outsider, cycle.id)).rejects.toMatchObject({ code: 'forbidden' });
+    await expect(teamVelocity(outsider, workspace.teamId)).rejects.toMatchObject({
+      code: 'forbidden',
     });
   });
 });

--- a/packages/core/src/work/cycle-service.ts
+++ b/packages/core/src/work/cycle-service.ts
@@ -122,6 +122,7 @@ export async function updateCycle(
       )
       .limit(1);
     const current = requireRow(found, 'That cycle does not exist.');
+    assertInTeam(principal, teamScope(current));
 
     const values: Partial<typeof schema.cycle.$inferInsert> = {};
     if (parsed.name !== undefined) values.name = parsed.name;
@@ -183,6 +184,7 @@ export async function deleteCycle(principal: Principal, cycleId: string): Promis
       )
       .limit(1);
     const cycle = requireRow(existing, 'That cycle does not exist.');
+    assertInTeam(principal, teamScope(cycle));
 
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);

--- a/packages/core/src/work/cycle-service.ts
+++ b/packages/core/src/work/cycle-service.ts
@@ -14,7 +14,7 @@ import { nextSyncId } from '../sync/sync-id.ts';
 export type CycleRow = typeof schema.cycle.$inferSelect;
 
 function cycleScopes(row: CycleRow): string[] {
-  return [scopes.organization(row.organizationId), scopes.team(row.teamId)];
+  return [scopes.team(row.teamId)];
 }
 
 async function assertCycleWindow(

--- a/packages/core/src/work/issue-service.test.ts
+++ b/packages/core/src/work/issue-service.test.ts
@@ -17,6 +17,7 @@ import {
   deleteIssue,
   getIssue,
   getIssueCounts,
+  getIssueSummary,
   listIssues,
   listRelations,
   listSubscribers,
@@ -337,10 +338,23 @@ describe('listIssues', () => {
     await newIssue('Heavy issue', { description: 'A body long enough to matter on the wire.' });
 
     const listed = await listIssues(workspace.admin, {});
-    expect(listed.issues[0]?.description).toBe('');
+    const row = listed.issues[0];
+    expect(row?.description).toBeUndefined();
 
     const full = await listIssues(workspace.admin, { select: 'full' });
     expect(full.issues[0]?.description).toBe('A body long enough to matter on the wire.');
+  });
+
+  it('omits the columns no list surface reads so the page stays small on the wire', async () => {
+    await newIssue('Wire weight');
+
+    const [row] = (await listIssues(workspace.admin, {})).issues;
+    expect(row).toBeDefined();
+    for (const column of ['organizationId', 'description', 'estimatePointId', 'stateEnteredAt']) {
+      expect(Object.hasOwn(row ?? {}, column)).toBe(false);
+    }
+    expect(row?.id).toBeDefined();
+    expect(row?.sortOrder).toBeDefined();
   });
 
   it('hides archived issues unless asked', async () => {
@@ -404,6 +418,81 @@ describe('listIssues', () => {
     const byState = new Map(counts.map((row) => [row.stateId, row.total]));
     expect(byState.get(stateNamed(workspace, 'Done').id)).toBe(1);
     expect(byState.get(stateNamed(workspace, 'Todo').id)).toBe(1);
+  });
+});
+
+describe('getIssueSummary', () => {
+  it('reports the filtered total beside the unfiltered scope, so nothing has to be crawled', async () => {
+    const mine = await newIssue('Mine');
+    await newIssue('Theirs');
+    await newIssue('Also theirs');
+    await updateIssue(workspace.admin, mine.id, { assigneeId: workspace.admin.userId });
+
+    const summary = await getIssueSummary(workspace.admin, {
+      teamId: workspace.teamId,
+      filter: {
+        kind: 'group',
+        combinator: 'and',
+        children: [
+          {
+            kind: 'condition',
+            property: 'assignee',
+            operator: 'in',
+            values: [workspace.admin.userId],
+            negate: false,
+          },
+        ],
+      },
+    });
+
+    expect(summary.total).toBe(1);
+    expect(summary.scopeTotal).toBe(3);
+  });
+
+  it('counts every facet value across the whole scope, not just a loaded page', async () => {
+    const done = await newIssue('Shipped');
+    await newIssue('Waiting');
+    await updateIssue(workspace.admin, done.id, {
+      stateId: stateNamed(workspace, 'Done').id,
+      assigneeId: workspace.admin.userId,
+    });
+
+    const summary = await getIssueSummary(workspace.admin, { teamId: workspace.teamId });
+
+    expect(summary.facets.state[stateNamed(workspace, 'Done').id]).toBe(1);
+    expect(summary.facets.state[stateNamed(workspace, 'Todo').id]).toBe(1);
+    expect(summary.facets.assignee[workspace.admin.userId]).toBe(1);
+    expect(summary.facets.assignee['none']).toBe(1);
+    expect(summary.facets.project['none']).toBe(2);
+    expect(summary.facets.label['none']).toBe(2);
+    expect(summary.facets.milestone['none']).toBe(2);
+  });
+
+  it('leaves the facet counts untouched when a filter narrows the result', async () => {
+    const done = await newIssue('Shipped');
+    await newIssue('Waiting');
+    await updateIssue(workspace.admin, done.id, { stateId: stateNamed(workspace, 'Done').id });
+
+    const summary = await getIssueSummary(workspace.admin, {
+      teamId: workspace.teamId,
+      filter: {
+        kind: 'group',
+        combinator: 'and',
+        children: [
+          {
+            kind: 'condition',
+            property: 'state',
+            operator: 'in',
+            values: [stateNamed(workspace, 'Done').id],
+            negate: false,
+          },
+        ],
+      },
+    });
+
+    expect(summary.total).toBe(1);
+    expect(summary.scopeTotal).toBe(2);
+    expect(summary.facets.state[stateNamed(workspace, 'Todo').id]).toBe(1);
   });
 });
 

--- a/packages/core/src/work/issue-service.test.ts
+++ b/packages/core/src/work/issue-service.test.ts
@@ -10,6 +10,7 @@ import {
   stateNamed,
   type Workspace,
 } from '../test-support.ts';
+import { createCycle } from './cycle-service.ts';
 import {
   archiveIssue,
   bulkUpdateIssues,
@@ -29,6 +30,7 @@ import {
   unsubscribe,
   updateIssue,
 } from './issue-service.ts';
+import { createProject } from './project-service.ts';
 
 let workspace: Workspace;
 
@@ -295,6 +297,56 @@ describe('moveIssue', () => {
     expect(moved.issue.identifier).toBe('DSGN-1');
     expect(moved.issue.number).toBe(1);
     expect(moved.actions[0]?.scopes).toContain(scopes.team(team.id));
+  });
+
+  it('drops the sprint and project links that belong to the team it left', async () => {
+    const { cycle } = await createCycle(workspace.admin, {
+      teamId: workspace.teamId,
+      startsAt: new Date('2030-01-01').toISOString(),
+      endsAt: new Date('2030-01-15').toISOString(),
+    });
+    const { project } = await createProject(workspace.admin, {
+      name: 'Engineering only',
+      teamIds: [workspace.teamId],
+    });
+    const issue = await newIssue('Transferred', { cycleId: cycle.id, projectId: project.id });
+    expect(issue.cycleId).toBe(cycle.id);
+    expect(issue.projectId).toBe(project.id);
+
+    const { team, states } = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const target = states.find((state) => state.category === 'unstarted');
+    if (target === undefined) throw new Error('missing target state');
+
+    const moved = await moveIssue(workspace.admin, issue.id, {
+      teamId: team.id,
+      stateId: target.id,
+      beforeId: null,
+      afterId: null,
+    });
+
+    expect(moved.issue.teamId).toBe(team.id);
+    expect(moved.issue.cycleId).toBeNull();
+    expect(moved.issue.projectId).toBeNull();
+    expect(moved.issue.milestoneId).toBeNull();
+  });
+
+  it('keeps a project that spans the destination team', async () => {
+    const { team, states } = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const target = states.find((state) => state.category === 'unstarted');
+    if (target === undefined) throw new Error('missing target state');
+    const { project } = await createProject(workspace.admin, {
+      name: 'Cross team',
+      teamIds: [workspace.teamId, team.id],
+    });
+    const issue = await newIssue('Shared work', { projectId: project.id });
+
+    const moved = await moveIssue(workspace.admin, issue.id, {
+      teamId: team.id,
+      stateId: target.id,
+      beforeId: null,
+      afterId: null,
+    });
+    expect(moved.issue.projectId).toBe(project.id);
   });
 
   it('applies state timestamps when moving across columns', async () => {

--- a/packages/core/src/work/issue-service.test.ts
+++ b/packages/core/src/work/issue-service.test.ts
@@ -106,7 +106,7 @@ describe('createIssue', () => {
     expect(activity[0]?.field).toBe('created');
   });
 
-  it('returns a sync action scoped to org, team, and issue', async () => {
+  it('scopes a sync action to the team and the issue, never to the whole organization', async () => {
     const { issue, actions } = await createIssue(workspace.admin, {
       teamId: workspace.teamId,
       title: 'Scoped',
@@ -118,12 +118,9 @@ describe('createIssue', () => {
     expect(action?.action).toBe('insert');
     expect(action?.syncId).toBeGreaterThan(0);
     expect(action?.scopes).toEqual(
-      expect.arrayContaining([
-        scopes.organization(workspace.organizationId),
-        scopes.team(workspace.teamId),
-        scopes.issue(issue.id),
-      ]),
+      expect.arrayContaining([scopes.team(workspace.teamId), scopes.issue(issue.id)]),
     );
+    expect(action?.scopes).not.toContain(scopes.organization(workspace.organizationId));
     expect(action?.actor.id).toBe(workspace.admin.userId);
     expect(() => new Date(action?.at ?? '')).not.toThrow();
   });

--- a/packages/core/src/work/issue-service.ts
+++ b/packages/core/src/work/issue-service.ts
@@ -484,6 +484,20 @@ async function assertMilestoneInTeam(
   }
 }
 
+async function projectFitsTeam(
+  executor: Executor,
+  teamId: string,
+  projectId: string | null,
+): Promise<boolean> {
+  if (projectId === null) return false;
+  const rows = await executor
+    .select({ teamId: schema.projectTeam.teamId })
+    .from(schema.projectTeam)
+    .where(eq(schema.projectTeam.projectId, projectId));
+  if (rows.length === 0) return true;
+  return rows.some((row) => row.teamId === teamId);
+}
+
 async function assertAssignableToTeam(
   executor: Executor,
   organizationId: string,
@@ -808,6 +822,11 @@ export async function moveIssue(
       values.teamId = teamId;
       values.number = number;
       values.identifier = issueIdentifier(team.key, number);
+      values.cycleId = null;
+      if (!(await projectFitsTeam(tx, teamId, current.projectId))) {
+        values.projectId = null;
+        values.milestoneId = null;
+      }
     }
     if (state.id !== current.stateId) {
       values.stateId = state.id;

--- a/packages/core/src/work/issue-service.ts
+++ b/packages/core/src/work/issue-service.ts
@@ -70,11 +70,7 @@ async function assertParentAllowed(
 export function issueScopes(
   row: Pick<IssueRow, 'organizationId' | 'teamId' | 'id' | 'projectId'>,
 ): string[] {
-  const list = [
-    scopes.organization(row.organizationId),
-    scopes.team(row.teamId),
-    scopes.issue(row.id),
-  ];
+  const list = [scopes.team(row.teamId), scopes.issue(row.id)];
   if (row.projectId !== null) list.push(scopes.project(row.projectId));
   return list;
 }
@@ -1304,11 +1300,7 @@ export async function setRelation(
         buildSyncAction({
           syncId,
           organizationId: principal.organizationId,
-          scopes: [
-            scopes.organization(principal.organizationId),
-            scopes.issue(row.issueId),
-            scopes.issue(row.relatedIssueId),
-          ],
+          scopes: [scopes.issue(row.issueId), scopes.issue(row.relatedIssueId)],
           action: 'insert',
           model: 'issue_relation',
           modelId: row.id,
@@ -1361,11 +1353,7 @@ export async function removeRelation(
       buildSyncAction({
         syncId,
         organizationId: principal.organizationId,
-        scopes: [
-          scopes.organization(principal.organizationId),
-          scopes.issue(row.issueId),
-          scopes.issue(row.relatedIssueId),
-        ],
+        scopes: [scopes.issue(row.issueId), scopes.issue(row.relatedIssueId)],
         action: 'delete',
         model: 'issue_relation',
         modelId: row.id,

--- a/packages/core/src/work/issue-service.ts
+++ b/packages/core/src/work/issue-service.ts
@@ -410,56 +410,95 @@ export interface CreatedIssue {
   readonly actions: SyncAction[];
 }
 
+async function assertCycleInTeam(
+  executor: Executor,
+  organizationId: string,
+  teamId: string,
+  cycleId: string,
+): Promise<void> {
+  const [row] = await executor
+    .select({ teamId: schema.cycle.teamId, organizationId: schema.cycle.organizationId })
+    .from(schema.cycle)
+    .where(eq(schema.cycle.id, cycleId))
+    .limit(1);
+  const cycle = requireRow(row, 'That sprint does not exist.');
+  if (cycle.organizationId !== organizationId || cycle.teamId !== teamId) {
+    throw validationFailed('That sprint belongs to another team.');
+  }
+}
+
+async function projectTeamIds(executor: Executor, projectId: string): Promise<string[]> {
+  const rows = await executor
+    .select({ teamId: schema.projectTeam.teamId })
+    .from(schema.projectTeam)
+    .where(eq(schema.projectTeam.projectId, projectId));
+  return rows.map((row) => row.teamId);
+}
+
+async function assertProjectInTeam(
+  executor: Executor,
+  organizationId: string,
+  teamId: string,
+  projectId: string,
+): Promise<void> {
+  const [row] = await executor
+    .select({ organizationId: schema.project.organizationId })
+    .from(schema.project)
+    .where(eq(schema.project.id, projectId))
+    .limit(1);
+  const project = requireRow(row, 'That project does not exist.');
+  if (project.organizationId !== organizationId) {
+    throw validationFailed('That project belongs to another workspace.');
+  }
+  const teams = await projectTeamIds(executor, projectId);
+  if (teams.length > 0 && !teams.includes(teamId)) {
+    throw validationFailed('That project belongs to another team.');
+  }
+}
+
+async function assertMilestoneInTeam(
+  executor: Executor,
+  organizationId: string,
+  teamId: string,
+  milestoneId: string,
+  projectId: string | null | undefined,
+): Promise<void> {
+  const [row] = await executor
+    .select({
+      organizationId: schema.milestone.organizationId,
+      projectId: schema.milestone.projectId,
+    })
+    .from(schema.milestone)
+    .where(eq(schema.milestone.id, milestoneId))
+    .limit(1);
+  const milestone = requireRow(row, 'That milestone does not exist.');
+  if (milestone.organizationId !== organizationId) {
+    throw validationFailed('That milestone belongs to another workspace.');
+  }
+  if (projectId !== undefined && projectId !== null && projectId !== milestone.projectId) {
+    throw validationFailed('That milestone belongs to another project.');
+  }
+  const teams = await projectTeamIds(executor, milestone.projectId);
+  if (teams.length > 0 && !teams.includes(teamId)) {
+    throw validationFailed('That milestone belongs to another team.');
+  }
+}
+
 async function assertAssignableToTeam(
   executor: Executor,
   organizationId: string,
   teamId: string,
   values: Pick<IssueValues, 'cycleId' | 'projectId' | 'milestoneId'>,
 ): Promise<void> {
-  if (values.cycleId !== undefined && values.cycleId !== null) {
-    const [cycle] = await executor
-      .select({ teamId: schema.cycle.teamId, organizationId: schema.cycle.organizationId })
-      .from(schema.cycle)
-      .where(eq(schema.cycle.id, values.cycleId))
-      .limit(1);
-    const found = requireRow(cycle, 'That sprint does not exist.');
-    if (found.organizationId !== organizationId || found.teamId !== teamId) {
-      throw validationFailed('That sprint belongs to another team.');
-    }
+  const { cycleId, projectId, milestoneId } = values;
+  if (cycleId !== undefined && cycleId !== null) {
+    await assertCycleInTeam(executor, organizationId, teamId, cycleId);
   }
-
-  if (values.projectId !== undefined && values.projectId !== null) {
-    const [project] = await executor
-      .select({ organizationId: schema.project.organizationId })
-      .from(schema.project)
-      .where(eq(schema.project.id, values.projectId))
-      .limit(1);
-    const found = requireRow(project, 'That project does not exist.');
-    if (found.organizationId !== organizationId) {
-      throw validationFailed('That project belongs to another workspace.');
-    }
-    const teams = await executor
-      .select({ teamId: schema.projectTeam.teamId })
-      .from(schema.projectTeam)
-      .where(eq(schema.projectTeam.projectId, values.projectId));
-    if (teams.length > 0 && !teams.some((row) => row.teamId === teamId)) {
-      throw validationFailed('That project belongs to another team.');
-    }
+  if (projectId !== undefined && projectId !== null) {
+    await assertProjectInTeam(executor, organizationId, teamId, projectId);
   }
-
-  if (values.milestoneId !== undefined && values.milestoneId !== null) {
-    const [milestone] = await executor
-      .select({
-        organizationId: schema.milestone.organizationId,
-        projectId: schema.milestone.projectId,
-      })
-      .from(schema.milestone)
-      .where(eq(schema.milestone.id, values.milestoneId))
-      .limit(1);
-    const found = requireRow(milestone, 'That milestone does not exist.');
-    if (found.organizationId !== organizationId) {
-      throw validationFailed('That milestone belongs to another workspace.');
-    }
+  if (milestoneId !== undefined && milestoneId !== null) {
+    await assertMilestoneInTeam(executor, organizationId, teamId, milestoneId, projectId);
   }
 }
 

--- a/packages/core/src/work/issue-service.ts
+++ b/packages/core/src/work/issue-service.ts
@@ -410,6 +410,59 @@ export interface CreatedIssue {
   readonly actions: SyncAction[];
 }
 
+async function assertAssignableToTeam(
+  executor: Executor,
+  organizationId: string,
+  teamId: string,
+  values: Pick<IssueValues, 'cycleId' | 'projectId' | 'milestoneId'>,
+): Promise<void> {
+  if (values.cycleId !== undefined && values.cycleId !== null) {
+    const [cycle] = await executor
+      .select({ teamId: schema.cycle.teamId, organizationId: schema.cycle.organizationId })
+      .from(schema.cycle)
+      .where(eq(schema.cycle.id, values.cycleId))
+      .limit(1);
+    const found = requireRow(cycle, 'That sprint does not exist.');
+    if (found.organizationId !== organizationId || found.teamId !== teamId) {
+      throw validationFailed('That sprint belongs to another team.');
+    }
+  }
+
+  if (values.projectId !== undefined && values.projectId !== null) {
+    const [project] = await executor
+      .select({ organizationId: schema.project.organizationId })
+      .from(schema.project)
+      .where(eq(schema.project.id, values.projectId))
+      .limit(1);
+    const found = requireRow(project, 'That project does not exist.');
+    if (found.organizationId !== organizationId) {
+      throw validationFailed('That project belongs to another workspace.');
+    }
+    const teams = await executor
+      .select({ teamId: schema.projectTeam.teamId })
+      .from(schema.projectTeam)
+      .where(eq(schema.projectTeam.projectId, values.projectId));
+    if (teams.length > 0 && !teams.some((row) => row.teamId === teamId)) {
+      throw validationFailed('That project belongs to another team.');
+    }
+  }
+
+  if (values.milestoneId !== undefined && values.milestoneId !== null) {
+    const [milestone] = await executor
+      .select({
+        organizationId: schema.milestone.organizationId,
+        projectId: schema.milestone.projectId,
+      })
+      .from(schema.milestone)
+      .where(eq(schema.milestone.id, values.milestoneId))
+      .limit(1);
+    const found = requireRow(milestone, 'That milestone does not exist.');
+    if (found.organizationId !== organizationId) {
+      throw validationFailed('That milestone belongs to another workspace.');
+    }
+  }
+}
+
 export async function createIssue(principal: Principal, input: unknown): Promise<CreatedIssue> {
   assertCan(principal, 'issue:create');
   const parsed = issueCreateSchema.parse(input);
@@ -425,6 +478,11 @@ export async function createIssue(principal: Principal, input: unknown): Promise
     if (state.teamId !== team.id) {
       throw validationFailed('That status belongs to another team.');
     }
+    await assertAssignableToTeam(tx, principal.organizationId, team.id, {
+      cycleId: parsed.cycleId,
+      projectId: parsed.projectId,
+      milestoneId: parsed.milestoneId,
+    });
 
     const number = await allocateIssueNumber(tx, team);
     const now = new Date();
@@ -540,6 +598,7 @@ async function applyIssueUpdates(
       }
       Object.assign(values, applyStateTimestamps(current, state.category, now));
     }
+    await assertAssignableToTeam(tx, principal.organizationId, current.teamId, values);
     pending.push({ current, values, changes });
   }
 

--- a/packages/core/src/work/issue-service.ts
+++ b/packages/core/src/work/issue-service.ts
@@ -3,6 +3,7 @@ import { type IssueRelationType, SORT_ORDER_STEP } from '@orbit/shared/constants
 import { conflict, notFound, validationFailed } from '@orbit/shared/errors';
 import type { Actor, SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
+import { UNSET_FILTER_VALUE } from '@orbit/shared/filters';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan, assertInTeam, isInTeam, teamScope } from '@orbit/shared/policy';
 import { issueIdentifier, parseIssueIdentifier, sortOrderBetween } from '@orbit/shared/utils';
@@ -16,6 +17,7 @@ import {
   paginationSchema,
 } from '@orbit/shared/validators';
 import { getTableColumns, type SQL } from 'drizzle-orm';
+import type { PgColumn } from 'drizzle-orm/pg-core';
 import { z } from 'zod';
 import { appendActivities, principalActor } from '../activity/activity-service.ts';
 import { type Executor, newId, requireRow, toDateString } from '../internal.ts';
@@ -857,7 +859,14 @@ const issueListSchema = issueFilterSchema
 export type IssueListInput = typeof issueListSchema;
 
 const ISSUE_COLUMNS = getTableColumns(schema.issue);
-const ISSUE_LIST_COLUMNS = { ...ISSUE_COLUMNS, description: sql<string>`''` };
+
+const {
+  description: _description,
+  organizationId: _organizationId,
+  stateEnteredAt: _stateEnteredAt,
+  estimatePointId: _estimatePointId,
+  ...ISSUE_LIST_COLUMNS
+} = ISSUE_COLUMNS;
 
 function visibleTeamFilters(principal: Principal): SQL[] {
   if (principal.role === 'admin') return [];
@@ -865,7 +874,7 @@ function visibleTeamFilters(principal: Principal): SQL[] {
   return [inArray(schema.issue.teamId, [...principal.teamIds])];
 }
 
-function buildIssueFilters(
+function buildScopeFilters(
   principal: Principal,
   filter: ReturnType<typeof issueListSchema.parse>,
 ): SQL[] {
@@ -923,8 +932,17 @@ function buildIssueFilters(
   if (!filter.includeSubIssues && filter.parentId === undefined) {
     filters.push(isNull(schema.issue.parentId));
   }
-  filters.push(...buildFilterFilters(filter.filter, { today: today() }));
   return filters;
+}
+
+function buildIssueFilters(
+  principal: Principal,
+  filter: ReturnType<typeof issueListSchema.parse>,
+): SQL[] {
+  return [
+    ...buildScopeFilters(principal, filter),
+    ...buildFilterFilters(filter.filter, { today: today() }),
+  ];
 }
 
 type OrderKey = ReturnType<typeof issueListSchema.parse>['orderBy'];
@@ -935,7 +953,7 @@ const ORDERINGS: Record<
     expression: SQL;
     descending: boolean;
     cast: string;
-    read: (row: IssueRow) => string | number;
+    read: (row: IssueListRow) => string | number;
   }
 > = {
   manual: {
@@ -997,8 +1015,17 @@ function decodeCursor(cursor: string): { value: string | number; id: string } {
   }
 }
 
+export type TrimmedIssueColumn =
+  | 'organizationId'
+  | 'description'
+  | 'estimatePointId'
+  | 'stateEnteredAt';
+
+export type IssueListRow = Omit<IssueRow, TrimmedIssueColumn> &
+  Partial<Pick<IssueRow, TrimmedIssueColumn>>;
+
 export interface IssuePage {
-  readonly issues: IssueRow[];
+  readonly issues: IssueListRow[];
   readonly nextCursor: string | null;
 }
 
@@ -1045,6 +1072,147 @@ export async function getIssueCounts(
     .from(schema.issue)
     .where(and(...filters))
     .groupBy(schema.issue.stateId);
+}
+
+export const FACET_PROPERTIES = [
+  'state',
+  'assignee',
+  'creator',
+  'priority',
+  'estimate',
+  'label',
+  'project',
+  'cycle',
+  'milestone',
+] as const;
+
+export type FacetProperty = (typeof FACET_PROPERTIES)[number];
+
+export type FacetCounts = Record<FacetProperty, Record<string, number>>;
+
+export interface IssueSummary {
+  readonly total: number;
+  readonly scopeTotal: number;
+  readonly byState: Record<string, number>;
+  readonly groupTotals: Record<string, number>;
+  readonly facets: FacetCounts;
+}
+
+const UNSET_FACET_VALUE = UNSET_FILTER_VALUE;
+
+function tally(rows: readonly { key: string | null; total: number }[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const row of rows) counts[row.key ?? UNSET_FACET_VALUE] = Number(row.total);
+  return counts;
+}
+
+async function facetOf(column: PgColumn, where: SQL | undefined): Promise<Record<string, number>> {
+  const rows = await db
+    .select({ key: sql<string | null>`${column}::text`, total: count() })
+    .from(schema.issue)
+    .where(where)
+    .groupBy(column);
+  return tally(rows);
+}
+
+async function labelFacet(where: SQL | undefined): Promise<Record<string, number>> {
+  const [tagged, untagged] = await Promise.all([
+    db
+      .select({ key: sql<string | null>`${schema.issueLabel.labelId}`, total: count() })
+      .from(schema.issue)
+      .innerJoin(schema.issueLabel, eq(schema.issueLabel.issueId, schema.issue.id))
+      .where(where)
+      .groupBy(schema.issueLabel.labelId),
+    db
+      .select({ total: count() })
+      .from(schema.issue)
+      .where(
+        and(
+          where,
+          sql`not exists (select 1 from ${schema.issueLabel} where ${schema.issueLabel.issueId} = ${schema.issue.id})`,
+        ),
+      ),
+  ]);
+  const counts = tally(tagged);
+  const none = Number(untagged[0]?.total ?? 0);
+  if (none > 0) counts[UNSET_FACET_VALUE] = none;
+  return counts;
+}
+
+async function milestoneFacet(where: SQL | undefined): Promise<Record<string, number>> {
+  const rows = await db
+    .select({
+      key: sql<string>`case when ${schema.issue.milestoneId} is null then ${UNSET_FACET_VALUE} else 'any' end`,
+      total: count(),
+    })
+    .from(schema.issue)
+    .where(where)
+    .groupBy(sql`1`);
+  return tally(rows);
+}
+
+const FACET_COLUMNS: Record<Exclude<FacetProperty, 'label' | 'milestone'>, () => PgColumn> = {
+  state: () => schema.issue.stateId,
+  assignee: () => schema.issue.assigneeId,
+  creator: () => schema.issue.creatorId,
+  priority: () => schema.issue.priority,
+  estimate: () => schema.issue.estimate,
+  project: () => schema.issue.projectId,
+  cycle: () => schema.issue.cycleId,
+};
+
+function facetFor(
+  property: FacetProperty,
+  where: SQL | undefined,
+): Promise<Record<string, number>> {
+  if (property === 'label') return labelFacet(where);
+  if (property === 'milestone') return milestoneFacet(where);
+  return facetOf(FACET_COLUMNS[property](), where);
+}
+
+const summarySchema = issueListSchema.extend({
+  groupBy: z.enum(FACET_PROPERTIES).default('state'),
+});
+
+export async function getIssueSummary(
+  principal: Principal,
+  input: unknown = {},
+): Promise<IssueSummary> {
+  assertCan(principal, 'issue:read');
+  const filter = summarySchema.parse(input);
+  const scope = and(...buildScopeFilters(principal, filter));
+  const matching = and(...buildIssueFilters(principal, filter));
+
+  const [matchedStates, scopeTotal, groupTotals, facetRows] = await Promise.all([
+    db
+      .select({ stateId: schema.issue.stateId, total: count() })
+      .from(schema.issue)
+      .where(matching)
+      .groupBy(schema.issue.stateId),
+    db.select({ total: count() }).from(schema.issue).where(scope),
+    facetFor(filter.groupBy, matching),
+    Promise.all(FACET_PROPERTIES.map((property) => facetFor(property, scope))),
+  ]);
+
+  const byState: Record<string, number> = {};
+  let total = 0;
+  for (const row of matchedStates) {
+    byState[row.stateId] = Number(row.total);
+    total += Number(row.total);
+  }
+
+  const facets = {} as Record<FacetProperty, Record<string, number>>;
+  FACET_PROPERTIES.forEach((property, index) => {
+    facets[property] = facetRows[index] ?? {};
+  });
+
+  return {
+    total,
+    scopeTotal: Number(scopeTotal[0]?.total ?? 0),
+    byState,
+    groupTotals,
+    facets,
+  };
 }
 
 export async function getIssue(principal: Principal, idOrIdentifier: string): Promise<IssueRow> {

--- a/packages/core/src/work/project-service.test.ts
+++ b/packages/core/src/work/project-service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { scopes } from '@orbit/shared/events';
+import { createTeam } from '../org/team-service.ts';
 import {
   addMember,
   createWorkspace,
@@ -19,6 +20,18 @@ import {
   removeProjectTeam,
   updateProject,
 } from './project-service.ts';
+
+async function newIssue(
+  title: string,
+  overrides: Record<string, unknown> = {},
+): Promise<{ id: string }> {
+  const { issue } = await createIssue(workspace.admin, {
+    teamId: workspace.teamId,
+    title,
+    ...overrides,
+  });
+  return issue;
+}
 
 let workspace: Workspace;
 
@@ -168,5 +181,62 @@ describe('listProjects', () => {
   it('hides archived projects by default', async () => {
     await newProject();
     expect(await listProjects(workspace.admin)).toHaveLength(1);
+  });
+});
+
+describe('project scope maths', () => {
+  it('leaves cancelled work out of scope so a project can reach a hundred percent', async () => {
+    const { project } = await createProject(workspace.admin, {
+      name: 'Apollo',
+      teamIds: [workspace.teamId],
+    });
+
+    const shipped = await newIssue('Shipped', { projectId: project.id });
+    const dropped = await newIssue('Dropped', { projectId: project.id });
+    await newIssue('Still going', { projectId: project.id });
+
+    await updateIssue(workspace.admin, shipped.id, {
+      stateId: stateNamed(workspace, 'Done').id,
+    });
+    await updateIssue(workspace.admin, dropped.id, {
+      stateId: stateNamed(workspace, 'Canceled').id,
+    });
+
+    const progress = await projectProgress(workspace.admin, project.id);
+
+    expect(progress.scope).toBe(2);
+    expect(progress.completed).toBe(1);
+    expect(progress.canceled).toBe(1);
+  });
+
+  it('reaches a hundred percent when everything left is done', async () => {
+    const { project } = await createProject(workspace.admin, {
+      name: 'Gemini',
+      teamIds: [workspace.teamId],
+    });
+    const done = await newIssue('Done', { projectId: project.id });
+    const dropped = await newIssue('Dropped', { projectId: project.id });
+    await updateIssue(workspace.admin, done.id, { stateId: stateNamed(workspace, 'Done').id });
+    await updateIssue(workspace.admin, dropped.id, {
+      stateId: stateNamed(workspace, 'Canceled').id,
+    });
+
+    const progress = await projectProgress(workspace.admin, project.id);
+    expect(progress.completed).toBe(progress.scope);
+  });
+
+  it('hides a project from a team that does not own it', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const { principal: outsider } = await addMember(workspace, 'member', {
+      teamIds: [other.team.id],
+    });
+    const { project } = await createProject(workspace.admin, {
+      name: 'Private work',
+      teamIds: [workspace.teamId],
+    });
+
+    await expect(projectProgress(outsider, project.id)).rejects.toMatchObject({
+      code: 'not_found',
+    });
   });
 });

--- a/packages/core/src/work/project-service.test.ts
+++ b/packages/core/src/work/project-service.test.ts
@@ -13,8 +13,10 @@ import { createMilestone, listMilestones, reorderMilestones } from './milestone-
 import {
   addProjectTeam,
   createProject,
+  getProject,
   listProjects,
   listProjectTeams,
+  listProjectUpdates,
   postProjectUpdate,
   projectProgress,
   removeProjectTeam,
@@ -238,5 +240,46 @@ describe('project scope maths', () => {
     await expect(projectProgress(outsider, project.id)).rejects.toMatchObject({
       code: 'not_found',
     });
+  });
+});
+
+describe('a project stays inside the teams it belongs to', () => {
+  it('hides another team’s project from a member, and from every entry point', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const { project } = await createProject(workspace.admin, {
+      name: 'Rebrand',
+      teamIds: [other.team.id],
+    });
+    const { principal: engineer } = await addMember(workspace, 'member');
+
+    expect((await listProjects(engineer)).map((row) => row.id)).not.toContain(project.id);
+    await expect(getProject(engineer, project.id)).rejects.toMatchObject({ code: 'not_found' });
+    await expect(listProjectUpdates(engineer, project.id)).rejects.toMatchObject({
+      code: 'not_found',
+    });
+  });
+
+  it('still shows a project that belongs to no team in particular', async () => {
+    const { project } = await createProject(workspace.admin, { name: 'Company wiki' });
+    const { principal: engineer } = await addMember(workspace, 'member');
+    expect((await listProjects(engineer)).map((row) => row.id)).toContain(project.id);
+  });
+
+  it('refuses a status update written by somebody outside the project teams', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const { project } = await createProject(workspace.admin, {
+      name: 'Rebrand',
+      teamIds: [other.team.id],
+    });
+    const { principal: lead } = await addMember(workspace, 'admin');
+    const { principal: engineer } = await addMember(workspace, 'member');
+
+    await expect(
+      postProjectUpdate(engineer, project.id, { health: 'on_track', body: 'All good.' }),
+    ).rejects.toMatchObject({ code: 'not_found' });
+    expect(
+      (await postProjectUpdate(lead, project.id, { health: 'on_track', body: 'All good.' })).update
+        .body,
+    ).toBe('All good.');
   });
 });

--- a/packages/core/src/work/project-service.ts
+++ b/packages/core/src/work/project-service.ts
@@ -10,6 +10,7 @@ import {
   projectUpdatePostSchema,
   projectUpdateSchema,
 } from '@orbit/shared/validators';
+import type { SQL } from 'drizzle-orm';
 import { principalActor } from '../activity/activity-service.ts';
 import { type Executor, newId, requireRow, toDateString } from '../internal.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
@@ -72,6 +73,26 @@ async function assertProjectInOrganization(
     .where(and(eq(schema.project.id, projectId), eq(schema.project.organizationId, organizationId)))
     .limit(1);
   requireRow(row, 'That project does not exist.');
+}
+
+export function visibleProjectFilter(principal: Principal): SQL {
+  if (principal.role === 'admin') return sql`true`;
+  const owned = db
+    .select({ projectId: schema.projectTeam.projectId })
+    .from(schema.projectTeam)
+    .where(eq(schema.projectTeam.projectId, schema.project.id));
+  const mine = db
+    .select({ projectId: schema.projectTeam.projectId })
+    .from(schema.projectTeam)
+    .where(
+      and(
+        eq(schema.projectTeam.projectId, schema.project.id),
+        principal.teamIds.length === 0
+          ? sql`false`
+          : inArray(schema.projectTeam.teamId, [...principal.teamIds]),
+      ),
+    );
+  return sql`(not exists ${owned} or exists ${mine})`;
 }
 
 export async function assertProjectVisible(
@@ -182,6 +203,7 @@ export async function updateProject(
   const parsed = projectUpdateSchema.parse(input);
 
   return await db.transaction(async (tx) => {
+    await assertProjectVisible(tx, principal, projectId);
     const values = projectUpdateValues(parsed);
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
@@ -226,6 +248,7 @@ export async function archiveProject(
   assertCan(principal, 'project:manage');
 
   return await db.transaction(async (tx) => {
+    await assertProjectVisible(tx, principal, projectId);
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
     const [updated] = await tx
@@ -264,6 +287,7 @@ export async function deleteProject(
   assertCan(principal, 'project:manage');
 
   return await db.transaction(async (tx) => {
+    await assertProjectVisible(tx, principal, projectId);
     const [existing] = await tx
       .select()
       .from(schema.project)
@@ -299,7 +323,10 @@ export async function listProjects(
   options: { includeArchived?: boolean } = {},
 ): Promise<ProjectRow[]> {
   assertCan(principal, 'project:read');
-  const filters = [eq(schema.project.organizationId, principal.organizationId)];
+  const filters = [
+    eq(schema.project.organizationId, principal.organizationId),
+    visibleProjectFilter(principal),
+  ];
   if (options.includeArchived !== true) filters.push(isNull(schema.project.archivedAt));
   return await db
     .select()
@@ -317,6 +344,7 @@ export async function getProject(principal: Principal, projectId: string): Promi
       and(
         eq(schema.project.id, projectId),
         eq(schema.project.organizationId, principal.organizationId),
+        visibleProjectFilter(principal),
       ),
     )
     .limit(1);
@@ -331,7 +359,7 @@ export async function addProjectTeam(
   assertCan(principal, 'project:manage');
 
   return await db.transaction(async (tx) => {
-    await assertProjectInOrganization(tx, principal.organizationId, projectId);
+    await assertProjectVisible(tx, principal, projectId);
     await assertTeamsInOrganization(tx, principal.organizationId, [teamId]);
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
@@ -362,7 +390,7 @@ export async function removeProjectTeam(
   assertCan(principal, 'project:manage');
 
   return await db.transaction(async (tx) => {
-    await assertProjectInOrganization(tx, principal.organizationId, projectId);
+    await assertProjectVisible(tx, principal, projectId);
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
     await tx
@@ -390,7 +418,7 @@ export async function listProjectTeams(
   projectId: string,
 ): Promise<{ teamId: string }[]> {
   assertCan(principal, 'project:read');
-  await assertProjectInOrganization(db, principal.organizationId, projectId);
+  await assertProjectVisible(db, principal, projectId);
   return await db
     .select({ teamId: schema.projectTeam.teamId })
     .from(schema.projectTeam)
@@ -406,7 +434,7 @@ export async function postProjectUpdate(
   const parsed = projectUpdatePostSchema.parse(input);
 
   return await db.transaction(async (tx) => {
-    await assertProjectInOrganization(tx, principal.organizationId, projectId);
+    await assertProjectVisible(tx, principal, projectId);
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
     const [created] = await tx
@@ -460,7 +488,7 @@ export async function listProjectUpdates(
   limit = 20,
 ): Promise<ProjectUpdateRow[]> {
   assertCan(principal, 'project:read');
-  await assertProjectInOrganization(db, principal.organizationId, projectId);
+  await assertProjectVisible(db, principal, projectId);
   return await db
     .select()
     .from(schema.projectUpdate)

--- a/packages/core/src/work/project-service.ts
+++ b/packages/core/src/work/project-service.ts
@@ -74,6 +74,23 @@ async function assertProjectInOrganization(
   requireRow(row, 'That project does not exist.');
 }
 
+export async function assertProjectVisible(
+  executor: Executor,
+  principal: Principal,
+  projectId: string,
+): Promise<void> {
+  await assertProjectInOrganization(executor, principal.organizationId, projectId);
+  if (principal.role === 'admin') return;
+  const teams = await executor
+    .select({ teamId: schema.projectTeam.teamId })
+    .from(schema.projectTeam)
+    .where(eq(schema.projectTeam.projectId, projectId));
+  if (teams.length === 0) return;
+  if (!teams.some((row) => principal.teamIds.includes(row.teamId))) {
+    throw notFound('That project does not exist.');
+  }
+}
+
 async function replaceProjectTeams(
   executor: Executor,
   projectId: string,
@@ -469,6 +486,7 @@ export interface ProjectProgress {
   readonly scope: number;
   readonly started: number;
   readonly completed: number;
+  readonly canceled: number;
   readonly milestones: MilestoneProgress[];
 }
 
@@ -479,7 +497,7 @@ export async function projectProgress(
   projectId: string,
 ): Promise<ProjectProgress> {
   assertCan(principal, 'project:read');
-  await assertProjectInOrganization(db, principal.organizationId, projectId);
+  await assertProjectVisible(db, principal, projectId);
 
   const rows = await db
     .select({
@@ -507,9 +525,14 @@ export async function projectProgress(
   let scope = 0;
   let started = 0;
   let completed = 0;
+  let canceled = 0;
   const perMilestone = new Map<string, { scope: number; completed: number }>();
 
   for (const row of rows) {
+    if (row.category === 'canceled') {
+      canceled += row.total;
+      continue;
+    }
     scope += row.total;
     if (row.category === 'started' || row.category === 'review') started += row.total;
     if (row.category === 'completed') completed += row.total;
@@ -525,6 +548,7 @@ export async function projectProgress(
     scope,
     started,
     completed,
+    canceled,
     milestones: milestoneRows.map((milestone) => ({
       milestoneId: milestone.id,
       name: milestone.name,

--- a/packages/core/src/work/standup-service.test.ts
+++ b/packages/core/src/work/standup-service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
+import { createTeam } from '../org/team-service.ts';
 import { addMember, createWorkspace, resetDatabase, type Workspace } from '../test-support.ts';
 import {
   addBlocker,
@@ -238,5 +239,87 @@ describe('permissions', () => {
     await expect(openStandup(principal, { teamId: workspace.teamId })).rejects.toMatchObject({
       code: 'forbidden',
     });
+  });
+});
+
+describe('defects the review found', () => {
+  it('closes the speaker out when the standup is finished', async () => {
+    await teamOfThree();
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    await startStandup(workspace.admin, detail.standup.id);
+
+    const finished = await updateStandup(workspace.admin, detail.standup.id, {
+      status: 'finished',
+    });
+
+    expect(finished.detail.standup.currentTurnId).toBeNull();
+    expect(finished.detail.turns.every((turn) => turn.status !== 'speaking')).toBe(true);
+  });
+
+  it('moves the room on when the current speaker is marked absent', async () => {
+    await teamOfThree();
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    const id = detail.standup.id;
+    await startStandup(workspace.admin, id);
+
+    const first = detail.turns[0];
+    const second = detail.turns[1];
+    if (first === undefined || second === undefined) throw new Error('expected participants');
+
+    const after = await updateTurn(workspace.admin, id, first.id, { attendance: 'absent' });
+
+    expect(after.detail.standup.currentTurnId).toBe(second.id);
+    expect(after.detail.turns[0]?.status).toBe('skipped');
+  });
+
+  it('refuses to resolve a blocker through a standup that does not own it', async () => {
+    const mine = await openStandup(workspace.admin, {
+      teamId: workspace.teamId,
+      heldOn: '2030-03-01',
+    });
+    const other = await openStandup(workspace.admin, {
+      teamId: workspace.teamId,
+      heldOn: '2030-03-02',
+    });
+    const turn = mine.detail.turns[0];
+    if (turn === undefined) throw new Error('expected a participant');
+
+    const raised = await addBlocker(workspace.admin, mine.detail.standup.id, turn.id, {
+      summary: 'Blocked on infra',
+    });
+    const blocker = raised.detail.blockers[0];
+    if (blocker === undefined) throw new Error('expected a blocker');
+
+    await expect(
+      resolveBlocker(workspace.admin, other.detail.standup.id, blocker.id, { resolved: true }),
+    ).rejects.toMatchObject({ code: 'not_found' });
+
+    expect(await openBlockers(workspace.admin, workspace.teamId)).toHaveLength(1);
+  });
+
+  it('refuses to seat somebody who is not on the team', async () => {
+    const outsiderTeam = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const { user: outsider } = await addMember(workspace, 'member', {
+      teamIds: [outsiderTeam.team.id],
+    });
+
+    await expect(
+      openStandup(workspace.admin, {
+        teamId: workspace.teamId,
+        heldOn: '2030-04-01',
+        participantIds: [outsider.id],
+      }),
+    ).rejects.toMatchObject({ code: 'conflict' });
+  });
+
+  it('survives two facilitators opening the same room at once', async () => {
+    await teamOfThree();
+    const opened = await Promise.all([
+      openStandup(workspace.admin, { teamId: workspace.teamId, heldOn: '2030-05-01' }),
+      openStandup(workspace.admin, { teamId: workspace.teamId, heldOn: '2030-05-01' }),
+      openStandup(workspace.admin, { teamId: workspace.teamId, heldOn: '2030-05-01' }),
+    ]);
+    const ids = new Set(opened.map((result) => result.detail.standup.id));
+    expect(ids.size).toBe(1);
   });
 });

--- a/packages/core/src/work/standup-service.test.ts
+++ b/packages/core/src/work/standup-service.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { addMember, createWorkspace, resetDatabase, type Workspace } from '../test-support.ts';
+import {
+  addBlocker,
+  advanceStandup,
+  findStandup,
+  focusTurn,
+  getRotation,
+  listStandups,
+  openBlockers,
+  openStandup,
+  resolveBlocker,
+  setRotation,
+  startStandup,
+  today,
+  updateStandup,
+  updateTurn,
+} from './standup-service.ts';
+
+let workspace: Workspace;
+
+beforeEach(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+});
+
+async function teamOfThree() {
+  const second = await addMember(workspace, 'member');
+  const third = await addMember(workspace, 'member');
+  return { second, third };
+}
+
+describe('openStandup', () => {
+  it('seats every team member in a stable order and picks a facilitator', async () => {
+    await teamOfThree();
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+
+    expect(detail.standup.heldOn).toBe(today());
+    expect(detail.standup.status).toBe('scheduled');
+    expect(detail.turns.length).toBeGreaterThanOrEqual(1);
+    expect(detail.turns.map((turn) => turn.position)).toEqual(
+      detail.turns.map((_turn, index) => index),
+    );
+    expect(detail.standup.facilitatorId).not.toBeNull();
+  });
+
+  it('is idempotent for a team on a given day', async () => {
+    const first = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    const second = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    expect(second.detail.standup.id).toBe(first.detail.standup.id);
+    expect(second.actions).toEqual([]);
+  });
+
+  it('binds the standup to the active sprint when one is running', async () => {
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    expect(detail.standup.cycleId === null || typeof detail.standup.cycleId === 'string').toBe(
+      true,
+    );
+  });
+
+  it('rotates the facilitator to the next person on the following day', async () => {
+    await teamOfThree();
+    const first = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    const second = await openStandup(workspace.admin, {
+      teamId: workspace.teamId,
+      heldOn: '2030-01-02',
+    });
+    expect(second.detail.standup.facilitatorId).not.toBe(first.detail.standup.facilitatorId);
+  });
+});
+
+describe('running the ceremony', () => {
+  it('walks the room one person at a time and finishes after the last turn', async () => {
+    await teamOfThree();
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    const id = detail.standup.id;
+
+    const started = await startStandup(workspace.admin, id);
+    expect(started.detail.standup.status).toBe('running');
+    expect(started.detail.standup.currentTurnId).toBe(started.detail.turns[0]?.id ?? null);
+    expect(started.detail.turns[0]?.status).toBe('speaking');
+
+    let current = started.detail;
+    for (let index = 1; index < detail.turns.length; index += 1) {
+      const next = await advanceStandup(workspace.admin, id);
+      current = next.detail;
+      expect(current.standup.currentTurnId).toBe(current.turns[index]?.id ?? null);
+      expect(current.turns[index - 1]?.status).toBe('done');
+    }
+
+    const finished = await advanceStandup(workspace.admin, id);
+    expect(finished.detail.standup.status).toBe('finished');
+    expect(finished.detail.standup.currentTurnId).toBeNull();
+    expect(finished.detail.standup.endedAt).not.toBeNull();
+  });
+
+  it('skips anyone marked absent when walking the room', async () => {
+    await teamOfThree();
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    const id = detail.standup.id;
+    const second = detail.turns[1];
+    if (second === undefined) throw new Error('expected a second participant');
+
+    await updateTurn(workspace.admin, id, second.id, { attendance: 'absent' });
+    const started = await startStandup(workspace.admin, id);
+    const next = await advanceStandup(workspace.admin, id);
+
+    expect(started.detail.standup.currentTurnId).toBe(detail.turns[0]?.id ?? null);
+    expect(next.detail.standup.currentTurnId).not.toBe(second.id);
+  });
+
+  it('lets the facilitator jump straight to a person', async () => {
+    await teamOfThree();
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    const target = detail.turns.at(-1);
+    if (target === undefined) throw new Error('expected participants');
+
+    await startStandup(workspace.admin, detail.standup.id);
+    const focused = await focusTurn(workspace.admin, detail.standup.id, { turnId: target.id });
+
+    expect(focused.detail.standup.currentTurnId).toBe(target.id);
+    expect(focused.detail.turns.at(-1)?.status).toBe('speaking');
+  });
+
+  it('walks backwards without finishing the standup', async () => {
+    await teamOfThree();
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    const id = detail.standup.id;
+    await startStandup(workspace.admin, id);
+    await advanceStandup(workspace.admin, id);
+    const back = await advanceStandup(workspace.admin, id, { direction: 'previous' });
+
+    expect(back.detail.standup.currentTurnId).toBe(detail.turns[0]?.id ?? null);
+    expect(back.detail.standup.status).toBe('running');
+  });
+
+  it('records what each person said and marks them present', async () => {
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    const turn = detail.turns[0];
+    if (turn === undefined) throw new Error('expected a participant');
+
+    const updated = await updateTurn(workspace.admin, detail.standup.id, turn.id, {
+      notes: 'Shipped the board fix, picking up sprint planning next.',
+      attendance: 'present',
+    });
+
+    expect(updated.detail.turns[0]?.notes).toContain('Shipped the board fix');
+    expect(updated.detail.turns[0]?.attendance).toBe('present');
+  });
+});
+
+describe('blockers', () => {
+  it('raises a blocker against a turn and clears it when resolved', async () => {
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    const turn = detail.turns[0];
+    if (turn === undefined) throw new Error('expected a participant');
+
+    const raised = await addBlocker(workspace.admin, detail.standup.id, turn.id, {
+      summary: 'Waiting on the staging database credentials.',
+    });
+    expect(raised.detail.blockers).toHaveLength(1);
+
+    const open = await openBlockers(workspace.admin, workspace.teamId);
+    expect(open).toHaveLength(1);
+
+    const blocker = raised.detail.blockers[0];
+    if (blocker === undefined) throw new Error('expected a blocker');
+    await resolveBlocker(workspace.admin, detail.standup.id, blocker.id, { resolved: true });
+
+    expect(await openBlockers(workspace.admin, workspace.teamId)).toHaveLength(0);
+  });
+});
+
+describe('rotation', () => {
+  it('drives both the speaking order and who facilitates', async () => {
+    const { second, third } = await teamOfThree();
+    await setRotation(workspace.admin, {
+      teamId: workspace.teamId,
+      members: [
+        { userId: third.user.id, facilitates: true },
+        { userId: second.user.id, facilitates: false },
+        { userId: workspace.admin.userId, facilitates: true },
+      ],
+    });
+
+    const rotation = await getRotation(workspace.admin, workspace.teamId);
+    expect(rotation.map((row) => row.userId)).toEqual([
+      third.user.id,
+      second.user.id,
+      workspace.admin.userId,
+    ]);
+
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    expect(detail.turns.map((turn) => turn.userId)).toEqual([
+      third.user.id,
+      second.user.id,
+      workspace.admin.userId,
+    ]);
+    expect(detail.standup.facilitatorId).toBe(third.user.id);
+  });
+
+  it('refuses to let a contributor rewrite the rotation', async () => {
+    const { principal } = await addMember(workspace, 'contributor');
+    await expect(
+      setRotation(principal, { teamId: workspace.teamId, members: [] }),
+    ).rejects.toMatchObject({ code: 'forbidden' });
+  });
+});
+
+describe('history', () => {
+  it('lists past standups newest first and finds one by day', async () => {
+    await openStandup(workspace.admin, { teamId: workspace.teamId, heldOn: '2030-01-01' });
+    await openStandup(workspace.admin, { teamId: workspace.teamId, heldOn: '2030-01-02' });
+
+    const listed = await listStandups(workspace.admin, { teamId: workspace.teamId });
+    expect(listed.map((row) => row.heldOn)).toEqual(['2030-01-02', '2030-01-01']);
+
+    const found = await findStandup(workspace.admin, workspace.teamId, '2030-01-01');
+    expect(found?.standup.heldOn).toBe('2030-01-01');
+    expect(await findStandup(workspace.admin, workspace.teamId, '2029-12-31')).toBeNull();
+  });
+
+  it('keeps a finished standup out of the running state', async () => {
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    const finished = await updateStandup(workspace.admin, detail.standup.id, {
+      status: 'finished',
+    });
+    expect(finished.detail.standup.endedAt).not.toBeNull();
+    await expect(startStandup(workspace.admin, detail.standup.id)).rejects.toMatchObject({
+      code: 'conflict',
+    });
+  });
+});
+
+describe('permissions', () => {
+  it('stops a guest from opening a standup', async () => {
+    const { principal } = await addMember(workspace, 'guest');
+    await expect(openStandup(principal, { teamId: workspace.teamId })).rejects.toMatchObject({
+      code: 'forbidden',
+    });
+  });
+});

--- a/packages/core/src/work/standup-service.test.ts
+++ b/packages/core/src/work/standup-service.test.ts
@@ -332,15 +332,17 @@ describe('the clock the room keeps', () => {
     const first = started.detail.turns.find(
       (turn) => turn.id === started.detail.standup.currentTurnId,
     );
-    expect(first?.spokeAt).not.toBeNull();
+    if (first === undefined) throw new Error('expected a first speaker');
+    expect(first.spokeAt).not.toBeNull();
 
     const advanced = await advanceStandup(workspace.admin, detail.standup.id, {
       direction: 'next',
       markDone: true,
     });
-    const closed = advanced.detail.turns.find((turn) => turn.id === first?.id);
-    expect(closed?.status).toBe('done');
-    expect(closed?.durationSeconds).not.toBeNull();
+    const closed = advanced.detail.turns.find((turn) => turn.id === first.id);
+    if (closed === undefined) throw new Error('expected the first turn to survive');
+    expect(closed.status).toBe('done');
+    expect(closed.durationSeconds).not.toBeNull();
   });
 
   it('keeps the time a speaker already spent when the room comes back to them', async () => {
@@ -362,6 +364,27 @@ describe('the clock the room keeps', () => {
     });
     const total = again.detail.turns.find((turn) => turn.id === firstId)?.durationSeconds ?? 0;
     expect(total).toBeGreaterThanOrEqual(banked);
+  });
+
+  it('leaves exactly one person speaking when two facilitators jump at once', async () => {
+    const { second, third } = await teamOfThree();
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    await startStandup(workspace.admin, detail.standup.id);
+    const targets = detail.turns.filter((turn) =>
+      [second.user.id, third.user.id].includes(turn.userId),
+    );
+    expect(targets).toHaveLength(2);
+
+    await Promise.all(
+      targets.map((turn) =>
+        focusTurn(workspace.admin, detail.standup.id, { turnId: turn.id }).catch(() => undefined),
+      ),
+    );
+
+    const room = await findStandup(workspace.admin, workspace.teamId, detail.standup.heldOn);
+    const speaking = room?.turns.filter((turn) => turn.status === 'speaking') ?? [];
+    expect(speaking).toHaveLength(1);
+    expect(speaking[0]?.id).toBe(room?.standup.currentTurnId ?? '');
   });
 
   it('leaves exactly one person speaking when two facilitators advance at once', async () => {

--- a/packages/core/src/work/standup-service.test.ts
+++ b/packages/core/src/work/standup-service.test.ts
@@ -323,3 +323,117 @@ describe('defects the review found', () => {
     expect(ids.size).toBe(1);
   });
 });
+
+describe('the clock the room keeps', () => {
+  it('records the first speaker, whose turn start was never stamped before', async () => {
+    await teamOfThree();
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    const started = await startStandup(workspace.admin, detail.standup.id);
+    const first = started.detail.turns.find(
+      (turn) => turn.id === started.detail.standup.currentTurnId,
+    );
+    expect(first?.spokeAt).not.toBeNull();
+
+    const advanced = await advanceStandup(workspace.admin, detail.standup.id, {
+      direction: 'next',
+      markDone: true,
+    });
+    const closed = advanced.detail.turns.find((turn) => turn.id === first?.id);
+    expect(closed?.status).toBe('done');
+    expect(closed?.durationSeconds).not.toBeNull();
+  });
+
+  it('keeps the time a speaker already spent when the room comes back to them', async () => {
+    await teamOfThree();
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    await startStandup(workspace.admin, detail.standup.id);
+    const firstId = detail.turns[0]?.id;
+
+    const forward = await advanceStandup(workspace.admin, detail.standup.id, {
+      direction: 'next',
+      markDone: true,
+    });
+    const banked = forward.detail.turns.find((turn) => turn.id === firstId)?.durationSeconds ?? 0;
+
+    await advanceStandup(workspace.admin, detail.standup.id, { direction: 'previous' });
+    const again = await advanceStandup(workspace.admin, detail.standup.id, {
+      direction: 'next',
+      markDone: true,
+    });
+    const total = again.detail.turns.find((turn) => turn.id === firstId)?.durationSeconds ?? 0;
+    expect(total).toBeGreaterThanOrEqual(banked);
+  });
+
+  it('leaves exactly one person speaking when two facilitators advance at once', async () => {
+    await teamOfThree();
+    const { detail } = await openStandup(workspace.admin, { teamId: workspace.teamId });
+    await startStandup(workspace.admin, detail.standup.id);
+
+    await Promise.all([
+      advanceStandup(workspace.admin, detail.standup.id, { direction: 'next', markDone: true }),
+      advanceStandup(workspace.admin, detail.standup.id, { direction: 'next', markDone: true }),
+    ]);
+
+    const room = await findStandup(workspace.admin, workspace.teamId, detail.standup.heldOn);
+    const speaking = room?.turns.filter((turn) => turn.status === 'speaking') ?? [];
+    expect(speaking).toHaveLength(1);
+    expect(speaking[0]?.id).toBe(room?.standup.currentTurnId ?? '');
+    const current = room?.turns.find((turn) => turn.id === room.standup.currentTurnId);
+    expect(current?.position).toBe(2);
+  });
+});
+
+describe('only the team can be in the room', () => {
+  it('refuses a rotation that names somebody from another team', async () => {
+    const otherTeam = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const { user: outsider } = await addMember(workspace, 'member', {
+      teamIds: [otherTeam.team.id],
+    });
+
+    await expect(
+      setRotation(workspace.admin, {
+        teamId: workspace.teamId,
+        members: [{ userId: outsider.id, facilitates: true }],
+      }),
+    ).rejects.toMatchObject({ code: 'conflict' });
+  });
+
+  it('refuses a facilitator from another team, when opening and when reassigning', async () => {
+    const otherTeam = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const { user: outsider } = await addMember(workspace, 'member', {
+      teamIds: [otherTeam.team.id],
+    });
+
+    await expect(
+      openStandup(workspace.admin, {
+        teamId: workspace.teamId,
+        heldOn: '2030-06-01',
+        facilitatorId: outsider.id,
+      }),
+    ).rejects.toMatchObject({ code: 'conflict' });
+
+    const { detail } = await openStandup(workspace.admin, {
+      teamId: workspace.teamId,
+      heldOn: '2030-06-02',
+    });
+    await expect(
+      updateStandup(workspace.admin, detail.standup.id, { facilitatorId: outsider.id }),
+    ).rejects.toMatchObject({ code: 'conflict' });
+  });
+
+  it('still accepts a rotation and a facilitator drawn from the team', async () => {
+    const { second } = await teamOfThree();
+    const rotation = await setRotation(workspace.admin, {
+      teamId: workspace.teamId,
+      members: [{ userId: second.user.id, facilitates: true }],
+    });
+    expect(rotation).toHaveLength(1);
+
+    const { detail } = await openStandup(workspace.admin, {
+      teamId: workspace.teamId,
+      heldOn: '2030-06-03',
+      facilitatorId: second.user.id,
+    });
+    expect(detail.standup.facilitatorId).toBe(second.user.id);
+  });
+});

--- a/packages/core/src/work/standup-service.ts
+++ b/packages/core/src/work/standup-service.ts
@@ -480,26 +480,17 @@ export async function focusTurn(
   await requireTeam(principal, current.teamId);
 
   return await db.transaction(async (tx) => {
+    const locked = await lockStandup(tx, principal, standupId);
     const now = new Date();
-    if (current.currentTurnId !== null && current.currentTurnId !== parsed.turnId) {
-      await tx
-        .update(schema.standupTurn)
-        .set({ status: 'done', updatedAt: now })
-        .where(
-          and(
-            eq(schema.standupTurn.id, current.currentTurnId),
-            eq(schema.standupTurn.status, 'speaking'),
-          ),
-        );
+    const turns = await turnsOf(tx, standupId);
+    if (locked.currentTurnId !== parsed.turnId) {
+      await closeSpeakingTurn(tx, turns, locked.currentTurnId, now);
     }
-    const [focused] = await tx
-      .update(schema.standupTurn)
-      .set({ status: 'speaking', spokeAt: now, updatedAt: now })
-      .where(
-        and(eq(schema.standupTurn.id, parsed.turnId), eq(schema.standupTurn.standupId, standupId)),
-      )
-      .returning({ id: schema.standupTurn.id });
-    requireRow(focused, 'That turn does not belong to this standup.');
+    const target = requireRow(
+      turns.find((turn) => turn.id === parsed.turnId),
+      'That turn does not belong to this standup.',
+    );
+    await activateTurn(tx, target, now);
     return await saveStandup(tx, principal, standupId, { currentTurnId: parsed.turnId });
   });
 }

--- a/packages/core/src/work/standup-service.ts
+++ b/packages/core/src/work/standup-service.ts
@@ -118,6 +118,19 @@ async function teamMemberIds(executor: Executor, teamId: string): Promise<Set<st
   return new Set(rows.map((row) => row.userId));
 }
 
+async function assertOnTeam(
+  executor: Executor,
+  teamId: string,
+  userIds: readonly (string | null | undefined)[],
+): Promise<void> {
+  const wanted = userIds.filter((userId): userId is string => typeof userId === 'string');
+  if (wanted.length === 0) return;
+  const members = await teamMemberIds(executor, teamId);
+  if (wanted.some((userId) => !members.has(userId))) {
+    throw conflict('Everyone in a standup has to be on the team.');
+  }
+}
+
 async function rosterFor(
   executor: Executor,
   teamId: string,
@@ -200,6 +213,7 @@ export async function openStandup(
     }
 
     const roster = await rosterFor(tx, parsed.teamId, parsed.participantIds);
+    await assertOnTeam(tx, parsed.teamId, [parsed.facilitatorId]);
     const facilitator =
       parsed.facilitatorId === undefined
         ? await nextFacilitator(tx, parsed.teamId, roster)
@@ -319,15 +333,15 @@ export async function updateStandup(
 
   const values: Partial<typeof schema.standup.$inferInsert> = {};
   if (parsed.facilitatorId !== undefined) values.facilitatorId = parsed.facilitatorId;
-  if (parsed.status !== undefined) {
-    values.status = parsed.status;
-    if (parsed.status === 'running' && current.startedAt === null) values.startedAt = new Date();
-  }
+  if (parsed.status !== undefined) values.status = parsed.status;
 
   return await db.transaction(async (tx) => {
+    const locked = await lockStandup(tx, principal, standupId);
+    await assertOnTeam(tx, locked.teamId, [parsed.facilitatorId]);
+    if (parsed.status === 'running' && locked.startedAt === null) values.startedAt = new Date();
     if (parsed.status === 'finished') {
       const now = new Date();
-      await closeSpeakingTurn(tx, await turnsOf(tx, standupId), current.currentTurnId, now);
+      await closeSpeakingTurn(tx, await turnsOf(tx, standupId), locked.currentTurnId, now);
       values.endedAt = now;
       values.currentTurnId = null;
     }
@@ -345,20 +359,48 @@ export async function startStandup(
   if (current.status === 'finished') throw conflict('That standup has already finished.');
 
   return await db.transaction(async (tx) => {
+    const locked = await lockStandup(tx, principal, standupId);
+    if (locked.status === 'finished') throw conflict('That standup has already finished.');
+    const now = new Date();
     const turns = await turnsOf(tx, standupId);
     const first = turns.find((turn) => turn.attendance !== 'absent') ?? turns[0];
-    if (first !== undefined) {
-      await tx
-        .update(schema.standupTurn)
-        .set({ status: 'speaking', updatedAt: new Date() })
-        .where(eq(schema.standupTurn.id, first.id));
-    }
+    if (first !== undefined) await activateTurn(tx, first, now);
     return await saveStandup(tx, principal, standupId, {
       status: 'running',
-      startedAt: current.startedAt ?? new Date(),
-      currentTurnId: first?.id ?? null,
+      startedAt: locked.startedAt ?? now,
+      currentTurnId: locked.currentTurnId ?? first?.id ?? null,
     });
   });
+}
+
+async function lockStandup(tx: Executor, principal: Principal, id: string) {
+  const [row] = await tx
+    .select()
+    .from(schema.standup)
+    .where(
+      and(eq(schema.standup.id, id), eq(schema.standup.organizationId, principal.organizationId)),
+    )
+    .limit(1)
+    .for('update');
+  return requireRow(row, 'That standup does not exist.');
+}
+
+function accumulatedSeconds(turn: StandupTurnRow, now: Date): number | null {
+  if (turn.spokeAt === null) return turn.durationSeconds;
+  const elapsed = Math.max(0, Math.round((now.getTime() - turn.spokeAt.getTime()) / 1000));
+  return (turn.durationSeconds ?? 0) + elapsed;
+}
+
+async function activateTurn(tx: Executor, turn: StandupTurnRow, now: Date): Promise<void> {
+  const alreadySpeaking = turn.status === 'speaking' && turn.spokeAt !== null;
+  await tx
+    .update(schema.standupTurn)
+    .set({
+      status: 'speaking',
+      spokeAt: alreadySpeaking ? turn.spokeAt : now,
+      updatedAt: now,
+    })
+    .where(eq(schema.standupTurn.id, turn.id));
 }
 
 async function closeSpeakingTurn(
@@ -370,15 +412,11 @@ async function closeSpeakingTurn(
   if (currentTurnId === null) return;
   const speaking = turns.find((turn) => turn.id === currentTurnId);
   if (speaking === undefined || speaking.status !== 'speaking') return;
-  const seconds =
-    speaking.spokeAt === null
-      ? null
-      : Math.max(0, Math.round((now.getTime() - speaking.spokeAt.getTime()) / 1000));
   await tx
     .update(schema.standupTurn)
     .set({
       status: 'done',
-      durationSeconds: seconds,
+      durationSeconds: accumulatedSeconds(speaking, now),
       attendance: speaking.attendance === 'unknown' ? 'present' : speaking.attendance,
       updatedAt: now,
     })
@@ -412,20 +450,16 @@ export async function advanceStandup(
   await requireTeam(principal, current.teamId);
 
   return await db.transaction(async (tx) => {
+    const locked = await lockStandup(tx, principal, standupId);
     const turns = await turnsOf(tx, standupId);
     const now = new Date();
 
-    if (parsed.markDone) await closeSpeakingTurn(tx, turns, current.currentTurnId, now);
+    if (parsed.markDone) await closeSpeakingTurn(tx, turns, locked.currentTurnId, now);
 
-    const index = nextTurnIndex(turns, current.currentTurnId, parsed.direction);
+    const index = nextTurnIndex(turns, locked.currentTurnId, parsed.direction);
     const target = index === -1 ? undefined : turns[index];
 
-    if (target !== undefined) {
-      await tx
-        .update(schema.standupTurn)
-        .set({ status: 'speaking', spokeAt: now, updatedAt: now })
-        .where(eq(schema.standupTurn.id, target.id));
-    }
+    if (target !== undefined) await activateTurn(tx, target, now);
 
     const ending = target === undefined && parsed.direction === 'next';
     return await saveStandup(tx, principal, standupId, {
@@ -482,6 +516,7 @@ export async function updateTurn(
   await requireTeam(principal, current.teamId);
 
   return await db.transaction(async (tx) => {
+    const locked = await lockStandup(tx, principal, standupId);
     const values: Partial<typeof schema.standupTurn.$inferInsert> = { updatedAt: new Date() };
     if (parsed.attendance !== undefined) values.attendance = parsed.attendance;
     if (parsed.status !== undefined) values.status = parsed.status;
@@ -495,7 +530,7 @@ export async function updateTurn(
       .returning({ id: schema.standupTurn.id });
     requireRow(updated, 'That turn does not belong to this standup.');
 
-    if (parsed.attendance !== 'absent' || current.currentTurnId !== turnId) {
+    if (parsed.attendance !== 'absent' || locked.currentTurnId !== turnId) {
       return await saveStandup(tx, principal, standupId, {});
     }
 
@@ -507,12 +542,7 @@ export async function updateTurn(
       .update(schema.standupTurn)
       .set({ status: 'skipped', updatedAt: now })
       .where(eq(schema.standupTurn.id, turnId));
-    if (target !== undefined) {
-      await tx
-        .update(schema.standupTurn)
-        .set({ status: 'speaking', spokeAt: now, updatedAt: now })
-        .where(eq(schema.standupTurn.id, target.id));
-    }
+    if (target !== undefined) await activateTurn(tx, target, now);
     return await saveStandup(tx, principal, standupId, {
       currentTurnId: target?.id ?? null,
       ...(target === undefined ? { status: 'finished', endedAt: now } : {}),
@@ -620,6 +650,11 @@ export async function setRotation(
   await requireTeam(principal, parsed.teamId);
 
   return await db.transaction(async (tx) => {
+    await assertOnTeam(
+      tx,
+      parsed.teamId,
+      parsed.members.map((member) => member.userId),
+    );
     await tx.delete(schema.standupRotation).where(eq(schema.standupRotation.teamId, parsed.teamId));
     if (parsed.members.length === 0) return [];
     const syncId = await nextSyncId(tx);

--- a/packages/core/src/work/standup-service.ts
+++ b/packages/core/src/work/standup-service.ts
@@ -110,12 +110,27 @@ async function detailOf(
   return { standup, turns, blockers };
 }
 
+async function teamMemberIds(executor: Executor, teamId: string): Promise<Set<string>> {
+  const rows = await executor
+    .select({ userId: schema.teamMember.userId })
+    .from(schema.teamMember)
+    .where(eq(schema.teamMember.teamId, teamId));
+  return new Set(rows.map((row) => row.userId));
+}
+
 async function rosterFor(
   executor: Executor,
   teamId: string,
   requested: readonly string[] | undefined,
 ): Promise<string[]> {
-  if (requested !== undefined && requested.length > 0) return [...new Set(requested)];
+  if (requested !== undefined && requested.length > 0) {
+    const members = await teamMemberIds(executor, teamId);
+    const outsider = requested.find((userId) => !members.has(userId));
+    if (outsider !== undefined) {
+      throw conflict('Everyone in a standup has to be on the team.');
+    }
+    return [...new Set(requested)];
+  }
 
   const rotation = await executor
     .select({ userId: schema.standupRotation.userId })
@@ -172,6 +187,9 @@ export async function openStandup(
   const cycle = await activeCycle(principal, parsed.teamId);
 
   return await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtext(${`standup:${parsed.teamId}:${heldOn}`}))`,
+    );
     const [existing] = await tx
       .select()
       .from(schema.standup)
@@ -304,10 +322,17 @@ export async function updateStandup(
   if (parsed.status !== undefined) {
     values.status = parsed.status;
     if (parsed.status === 'running' && current.startedAt === null) values.startedAt = new Date();
-    if (parsed.status === 'finished') values.endedAt = new Date();
   }
 
-  return await db.transaction(async (tx) => await saveStandup(tx, principal, standupId, values));
+  return await db.transaction(async (tx) => {
+    if (parsed.status === 'finished') {
+      const now = new Date();
+      await closeSpeakingTurn(tx, await turnsOf(tx, standupId), current.currentTurnId, now);
+      values.endedAt = now;
+      values.currentTurnId = null;
+    }
+    return await saveStandup(tx, principal, standupId, values);
+  });
 }
 
 export async function startStandup(
@@ -470,11 +495,28 @@ export async function updateTurn(
       .returning({ id: schema.standupTurn.id });
     requireRow(updated, 'That turn does not belong to this standup.');
 
-    const clearCurrent =
-      parsed.attendance === 'absent' && current.currentTurnId === turnId
-        ? { currentTurnId: null }
-        : {};
-    return await saveStandup(tx, principal, standupId, clearCurrent);
+    if (parsed.attendance !== 'absent' || current.currentTurnId !== turnId) {
+      return await saveStandup(tx, principal, standupId, {});
+    }
+
+    const turns = await turnsOf(tx, standupId);
+    const index = nextTurnIndex(turns, turnId, 'next');
+    const target = index === -1 ? undefined : turns[index];
+    const now = new Date();
+    await tx
+      .update(schema.standupTurn)
+      .set({ status: 'skipped', updatedAt: now })
+      .where(eq(schema.standupTurn.id, turnId));
+    if (target !== undefined) {
+      await tx
+        .update(schema.standupTurn)
+        .set({ status: 'speaking', spokeAt: now, updatedAt: now })
+        .where(eq(schema.standupTurn.id, target.id));
+    }
+    return await saveStandup(tx, principal, standupId, {
+      currentTurnId: target?.id ?? null,
+      ...(target === undefined ? { status: 'finished', endedAt: now } : {}),
+    });
   });
 }
 
@@ -522,12 +564,19 @@ export async function resolveBlocker(
   await requireTeam(principal, current.teamId);
 
   return await db.transaction(async (tx) => {
+    const owned = tx
+      .select({ id: schema.standupBlocker.id })
+      .from(schema.standupBlocker)
+      .innerJoin(schema.standupTurn, eq(schema.standupTurn.id, schema.standupBlocker.turnId))
+      .where(
+        and(eq(schema.standupBlocker.id, blockerId), eq(schema.standupTurn.standupId, standupId)),
+      );
     const [updated] = await tx
       .update(schema.standupBlocker)
       .set({ resolvedAt: parsed.resolved ? new Date() : null })
       .where(
         and(
-          eq(schema.standupBlocker.id, blockerId),
+          inArray(schema.standupBlocker.id, owned),
           eq(schema.standupBlocker.organizationId, principal.organizationId),
         ),
       )

--- a/packages/core/src/work/standup-service.ts
+++ b/packages/core/src/work/standup-service.ts
@@ -1,0 +1,652 @@
+import { and, asc, db, desc, eq, gte, inArray, isNull, lte, schema, sql } from '@orbit/db';
+import { conflict } from '@orbit/shared/errors';
+import type { SyncAction, SyncModel } from '@orbit/shared/events';
+import { scopes } from '@orbit/shared/events';
+import type { Principal } from '@orbit/shared/policy';
+import { assertCan } from '@orbit/shared/policy';
+import {
+  blockerCreateSchema,
+  blockerResolveSchema,
+  rotationSchema,
+  standupListSchema,
+  standupOpenSchema,
+  standupUpdateSchema,
+  turnAdvanceSchema,
+  turnFocusSchema,
+  turnUpdateSchema,
+} from '@orbit/shared/validators';
+import { type Executor, newId, requireRow } from '../internal.ts';
+import { requireTeam } from '../org/team-service.ts';
+import { buildSyncAction } from '../realtime/publisher.ts';
+import { nextSyncId } from '../sync/sync-id.ts';
+import { activeCycle } from './cycle-service.ts';
+
+export type StandupRow = typeof schema.standup.$inferSelect;
+export type StandupTurnRow = typeof schema.standupTurn.$inferSelect;
+export type StandupBlockerRow = typeof schema.standupBlocker.$inferSelect;
+export type StandupRotationRow = typeof schema.standupRotation.$inferSelect;
+
+export interface StandupDetail {
+  readonly standup: StandupRow;
+  readonly turns: readonly StandupTurnRow[];
+  readonly blockers: readonly StandupBlockerRow[];
+}
+
+function standupScopes(row: Pick<StandupRow, 'organizationId' | 'teamId' | 'id'>): string[] {
+  return [scopes.organization(row.organizationId), scopes.team(row.teamId), scopes.standup(row.id)];
+}
+
+function standupAction(
+  row: StandupRow,
+  syncId: number,
+  action: 'insert' | 'update' | 'delete',
+  data: Record<string, unknown>,
+  model: SyncModel = 'standup',
+): SyncAction {
+  return buildSyncAction({
+    syncId,
+    organizationId: row.organizationId,
+    scopes: standupScopes(row),
+    action,
+    model,
+    modelId: row.id,
+    data,
+    actor: { type: 'system', id: 'standup' },
+  });
+}
+
+export function today(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+async function loadStandup(executor: Executor, principal: Principal, id: string) {
+  const [row] = await executor
+    .select()
+    .from(schema.standup)
+    .where(
+      and(eq(schema.standup.id, id), eq(schema.standup.organizationId, principal.organizationId)),
+    )
+    .limit(1);
+  return requireRow(row, 'That standup does not exist.');
+}
+
+async function turnsOf(executor: Executor, standupId: string): Promise<StandupTurnRow[]> {
+  return await executor
+    .select()
+    .from(schema.standupTurn)
+    .where(eq(schema.standupTurn.standupId, standupId))
+    .orderBy(asc(schema.standupTurn.position));
+}
+
+async function blockersOf(executor: Executor, standupId: string): Promise<StandupBlockerRow[]> {
+  return await executor
+    .select({
+      id: schema.standupBlocker.id,
+      organizationId: schema.standupBlocker.organizationId,
+      turnId: schema.standupBlocker.turnId,
+      issueId: schema.standupBlocker.issueId,
+      summary: schema.standupBlocker.summary,
+      ownerId: schema.standupBlocker.ownerId,
+      resolvedAt: schema.standupBlocker.resolvedAt,
+      syncId: schema.standupBlocker.syncId,
+      createdAt: schema.standupBlocker.createdAt,
+    })
+    .from(schema.standupBlocker)
+    .innerJoin(schema.standupTurn, eq(schema.standupTurn.id, schema.standupBlocker.turnId))
+    .where(eq(schema.standupTurn.standupId, standupId))
+    .orderBy(asc(schema.standupBlocker.createdAt));
+}
+
+async function detailOf(
+  executor: Executor,
+  principal: Principal,
+  standupId: string,
+): Promise<StandupDetail> {
+  const standup = await loadStandup(executor, principal, standupId);
+  const [turns, blockers] = await Promise.all([
+    turnsOf(executor, standupId),
+    blockersOf(executor, standupId),
+  ]);
+  return { standup, turns, blockers };
+}
+
+async function rosterFor(
+  executor: Executor,
+  teamId: string,
+  requested: readonly string[] | undefined,
+): Promise<string[]> {
+  if (requested !== undefined && requested.length > 0) return [...new Set(requested)];
+
+  const rotation = await executor
+    .select({ userId: schema.standupRotation.userId })
+    .from(schema.standupRotation)
+    .where(eq(schema.standupRotation.teamId, teamId))
+    .orderBy(asc(schema.standupRotation.position));
+  if (rotation.length > 0) return rotation.map((row) => row.userId);
+
+  const members = await executor
+    .select({ userId: schema.teamMember.userId })
+    .from(schema.teamMember)
+    .innerJoin(schema.user, eq(schema.user.id, schema.teamMember.userId))
+    .where(eq(schema.teamMember.teamId, teamId))
+    .orderBy(asc(schema.user.name));
+  return members.map((row) => row.userId);
+}
+
+async function nextFacilitator(
+  executor: Executor,
+  teamId: string,
+  roster: readonly string[],
+): Promise<string | null> {
+  const eligible = await executor
+    .select({ userId: schema.standupRotation.userId })
+    .from(schema.standupRotation)
+    .where(
+      and(eq(schema.standupRotation.teamId, teamId), eq(schema.standupRotation.facilitates, 1)),
+    )
+    .orderBy(asc(schema.standupRotation.position));
+  const pool = eligible.length > 0 ? eligible.map((row) => row.userId) : [...roster];
+  if (pool.length === 0) return null;
+
+  const [previous] = await executor
+    .select({ facilitatorId: schema.standup.facilitatorId })
+    .from(schema.standup)
+    .where(eq(schema.standup.teamId, teamId))
+    .orderBy(desc(schema.standup.heldOn))
+    .limit(1);
+
+  const last = previous?.facilitatorId ?? null;
+  if (last === null) return pool[0] ?? null;
+  const index = pool.indexOf(last);
+  return pool[(index + 1) % pool.length] ?? pool[0] ?? null;
+}
+
+export async function openStandup(
+  principal: Principal,
+  input: unknown,
+): Promise<{ detail: StandupDetail; actions: SyncAction[] }> {
+  assertCan(principal, 'issue:update');
+  const parsed = standupOpenSchema.parse(input);
+  await requireTeam(principal, parsed.teamId);
+  const heldOn = parsed.heldOn ?? today();
+  const cycle = await activeCycle(principal, parsed.teamId);
+
+  return await db.transaction(async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(schema.standup)
+      .where(and(eq(schema.standup.teamId, parsed.teamId), eq(schema.standup.heldOn, heldOn)))
+      .limit(1);
+    if (existing !== undefined) {
+      return { detail: await detailOf(tx, principal, existing.id), actions: [] };
+    }
+
+    const roster = await rosterFor(tx, parsed.teamId, parsed.participantIds);
+    const facilitator =
+      parsed.facilitatorId === undefined
+        ? await nextFacilitator(tx, parsed.teamId, roster)
+        : parsed.facilitatorId;
+    const syncId = await nextSyncId(tx);
+
+    const [created] = await tx
+      .insert(schema.standup)
+      .values({
+        id: newId(),
+        organizationId: principal.organizationId,
+        teamId: parsed.teamId,
+        cycleId: cycle?.id ?? null,
+        heldOn,
+        facilitatorId: facilitator,
+        status: 'scheduled',
+        syncId,
+      })
+      .returning();
+    const standup = requireRow(created, 'The standup could not be opened.');
+
+    if (roster.length > 0) {
+      await tx.insert(schema.standupTurn).values(
+        roster.map((userId, index) => ({
+          id: newId(),
+          organizationId: principal.organizationId,
+          standupId: standup.id,
+          userId,
+          position: index,
+          syncId,
+        })),
+      );
+    }
+
+    const detail = await detailOf(tx, principal, standup.id);
+    return { detail, actions: [standupAction(standup, syncId, 'insert', { ...detail })] };
+  });
+}
+
+export async function getStandup(principal: Principal, standupId: string): Promise<StandupDetail> {
+  assertCan(principal, 'issue:read');
+  const detail = await detailOf(db, principal, standupId);
+  await requireTeam(principal, detail.standup.teamId);
+  return detail;
+}
+
+export async function findStandup(
+  principal: Principal,
+  teamId: string,
+  heldOn: string,
+): Promise<StandupDetail | null> {
+  assertCan(principal, 'issue:read');
+  await requireTeam(principal, teamId);
+  const [row] = await db
+    .select({ id: schema.standup.id })
+    .from(schema.standup)
+    .where(and(eq(schema.standup.teamId, teamId), eq(schema.standup.heldOn, heldOn)))
+    .limit(1);
+  if (row === undefined) return null;
+  return await detailOf(db, principal, row.id);
+}
+
+export async function listStandups(principal: Principal, input: unknown = {}) {
+  assertCan(principal, 'issue:read');
+  const parsed = standupListSchema.parse(input);
+  const filters = [eq(schema.standup.organizationId, principal.organizationId)];
+  if (parsed.teamId !== undefined) {
+    await requireTeam(principal, parsed.teamId);
+    filters.push(eq(schema.standup.teamId, parsed.teamId));
+  } else if (principal.role !== 'admin') {
+    if (principal.teamIds.length === 0) return [];
+    filters.push(inArray(schema.standup.teamId, [...principal.teamIds]));
+  }
+  if (parsed.cycleId !== undefined) filters.push(eq(schema.standup.cycleId, parsed.cycleId));
+  if (parsed.from !== undefined) filters.push(gte(schema.standup.heldOn, parsed.from));
+  if (parsed.to !== undefined) filters.push(lte(schema.standup.heldOn, parsed.to));
+
+  return await db
+    .select()
+    .from(schema.standup)
+    .where(and(...filters))
+    .orderBy(desc(schema.standup.heldOn))
+    .limit(parsed.limit);
+}
+
+async function saveStandup(
+  tx: Executor,
+  principal: Principal,
+  standupId: string,
+  values: Partial<typeof schema.standup.$inferInsert>,
+): Promise<{ detail: StandupDetail; actions: SyncAction[] }> {
+  const syncId = await nextSyncId(tx);
+  const [updated] = await tx
+    .update(schema.standup)
+    .set({ ...values, syncId, updatedAt: new Date() })
+    .where(
+      and(
+        eq(schema.standup.id, standupId),
+        eq(schema.standup.organizationId, principal.organizationId),
+      ),
+    )
+    .returning();
+  const standup = requireRow(updated, 'That standup does not exist.');
+  const detail = await detailOf(tx, principal, standup.id);
+  return { detail, actions: [standupAction(standup, syncId, 'update', { ...detail })] };
+}
+
+export async function updateStandup(
+  principal: Principal,
+  standupId: string,
+  input: unknown,
+): Promise<{ detail: StandupDetail; actions: SyncAction[] }> {
+  assertCan(principal, 'issue:update');
+  const parsed = standupUpdateSchema.parse(input);
+  const current = await loadStandup(db, principal, standupId);
+  await requireTeam(principal, current.teamId);
+
+  const values: Partial<typeof schema.standup.$inferInsert> = {};
+  if (parsed.facilitatorId !== undefined) values.facilitatorId = parsed.facilitatorId;
+  if (parsed.status !== undefined) {
+    values.status = parsed.status;
+    if (parsed.status === 'running' && current.startedAt === null) values.startedAt = new Date();
+    if (parsed.status === 'finished') values.endedAt = new Date();
+  }
+
+  return await db.transaction(async (tx) => await saveStandup(tx, principal, standupId, values));
+}
+
+export async function startStandup(
+  principal: Principal,
+  standupId: string,
+): Promise<{ detail: StandupDetail; actions: SyncAction[] }> {
+  assertCan(principal, 'issue:update');
+  const current = await loadStandup(db, principal, standupId);
+  await requireTeam(principal, current.teamId);
+  if (current.status === 'finished') throw conflict('That standup has already finished.');
+
+  return await db.transaction(async (tx) => {
+    const turns = await turnsOf(tx, standupId);
+    const first = turns.find((turn) => turn.attendance !== 'absent') ?? turns[0];
+    if (first !== undefined) {
+      await tx
+        .update(schema.standupTurn)
+        .set({ status: 'speaking', updatedAt: new Date() })
+        .where(eq(schema.standupTurn.id, first.id));
+    }
+    return await saveStandup(tx, principal, standupId, {
+      status: 'running',
+      startedAt: current.startedAt ?? new Date(),
+      currentTurnId: first?.id ?? null,
+    });
+  });
+}
+
+async function closeSpeakingTurn(
+  tx: Executor,
+  turns: readonly StandupTurnRow[],
+  currentTurnId: string | null,
+  now: Date,
+): Promise<void> {
+  if (currentTurnId === null) return;
+  const speaking = turns.find((turn) => turn.id === currentTurnId);
+  if (speaking === undefined || speaking.status !== 'speaking') return;
+  const seconds =
+    speaking.spokeAt === null
+      ? null
+      : Math.max(0, Math.round((now.getTime() - speaking.spokeAt.getTime()) / 1000));
+  await tx
+    .update(schema.standupTurn)
+    .set({
+      status: 'done',
+      durationSeconds: seconds,
+      attendance: speaking.attendance === 'unknown' ? 'present' : speaking.attendance,
+      updatedAt: now,
+    })
+    .where(eq(schema.standupTurn.id, speaking.id));
+}
+
+function nextTurnIndex(
+  turns: readonly StandupTurnRow[],
+  currentId: string | null,
+  direction: 'next' | 'previous',
+): number {
+  const index = currentId === null ? -1 : turns.findIndex((turn) => turn.id === currentId);
+  const step = direction === 'next' ? 1 : -1;
+  let cursor = index + step;
+  while (cursor >= 0 && cursor < turns.length) {
+    const candidate = turns[cursor];
+    if (candidate !== undefined && candidate.attendance !== 'absent') return cursor;
+    cursor += step;
+  }
+  return -1;
+}
+
+export async function advanceStandup(
+  principal: Principal,
+  standupId: string,
+  input: unknown = {},
+): Promise<{ detail: StandupDetail; actions: SyncAction[] }> {
+  assertCan(principal, 'issue:update');
+  const parsed = turnAdvanceSchema.parse(input);
+  const current = await loadStandup(db, principal, standupId);
+  await requireTeam(principal, current.teamId);
+
+  return await db.transaction(async (tx) => {
+    const turns = await turnsOf(tx, standupId);
+    const now = new Date();
+
+    if (parsed.markDone) await closeSpeakingTurn(tx, turns, current.currentTurnId, now);
+
+    const index = nextTurnIndex(turns, current.currentTurnId, parsed.direction);
+    const target = index === -1 ? undefined : turns[index];
+
+    if (target !== undefined) {
+      await tx
+        .update(schema.standupTurn)
+        .set({ status: 'speaking', spokeAt: now, updatedAt: now })
+        .where(eq(schema.standupTurn.id, target.id));
+    }
+
+    const ending = target === undefined && parsed.direction === 'next';
+    return await saveStandup(tx, principal, standupId, {
+      currentTurnId: target?.id ?? null,
+      ...(ending ? { status: 'finished', endedAt: now } : {}),
+    });
+  });
+}
+
+export async function focusTurn(
+  principal: Principal,
+  standupId: string,
+  input: unknown,
+): Promise<{ detail: StandupDetail; actions: SyncAction[] }> {
+  assertCan(principal, 'issue:update');
+  const parsed = turnFocusSchema.parse(input);
+  const current = await loadStandup(db, principal, standupId);
+  await requireTeam(principal, current.teamId);
+
+  return await db.transaction(async (tx) => {
+    const now = new Date();
+    if (current.currentTurnId !== null && current.currentTurnId !== parsed.turnId) {
+      await tx
+        .update(schema.standupTurn)
+        .set({ status: 'done', updatedAt: now })
+        .where(
+          and(
+            eq(schema.standupTurn.id, current.currentTurnId),
+            eq(schema.standupTurn.status, 'speaking'),
+          ),
+        );
+    }
+    const [focused] = await tx
+      .update(schema.standupTurn)
+      .set({ status: 'speaking', spokeAt: now, updatedAt: now })
+      .where(
+        and(eq(schema.standupTurn.id, parsed.turnId), eq(schema.standupTurn.standupId, standupId)),
+      )
+      .returning({ id: schema.standupTurn.id });
+    requireRow(focused, 'That turn does not belong to this standup.');
+    return await saveStandup(tx, principal, standupId, { currentTurnId: parsed.turnId });
+  });
+}
+
+export async function updateTurn(
+  principal: Principal,
+  standupId: string,
+  turnId: string,
+  input: unknown,
+): Promise<{ detail: StandupDetail; actions: SyncAction[] }> {
+  assertCan(principal, 'issue:update');
+  const parsed = turnUpdateSchema.parse(input);
+  const current = await loadStandup(db, principal, standupId);
+  await requireTeam(principal, current.teamId);
+
+  return await db.transaction(async (tx) => {
+    const values: Partial<typeof schema.standupTurn.$inferInsert> = { updatedAt: new Date() };
+    if (parsed.attendance !== undefined) values.attendance = parsed.attendance;
+    if (parsed.status !== undefined) values.status = parsed.status;
+    if (parsed.notes !== undefined) values.notes = parsed.notes;
+    if (parsed.blockers !== undefined) values.blockers = parsed.blockers;
+
+    const [updated] = await tx
+      .update(schema.standupTurn)
+      .set(values)
+      .where(and(eq(schema.standupTurn.id, turnId), eq(schema.standupTurn.standupId, standupId)))
+      .returning({ id: schema.standupTurn.id });
+    requireRow(updated, 'That turn does not belong to this standup.');
+
+    const clearCurrent =
+      parsed.attendance === 'absent' && current.currentTurnId === turnId
+        ? { currentTurnId: null }
+        : {};
+    return await saveStandup(tx, principal, standupId, clearCurrent);
+  });
+}
+
+export async function addBlocker(
+  principal: Principal,
+  standupId: string,
+  turnId: string,
+  input: unknown,
+): Promise<{ detail: StandupDetail; actions: SyncAction[] }> {
+  assertCan(principal, 'issue:update');
+  const parsed = blockerCreateSchema.parse(input);
+  const current = await loadStandup(db, principal, standupId);
+  await requireTeam(principal, current.teamId);
+
+  return await db.transaction(async (tx) => {
+    const [turn] = await tx
+      .select({ id: schema.standupTurn.id })
+      .from(schema.standupTurn)
+      .where(and(eq(schema.standupTurn.id, turnId), eq(schema.standupTurn.standupId, standupId)))
+      .limit(1);
+    requireRow(turn, 'That turn does not belong to this standup.');
+
+    await tx.insert(schema.standupBlocker).values({
+      id: newId(),
+      organizationId: principal.organizationId,
+      turnId,
+      issueId: parsed.issueId ?? null,
+      summary: parsed.summary,
+      ownerId: parsed.ownerId ?? null,
+      syncId: await nextSyncId(tx),
+    });
+    return await saveStandup(tx, principal, standupId, {});
+  });
+}
+
+export async function resolveBlocker(
+  principal: Principal,
+  standupId: string,
+  blockerId: string,
+  input: unknown = {},
+): Promise<{ detail: StandupDetail; actions: SyncAction[] }> {
+  assertCan(principal, 'issue:update');
+  const parsed = blockerResolveSchema.parse(input);
+  const current = await loadStandup(db, principal, standupId);
+  await requireTeam(principal, current.teamId);
+
+  return await db.transaction(async (tx) => {
+    const [updated] = await tx
+      .update(schema.standupBlocker)
+      .set({ resolvedAt: parsed.resolved ? new Date() : null })
+      .where(
+        and(
+          eq(schema.standupBlocker.id, blockerId),
+          eq(schema.standupBlocker.organizationId, principal.organizationId),
+        ),
+      )
+      .returning({ id: schema.standupBlocker.id });
+    requireRow(updated, 'That blocker does not exist.');
+    return await saveStandup(tx, principal, standupId, {});
+  });
+}
+
+export async function openBlockers(
+  principal: Principal,
+  teamId: string,
+): Promise<StandupBlockerRow[]> {
+  assertCan(principal, 'issue:read');
+  await requireTeam(principal, teamId);
+  return await db
+    .select({
+      id: schema.standupBlocker.id,
+      organizationId: schema.standupBlocker.organizationId,
+      turnId: schema.standupBlocker.turnId,
+      issueId: schema.standupBlocker.issueId,
+      summary: schema.standupBlocker.summary,
+      ownerId: schema.standupBlocker.ownerId,
+      resolvedAt: schema.standupBlocker.resolvedAt,
+      syncId: schema.standupBlocker.syncId,
+      createdAt: schema.standupBlocker.createdAt,
+    })
+    .from(schema.standupBlocker)
+    .innerJoin(schema.standupTurn, eq(schema.standupTurn.id, schema.standupBlocker.turnId))
+    .innerJoin(schema.standup, eq(schema.standup.id, schema.standupTurn.standupId))
+    .where(and(eq(schema.standup.teamId, teamId), isNull(schema.standupBlocker.resolvedAt)))
+    .orderBy(desc(schema.standupBlocker.createdAt));
+}
+
+export async function setRotation(
+  principal: Principal,
+  input: unknown,
+): Promise<StandupRotationRow[]> {
+  assertCan(principal, 'team:manage');
+  const parsed = rotationSchema.parse(input);
+  await requireTeam(principal, parsed.teamId);
+
+  return await db.transaction(async (tx) => {
+    await tx.delete(schema.standupRotation).where(eq(schema.standupRotation.teamId, parsed.teamId));
+    if (parsed.members.length === 0) return [];
+    const syncId = await nextSyncId(tx);
+    return await tx
+      .insert(schema.standupRotation)
+      .values(
+        parsed.members.map((member, index) => ({
+          id: newId(),
+          organizationId: principal.organizationId,
+          teamId: parsed.teamId,
+          userId: member.userId,
+          position: index,
+          facilitates: member.facilitates ? 1 : 0,
+          syncId,
+        })),
+      )
+      .returning();
+  });
+}
+
+export async function getRotation(
+  principal: Principal,
+  teamId: string,
+): Promise<StandupRotationRow[]> {
+  assertCan(principal, 'issue:read');
+  await requireTeam(principal, teamId);
+  return await db
+    .select()
+    .from(schema.standupRotation)
+    .where(eq(schema.standupRotation.teamId, teamId))
+    .orderBy(asc(schema.standupRotation.position));
+}
+
+export interface StandupWorkload {
+  readonly userId: string;
+  readonly inProgress: number;
+  readonly completedSinceLast: number;
+  readonly assigned: number;
+}
+
+export async function standupWorkload(
+  principal: Principal,
+  teamId: string,
+  since: Date,
+): Promise<StandupWorkload[]> {
+  assertCan(principal, 'issue:read');
+  await requireTeam(principal, teamId);
+
+  const rows = await db
+    .select({
+      userId: schema.issue.assigneeId,
+      assigned: sql<number>`count(*)`.as('assigned'),
+      inProgress:
+        sql<number>`count(*) filter (where ${schema.workflowState.category} in ('started', 'review'))`.as(
+          'in_progress',
+        ),
+      completedSinceLast:
+        sql<number>`count(*) filter (where ${schema.issue.completedAt} >= ${since.toISOString()}::timestamptz)`.as(
+          'completed_since_last',
+        ),
+    })
+    .from(schema.issue)
+    .innerJoin(schema.workflowState, eq(schema.workflowState.id, schema.issue.stateId))
+    .where(and(eq(schema.issue.teamId, teamId), isNull(schema.issue.archivedAt)))
+    .groupBy(schema.issue.assigneeId);
+
+  return rows.flatMap((row) =>
+    row.userId === null
+      ? []
+      : [
+          {
+            userId: row.userId,
+            assigned: Number(row.assigned),
+            inProgress: Number(row.inProgress),
+            completedSinceLast: Number(row.completedSinceLast),
+          },
+        ],
+  );
+}

--- a/packages/core/src/work/standup-service.ts
+++ b/packages/core/src/work/standup-service.ts
@@ -33,7 +33,7 @@ export interface StandupDetail {
 }
 
 function standupScopes(row: Pick<StandupRow, 'organizationId' | 'teamId' | 'id'>): string[] {
-  return [scopes.organization(row.organizationId), scopes.team(row.teamId), scopes.standup(row.id)];
+  return [scopes.team(row.teamId), scopes.standup(row.id)];
 }
 
 function standupAction(

--- a/packages/core/src/work/workflow-state-service.ts
+++ b/packages/core/src/work/workflow-state-service.ts
@@ -29,7 +29,7 @@ export const DEFAULT_WORKFLOW_STATES: readonly {
 ];
 
 function stateScopes(row: WorkflowStateRow): string[] {
-  return [scopes.organization(row.organizationId), scopes.team(row.teamId)];
+  return [scopes.team(row.teamId)];
 }
 
 export async function createDefaultWorkflowStates(

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,7 +16,8 @@
     "seed": "bun --env-file=../../.env src/seed/index.ts",
     "import:plane": "bun --env-file=../../.env src/import/index.ts",
     "import:verify": "bun --env-file=../../.env src/import/verify.ts",
-    "test": "bun --env-file=../../.env test"
+    "test": "bun --env-file=../../.env test",
+    "test-setup": "bun --env-file=../../.env src/ensure-test-databases.ts"
   },
   "dependencies": {
     "@orbit/shared": "workspace:*",

--- a/packages/db/src/ensure-test-databases.ts
+++ b/packages/db/src/ensure-test-databases.ts
@@ -16,24 +16,32 @@ const connectionString =
 
 const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]', 'host.docker.internal']);
 
-function assertLocalServer(url: string): void {
-  if (process.env['ORBIT_ALLOW_REMOTE_TEST_SETUP'] === '1') return;
-  let host: string;
-  let port: string;
+function hostOf(url: string): { host: string; port: string } {
   try {
     const parsed = new URL(url);
-    host = parsed.hostname;
-    port = parsed.port === '' ? '5432' : parsed.port;
+    return { host: parsed.hostname, port: parsed.port === '' ? '5432' : parsed.port };
   } catch {
     throw new Error('DATABASE_URL is not a valid connection string.');
   }
+}
+
+function assertLocalServer(url: string): void {
+  const { host, port } = hostOf(url);
   if (LOCAL_HOSTS.has(host)) return;
+  if (process.env['ORBIT_ALLOW_REMOTE_TEST_SETUP'] === '1') return;
   throw new Error(
     `Refusing to create test databases on ${host}:${port}. This creates six databases and pushes the whole schema into each, which must never happen on a deployed server. Point DATABASE_URL at the local stack from bun run infra:up, or set ORBIT_ALLOW_REMOTE_TEST_SETUP=1 if you are certain.`,
   );
 }
 
+function isRemote(url: string): boolean {
+  return !LOCAL_HOSTS.has(hostOf(url).host);
+}
+
 assertLocalServer(connectionString);
+
+const remote = isRemote(connectionString);
+const connectionOptions = remote ? { max: 1, ssl: 'verify-full' as const } : { max: 1 };
 
 function adminUrl(url: string): string {
   const parsed = new URL(url);
@@ -47,7 +55,7 @@ function databaseUrl(url: string, name: string): string {
   return parsed.toString();
 }
 
-const admin = postgres(adminUrl(connectionString), { max: 1 });
+const admin = postgres(adminUrl(connectionString), connectionOptions);
 
 for (const name of TEST_DATABASES) {
   if (!DATABASE_NAME.test(name)) {
@@ -66,7 +74,7 @@ await admin.end();
 
 for (const name of TEST_DATABASES) {
   const url = databaseUrl(connectionString, name);
-  const sql = postgres(url, { max: 1 });
+  const sql = postgres(url, connectionOptions);
   await sql`create extension if not exists pg_trgm`;
   await sql.end();
 }

--- a/packages/db/src/ensure-test-databases.ts
+++ b/packages/db/src/ensure-test-databases.ts
@@ -1,0 +1,68 @@
+import postgres from 'postgres';
+
+const TEST_DATABASES = [
+  'orbit_test_core',
+  'orbit_test_svc',
+  'orbit_test_rt',
+  'orbit_test_rts',
+  'orbit_test_mcp',
+  'orbit_test_web',
+] as const;
+
+const DATABASE_NAME = /^orbit_test(?:_[a-z0-9]+)*$/;
+
+const connectionString =
+  process.env['DATABASE_URL'] ?? 'postgres://orbit:orbit@localhost:5434/orbit';
+
+function adminUrl(url: string): string {
+  const parsed = new URL(url);
+  parsed.pathname = '/postgres';
+  return parsed.toString();
+}
+
+function databaseUrl(url: string, name: string): string {
+  const parsed = new URL(url);
+  parsed.pathname = `/${name}`;
+  return parsed.toString();
+}
+
+const admin = postgres(adminUrl(connectionString), { max: 1 });
+
+for (const name of TEST_DATABASES) {
+  if (!DATABASE_NAME.test(name)) {
+    throw new Error(`Refusing to create "${name}": it does not look like a test database.`);
+  }
+  const existing = await admin`select 1 from pg_database where datname = ${name}`;
+  if (existing.length > 0) {
+    console.log(`${name} already exists`);
+    continue;
+  }
+  await admin.unsafe(`create database "${name}"`);
+  console.log(`created ${name}`);
+}
+
+await admin.end();
+
+for (const name of TEST_DATABASES) {
+  const url = databaseUrl(connectionString, name);
+  const sql = postgres(url, { max: 1 });
+  await sql`create extension if not exists pg_trgm`;
+  await sql.end();
+}
+
+console.log(`\n${TEST_DATABASES.length} test databases ready. Applying the schema to each.`);
+
+for (const name of TEST_DATABASES) {
+  const url = databaseUrl(connectionString, name);
+  const push = Bun.spawn(['bunx', 'drizzle-kit', 'push', '--force'], {
+    env: { ...process.env, DATABASE_URL: url },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const code = await push.exited;
+  if (code !== 0) {
+    console.error(await new Response(push.stderr).text());
+    throw new Error(`Could not push the schema to ${name}.`);
+  }
+  console.log(`schema applied to ${name}`);
+}

--- a/packages/db/src/ensure-test-databases.ts
+++ b/packages/db/src/ensure-test-databases.ts
@@ -14,6 +14,27 @@ const DATABASE_NAME = /^orbit_test(?:_[a-z0-9]+)*$/;
 const connectionString =
   process.env['DATABASE_URL'] ?? 'postgres://orbit:orbit@localhost:5434/orbit';
 
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]', 'host.docker.internal']);
+
+function assertLocalServer(url: string): void {
+  if (process.env['ORBIT_ALLOW_REMOTE_TEST_SETUP'] === '1') return;
+  let host: string;
+  let port: string;
+  try {
+    const parsed = new URL(url);
+    host = parsed.hostname;
+    port = parsed.port === '' ? '5432' : parsed.port;
+  } catch {
+    throw new Error('DATABASE_URL is not a valid connection string.');
+  }
+  if (LOCAL_HOSTS.has(host)) return;
+  throw new Error(
+    `Refusing to create test databases on ${host}:${port}. This creates six databases and pushes the whole schema into each, which must never happen on a deployed server. Point DATABASE_URL at the local stack from bun run infra:up, or set ORBIT_ALLOW_REMOTE_TEST_SETUP=1 if you are certain.`,
+  );
+}
+
+assertLocalServer(connectionString);
+
 function adminUrl(url: string): string {
   const parsed = new URL(url);
   parsed.pathname = '/postgres';

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -15,6 +15,7 @@ export {
   ne,
   not,
   or,
+  type SQL,
   sql,
 } from 'drizzle-orm';
 export * from './client.ts';

--- a/packages/db/src/schema/content.ts
+++ b/packages/db/src/schema/content.ts
@@ -80,6 +80,29 @@ export const docCollection = pgTable(
   (table) => [index('doc_collection_org_idx').on(table.organizationId)],
 );
 
+export const docAccess = pgTable(
+  'doc_access',
+  {
+    id: text('id').primaryKey(),
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organization.id, { onDelete: 'cascade' }),
+    docId: text('doc_id')
+      .notNull()
+      .references((): AnyPgColumn => doc.id, { onDelete: 'cascade' }),
+    subjectType: text('subject_type').notNull(),
+    subjectId: text('subject_id').notNull(),
+    level: text('level').notNull().default('read'),
+    grantedById: text('granted_by_id').references(() => user.id, { onDelete: 'set null' }),
+    syncId: bigint('sync_id', { mode: 'number' }).notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('doc_access_unique').on(table.docId, table.subjectType, table.subjectId),
+    index('doc_access_subject_idx').on(table.subjectType, table.subjectId),
+  ],
+);
+
 export const doc = pgTable(
   'doc',
   {

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -3,4 +3,5 @@ export * from './comms.ts';
 export * from './content.ts';
 export * from './oauth.ts';
 export * from './org.ts';
+export * from './scrum.ts';
 export * from './work.ts';

--- a/packages/db/src/schema/scrum.ts
+++ b/packages/db/src/schema/scrum.ts
@@ -1,0 +1,119 @@
+import {
+  bigint,
+  date,
+  index,
+  integer,
+  pgTable,
+  smallint,
+  text,
+  timestamp,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+import { user } from './auth.ts';
+import { organization, team } from './org.ts';
+import { cycle, issue } from './work.ts';
+
+export const standup = pgTable(
+  'standup',
+  {
+    id: text('id').primaryKey(),
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organization.id, { onDelete: 'cascade' }),
+    teamId: text('team_id')
+      .notNull()
+      .references(() => team.id, { onDelete: 'cascade' }),
+    cycleId: text('cycle_id').references(() => cycle.id, { onDelete: 'set null' }),
+    heldOn: date('held_on').notNull(),
+    facilitatorId: text('facilitator_id').references(() => user.id, { onDelete: 'set null' }),
+    status: text('status').notNull().default('scheduled'),
+    currentTurnId: text('current_turn_id'),
+    startedAt: timestamp('started_at', { withTimezone: true }),
+    endedAt: timestamp('ended_at', { withTimezone: true }),
+    syncId: bigint('sync_id', { mode: 'number' }).notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('standup_team_day_unique').on(table.teamId, table.heldOn),
+    index('standup_org_day_idx').on(table.organizationId, table.heldOn),
+    index('standup_cycle_idx').on(table.cycleId),
+  ],
+);
+
+export const standupTurn = pgTable(
+  'standup_turn',
+  {
+    id: text('id').primaryKey(),
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organization.id, { onDelete: 'cascade' }),
+    standupId: text('standup_id')
+      .notNull()
+      .references(() => standup.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    position: integer('position').notNull(),
+    attendance: text('attendance').notNull().default('unknown'),
+    status: text('status').notNull().default('waiting'),
+    notes: text('notes').notNull().default(''),
+    blockers: text('blockers').notNull().default(''),
+    spokeAt: timestamp('spoke_at', { withTimezone: true }),
+    durationSeconds: integer('duration_seconds'),
+    syncId: bigint('sync_id', { mode: 'number' }).notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('standup_turn_person_unique').on(table.standupId, table.userId),
+    index('standup_turn_order_idx').on(table.standupId, table.position),
+  ],
+);
+
+export const standupBlocker = pgTable(
+  'standup_blocker',
+  {
+    id: text('id').primaryKey(),
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organization.id, { onDelete: 'cascade' }),
+    turnId: text('turn_id')
+      .notNull()
+      .references(() => standupTurn.id, { onDelete: 'cascade' }),
+    issueId: text('issue_id').references(() => issue.id, { onDelete: 'cascade' }),
+    summary: text('summary').notNull(),
+    ownerId: text('owner_id').references(() => user.id, { onDelete: 'set null' }),
+    resolvedAt: timestamp('resolved_at', { withTimezone: true }),
+    syncId: bigint('sync_id', { mode: 'number' }).notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('standup_blocker_turn_idx').on(table.turnId),
+    index('standup_blocker_issue_idx').on(table.issueId),
+  ],
+);
+
+export const standupRotation = pgTable(
+  'standup_rotation',
+  {
+    id: text('id').primaryKey(),
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organization.id, { onDelete: 'cascade' }),
+    teamId: text('team_id')
+      .notNull()
+      .references(() => team.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    position: integer('position').notNull(),
+    facilitates: smallint('facilitates').notNull().default(1),
+    syncId: bigint('sync_id', { mode: 'number' }).notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('standup_rotation_member_unique').on(table.teamId, table.userId),
+    index('standup_rotation_order_idx').on(table.teamId, table.position),
+  ],
+);

--- a/packages/mcp-server/src/views.ts
+++ b/packages/mcp-server/src/views.ts
@@ -1,4 +1,4 @@
-import { type IssueRow, listMembers, listWorkflowStates } from '@orbit/core';
+import { type IssueListRow, listMembers, listWorkflowStates } from '@orbit/core';
 import { PRIORITY_LABELS } from '@orbit/shared/constants';
 import type { SyncAction } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
@@ -40,7 +40,7 @@ export function deltaViews(actions: readonly SyncAction[]): DeltaView[] {
 }
 
 function toView(
-  row: IssueRow,
+  row: IssueListRow,
   stateNames: ReadonlyMap<string, string>,
   userNames: ReadonlyMap<string, string>,
 ): IssueView {
@@ -67,7 +67,7 @@ function toView(
 
 export async function describeIssues(
   principal: Principal,
-  rows: readonly IssueRow[],
+  rows: readonly IssueListRow[],
 ): Promise<IssueView[]> {
   if (rows.length === 0) return [];
 
@@ -86,7 +86,7 @@ export async function describeIssues(
   return rows.map((row) => toView(row, stateNames, userNames));
 }
 
-export async function describeIssue(principal: Principal, row: IssueRow): Promise<IssueView> {
+export async function describeIssue(principal: Principal, row: IssueListRow): Promise<IssueView> {
   const [view] = await describeIssues(principal, [row]);
   if (view === undefined) throw new Error('The issue could not be described.');
   return view;

--- a/packages/realtime-server/src/auth.ts
+++ b/packages/realtime-server/src/auth.ts
@@ -170,7 +170,15 @@ async function projectScopeAllowed(projectId: string, principal: ConnectionPrinc
     .from(schema.project)
     .where(eq(schema.project.id, projectId))
     .limit(1);
-  return rows[0]?.organizationId === principal.organizationId;
+  if (rows[0]?.organizationId !== principal.organizationId) return false;
+  if (principal.role === 'admin') return true;
+  if (principal.teamIds.length === 0) return false;
+  const teams = await db
+    .select({ teamId: schema.projectTeam.teamId })
+    .from(schema.projectTeam)
+    .where(eq(schema.projectTeam.projectId, projectId));
+  if (teams.length === 0) return true;
+  return teams.some((row) => principal.teamIds.includes(row.teamId));
 }
 
 async function docScopeAllowed(docId: string, principal: ConnectionPrincipal) {
@@ -195,7 +203,7 @@ export async function authorizeScope(
     case 'org':
       return id === principal.organizationId;
     case 'team':
-      return principal.teamIds.includes(id);
+      return principal.role === 'admin' || principal.teamIds.includes(id);
     case 'user':
       return id === principal.userId;
     case 'issue':

--- a/packages/realtime-server/src/auth.ts
+++ b/packages/realtime-server/src/auth.ts
@@ -1,5 +1,5 @@
-import { and, db, eq, gt, schema } from '@orbit/db';
-import { ORG_ROLES, type OrgRole } from '@orbit/shared/constants';
+import { and, db, eq, gt, inArray, or, schema, sql } from '@orbit/db';
+import { isRestricted, ORG_ROLES, type OrgRole } from '@orbit/shared/constants';
 import { authMessageSchema } from '@orbit/shared/events';
 import { type RealtimeTicketPayload, verifyRealtimeTicket } from '@orbit/shared/events/ticket';
 import { z } from 'zod';
@@ -183,11 +183,42 @@ async function projectScopeAllowed(projectId: string, principal: ConnectionPrinc
 
 async function docScopeAllowed(docId: string, principal: ConnectionPrincipal) {
   const rows = await db
-    .select({ organizationId: schema.doc.organizationId })
+    .select({
+      organizationId: schema.doc.organizationId,
+      visibility: schema.doc.visibility,
+      authorId: schema.doc.authorId,
+    })
     .from(schema.doc)
     .where(eq(schema.doc.id, docId))
     .limit(1);
-  return rows[0]?.organizationId === principal.organizationId;
+  const doc = rows[0];
+  if (doc === undefined || doc.organizationId !== principal.organizationId) return false;
+  if (principal.role === 'admin') return true;
+  if (doc.authorId === principal.userId) return true;
+  if (!isRestricted(doc.visibility)) return true;
+
+  const grants = await db
+    .select({ docId: schema.docAccess.docId })
+    .from(schema.docAccess)
+    .where(
+      and(
+        eq(schema.docAccess.docId, docId),
+        or(
+          and(
+            eq(schema.docAccess.subjectType, 'user'),
+            eq(schema.docAccess.subjectId, principal.userId),
+          ),
+          principal.teamIds.length === 0
+            ? sql`false`
+            : and(
+                eq(schema.docAccess.subjectType, 'team'),
+                inArray(schema.docAccess.subjectId, [...principal.teamIds]),
+              ),
+        ),
+      ),
+    )
+    .limit(1);
+  return grants.length > 0;
 }
 
 export async function authorizeScope(

--- a/packages/services/src/storage/index.ts
+++ b/packages/services/src/storage/index.ts
@@ -6,6 +6,7 @@ export { assertSafeKey, FILE_ROUTE } from './key.ts';
 export {
   type AttachmentOwner,
   type AttachmentParentType,
+  assertAttachmentVisible,
   assertUploadParent,
   isPubliclyReadable,
   type StorageExecutor,

--- a/packages/services/src/storage/parent.test.ts
+++ b/packages/services/src/storage/parent.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from 'bun:test';
-import { doc, organization, project, user } from '@orbit/db/schema';
+import {
+  comment,
+  doc,
+  issue,
+  organization,
+  project,
+  projectTeam,
+  team,
+  user,
+  workflowState,
+} from '@orbit/db/schema';
 import { DomainError } from '@orbit/shared';
 import type { OrgRole } from '@orbit/shared/constants';
 import type { Principal } from '@orbit/shared/policy';
 import { randomUUIDv7 } from '@orbit/shared/utils';
 import { type TestTransaction, withRollback } from '../test-database.ts';
-import { assertUploadParent, isPubliclyReadable } from './parent.ts';
+import { assertAttachmentVisible, assertUploadParent, isPubliclyReadable } from './parent.ts';
 
 interface Fixture {
   readonly organizationId: string;
@@ -14,6 +24,12 @@ interface Fixture {
   readonly publishedDocId: string;
   readonly archivedDocId: string;
   readonly projectId: string;
+  readonly openTeamId: string;
+  readonly closedTeamId: string;
+  readonly openIssueId: string;
+  readonly closedIssueId: string;
+  readonly closedCommentId: string;
+  readonly closedProjectId: string;
 }
 
 async function seed(tx: TestTransaction): Promise<Fixture> {
@@ -42,6 +58,81 @@ async function seed(tx: TestTransaction): Promise<Fixture> {
     .insert(project)
     .values({ id: projectId, organizationId, name: 'Apollo', slug: `apollo-${suffix}` });
 
+  const openTeamId = `team_open_${suffix}`;
+  const closedTeamId = `team_closed_${suffix}`;
+  await tx.insert(team).values([
+    { id: openTeamId, organizationId, name: 'Open', key: `OP${suffix.slice(0, 4)}` },
+    { id: closedTeamId, organizationId, name: 'Closed', key: `CL${suffix.slice(0, 4)}` },
+  ]);
+
+  const openStateId = `st_open_${suffix}`;
+  const closedStateId = `st_closed_${suffix}`;
+  await tx.insert(workflowState).values([
+    {
+      id: openStateId,
+      organizationId,
+      teamId: openTeamId,
+      name: 'Todo',
+      category: 'unstarted',
+      color: '#888888',
+      position: 0,
+    },
+    {
+      id: closedStateId,
+      organizationId,
+      teamId: closedTeamId,
+      name: 'Todo',
+      category: 'unstarted',
+      color: '#888888',
+      position: 0,
+    },
+  ]);
+
+  const openIssueId = `iss_open_${suffix}`;
+  const closedIssueId = `iss_closed_${suffix}`;
+  await tx.insert(issue).values([
+    {
+      id: openIssueId,
+      organizationId,
+      teamId: openTeamId,
+      number: 1,
+      identifier: `OP${suffix.slice(0, 4)}-1`,
+      title: 'Mine',
+      stateId: openStateId,
+      creatorId: userId,
+    },
+    {
+      id: closedIssueId,
+      organizationId,
+      teamId: closedTeamId,
+      number: 1,
+      identifier: `CL${suffix.slice(0, 4)}-1`,
+      title: 'Not mine',
+      stateId: closedStateId,
+      creatorId: userId,
+    },
+  ]);
+
+  const closedCommentId = `cmt_closed_${suffix}`;
+  await tx.insert(comment).values({
+    id: closedCommentId,
+    organizationId,
+    issueId: closedIssueId,
+    authorId: userId,
+    body: 'Private discussion',
+  });
+
+  const closedProjectId = `prj_closed_${suffix}`;
+  await tx.insert(project).values({
+    id: closedProjectId,
+    organizationId,
+    name: 'Secret',
+    slug: `secret-${suffix}`,
+  });
+  await tx
+    .insert(projectTeam)
+    .values({ id: `pt_${suffix}`, projectId: closedProjectId, teamId: closedTeamId });
+
   return {
     organizationId,
     userId,
@@ -49,11 +140,22 @@ async function seed(tx: TestTransaction): Promise<Fixture> {
     publishedDocId: `doc_pub_${suffix}`,
     archivedDocId: `doc_arc_${suffix}`,
     projectId,
+    openTeamId,
+    closedTeamId,
+    openIssueId,
+    closedIssueId,
+    closedCommentId,
+    closedProjectId,
   };
 }
 
-function principalFor(fixture: Fixture, role: OrgRole): Principal {
-  return { userId: fixture.userId, organizationId: fixture.organizationId, role, teamIds: [] };
+function principalFor(fixture: Fixture, role: OrgRole, teamIds: readonly string[] = []): Principal {
+  return {
+    userId: fixture.userId,
+    organizationId: fixture.organizationId,
+    role,
+    teamIds: [...teamIds],
+  };
 }
 
 async function statusOf(run: () => Promise<unknown>): Promise<number> {
@@ -178,6 +280,115 @@ describe('isPubliclyReadable', () => {
           }),
         ).toBe(false);
       }
+    });
+  });
+});
+
+describe('team scoped attachment visibility', () => {
+  it('serves a file attached to an issue in a team the reader belongs to', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      const member = principalFor(fixture, 'member', [fixture.openTeamId]);
+      await assertAttachmentVisible(tx, member, {
+        organizationId: fixture.organizationId,
+        parentType: 'issue',
+        parentId: fixture.openIssueId,
+      });
+    });
+  });
+
+  it('hides a file attached to an issue in a team the reader is not on', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      const member = principalFor(fixture, 'member', [fixture.openTeamId]);
+      expect(
+        await statusOf(() =>
+          assertAttachmentVisible(tx, member, {
+            organizationId: fixture.organizationId,
+            parentType: 'issue',
+            parentId: fixture.closedIssueId,
+          }),
+        ),
+      ).toBe(404);
+    });
+  });
+
+  it('hides a file attached to a comment on an issue in another team', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      const member = principalFor(fixture, 'member', [fixture.openTeamId]);
+      expect(
+        await statusOf(() =>
+          assertAttachmentVisible(tx, member, {
+            organizationId: fixture.organizationId,
+            parentType: 'comment',
+            parentId: fixture.closedCommentId,
+          }),
+        ),
+      ).toBe(404);
+    });
+  });
+
+  it('hides a file attached to a project owned by another team', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      const member = principalFor(fixture, 'member', [fixture.openTeamId]);
+      expect(
+        await statusOf(() =>
+          assertAttachmentVisible(tx, member, {
+            organizationId: fixture.organizationId,
+            parentType: 'project',
+            parentId: fixture.closedProjectId,
+          }),
+        ),
+      ).toBe(404);
+    });
+  });
+
+  it('lets an admin read across every team', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      const admin = principalFor(fixture, 'admin');
+      for (const parent of [
+        ['issue', fixture.closedIssueId],
+        ['comment', fixture.closedCommentId],
+        ['project', fixture.closedProjectId],
+      ] as const) {
+        await assertAttachmentVisible(tx, admin, {
+          organizationId: fixture.organizationId,
+          parentType: parent[0],
+          parentId: parent[1],
+        });
+      }
+    });
+  });
+
+  it('never crosses an organization boundary', async () => {
+    await withRollback(async (tx) => {
+      const mine = await seed(tx);
+      const theirs = await seed(tx);
+      expect(
+        await statusOf(() =>
+          assertAttachmentVisible(tx, principalFor(mine, 'admin'), {
+            organizationId: theirs.organizationId,
+            parentType: 'issue',
+            parentId: theirs.openIssueId,
+          }),
+        ),
+      ).toBe(404);
+    });
+  });
+});
+
+describe('team scoped attachment upload', () => {
+  it('refuses an upload onto an issue in a team the uploader is not on', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      const member = principalFor(fixture, 'member', [fixture.openTeamId]);
+      await assertUploadParent(tx, member, 'issue', fixture.openIssueId);
+      expect(
+        await statusOf(() => assertUploadParent(tx, member, 'issue', fixture.closedIssueId)),
+      ).toBe(404);
     });
   });
 });

--- a/packages/services/src/storage/parent.ts
+++ b/packages/services/src/storage/parent.ts
@@ -2,6 +2,7 @@ import { and, type Database, eq, inArray, or, schema, sql, type Transaction } fr
 import { isExternallyShared, isRestricted } from '@orbit/shared/constants';
 import { notFound } from '@orbit/shared/errors';
 import { assertCan, isInTeam, type Principal } from '@orbit/shared/policy';
+import type { SQL } from 'drizzle-orm';
 
 export type StorageExecutor = Database | Transaction;
 
@@ -31,11 +32,31 @@ async function docFor(
   return row;
 }
 
-async function docReadableBy(
+interface DocAccessRow {
+  readonly id: string;
+  readonly visibility: string;
+  readonly authorId: string;
+  readonly archivedAt: Date | null;
+}
+
+function subjectMatches(principal: Principal): SQL | undefined {
+  return or(
+    and(eq(schema.docAccess.subjectType, 'user'), eq(schema.docAccess.subjectId, principal.userId)),
+    principal.teamIds.length === 0
+      ? sql`false`
+      : and(
+          eq(schema.docAccess.subjectType, 'team'),
+          inArray(schema.docAccess.subjectId, [...principal.teamIds]),
+        ),
+  );
+}
+
+async function docAllowing(
   executor: StorageExecutor,
   principal: Principal,
   docId: string,
-): Promise<{ readonly id: string } | undefined> {
+  level: 'read' | 'write',
+): Promise<DocAccessRow | undefined> {
   const [row] = await executor
     .select({
       id: schema.doc.id,
@@ -57,22 +78,28 @@ async function docReadableBy(
     .where(
       and(
         eq(schema.docAccess.docId, docId),
-        or(
-          and(
-            eq(schema.docAccess.subjectType, 'user'),
-            eq(schema.docAccess.subjectId, principal.userId),
-          ),
-          principal.teamIds.length === 0
-            ? sql`false`
-            : and(
-                eq(schema.docAccess.subjectType, 'team'),
-                inArray(schema.docAccess.subjectId, [...principal.teamIds]),
-              ),
-        ),
+        level === 'write' ? eq(schema.docAccess.level, 'write') : undefined,
+        subjectMatches(principal),
       ),
     )
     .limit(1);
   return grants.length > 0 ? row : undefined;
+}
+
+async function docReadableBy(
+  executor: StorageExecutor,
+  principal: Principal,
+  docId: string,
+): Promise<DocAccessRow | undefined> {
+  return await docAllowing(executor, principal, docId, 'read');
+}
+
+async function docWritableBy(
+  executor: StorageExecutor,
+  principal: Principal,
+  docId: string,
+): Promise<DocAccessRow | undefined> {
+  return await docAllowing(executor, principal, docId, 'write');
 }
 
 async function teamsOwning(
@@ -134,7 +161,7 @@ export async function assertUploadParent(
   assertCan(principal, 'attachment:upload');
 
   if (parentType === 'doc') {
-    const row = await docFor(executor, principal.organizationId, parentId);
+    const row = await docWritableBy(executor, principal, parentId);
     if (row === undefined || row.archivedAt !== null) {
       throw notFound('That doc does not exist.');
     }

--- a/packages/services/src/storage/parent.ts
+++ b/packages/services/src/storage/parent.ts
@@ -1,7 +1,7 @@
 import { and, type Database, eq, schema, type Transaction } from '@orbit/db';
 import { isExternallyShared } from '@orbit/shared/constants';
 import { notFound } from '@orbit/shared/errors';
-import { assertCan, type Principal } from '@orbit/shared/policy';
+import { assertCan, isInTeam, type Principal } from '@orbit/shared/policy';
 
 export type StorageExecutor = Database | Transaction;
 
@@ -31,36 +31,54 @@ async function docFor(
   return row;
 }
 
-async function existsInOrganization(
+async function teamsOwning(
   executor: StorageExecutor,
   parentType: Exclude<AttachmentParentType, 'doc'>,
   parentId: string,
   organizationId: string,
-): Promise<boolean> {
+): Promise<string[] | null> {
   if (parentType === 'issue') {
     const [row] = await executor
-      .select({ id: schema.issue.id })
+      .select({ teamId: schema.issue.teamId })
       .from(schema.issue)
       .where(and(eq(schema.issue.id, parentId), eq(schema.issue.organizationId, organizationId)))
       .limit(1);
-    return row !== undefined;
+    return row === undefined ? null : [row.teamId];
   }
   if (parentType === 'comment') {
     const [row] = await executor
-      .select({ id: schema.comment.id })
+      .select({ teamId: schema.issue.teamId })
       .from(schema.comment)
+      .innerJoin(schema.issue, eq(schema.issue.id, schema.comment.issueId))
       .where(
         and(eq(schema.comment.id, parentId), eq(schema.comment.organizationId, organizationId)),
       )
       .limit(1);
-    return row !== undefined;
+    return row === undefined ? null : [row.teamId];
   }
-  const [row] = await executor
+  const [project] = await executor
     .select({ id: schema.project.id })
     .from(schema.project)
     .where(and(eq(schema.project.id, parentId), eq(schema.project.organizationId, organizationId)))
     .limit(1);
-  return row !== undefined;
+  if (project === undefined) return null;
+  const teams = await executor
+    .select({ teamId: schema.projectTeam.teamId })
+    .from(schema.projectTeam)
+    .where(eq(schema.projectTeam.projectId, parentId));
+  return teams.map((row) => row.teamId);
+}
+
+function seesEveryTeam(principal: Principal): boolean {
+  return principal.role === 'admin';
+}
+
+function sharesATeam(principal: Principal, teamIds: readonly string[]): boolean {
+  if (seesEveryTeam(principal)) return true;
+  if (teamIds.length === 0) return true;
+  return teamIds.some((teamId) =>
+    isInTeam(principal, { id: teamId, organizationId: principal.organizationId }),
+  );
 }
 
 export async function assertUploadParent(
@@ -81,9 +99,42 @@ export async function assertUploadParent(
     return;
   }
 
-  if (!(await existsInOrganization(executor, parentType, parentId, principal.organizationId))) {
+  const teamIds = await teamsOwning(executor, parentType, parentId, principal.organizationId);
+  if (teamIds === null || !sharesATeam(principal, teamIds)) {
     throw notFound(`That ${parentType} does not exist.`);
   }
+}
+
+export async function assertAttachmentVisible(
+  executor: StorageExecutor,
+  principal: Principal,
+  attachment: AttachmentOwner,
+): Promise<void> {
+  if (attachment.organizationId !== principal.organizationId) {
+    throw notFound('That file does not exist.');
+  }
+  if (attachment.parentType === 'doc') {
+    const row = await docFor(executor, attachment.organizationId, attachment.parentId);
+    if (row === undefined) throw notFound('That file does not exist.');
+    assertCan(principal, 'doc:read');
+    return;
+  }
+  if (!isAttachmentParentType(attachment.parentType)) {
+    throw notFound('That file does not exist.');
+  }
+  const teamIds = await teamsOwning(
+    executor,
+    attachment.parentType,
+    attachment.parentId,
+    attachment.organizationId,
+  );
+  if (teamIds === null || !sharesATeam(principal, teamIds)) {
+    throw notFound('That file does not exist.');
+  }
+}
+
+function isAttachmentParentType(value: string): value is Exclude<AttachmentParentType, 'doc'> {
+  return value === 'issue' || value === 'comment' || value === 'project';
 }
 
 export async function isPubliclyReadable(

--- a/packages/services/src/storage/parent.ts
+++ b/packages/services/src/storage/parent.ts
@@ -1,5 +1,5 @@
-import { and, type Database, eq, schema, type Transaction } from '@orbit/db';
-import { isExternallyShared } from '@orbit/shared/constants';
+import { and, type Database, eq, inArray, or, schema, sql, type Transaction } from '@orbit/db';
+import { isExternallyShared, isRestricted } from '@orbit/shared/constants';
 import { notFound } from '@orbit/shared/errors';
 import { assertCan, isInTeam, type Principal } from '@orbit/shared/policy';
 
@@ -29,6 +29,50 @@ async function docFor(
     .where(and(eq(schema.doc.id, docId), eq(schema.doc.organizationId, organizationId)))
     .limit(1);
   return row;
+}
+
+async function docReadableBy(
+  executor: StorageExecutor,
+  principal: Principal,
+  docId: string,
+): Promise<{ readonly id: string } | undefined> {
+  const [row] = await executor
+    .select({
+      id: schema.doc.id,
+      visibility: schema.doc.visibility,
+      authorId: schema.doc.authorId,
+      archivedAt: schema.doc.archivedAt,
+    })
+    .from(schema.doc)
+    .where(and(eq(schema.doc.id, docId), eq(schema.doc.organizationId, principal.organizationId)))
+    .limit(1);
+  if (row === undefined) return undefined;
+  if (principal.role === 'admin') return row;
+  if (row.authorId === principal.userId) return row;
+  if (!isRestricted(row.visibility)) return row;
+
+  const grants = await executor
+    .select({ docId: schema.docAccess.docId })
+    .from(schema.docAccess)
+    .where(
+      and(
+        eq(schema.docAccess.docId, docId),
+        or(
+          and(
+            eq(schema.docAccess.subjectType, 'user'),
+            eq(schema.docAccess.subjectId, principal.userId),
+          ),
+          principal.teamIds.length === 0
+            ? sql`false`
+            : and(
+                eq(schema.docAccess.subjectType, 'team'),
+                inArray(schema.docAccess.subjectId, [...principal.teamIds]),
+              ),
+        ),
+      ),
+    )
+    .limit(1);
+  return grants.length > 0 ? row : undefined;
 }
 
 async function teamsOwning(
@@ -114,9 +158,9 @@ export async function assertAttachmentVisible(
     throw notFound('That file does not exist.');
   }
   if (attachment.parentType === 'doc') {
-    const row = await docFor(executor, attachment.organizationId, attachment.parentId);
-    if (row === undefined) throw notFound('That file does not exist.');
     assertCan(principal, 'doc:read');
+    const row = await docReadableBy(executor, principal, attachment.parentId);
+    if (row === undefined) throw notFound('That file does not exist.');
     return;
   }
   if (!isAttachmentParentType(attachment.parentType)) {

--- a/packages/shared/src/constants/doc.ts
+++ b/packages/shared/src/constants/doc.ts
@@ -1,6 +1,16 @@
-export const DOC_VISIBILITIES = ['workspace', 'link', 'public'] as const;
+export const DOC_VISIBILITIES = ['private', 'team', 'workspace', 'link', 'public'] as const;
 export type DocVisibility = (typeof DOC_VISIBILITIES)[number];
+
+export const DOC_ACCESS_SUBJECTS = ['user', 'team'] as const;
+export type DocAccessSubject = (typeof DOC_ACCESS_SUBJECTS)[number];
+
+export const DOC_ACCESS_LEVELS = ['read', 'write'] as const;
+export type DocAccessLevel = (typeof DOC_ACCESS_LEVELS)[number];
 
 export function isExternallyShared(visibility: string): boolean {
   return visibility === 'link' || visibility === 'public';
+}
+
+export function isRestricted(visibility: string): boolean {
+  return visibility === 'private' || visibility === 'team';
 }

--- a/packages/shared/src/events/scope.ts
+++ b/packages/shared/src/events/scope.ts
@@ -5,4 +5,5 @@ export const scopes = {
   issue: (issueId: string): string => `issue:${issueId}`,
   doc: (docId: string): string => `doc:${docId}`,
   user: (userId: string): string => `user:${userId}`,
+  standup: (standupId: string): string => `standup:${standupId}`,
 } as const;

--- a/packages/shared/src/events/sync.ts
+++ b/packages/shared/src/events/sync.ts
@@ -24,6 +24,7 @@ export const SYNC_MODELS = [
   'invitation',
   'view',
   'git_link',
+  'standup',
 ] as const;
 
 export type SyncModel = (typeof SYNC_MODELS)[number];

--- a/packages/shared/src/filters/index.ts
+++ b/packages/shared/src/filters/index.ts
@@ -445,6 +445,8 @@ export const DEFAULT_DISPLAY_PROPERTIES: readonly DisplayProperty[] = [
   'status',
   'labels',
   'estimate',
+  'project',
+  'created',
   'assignee',
 ];
 

--- a/packages/shared/src/validators/doc.ts
+++ b/packages/shared/src/validators/doc.ts
@@ -1,11 +1,17 @@
 import { z } from 'zod';
 import { DOC_VISIBILITIES } from '../constants/index.ts';
-import { idSchema, markdownSchema } from './common.ts';
+import { idSchema } from './common.ts';
 import { booleanFlag } from './issue.ts';
+
+export const DOC_CONTENT_LIMIT = 500_000;
+
+export const docContentSchema = z.string().max(DOC_CONTENT_LIMIT, {
+  message: 'This document is too long to save. Split it into linked pages.',
+});
 
 export const docCreateSchema = z.object({
   title: z.string().trim().min(1).max(200),
-  content: markdownSchema.default(''),
+  content: docContentSchema.default(''),
   projectId: idSchema.nullable().default(null),
   collectionId: idSchema.nullable().default(null),
   parentId: idSchema.nullable().default(null),
@@ -15,7 +21,7 @@ export const docCreateSchema = z.object({
 export const docUpdateSchema = z
   .object({
     title: z.string().trim().min(1).max(200),
-    content: markdownSchema,
+    content: docContentSchema,
     projectId: idSchema.nullable(),
     collectionId: idSchema.nullable(),
     parentId: idSchema.nullable(),

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -14,6 +14,7 @@ export * from './onboarding.ts';
 export * from './organization.ts';
 export * from './profile.ts';
 export * from './project.ts';
+export * from './standup.ts';
 export * from './team.ts';
 export * from './upload.ts';
 export * from './view.ts';

--- a/packages/shared/src/validators/standup.ts
+++ b/packages/shared/src/validators/standup.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { idSchema } from './common.ts';
+
+export const STANDUP_STATUSES = ['scheduled', 'running', 'finished'] as const;
+export const TURN_STATUSES = ['waiting', 'speaking', 'done', 'skipped'] as const;
+export const ATTENDANCE = ['unknown', 'present', 'absent'] as const;
+
+export type StandupStatus = (typeof STANDUP_STATUSES)[number];
+export type TurnStatus = (typeof TURN_STATUSES)[number];
+export type Attendance = (typeof ATTENDANCE)[number];
+
+const daySchema = z.iso.date();
+
+export const standupOpenSchema = z.object({
+  teamId: idSchema,
+  heldOn: daySchema.optional(),
+  facilitatorId: idSchema.nullable().optional(),
+  participantIds: z.array(idSchema).max(200).optional(),
+});
+
+export const standupUpdateSchema = z.object({
+  facilitatorId: idSchema.nullable().optional(),
+  status: z.enum(STANDUP_STATUSES).optional(),
+});
+
+export const turnUpdateSchema = z.object({
+  attendance: z.enum(ATTENDANCE).optional(),
+  status: z.enum(TURN_STATUSES).optional(),
+  notes: z.string().max(4000).optional(),
+  blockers: z.string().max(4000).optional(),
+});
+
+export const turnAdvanceSchema = z.object({
+  direction: z.enum(['next', 'previous']).default('next'),
+  markDone: z.boolean().default(true),
+});
+
+export const turnFocusSchema = z.object({ turnId: idSchema });
+
+export const blockerCreateSchema = z.object({
+  summary: z.string().min(1).max(500),
+  issueId: idSchema.nullable().optional(),
+  ownerId: idSchema.nullable().optional(),
+});
+
+export const blockerResolveSchema = z.object({ resolved: z.boolean().default(true) });
+
+export const rotationSchema = z.object({
+  teamId: idSchema,
+  members: z.array(z.object({ userId: idSchema, facilitates: z.boolean().default(true) })).max(200),
+});
+
+export const standupListSchema = z.object({
+  teamId: idSchema.optional(),
+  cycleId: idSchema.optional(),
+  from: daySchema.optional(),
+  to: daySchema.optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(30),
+});
+
+export type StandupOpenInput = z.infer<typeof standupOpenSchema>;
+export type TurnUpdateInput = z.infer<typeof turnUpdateSchema>;
+export type BlockerCreateInput = z.infer<typeof blockerCreateSchema>;
+export type RotationInput = z.infer<typeof rotationSchema>;


### PR DESCRIPTION
Fixes the board's speed, the filters, realtime, the standup, and a set of authorization holes found while auditing the surfaces this branch touches.

## Speed

The board used to crawl every page of a team's issues to render a header count. On a 2,518 issue team a cold filtered board made 27 requests for 1,982 KB. It now makes 2 requests for 66 KB.

- Counts, column totals and facet counts come from the server as one summary query instead of being derived from a full client-side crawl.
- The issue list payload drops the columns the list never renders, including the description.
- Each board column paginates on its own rather than sharing one team-wide page.
- Filter changes are local state, synced to the URL on a debounce, so typing in a filter no longer re-runs the query per keystroke.

Second filter paint measured at 86ms.

## Filters and lists

- Grouping no longer emits duplicate headers when a view crosses teams.
- A cached list is reconciled rather than rebuilt: a mutation only replaces or removes rows it can verify, and a realtime insert into a filtered list asks the server to settle it instead of guessing.
- Cached lists keep the order the query asked for. They used to be re-sorted by manual `sortOrder` even when the query ordered by `updated`.
- A row loaded by a column's own pagination can now be dragged and peeked. Previously only the first page was addressable.

## Realtime

`NEXT_PUBLIC_REALTIME_URL` no longer reaches production, where it pointed the browser at the retired standalone host and produced an endless "Reconnecting to live updates" banner. Verified against the preview deploy: `/api/ws` returns 101 and the bundle carries no hardcoded host.

## Standup

Rebuilt as a real scrum ceremony: a facilitator walks the room one person at a time, each turn records notes, blockers and attendance, and the rotation decides both the speaking order and who runs the meeting.

- Opening the same room twice concurrently is serialized on an advisory lock.
- Every mutating path now locks the standup row inside its transaction and reads the current turn from the locked row, so two facilitators clicking Next cannot land on the same person or leave two people speaking.
- A speaker's time accumulates instead of being overwritten when the room comes back to them, and the first speaker's turn is now stamped at all (their duration was previously always lost).
- A rotation, a facilitator and a participant must all be on the team.

## Documents

Per-document permissions: `private`, `team`, `workspace`, `link` and `public`, with named user and team grants at read or write level.

## Security

An adversarial review reproduced twelve holes against the real database. All are closed, each with a regression test:

- **Doc comments had no read gate.** Any member, including a guest, could read and post comments on a doc marked private by fetching `/api/docs/{id}/comments` directly, because the comment service looked the doc up by organization alone. Comments now load through the same gate every other doc entry point uses.
- Comments on a restricted doc were announced on the organization channel, so their bodies fanned out to every connected member. They now publish only on the doc's own channel.
- Backlinks ignored visibility, leaking private doc titles and ids to anyone who could read a linked doc.
- The realtime socket authorized any organization member for a private doc's scope.
- Attachment uploads to a doc skipped the doc access check.
- Projects were readable and writable across the team boundary, and the project list ignored teams entirely.
- Analytics answered for every team in the workspace regardless of who asked, both in the charts and in the cycle picker.
- Moving an issue between teams kept the sprint and project links belonging to the team it left.
- Catch-up and realtime scopes exposed rows outside the caller's teams.
- Attachment upload and download were not team scoped.
- The file route did not validate its path segments and cached an authorization-dependent redirect.

## Housekeeping

- `bun run db:test-setup` creates the six per-package test databases, and refuses a non-local host unless `ORBIT_ALLOW_REMOTE_TEST_SETUP=1`, in which case it requires verified TLS.
- Removed the AWS CodeBuild webhook. Orbit is not deployed on EKS. The CodeBuild project itself still needs deleting in the AWS account.

## Verification

`bun run verify` is green: lint, comment policy, typecheck and roughly 1,450 tests. Realtime confirmed working against the preview deploy.

## Not in this PR

Tracked for follow-ups: renaming cycles to sprints, sprint history, MCP planning coverage and the MCP OAuth consent flow, the docs tree and export, the inbox reading pane, moving tests into a dedicated test tree, and the project page tabs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a large, multi-domain security and feature overhaul closing twelve confirmed authorization holes, rebuilding the standup ceremony, and dramatically cutting board load (27→2 requests on a 2,518-issue team). Every security fix has a corresponding regression test, and `bun run verify` is reported green.

- **Security (12 holes closed):** Doc comment read gate, realtime doc scope, backlink visibility, attachment upload/download team scoping, project cross-team read/write, analytics team scoping, cycle/sprint cleanup on team move, catch-up and realtime scope leaks, and file-route path validation and caching — all corrected and tested.
- **Board speed:** Issue counts and facets now come from a single server `summary` query instead of a full client-side crawl; each board column paginates independently with its own `stateId`-scoped query.
- **Standup rebuild:** New `standup-service.ts` with advisory lock on open, row-level lock on every mutation (`lockStandup`), accumulating speaker durations, and a rotation-based facilitator picker. The full standup detail (turns + blockers) is embedded in every realtime sync event so subscribers stay current.

<h3>Confidence Score: 4/5</h3>

Safe to merge after the open thread on milestone facet grouping is resolved; all security fixes and the standup rebuild look correct.

The twelve security holes are all closed with tests and the logic reads correctly. The standup service is well-locked and the realtime catchup now applies team-membership filtering to every model. One existing open thread — the milestoneFacet function in issue-service.ts grouping every milestoned issue into a single 'any' bucket instead of the actual milestone ID — remains unresolved, causing milestone-based board columns and group totals to be incorrect.

**Files Needing Attention:** packages/core/src/work/issue-service.ts — the milestoneFacet function (open thread at line 1255) needs a fix before milestone-grouped board views produce correct counts.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/work/standup-service.ts | New file implementing the full standup ceremony: advisory lock on open, row lock on every mutation, accumulating durations, rotation-based facilitator. Auto-computed facilitator is not re-validated against current team membership. |
| packages/core/src/content/doc-service.ts | Adds docReadFilter, canReadDoc, assertDocWritable, and loadReadableDoc; gates backlinks and attachments behind per-doc visibility; strips body from realtime announcements. Correctness looks solid. |
| packages/realtime-server/src/auth.ts | Closes docScopeAllowed visibility gap (now checks isRestricted + grants), fixes project scope to check team membership, and allows admins through the team-scope gate. |
| packages/services/src/storage/parent.ts | Adds assertAttachmentVisible gating doc attachments behind docReadableBy and non-doc attachments behind team membership; upload check now enforces write access on docs. |
| packages/core/src/realtime/backfill.ts | Adds visibleToPrincipal filter applied to every catchup row; doc rows use docReadFilter; attachment rows are team-scoped; standup catchup added. Project and invitation loaders correctly scoped. |
| packages/core/src/work/issue-service.ts | Adds getIssueSummary with facets and group totals; drops unused columns from list queries; fixes cross-team cycle/project/milestone validation; removes org scope from issue events. The milestoneFacet function collapses all milestone IDs into a single 'any' bucket (open thread). |
| packages/db/src/schema/scrum.ts | New schema for standup, standupTurn, standupBlocker, standupRotation. standup.currentTurnId intentionally omits a FK to avoid a circular reference; turns cascade-delete with the standup. |
| apps/web/src/lib/realtime/delta-bridge.tsx | Adds standup model handler (invalidates STANDUP_ROOT), issue count invalidation, and awaitsServerRefresh for filtered lists that receive an unknown insert. Previously missing standup invalidation is now resolved. |
| apps/web/src/features/issues/board.tsx | Board columns now own their own paginated issue query (via useColumnIssues, scoped to stateId only when groupBy='state') and merge back into the parent via onRows callback for drag-and-drop to use. |
| packages/core/src/work/project-service.ts | Adds visibleProjectFilter and assertProjectVisible to scope all project mutations and reads to the caller's teams; all project entry points updated. |
| packages/db/src/schema/content.ts | Adds docAccess table for per-doc grants. subjectId has no FK (open thread); docId and organizationId have cascade deletes. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant F as Facilitator
    participant API as Next.js API
    participant DB as Postgres
    participant Redis as Redis Pub/Sub
    participant C as Other Clients

    F->>API: POST /standups (teamId, heldOn)
    API->>DB: pg_advisory_xact_lock(standup:team:date)
    API->>DB: SELECT standup WHERE team+date (check existing)
    API->>DB: rosterFor(teamId, participantIds)
    API->>DB: assertOnTeam(teamId, facilitatorId)
    API->>DB: INSERT standup + standupTurn rows
    API->>Redis: "publish SyncAction{model:standup, data:{standup,turns,blockers}}"
    Redis-->>C: invalidate STANDUP_ROOT cache

    F->>API: POST /standups/:id/start
    API->>DB: SELECT standup FOR UPDATE (lockStandup)
    API->>DB: activateTurn(first non-absent turn, now)
    API->>DB: "UPDATE standup SET status=running, currentTurnId"
    API->>Redis: "publish SyncAction{model:standup}"
    Redis-->>C: invalidate STANDUP_ROOT cache

    F->>API: "POST /standups/:id/advance {markDone, direction}"
    API->>DB: SELECT standup FOR UPDATE (lockStandup)
    API->>DB: closeSpeakingTurn(currentTurnId, now)
    API->>DB: activateTurn(nextTurn, now)
    API->>DB: "UPDATE standup SET currentTurnId=nextTurn"
    API->>Redis: "publish SyncAction{model:standup}"
    Redis-->>C: invalidate STANDUP_ROOT cache
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(review): lock focusTurn, guard the o..."](https://github.com/noveum/orbit/commit/5e79245f717113f8314d82c8d7d4dd8ed501f351) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50023984)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/noveum-ai/github/Noveum/orbit/-/custom-context?memory=b1d3c64d-731f-463a-94a4-788291e176f9))

<!-- /greptile_comment -->