### PR TITLE
Count past sprints from their issues, and add the production schema catch-up

### DIFF
--- a/apps/web/src/features/cycles/data.ts
+++ b/apps/web/src/features/cycles/data.ts
@@ -4,7 +4,8 @@ import {
   cycleProgress,
   getCycleByNumber,
   pastCycles,
-  type SprintOutcome,
+  type RecordedOutcome,
+  sprintOutcome,
   upcomingCycles,
 } from '@orbit/core';
 import { and, asc, db, eq, isNull, schema } from '@orbit/db';
@@ -12,7 +13,6 @@ import type { StateCategory } from '@orbit/shared/constants';
 import { STATE_CATEGORIES } from '@orbit/shared/constants';
 import type { Principal } from '@orbit/shared/policy';
 import { sprintLabel } from '@orbit/shared/utils';
-import { sprintOutcomeSchema } from '@orbit/shared/validators';
 
 export interface CycleIssueView {
   readonly id: string;
@@ -58,11 +58,6 @@ export interface UpcomingCycleView {
   readonly startsAt: string;
   readonly endsAt: string;
   readonly teamKey: string;
-}
-
-function readOutcome(value: Record<string, unknown> | null): SprintOutcome | null {
-  const parsed = sprintOutcomeSchema.safeParse(value);
-  return parsed.success ? parsed.data : null;
 }
 
 function toCategory(value: string): StateCategory {
@@ -190,7 +185,7 @@ export interface PastSprintView {
   readonly startsAt: string;
   readonly endsAt: string;
   readonly completedAt: string;
-  readonly outcome: SprintOutcome | null;
+  readonly outcome: RecordedOutcome | null;
 }
 
 export async function listPastSprintViews(
@@ -199,7 +194,8 @@ export async function listPastSprintViews(
   limit = 12,
 ): Promise<PastSprintView[]> {
   const rows = await pastCycles(principal, team.id, limit);
-  return rows.map((cycle) => ({
+  const outcomes = await Promise.all(rows.map((cycle) => sprintOutcome(principal, cycle.id)));
+  return rows.map((cycle, index) => ({
     id: cycle.id,
     name: sprintLabel(cycle),
     number: cycle.number,
@@ -207,7 +203,7 @@ export async function listPastSprintViews(
     startsAt: cycle.startsAt.toISOString(),
     endsAt: cycle.endsAt.toISOString(),
     completedAt: (cycle.completedAt ?? cycle.endsAt).toISOString(),
-    outcome: readOutcome(cycle.progressSnapshot),
+    outcome: outcomes[index] ?? null,
   }));
 }
 
@@ -215,12 +211,13 @@ export async function getSprintView(
   principal: Principal,
   team: { id: string; key: string; name: string },
   number: number,
-): Promise<(CycleView & { readonly outcome: SprintOutcome | null }) | null> {
+): Promise<(CycleView & { readonly outcome: RecordedOutcome | null }) | null> {
   const cycle = await getCycleByNumber(principal, team.id, number);
   if (cycle === null) return null;
-  const [progress, issues] = await Promise.all([
+  const [progress, issues, outcome] = await Promise.all([
     cycleProgress(principal, cycle.id),
     loadCycleIssues(cycle.id),
+    sprintOutcome(principal, cycle.id),
   ]);
   return {
     id: cycle.id,
@@ -234,6 +231,6 @@ export async function getSprintView(
     progress,
     groups: issues.groups,
     assignees: issues.assignees,
-    outcome: readOutcome(cycle.progressSnapshot),
+    outcome,
   };
 }

--- a/apps/web/src/features/cycles/data.ts
+++ b/apps/web/src/features/cycles/data.ts
@@ -6,6 +6,7 @@ import {
   pastCycles,
   type RecordedOutcome,
   sprintOutcome,
+  sprintOutcomes,
   upcomingCycles,
 } from '@orbit/core';
 import { and, asc, db, eq, isNull, schema } from '@orbit/db';
@@ -194,7 +195,7 @@ export async function listPastSprintViews(
   limit = 12,
 ): Promise<PastSprintView[]> {
   const rows = await pastCycles(principal, team.id, limit);
-  const outcomes = await Promise.all(rows.map((cycle) => sprintOutcome(principal, cycle.id)));
+  const outcomes = await sprintOutcomes(principal, rows);
   return rows.map((cycle, index) => ({
     id: cycle.id,
     name: sprintLabel(cycle),

--- a/apps/web/src/features/cycles/sprint-history.tsx
+++ b/apps/web/src/features/cycles/sprint-history.tsx
@@ -20,7 +20,7 @@ function Bar({ completed, scope }: { readonly completed: number; readonly scope:
 
 function Outcome({ sprint }: { readonly sprint: PastSprintView }) {
   if (sprint.outcome === null) {
-    return <p className="text-2xs text-faint">Nothing was ever in this sprint.</p>;
+    return <p className="text-2xs text-faint">No recorded outcome for this sprint.</p>;
   }
   const { scope, completed, canceled, rolledOver, points, reconstructed } = sprint.outcome;
   return (
@@ -41,7 +41,7 @@ function Outcome({ sprint }: { readonly sprint: PastSprintView }) {
         {reconstructed ? (
           <span
             data-testid="sprint-outcome-reconstructed"
-            title="This sprint closed before Orbit recorded outcomes, so these are counted from the issues still in it."
+            title="Closed before Orbit recorded outcomes, so this is counted from the issues still in the sprint. Anything rolled over into a later sprint is not included."
             className="text-faint"
           >
             counted from its issues

--- a/apps/web/src/features/cycles/sprint-history.tsx
+++ b/apps/web/src/features/cycles/sprint-history.tsx
@@ -20,13 +20,9 @@ function Bar({ completed, scope }: { readonly completed: number; readonly scope:
 
 function Outcome({ sprint }: { readonly sprint: PastSprintView }) {
   if (sprint.outcome === null) {
-    return (
-      <p className="text-2xs text-faint">
-        Closed before Orbit recorded sprint outcomes, so its numbers are not available.
-      </p>
-    );
+    return <p className="text-2xs text-faint">Nothing was ever in this sprint.</p>;
   }
-  const { scope, completed, rolledOver, points } = sprint.outcome;
+  const { scope, completed, canceled, rolledOver, points, reconstructed } = sprint.outcome;
   return (
     <div className="flex flex-col gap-1.5">
       <Bar completed={completed} scope={scope} />
@@ -35,10 +31,20 @@ function Outcome({ sprint }: { readonly sprint: PastSprintView }) {
           <span className="text-text">{completed}</span> of {scope} done
         </span>
         <span>{percent(completed, scope)}%</span>
+        {canceled > 0 ? <span>{canceled} cancelled</span> : null}
         {rolledOver > 0 ? <span>{rolledOver} rolled over</span> : null}
         {points.scope > 0 ? (
           <span>
             {points.completed}/{points.scope} pts
+          </span>
+        ) : null}
+        {reconstructed ? (
+          <span
+            data-testid="sprint-outcome-reconstructed"
+            title="This sprint closed before Orbit recorded outcomes, so these are counted from the issues still in it."
+            className="text-faint"
+          >
+            counted from its issues
           </span>
         ) : null}
       </div>

--- a/packages/core/src/work/cycle-service.ts
+++ b/packages/core/src/work/cycle-service.ts
@@ -7,6 +7,7 @@ import {
   eq,
   gt,
   gte,
+  inArray,
   isNotNull,
   isNull,
   lt,
@@ -428,18 +429,56 @@ export async function sprintOutcome(
   cycleId: string,
 ): Promise<RecordedOutcome | null> {
   const cycle = await getCycle(principal, cycleId);
-  if (cycle.completedAt === null) return null;
+  const [outcome] = await outcomesFor([cycle]);
+  return outcome ?? null;
+}
 
-  const stored = readStoredOutcome(cycle.progressSnapshot);
-  if (stored !== null) return { ...stored, reconstructed: false };
+export async function sprintOutcomes(
+  principal: Principal,
+  cycles: readonly CycleRow[],
+): Promise<(RecordedOutcome | null)[]> {
+  assertCan(principal, 'project:read');
+  return await outcomesFor(cycles);
+}
 
-  const rows = await db
-    .select({ category: CYCLE_CATEGORY, estimate: schema.issue.estimate })
-    .from(schema.issue)
-    .innerJoin(schema.workflowState, eq(schema.workflowState.id, schema.issue.stateId))
-    .where(and(eq(schema.issue.cycleId, cycleId), isNull(schema.issue.archivedAt)));
+async function outcomesFor(cycles: readonly CycleRow[]): Promise<(RecordedOutcome | null)[]> {
+  const needsCounting = cycles.filter(
+    (cycle) => cycle.completedAt !== null && readStoredOutcome(cycle.progressSnapshot) === null,
+  );
 
-  return { ...outcomeOf(rows, 0, cycle.completedAt), reconstructed: true };
+  const counted = new Map<string, { category: string; estimate: number | null }[]>();
+  if (needsCounting.length > 0) {
+    const rows = await db
+      .select({
+        cycleId: schema.issue.cycleId,
+        category: CYCLE_CATEGORY,
+        estimate: schema.issue.estimate,
+      })
+      .from(schema.issue)
+      .innerJoin(schema.workflowState, eq(schema.workflowState.id, schema.issue.stateId))
+      .where(
+        and(
+          inArray(
+            schema.issue.cycleId,
+            needsCounting.map((cycle) => cycle.id),
+          ),
+          isNull(schema.issue.archivedAt),
+        ),
+      );
+    for (const row of rows) {
+      if (row.cycleId === null) continue;
+      const list = counted.get(row.cycleId) ?? [];
+      list.push({ category: row.category, estimate: row.estimate });
+      counted.set(row.cycleId, list);
+    }
+  }
+
+  return cycles.map((cycle) => {
+    if (cycle.completedAt === null) return null;
+    const stored = readStoredOutcome(cycle.progressSnapshot);
+    if (stored !== null) return { ...stored, reconstructed: false };
+    return { ...outcomeOf(counted.get(cycle.id) ?? [], 0, cycle.completedAt), reconstructed: true };
+  });
 }
 
 export async function pastCycles(

--- a/packages/core/src/work/cycle-service.ts
+++ b/packages/core/src/work/cycle-service.ts
@@ -21,6 +21,7 @@ import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan, assertInTeam, teamScope } from '@orbit/shared/policy';
 import { cycleCreateSchema, cycleUpdateSchema } from '@orbit/shared/validators';
+import { z } from 'zod';
 import { principalActor } from '../activity/activity-service.ts';
 import { addUtcDays, type Executor, newId, requireRow, startOfUtcDay } from '../internal.ts';
 import { requireTeam } from '../org/team-service.ts';
@@ -400,6 +401,45 @@ function outcomeOf(
     points: { scope: points(rows), completed: points(done) },
     closedAt: now.toISOString(),
   };
+}
+
+function readStoredOutcome(value: unknown): SprintOutcome | null {
+  const parsed = storedOutcomeSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+const storedOutcomeSchema = z.object({
+  scope: z.number(),
+  completed: z.number(),
+  canceled: z.number().default(0),
+  rolledOver: z.number().default(0),
+  points: z
+    .object({ scope: z.number(), completed: z.number() })
+    .default({ scope: 0, completed: 0 }),
+  closedAt: z.string(),
+});
+
+export interface RecordedOutcome extends SprintOutcome {
+  readonly reconstructed: boolean;
+}
+
+export async function sprintOutcome(
+  principal: Principal,
+  cycleId: string,
+): Promise<RecordedOutcome | null> {
+  const cycle = await getCycle(principal, cycleId);
+  if (cycle.completedAt === null) return null;
+
+  const stored = readStoredOutcome(cycle.progressSnapshot);
+  if (stored !== null) return { ...stored, reconstructed: false };
+
+  const rows = await db
+    .select({ category: CYCLE_CATEGORY, estimate: schema.issue.estimate })
+    .from(schema.issue)
+    .innerJoin(schema.workflowState, eq(schema.workflowState.id, schema.issue.stateId))
+    .where(and(eq(schema.issue.cycleId, cycleId), isNull(schema.issue.archivedAt)));
+
+  return { ...outcomeOf(rows, 0, cycle.completedAt), reconstructed: true };
 }
 
 export async function pastCycles(

--- a/packages/core/tests/work/cycle-service.test.ts
+++ b/packages/core/tests/work/cycle-service.test.ts
@@ -21,6 +21,7 @@ import {
   getCycleByNumber,
   listCycles,
   pastCycles,
+  sprintOutcome,
   upcomingCycles,
   updateCycle,
 } from '../../src/work/cycle-service.ts';
@@ -493,5 +494,58 @@ describe('two people closing the same sprint at once', () => {
     expect(closed.nextCycle.id).not.toBe(later.cycle.id);
     expect(closed.nextCycle.completedAt).toBeNull();
     expect(closed.nextCycle.number).toBeGreaterThan(later.cycle.number);
+  });
+});
+
+describe('sprintOutcome', () => {
+  it('hands back what was recorded when the sprint was closed', async () => {
+    const cycle = await firstCycle();
+    await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Shipped',
+      cycleId: cycle.id,
+      estimate: 5,
+    });
+    const closed = await completeCycle(workspace.admin, cycle.id);
+
+    const outcome = await sprintOutcome(workspace.admin, closed.cycle.id);
+    expect(outcome?.reconstructed).toBe(false);
+    expect(outcome?.scope).toBe(1);
+  });
+
+  it('counts a sprint closed before outcomes were recorded, rather than saying nothing', async () => {
+    const cycle = await firstCycle();
+    const done = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Finished',
+      cycleId: cycle.id,
+      estimate: 5,
+    });
+    await updateIssue(workspace.admin, done.issue.id, {
+      stateId: stateNamed(workspace, 'Done').id,
+    });
+    await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Left over',
+      cycleId: cycle.id,
+      estimate: 3,
+    });
+    const closed = await completeCycle(workspace.admin, cycle.id);
+
+    await db
+      .update(schema.cycle)
+      .set({ progressSnapshot: null })
+      .where(eq(schema.cycle.id, closed.cycle.id));
+
+    const outcome = await sprintOutcome(workspace.admin, closed.cycle.id);
+    expect(outcome?.reconstructed).toBe(true);
+    expect(outcome?.scope).toBe(1);
+    expect(outcome?.completed).toBe(1);
+    expect(outcome?.points).toEqual({ scope: 5, completed: 5 });
+  });
+
+  it('has nothing to say about a sprint still running', async () => {
+    const cycle = await firstCycle();
+    expect(await sprintOutcome(workspace.admin, cycle.id)).toBeNull();
   });
 });

--- a/packages/core/tests/work/cycle-service.test.ts
+++ b/packages/core/tests/work/cycle-service.test.ts
@@ -22,6 +22,7 @@ import {
   listCycles,
   pastCycles,
   sprintOutcome,
+  sprintOutcomes,
   upcomingCycles,
   updateCycle,
 } from '../../src/work/cycle-service.ts';
@@ -547,5 +548,87 @@ describe('sprintOutcome', () => {
   it('has nothing to say about a sprint still running', async () => {
     const cycle = await firstCycle();
     expect(await sprintOutcome(workspace.admin, cycle.id)).toBeNull();
+  });
+});
+
+describe('sprintOutcomes', () => {
+  it('answers for a page of sprints in one pass, recorded or counted', async () => {
+    const first = await firstCycle();
+    const one = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'In the first',
+      cycleId: first.id,
+      estimate: 2,
+    });
+    await updateIssue(workspace.admin, one.issue.id, {
+      stateId: stateNamed(workspace, 'Done').id,
+    });
+    const closedFirst = await completeCycle(workspace.admin, first.id);
+
+    const second = await createCycle(workspace.admin, {
+      teamId: workspace.teamId,
+      startsAt: daysFromNow(200),
+      endsAt: daysFromNow(214),
+    });
+    const two = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'In the second',
+      cycleId: second.cycle.id,
+      estimate: 8,
+    });
+    await updateIssue(workspace.admin, two.issue.id, {
+      stateId: stateNamed(workspace, 'Done').id,
+    });
+    const closedSecond = await completeCycle(workspace.admin, second.cycle.id);
+
+    await db
+      .update(schema.cycle)
+      .set({ progressSnapshot: null })
+      .where(eq(schema.cycle.id, closedSecond.cycle.id));
+
+    const outcomes = await sprintOutcomes(workspace.admin, [
+      await getCycle(workspace.admin, closedFirst.cycle.id),
+      await getCycle(workspace.admin, closedSecond.cycle.id),
+    ]);
+
+    expect(outcomes).toHaveLength(2);
+    expect(outcomes[0]?.reconstructed).toBe(false);
+    expect(outcomes[0]?.points.scope).toBe(2);
+    expect(outcomes[1]?.reconstructed).toBe(true);
+    expect(outcomes[1]?.points.scope).toBe(8);
+  });
+
+  it('counts only what is still in the sprint, since a rollover moved the rest away', async () => {
+    const cycle = await firstCycle();
+    const done = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Finished',
+      cycleId: cycle.id,
+      estimate: 3,
+    });
+    await updateIssue(workspace.admin, done.issue.id, {
+      stateId: stateNamed(workspace, 'Done').id,
+    });
+    await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Rolled over',
+      cycleId: cycle.id,
+      estimate: 5,
+    });
+    const closed = await completeCycle(workspace.admin, cycle.id);
+    expect(closed.rolledOverIssueIds).toHaveLength(1);
+
+    await db
+      .update(schema.cycle)
+      .set({ progressSnapshot: null })
+      .where(eq(schema.cycle.id, closed.cycle.id));
+
+    const [outcome] = await sprintOutcomes(workspace.admin, [
+      await getCycle(workspace.admin, closed.cycle.id),
+    ]);
+
+    expect(outcome?.reconstructed).toBe(true);
+    expect(outcome?.scope).toBe(1);
+    expect(outcome?.points.scope).toBe(3);
   });
 });

--- a/packages/db/catchup/production-schema-catchup.sql
+++ b/packages/db/catchup/production-schema-catchup.sql
@@ -93,70 +93,136 @@ create unique index if not exists standup_turn_person_unique on public.standup_t
 
 do $$
 begin
-  if not exists (select 1 from pg_constraint where conname = 'doc_access_pkey') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'doc_access_pkey' and conrelid = 'public.doc_access'::regclass
+  ) then
     alter table public.doc_access add constraint doc_access_pkey PRIMARY KEY (id);
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_pkey') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_blocker_pkey' and conrelid = 'public.standup_blocker'::regclass
+  ) then
     alter table public.standup_blocker add constraint standup_blocker_pkey PRIMARY KEY (id);
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_pkey') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_pkey' and conrelid = 'public.standup'::regclass
+  ) then
     alter table public.standup add constraint standup_pkey PRIMARY KEY (id);
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_pkey') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_rotation_pkey' and conrelid = 'public.standup_rotation'::regclass
+  ) then
     alter table public.standup_rotation add constraint standup_rotation_pkey PRIMARY KEY (id);
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_turn_pkey') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_turn_pkey' and conrelid = 'public.standup_turn'::regclass
+  ) then
     alter table public.standup_turn add constraint standup_turn_pkey PRIMARY KEY (id);
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'doc_access_doc_id_doc_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'doc_access_doc_id_doc_id_fk' and conrelid = 'public.doc_access'::regclass
+  ) then
     alter table public.doc_access add constraint doc_access_doc_id_doc_id_fk FOREIGN KEY (doc_id) REFERENCES public.doc(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'doc_access_granted_by_id_user_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'doc_access_granted_by_id_user_id_fk' and conrelid = 'public.doc_access'::regclass
+  ) then
     alter table public.doc_access add constraint doc_access_granted_by_id_user_id_fk FOREIGN KEY (granted_by_id) REFERENCES public."user"(id) ON DELETE SET NULL;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'doc_access_organization_id_organization_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'doc_access_organization_id_organization_id_fk' and conrelid = 'public.doc_access'::regclass
+  ) then
     alter table public.doc_access add constraint doc_access_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_issue_id_issue_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_blocker_issue_id_issue_id_fk' and conrelid = 'public.standup_blocker'::regclass
+  ) then
     alter table public.standup_blocker add constraint standup_blocker_issue_id_issue_id_fk FOREIGN KEY (issue_id) REFERENCES public.issue(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_organization_id_organization_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_blocker_organization_id_organization_id_fk' and conrelid = 'public.standup_blocker'::regclass
+  ) then
     alter table public.standup_blocker add constraint standup_blocker_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_owner_id_user_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_blocker_owner_id_user_id_fk' and conrelid = 'public.standup_blocker'::regclass
+  ) then
     alter table public.standup_blocker add constraint standup_blocker_owner_id_user_id_fk FOREIGN KEY (owner_id) REFERENCES public."user"(id) ON DELETE SET NULL;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_turn_id_standup_turn_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_blocker_turn_id_standup_turn_id_fk' and conrelid = 'public.standup_blocker'::regclass
+  ) then
     alter table public.standup_blocker add constraint standup_blocker_turn_id_standup_turn_id_fk FOREIGN KEY (turn_id) REFERENCES public.standup_turn(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_cycle_id_cycle_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_cycle_id_cycle_id_fk' and conrelid = 'public.standup'::regclass
+  ) then
     alter table public.standup add constraint standup_cycle_id_cycle_id_fk FOREIGN KEY (cycle_id) REFERENCES public.cycle(id) ON DELETE SET NULL;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_facilitator_id_user_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_facilitator_id_user_id_fk' and conrelid = 'public.standup'::regclass
+  ) then
     alter table public.standup add constraint standup_facilitator_id_user_id_fk FOREIGN KEY (facilitator_id) REFERENCES public."user"(id) ON DELETE SET NULL;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_organization_id_organization_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_organization_id_organization_id_fk' and conrelid = 'public.standup'::regclass
+  ) then
     alter table public.standup add constraint standup_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_organization_id_organization_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_rotation_organization_id_organization_id_fk' and conrelid = 'public.standup_rotation'::regclass
+  ) then
     alter table public.standup_rotation add constraint standup_rotation_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_team_id_team_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_rotation_team_id_team_id_fk' and conrelid = 'public.standup_rotation'::regclass
+  ) then
     alter table public.standup_rotation add constraint standup_rotation_team_id_team_id_fk FOREIGN KEY (team_id) REFERENCES public.team(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_user_id_user_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_rotation_user_id_user_id_fk' and conrelid = 'public.standup_rotation'::regclass
+  ) then
     alter table public.standup_rotation add constraint standup_rotation_user_id_user_id_fk FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_team_id_team_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_team_id_team_id_fk' and conrelid = 'public.standup'::regclass
+  ) then
     alter table public.standup add constraint standup_team_id_team_id_fk FOREIGN KEY (team_id) REFERENCES public.team(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_turn_organization_id_organization_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_turn_organization_id_organization_id_fk' and conrelid = 'public.standup_turn'::regclass
+  ) then
     alter table public.standup_turn add constraint standup_turn_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_turn_standup_id_standup_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_turn_standup_id_standup_id_fk' and conrelid = 'public.standup_turn'::regclass
+  ) then
     alter table public.standup_turn add constraint standup_turn_standup_id_standup_id_fk FOREIGN KEY (standup_id) REFERENCES public.standup(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_turn_user_id_user_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_turn_user_id_user_id_fk' and conrelid = 'public.standup_turn'::regclass
+  ) then
     alter table public.standup_turn add constraint standup_turn_user_id_user_id_fk FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
   end if;
 end $$;

--- a/packages/db/catchup/production-schema-catchup.sql
+++ b/packages/db/catchup/production-schema-catchup.sql
@@ -1,0 +1,164 @@
+-- Brings a database created before the standup and doc sharing work up to the current schema.
+-- Adds five tables: standup, standup_turn, standup_blocker, standup_rotation, doc_access.
+-- Nothing else in the schema changed, so no existing table or column is touched.
+--
+-- Safe to run more than once: every statement checks first, and the whole thing is one
+-- transaction, so a failure leaves the database exactly as it was.
+--
+-- Apply it either by pasting it into the Supabase SQL editor, or with
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f packages/db/catchup/production-schema-catchup.sql
+-- using the direct connection on port 5432, not the pooler on 6543.
+
+begin;
+
+create table if not exists public.doc_access (
+    id text NOT NULL,
+    organization_id text NOT NULL,
+    doc_id text NOT NULL,
+    subject_type text NOT NULL,
+    subject_id text NOT NULL,
+    level text DEFAULT 'read'::text NOT NULL,
+    granted_by_id text,
+    sync_id bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+create table if not exists public.standup (
+    id text NOT NULL,
+    organization_id text NOT NULL,
+    team_id text NOT NULL,
+    cycle_id text,
+    held_on date NOT NULL,
+    facilitator_id text,
+    status text DEFAULT 'scheduled'::text NOT NULL,
+    current_turn_id text,
+    started_at timestamp with time zone,
+    ended_at timestamp with time zone,
+    sync_id bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+create table if not exists public.standup_blocker (
+    id text NOT NULL,
+    organization_id text NOT NULL,
+    turn_id text NOT NULL,
+    issue_id text,
+    summary text NOT NULL,
+    owner_id text,
+    resolved_at timestamp with time zone,
+    sync_id bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+create table if not exists public.standup_rotation (
+    id text NOT NULL,
+    organization_id text NOT NULL,
+    team_id text NOT NULL,
+    user_id text NOT NULL,
+    "position" integer NOT NULL,
+    facilitates smallint DEFAULT 1 NOT NULL,
+    sync_id bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+create table if not exists public.standup_turn (
+    id text NOT NULL,
+    organization_id text NOT NULL,
+    standup_id text NOT NULL,
+    user_id text NOT NULL,
+    "position" integer NOT NULL,
+    attendance text DEFAULT 'unknown'::text NOT NULL,
+    status text DEFAULT 'waiting'::text NOT NULL,
+    notes text DEFAULT ''::text NOT NULL,
+    blockers text DEFAULT ''::text NOT NULL,
+    spoke_at timestamp with time zone,
+    duration_seconds integer,
+    sync_id bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+create index if not exists doc_access_subject_idx on public.doc_access USING btree (subject_type, subject_id);
+create unique index if not exists doc_access_unique on public.doc_access USING btree (doc_id, subject_type, subject_id);
+create index if not exists standup_blocker_issue_idx on public.standup_blocker USING btree (issue_id);
+create index if not exists standup_blocker_turn_idx on public.standup_blocker USING btree (turn_id);
+create index if not exists standup_cycle_idx on public.standup USING btree (cycle_id);
+create index if not exists standup_org_day_idx on public.standup USING btree (organization_id, held_on);
+create unique index if not exists standup_rotation_member_unique on public.standup_rotation USING btree (team_id, user_id);
+create index if not exists standup_rotation_order_idx on public.standup_rotation USING btree (team_id, "position");
+create unique index if not exists standup_team_day_unique on public.standup USING btree (team_id, held_on);
+create index if not exists standup_turn_order_idx on public.standup_turn USING btree (standup_id, "position");
+create unique index if not exists standup_turn_person_unique on public.standup_turn USING btree (standup_id, user_id);
+
+do $$
+begin
+  if not exists (select 1 from pg_constraint where conname = 'doc_access_pkey') then
+    alter table public.doc_access add constraint doc_access_pkey PRIMARY KEY (id);
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_pkey') then
+    alter table public.standup_blocker add constraint standup_blocker_pkey PRIMARY KEY (id);
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_pkey') then
+    alter table public.standup add constraint standup_pkey PRIMARY KEY (id);
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_pkey') then
+    alter table public.standup_rotation add constraint standup_rotation_pkey PRIMARY KEY (id);
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_turn_pkey') then
+    alter table public.standup_turn add constraint standup_turn_pkey PRIMARY KEY (id);
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'doc_access_doc_id_doc_id_fk') then
+    alter table public.doc_access add constraint doc_access_doc_id_doc_id_fk FOREIGN KEY (doc_id) REFERENCES public.doc(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'doc_access_granted_by_id_user_id_fk') then
+    alter table public.doc_access add constraint doc_access_granted_by_id_user_id_fk FOREIGN KEY (granted_by_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'doc_access_organization_id_organization_id_fk') then
+    alter table public.doc_access add constraint doc_access_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_issue_id_issue_id_fk') then
+    alter table public.standup_blocker add constraint standup_blocker_issue_id_issue_id_fk FOREIGN KEY (issue_id) REFERENCES public.issue(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_organization_id_organization_id_fk') then
+    alter table public.standup_blocker add constraint standup_blocker_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_owner_id_user_id_fk') then
+    alter table public.standup_blocker add constraint standup_blocker_owner_id_user_id_fk FOREIGN KEY (owner_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_turn_id_standup_turn_id_fk') then
+    alter table public.standup_blocker add constraint standup_blocker_turn_id_standup_turn_id_fk FOREIGN KEY (turn_id) REFERENCES public.standup_turn(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_cycle_id_cycle_id_fk') then
+    alter table public.standup add constraint standup_cycle_id_cycle_id_fk FOREIGN KEY (cycle_id) REFERENCES public.cycle(id) ON DELETE SET NULL;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_facilitator_id_user_id_fk') then
+    alter table public.standup add constraint standup_facilitator_id_user_id_fk FOREIGN KEY (facilitator_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_organization_id_organization_id_fk') then
+    alter table public.standup add constraint standup_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_organization_id_organization_id_fk') then
+    alter table public.standup_rotation add constraint standup_rotation_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_team_id_team_id_fk') then
+    alter table public.standup_rotation add constraint standup_rotation_team_id_team_id_fk FOREIGN KEY (team_id) REFERENCES public.team(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_user_id_user_id_fk') then
+    alter table public.standup_rotation add constraint standup_rotation_user_id_user_id_fk FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_team_id_team_id_fk') then
+    alter table public.standup add constraint standup_team_id_team_id_fk FOREIGN KEY (team_id) REFERENCES public.team(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_turn_organization_id_organization_id_fk') then
+    alter table public.standup_turn add constraint standup_turn_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_turn_standup_id_standup_id_fk') then
+    alter table public.standup_turn add constraint standup_turn_standup_id_standup_id_fk FOREIGN KEY (standup_id) REFERENCES public.standup(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_turn_user_id_user_id_fk') then
+    alter table public.standup_turn add constraint standup_turn_user_id_user_id_fk FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+  end if;
+end $$;
+
+commit;


### PR DESCRIPTION
**Past sprints show real numbers again.** Every finished sprint read *"Closed before Orbit recorded sprint outcomes, so its numbers are not available"*, which is true of all of them in a workspace imported from Linear or Plane, so the Sprints page was effectively blank. A sprint with no stored snapshot is now counted from the issues still in it: scope, completed, cancelled and points, from the same workflow state categories the live progress reads. A recorded snapshot still wins where there is one, and a reconstruction says so quietly so nobody mistakes it for a record made at the time.

This is the first part of the larger Sprints work. The charts, capacity, status pills and the per-assignee, label, priority and project breakdowns are still to come.

**A catch-up script for the deployed database.** Production still runs the schema from before the standup work and doc sharing landed, so it is missing `standup`, `standup_turn`, `standup_blocker`, `standup_rotation` and `doc_access`. Those five tables are the only schema additions since; nothing existing changed.

`packages/db/catchup/production-schema-catchup.sql` creates exactly those, with their indexes and foreign keys, guards every statement so it can be run twice, and wraps the lot in one transaction. It was rehearsed against a copy of the development database with those tables dropped: applied twice, then compared table by table against the reference schema. Identical.

It exists as a file rather than a push because the deployed database cannot be reached from a developer machine: Supabase's direct endpoint for that project is IPv6 only, and the session pooler does not recognise the tenant in any region. Pasting the script into the Supabase SQL editor needs no credentials and no network path.

`bun run verify` is green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reconstructs missing historical sprint outcomes from the issues that remain assigned to each completed sprint and adds an idempotent production schema catch-up script.
- Batches outcome reconstruction for the sprint-history page into a single issue query.
- Preserves stored snapshots when available and labels reconstructed outcomes in the UI.
- Adds the five missing standup and document-access tables, indexes, and foreign keys in one transaction.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported history-page query fan-out is replaced by a bounded batched query.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/cycles/data.ts | Replaces per-sprint outcome loading with one batched call while retaining single-sprint outcome loading for the detail view. |
| apps/web/src/features/cycles/sprint-history.tsx | Displays cancelled counts and identifies outcomes reconstructed from current sprint issue membership. |
| packages/core/src/work/cycle-service.ts | Adds stored-outcome parsing and batched reconstruction using one issue query across all completed sprints lacking snapshots. |
| packages/core/tests/work/cycle-service.test.ts | Covers stored, reconstructed, active, batched, and rollover outcome behavior. |
| packages/db/catchup/production-schema-catchup.sql | Adds the missing standup and document-access schema objects with guarded DDL inside one transaction. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Page as Sprint history page
  participant Data as listPastSprintViews
  participant Core as sprintOutcomes
  participant DB as Database
  Page->>Data: Request past sprints
  Data->>DB: Fetch past cycles
  DB-->>Data: Cycle rows
  Data->>Core: Reconstruct outcomes in batch
  Core->>DB: Fetch issues for all missing snapshots
  DB-->>Core: Matching issues
  Core-->>Data: Ordered recorded/reconstructed outcomes
  Data-->>Page: Past sprint views
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(sprints): count a page of sprints in..."](https://github.com/noveum/orbit/commit/f78880b57e3a62ee1b56f012ddf256af0ee9e659) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50447735)</sub>

<!-- /greptile_comment -->