### PR TITLE
My issues opens on a board it remembers, and the create dialog matches Linear

### DIFF
--- a/apps/web/src/app/.well-known/openid-configuration/route.ts
+++ b/apps/web/src/app/.well-known/openid-configuration/route.ts
@@ -1,0 +1,1 @@
+export { dynamic, GET, OPTIONS, runtime } from '../oauth-authorization-server/route.ts';

--- a/apps/web/src/app/.well-known/openid-configuration/route.ts
+++ b/apps/web/src/app/.well-known/openid-configuration/route.ts
@@ -1,1 +1,4 @@
-export { dynamic, GET, OPTIONS, runtime } from '../oauth-authorization-server/route.ts';
+export { GET, OPTIONS } from '../oauth-authorization-server/route.ts';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';

--- a/apps/web/src/app/api/view-preferences/route.ts
+++ b/apps/web/src/app/api/view-preferences/route.ts
@@ -1,4 +1,5 @@
 import { listViewPreferences, saveViewPreference } from '@orbit/core';
+import { viewPreferenceSchema } from '@orbit/shared/validators';
 import { handle } from '@/lib/api/handler.ts';
 
 export async function GET(): Promise<Response> {
@@ -8,7 +9,8 @@ export async function GET(): Promise<Response> {
 }
 
 export async function PUT(request: Request): Promise<Response> {
-  return await handle(async (principal) => ({
-    preference: await saveViewPreference(principal, await request.json()),
-  }));
+  return await handle(async (principal) => {
+    const input = viewPreferenceSchema.parse(await request.json());
+    return { preference: await saveViewPreference(principal, input) };
+  });
 }

--- a/apps/web/src/app/api/view-preferences/route.ts
+++ b/apps/web/src/app/api/view-preferences/route.ts
@@ -1,0 +1,14 @@
+import { listViewPreferences, saveViewPreference } from '@orbit/core';
+import { handle } from '@/lib/api/handler.ts';
+
+export async function GET(): Promise<Response> {
+  return await handle(async (principal) => ({
+    preferences: await listViewPreferences(principal),
+  }));
+}
+
+export async function PUT(request: Request): Promise<Response> {
+  return await handle(async (principal) => ({
+    preference: await saveViewPreference(principal, await request.json()),
+  }));
+}

--- a/apps/web/src/features/cycles/data.ts
+++ b/apps/web/src/features/cycles/data.ts
@@ -4,7 +4,8 @@ import {
   cycleProgress,
   getCycleByNumber,
   pastCycles,
-  type SprintOutcome,
+  type RecordedOutcome,
+  sprintOutcome,
   upcomingCycles,
 } from '@orbit/core';
 import { and, asc, db, eq, isNull, schema } from '@orbit/db';
@@ -12,7 +13,6 @@ import type { StateCategory } from '@orbit/shared/constants';
 import { STATE_CATEGORIES } from '@orbit/shared/constants';
 import type { Principal } from '@orbit/shared/policy';
 import { sprintLabel } from '@orbit/shared/utils';
-import { sprintOutcomeSchema } from '@orbit/shared/validators';
 
 export interface CycleIssueView {
   readonly id: string;
@@ -58,11 +58,6 @@ export interface UpcomingCycleView {
   readonly startsAt: string;
   readonly endsAt: string;
   readonly teamKey: string;
-}
-
-function readOutcome(value: Record<string, unknown> | null): SprintOutcome | null {
-  const parsed = sprintOutcomeSchema.safeParse(value);
-  return parsed.success ? parsed.data : null;
 }
 
 function toCategory(value: string): StateCategory {
@@ -190,7 +185,7 @@ export interface PastSprintView {
   readonly startsAt: string;
   readonly endsAt: string;
   readonly completedAt: string;
-  readonly outcome: SprintOutcome | null;
+  readonly outcome: RecordedOutcome | null;
 }
 
 export async function listPastSprintViews(
@@ -199,7 +194,8 @@ export async function listPastSprintViews(
   limit = 12,
 ): Promise<PastSprintView[]> {
   const rows = await pastCycles(principal, team.id, limit);
-  return rows.map((cycle) => ({
+  const outcomes = await Promise.all(rows.map((cycle) => sprintOutcome(principal, cycle.id)));
+  return rows.map((cycle, index) => ({
     id: cycle.id,
     name: sprintLabel(cycle),
     number: cycle.number,
@@ -207,7 +203,7 @@ export async function listPastSprintViews(
     startsAt: cycle.startsAt.toISOString(),
     endsAt: cycle.endsAt.toISOString(),
     completedAt: (cycle.completedAt ?? cycle.endsAt).toISOString(),
-    outcome: readOutcome(cycle.progressSnapshot),
+    outcome: outcomes[index] ?? null,
   }));
 }
 
@@ -215,12 +211,13 @@ export async function getSprintView(
   principal: Principal,
   team: { id: string; key: string; name: string },
   number: number,
-): Promise<(CycleView & { readonly outcome: SprintOutcome | null }) | null> {
+): Promise<(CycleView & { readonly outcome: RecordedOutcome | null }) | null> {
   const cycle = await getCycleByNumber(principal, team.id, number);
   if (cycle === null) return null;
-  const [progress, issues] = await Promise.all([
+  const [progress, issues, outcome] = await Promise.all([
     cycleProgress(principal, cycle.id),
     loadCycleIssues(cycle.id),
+    sprintOutcome(principal, cycle.id),
   ]);
   return {
     id: cycle.id,
@@ -234,6 +231,6 @@ export async function getSprintView(
     progress,
     groups: issues.groups,
     assignees: issues.assignees,
-    outcome: readOutcome(cycle.progressSnapshot),
+    outcome,
   };
 }

--- a/apps/web/src/features/cycles/data.ts
+++ b/apps/web/src/features/cycles/data.ts
@@ -6,6 +6,7 @@ import {
   pastCycles,
   type RecordedOutcome,
   sprintOutcome,
+  sprintOutcomes,
   upcomingCycles,
 } from '@orbit/core';
 import { and, asc, db, eq, isNull, schema } from '@orbit/db';
@@ -194,7 +195,7 @@ export async function listPastSprintViews(
   limit = 12,
 ): Promise<PastSprintView[]> {
   const rows = await pastCycles(principal, team.id, limit);
-  const outcomes = await Promise.all(rows.map((cycle) => sprintOutcome(principal, cycle.id)));
+  const outcomes = await sprintOutcomes(principal, rows);
   return rows.map((cycle, index) => ({
     id: cycle.id,
     name: sprintLabel(cycle),

--- a/apps/web/src/features/cycles/sprint-history.tsx
+++ b/apps/web/src/features/cycles/sprint-history.tsx
@@ -20,7 +20,7 @@ function Bar({ completed, scope }: { readonly completed: number; readonly scope:
 
 function Outcome({ sprint }: { readonly sprint: PastSprintView }) {
   if (sprint.outcome === null) {
-    return <p className="text-2xs text-faint">Nothing was ever in this sprint.</p>;
+    return <p className="text-2xs text-faint">No recorded outcome for this sprint.</p>;
   }
   const { scope, completed, canceled, rolledOver, points, reconstructed } = sprint.outcome;
   return (
@@ -41,7 +41,7 @@ function Outcome({ sprint }: { readonly sprint: PastSprintView }) {
         {reconstructed ? (
           <span
             data-testid="sprint-outcome-reconstructed"
-            title="This sprint closed before Orbit recorded outcomes, so these are counted from the issues still in it."
+            title="Closed before Orbit recorded outcomes, so this is counted from the issues still in the sprint. Anything rolled over into a later sprint is not included."
             className="text-faint"
           >
             counted from its issues

--- a/apps/web/src/features/cycles/sprint-history.tsx
+++ b/apps/web/src/features/cycles/sprint-history.tsx
@@ -20,13 +20,9 @@ function Bar({ completed, scope }: { readonly completed: number; readonly scope:
 
 function Outcome({ sprint }: { readonly sprint: PastSprintView }) {
   if (sprint.outcome === null) {
-    return (
-      <p className="text-2xs text-faint">
-        Closed before Orbit recorded sprint outcomes, so its numbers are not available.
-      </p>
-    );
+    return <p className="text-2xs text-faint">Nothing was ever in this sprint.</p>;
   }
-  const { scope, completed, rolledOver, points } = sprint.outcome;
+  const { scope, completed, canceled, rolledOver, points, reconstructed } = sprint.outcome;
   return (
     <div className="flex flex-col gap-1.5">
       <Bar completed={completed} scope={scope} />
@@ -35,10 +31,20 @@ function Outcome({ sprint }: { readonly sprint: PastSprintView }) {
           <span className="text-text">{completed}</span> of {scope} done
         </span>
         <span>{percent(completed, scope)}%</span>
+        {canceled > 0 ? <span>{canceled} cancelled</span> : null}
         {rolledOver > 0 ? <span>{rolledOver} rolled over</span> : null}
         {points.scope > 0 ? (
           <span>
             {points.completed}/{points.scope} pts
+          </span>
+        ) : null}
+        {reconstructed ? (
+          <span
+            data-testid="sprint-outcome-reconstructed"
+            title="This sprint closed before Orbit recorded outcomes, so these are counted from the issues still in it."
+            className="text-faint"
+          >
+            counted from its issues
           </span>
         ) : null}
       </div>

--- a/apps/web/src/features/docs/doc-editor.tsx
+++ b/apps/web/src/features/docs/doc-editor.tsx
@@ -150,88 +150,89 @@ export function DocEditor({
     [uploadFiles],
   );
 
+  const modeSwitch = (
+    <div className="flex items-center gap-0.5 rounded-md bg-surface-2 p-0.5">
+      {(['rich', 'markdown'] as const).map((option) => (
+        <button
+          key={option}
+          type="button"
+          data-testid={`editor-mode-${option}`}
+          aria-pressed={mode === option}
+          onClick={() => setMode(option)}
+          className={cn(
+            'rounded-sm px-2 py-1 text-2xs transition-colors duration-[var(--duration-fast)]',
+            mode === option ? 'bg-surface text-text shadow-sm' : 'text-faint hover:text-muted',
+          )}
+        >
+          {option === 'rich' ? 'Rich text' : 'Markdown'}
+        </button>
+      ))}
+    </div>
+  );
+
+  const uploadStatus = uploading ? (
+    <span className="text-2xs text-faint" data-testid="upload-progress" aria-live="polite">
+      Uploading {percent}%
+    </span>
+  ) : undefined;
+
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="doc-editor">
-      <div className="flex flex-wrap items-center gap-1 border-border border-b px-3 py-1.5">
-        <div className="flex items-center gap-0.5 rounded-md bg-surface-2 p-0.5">
-          {(['rich', 'markdown'] as const).map((option) => (
-            <button
-              key={option}
-              type="button"
-              data-testid={`editor-mode-${option}`}
-              aria-pressed={mode === option}
-              onClick={() => setMode(option)}
-              className={cn(
-                'rounded-sm px-2 py-1 text-2xs transition-colors duration-[var(--duration-fast)]',
-                mode === option ? 'bg-surface text-text shadow-sm' : 'text-faint hover:text-muted',
-              )}
+      {mode === 'markdown' ? (
+        <div className="flex flex-wrap items-center gap-1 border-border border-b px-3 py-1.5">
+          {modeSwitch}
+          <span aria-hidden="true" className="mx-1 h-4 w-px bg-border" />
+          <Tooltip label="Bold" shortcut={['mod', 'b']} side="bottom">
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label="Bold"
+              className="size-7 px-0"
+              onClick={() => applyEdit(wrapSelection(selection(), '**'))}
             >
-              {option === 'rich' ? 'Rich text' : 'Markdown'}
-            </button>
+              <Bold className="size-3.5" aria-hidden="true" />
+            </Button>
+          </Tooltip>
+          <Tooltip label="Italic" shortcut={['mod', 'i']} side="bottom">
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label="Italic"
+              className="size-7 px-0"
+              onClick={() => applyEdit(wrapSelection(selection(), '_'))}
+            >
+              <Italic className="size-3.5" aria-hidden="true" />
+            </Button>
+          </Tooltip>
+          <Tooltip label="Link" shortcut={['mod', 'k']} side="bottom">
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label="Link"
+              className="size-7 px-0"
+              onClick={() => applyEdit(linkSelection(selection()))}
+            >
+              <Link2 className="size-3.5" aria-hidden="true" />
+            </Button>
+          </Tooltip>
+
+          {SNIPPET_ITEMS.map((item) => (
+            <Tooltip key={item.name} label={item.label} side="bottom">
+              <Button
+                variant="ghost"
+                size="sm"
+                aria-label={item.label}
+                data-testid={`insert-${item.name}`}
+                className="size-7 px-0"
+                onClick={() => insertSnippet(item.name)}
+              >
+                <item.icon className="size-3.5" aria-hidden="true" />
+              </Button>
+            </Tooltip>
           ))}
-        </div>
 
-        {mode === 'markdown' ? (
-          <>
-            <span aria-hidden="true" className="mx-1 h-4 w-px bg-border" />
-            <Tooltip label="Bold" shortcut={['mod', 'b']} side="bottom">
-              <Button
-                variant="ghost"
-                size="sm"
-                aria-label="Bold"
-                className="size-7 px-0"
-                onClick={() => applyEdit(wrapSelection(selection(), '**'))}
-              >
-                <Bold className="size-3.5" aria-hidden="true" />
-              </Button>
-            </Tooltip>
-            <Tooltip label="Italic" shortcut={['mod', 'i']} side="bottom">
-              <Button
-                variant="ghost"
-                size="sm"
-                aria-label="Italic"
-                className="size-7 px-0"
-                onClick={() => applyEdit(wrapSelection(selection(), '_'))}
-              >
-                <Italic className="size-3.5" aria-hidden="true" />
-              </Button>
-            </Tooltip>
-            <Tooltip label="Link" shortcut={['mod', 'k']} side="bottom">
-              <Button
-                variant="ghost"
-                size="sm"
-                aria-label="Link"
-                className="size-7 px-0"
-                onClick={() => applyEdit(linkSelection(selection()))}
-              >
-                <Link2 className="size-3.5" aria-hidden="true" />
-              </Button>
-            </Tooltip>
-
-            {SNIPPET_ITEMS.map((item) => (
-              <Tooltip key={item.name} label={item.label} side="bottom">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  aria-label={item.label}
-                  data-testid={`insert-${item.name}`}
-                  className="size-7 px-0"
-                  onClick={() => insertSnippet(item.name)}
-                >
-                  <item.icon className="size-3.5" aria-hidden="true" />
-                </Button>
-              </Tooltip>
-            ))}
-          </>
-        ) : null}
-
-        <span className="ml-auto flex items-center gap-2">
-          {uploading ? (
-            <span className="text-2xs text-faint" data-testid="upload-progress" aria-live="polite">
-              Uploading {percent}%
-            </span>
-          ) : null}
-          {mode === 'markdown' ? (
+          <span className="ml-auto flex items-center gap-2">
+            {uploadStatus}
             <Button
               variant={preview ? 'primary' : 'secondary'}
               size="sm"
@@ -241,9 +242,9 @@ export function DocEditor({
             >
               {preview ? 'Editing preview' : 'Preview'}
             </Button>
-          ) : null}
-        </span>
-      </div>
+          </span>
+        </div>
+      ) : null}
 
       {mode === 'rich' ? (
         <div className="flex min-h-0 flex-1">
@@ -258,6 +259,8 @@ export function DocEditor({
               ariaLabel="Doc body"
               testId="doc-rich-editor"
               footer={footer}
+              toolbarLeading={modeSwitch}
+              toolbarTrailing={uploadStatus}
               {...(scrollRef === undefined ? {} : { scrollRef })}
             />
           </div>

--- a/apps/web/src/features/docs/doc-surface.tsx
+++ b/apps/web/src/features/docs/doc-surface.tsx
@@ -477,14 +477,14 @@ function EditSession({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex flex-col gap-3 border-border border-b px-6 pt-5 pb-3">
+      <div className="flex flex-col gap-1 px-6 pt-3 pb-1">
         <DocContextRow doc={doc} collectionName={collectionName} projectName={projectName} />
         <Input
           value={title}
           aria-label="Doc title"
           data-testid="doc-title-input"
           onChange={(event) => setTitle(event.target.value)}
-          className="h-auto border-0 bg-transparent px-0 font-semibold text-text text-xl focus-visible:border-0"
+          className="h-auto border-0 bg-transparent px-0 py-0 font-semibold text-text text-xl focus-visible:border-0"
         />
       </div>
       <DocEditor

--- a/apps/web/src/features/docs/editor/editor-toolbar.tsx
+++ b/apps/web/src/features/docs/editor/editor-toolbar.tsx
@@ -86,6 +86,8 @@ export interface EditorToolbarProps {
   readonly compact?: boolean;
   readonly className?: string;
   readonly testId?: string;
+  readonly leading?: ReactNode | undefined;
+  readonly trailing?: ReactNode | undefined;
 }
 
 export function EditorToolbar({
@@ -94,6 +96,8 @@ export function EditorToolbar({
   compact = false,
   className,
   testId = 'editor-toolbar',
+  leading,
+  trailing,
 }: EditorToolbarProps) {
   const state = useEditorState({
     editor,
@@ -137,6 +141,12 @@ export function EditorToolbar({
           className,
         )}
       >
+        {leading === undefined ? null : (
+          <>
+            {leading}
+            <span aria-hidden="true" className="mx-1 h-4 w-px bg-border" />
+          </>
+        )}
         {compact ? null : (
           <>
             <ToolbarButton
@@ -331,6 +341,7 @@ export function EditorToolbar({
           enabled={state.hasSelection || state.link}
           testId={testId}
         />
+        {trailing === undefined ? null : <span className="ml-auto">{trailing}</span>}
       </div>
     </TooltipProvider>
   );

--- a/apps/web/src/features/docs/editor/rich-text-editor.tsx
+++ b/apps/web/src/features/docs/editor/rich-text-editor.tsx
@@ -54,6 +54,8 @@ export interface RichTextEditorProps {
   readonly onReady?: (editor: Editor) => void;
   readonly onUpload?: (file: File) => Promise<UploadedAttachment>;
   readonly footer?: React.ReactNode;
+  readonly toolbarLeading?: React.ReactNode | undefined;
+  readonly toolbarTrailing?: React.ReactNode | undefined;
   readonly onBlur?: () => void;
   readonly scrollRef?: RefObject<HTMLDivElement | null>;
 }
@@ -110,6 +112,8 @@ export function RichTextEditor({
   onReady,
   onUpload,
   footer,
+  toolbarLeading,
+  toolbarTrailing,
   onBlur,
   scrollRef,
 }: RichTextEditorProps) {
@@ -398,11 +402,15 @@ export function RichTextEditor({
           className={toolbar === 'compact' ? 'mb-2 border-border border-b pb-2' : ''}
           onPickFile={() => fileRef.current?.click()}
           testId={`${testId}-toolbar`}
+          leading={toolbarLeading}
+          trailing={toolbarTrailing}
         />
       ) : null}
       <div
         ref={scrollRef}
-        className={toolbar === 'full' ? 'min-h-0 flex-1 overflow-y-auto px-6 py-5' : 'contents'}
+        className={
+          toolbar === 'full' ? 'min-h-0 flex-1 overflow-y-auto px-6 pt-3 pb-16' : 'contents'
+        }
       >
         <EditorContent editor={editor} className={cn(docProseClassName, editorSurfaceClassName)} />
         {footer}

--- a/apps/web/src/features/filters/layout-toggle.tsx
+++ b/apps/web/src/features/filters/layout-toggle.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Columns3, List } from 'lucide-react';
+import { cn } from '@/lib/cn.ts';
+import type { ViewLayoutMode } from './view-config.ts';
+
+const OPTIONS: readonly { mode: ViewLayoutMode; label: string; icon: typeof List }[] = [
+  { mode: 'list', label: 'List', icon: List },
+  { mode: 'board', label: 'Board', icon: Columns3 },
+];
+
+export interface LayoutToggleProps {
+  readonly layout: ViewLayoutMode;
+  readonly onChange: (next: ViewLayoutMode) => void;
+}
+
+export function LayoutToggle({ layout, onChange }: LayoutToggleProps) {
+  return (
+    <div className="flex items-center gap-0.5 rounded-md border border-border p-0.5">
+      {OPTIONS.map((option) => (
+        <button
+          key={option.mode}
+          type="button"
+          aria-pressed={layout === option.mode}
+          aria-label={`Show as a ${option.label.toLowerCase()}`}
+          data-testid={`layout-${option.mode}`}
+          onClick={() => onChange(option.mode)}
+          className={cn(
+            'flex h-6 items-center gap-1.5 rounded-md px-2 text-2xs',
+            'transition-colors duration-[var(--duration-fast)] motion-reduce:transition-none',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
+            layout === option.mode ? 'bg-surface-2 text-text' : 'text-faint hover:text-muted',
+          )}
+        >
+          <option.icon className="size-3.5" aria-hidden="true" />
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/filters/use-layout-preference.ts
+++ b/apps/web/src/features/filters/use-layout-preference.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import type { ViewPage } from '@orbit/shared/filters';
+import { VIEW_LAYOUT_MODES } from '@orbit/shared/filters';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { apiFetch } from '@/lib/query/fetcher.ts';
+import { VIEW_PREFERENCES_ROOT } from '@/lib/query/keys.ts';
+import type { ViewPreferences } from '@/lib/query/schemas.ts';
+import { viewPreferencesSchema } from '@/lib/query/schemas.ts';
+import type { ViewLayoutMode } from './view-config.ts';
+
+export function isLayoutMode(value: string): value is ViewLayoutMode {
+  return (VIEW_LAYOUT_MODES as readonly string[]).includes(value);
+}
+
+export function storedLayout(
+  preferences: ViewPreferences | undefined,
+  page: ViewPage,
+  scope: string,
+): ViewLayoutMode | null {
+  const found = preferences?.preferences.find(
+    (entry) => entry.page === page && entry.scope === scope,
+  );
+  if (found === undefined) return null;
+  return isLayoutMode(found.layout) ? found.layout : null;
+}
+
+export interface LayoutPreference {
+  readonly layout: ViewLayoutMode;
+  readonly setLayout: (next: ViewLayoutMode) => void;
+}
+
+export function useLayoutPreference(
+  page: ViewPage,
+  scope: string,
+  fallback: ViewLayoutMode,
+): LayoutPreference {
+  const client = useQueryClient();
+
+  const preferences = useQuery({
+    queryKey: [VIEW_PREFERENCES_ROOT],
+    queryFn: async ({ signal }): Promise<ViewPreferences> =>
+      await apiFetch('/api/view-preferences', viewPreferencesSchema, { signal }),
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  const save = useMutation({
+    mutationFn: async (layout: ViewLayoutMode) =>
+      await apiFetch('/api/view-preferences', viewPreferencesSchema.partial(), {
+        method: 'PUT',
+        body: { page, scope, layout, display: {} },
+      }),
+  });
+
+  const setLayout = useCallback(
+    (next: ViewLayoutMode) => {
+      client.setQueryData<ViewPreferences>([VIEW_PREFERENCES_ROOT], (current) => {
+        const rest = (current?.preferences ?? []).filter(
+          (entry) => !(entry.page === page && entry.scope === scope),
+        );
+        return { preferences: [...rest, { page, scope, layout: next, display: {} }] };
+      });
+      save.mutate(next);
+    },
+    [client, page, scope, save],
+  );
+
+  return { layout: storedLayout(preferences.data, page, scope) ?? fallback, setLayout };
+}

--- a/apps/web/src/features/filters/use-layout-preference.ts
+++ b/apps/web/src/features/filters/use-layout-preference.ts
@@ -4,7 +4,8 @@ import type { ViewPage } from '@orbit/shared/filters';
 import { VIEW_LAYOUT_MODES } from '@orbit/shared/filters';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
-import { apiFetch } from '@/lib/query/fetcher.ts';
+import { useToast } from '@/components/ui/toast.tsx';
+import { apiFetch, messageOf } from '@/lib/query/fetcher.ts';
 import { VIEW_PREFERENCES_ROOT } from '@/lib/query/keys.ts';
 import type { ViewPreferences } from '@/lib/query/schemas.ts';
 import { viewPreferencesSchema } from '@/lib/query/schemas.ts';
@@ -37,6 +38,7 @@ export function useLayoutPreference(
   fallback: ViewLayoutMode,
 ): LayoutPreference {
   const client = useQueryClient();
+  const { toast } = useToast();
 
   const preferences = useQuery({
     queryKey: [VIEW_PREFERENCES_ROOT],
@@ -46,6 +48,7 @@ export function useLayoutPreference(
   });
 
   const save = useMutation({
+    scope: { id: `view-preference:${page}:${scope}` },
     mutationFn: async (layout: ViewLayoutMode) =>
       await apiFetch('/api/view-preferences', viewPreferencesSchema.partial(), {
         method: 'PUT',
@@ -61,9 +64,15 @@ export function useLayoutPreference(
       });
       return { previous };
     },
-    onError: (_error, _layout, context) => {
-      if (context?.previous === undefined) return;
-      client.setQueryData<ViewPreferences>([VIEW_PREFERENCES_ROOT], context.previous);
+    onError: (error, _layout, context) => {
+      if (context?.previous !== undefined) {
+        client.setQueryData<ViewPreferences>([VIEW_PREFERENCES_ROOT], context.previous);
+      }
+      toast({
+        title: 'Could not remember that layout',
+        description: messageOf(error),
+        tone: 'danger',
+      });
     },
     onSettled: () => {
       client.invalidateQueries({ queryKey: [VIEW_PREFERENCES_ROOT] }).catch(() => undefined);

--- a/apps/web/src/features/filters/use-layout-preference.ts
+++ b/apps/web/src/features/filters/use-layout-preference.ts
@@ -51,20 +51,27 @@ export function useLayoutPreference(
         method: 'PUT',
         body: { page, scope, layout, display: {} },
       }),
-  });
-
-  const setLayout = useCallback(
-    (next: ViewLayoutMode) => {
+    onMutate: (layout: ViewLayoutMode) => {
+      const previous = client.getQueryData<ViewPreferences>([VIEW_PREFERENCES_ROOT]);
       client.setQueryData<ViewPreferences>([VIEW_PREFERENCES_ROOT], (current) => {
         const rest = (current?.preferences ?? []).filter(
           (entry) => !(entry.page === page && entry.scope === scope),
         );
-        return { preferences: [...rest, { page, scope, layout: next, display: {} }] };
+        return { preferences: [...rest, { page, scope, layout, display: {} }] };
       });
-      save.mutate(next);
+      return { previous };
     },
-    [client, page, scope, save],
-  );
+    onError: (_error, _layout, context) => {
+      if (context?.previous === undefined) return;
+      client.setQueryData<ViewPreferences>([VIEW_PREFERENCES_ROOT], context.previous);
+    },
+    onSettled: () => {
+      client.invalidateQueries({ queryKey: [VIEW_PREFERENCES_ROOT] }).catch(() => undefined);
+    },
+  });
+
+  const mutate = save.mutate;
+  const setLayout = useCallback((next: ViewLayoutMode) => mutate(next), [mutate]);
 
   return { layout: storedLayout(preferences.data, page, scope) ?? fallback, setLayout };
 }

--- a/apps/web/src/features/issues/board.tsx
+++ b/apps/web/src/features/issues/board.tsx
@@ -382,7 +382,7 @@ function BoardColumn({
           setVisibleCount((count) => Math.min(count + VISIBLE_STEP, loaded));
           return;
         }
-        if (!canFetchMore) return;
+        if (!canFetchMore || columnLoadingMore) return;
         const laidOut = root.scrollHeight > 0;
         const fits = laidOut && root.scrollHeight <= root.clientHeight;
         if (scrolledRef.current || fits) loadMore?.();
@@ -391,7 +391,7 @@ function BoardColumn({
     );
     observer.observe(node);
     return () => observer.disconnect();
-  }, [wantsSentinel, hasHiddenLocal, canFetchMore, loaded, loadMore]);
+  }, [wantsSentinel, hasHiddenLocal, canFetchMore, columnLoadingMore, loaded, loadMore]);
 
   const markScrolled = useCallback(() => {
     scrolledRef.current = true;

--- a/apps/web/src/features/issues/board.tsx
+++ b/apps/web/src/features/issues/board.tsx
@@ -380,9 +380,11 @@ function BoardColumn({
         if (!entries.some((entry) => entry.isIntersecting)) return;
         if (hasHiddenLocal) {
           setVisibleCount((count) => Math.min(count + VISIBLE_STEP, loaded));
-        } else if (scrolledRef.current && canFetchMore) {
-          loadMore?.();
+          return;
         }
+        if (!canFetchMore) return;
+        const settled = root.scrollHeight <= root.clientHeight;
+        if (scrolledRef.current || settled) loadMore?.();
       },
       { root, rootMargin: '240px' },
     );

--- a/apps/web/src/features/issues/board.tsx
+++ b/apps/web/src/features/issues/board.tsx
@@ -19,17 +19,18 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import type { DisplayOptions, DisplayProperty } from '@orbit/shared/filters';
+import type { DisplayOptions, DisplayProperty, GroupByField } from '@orbit/shared/filters';
 import { DEFAULT_DISPLAY_PROPERTIES, emptyFilterGroup } from '@orbit/shared/filters';
 import { Plus } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { applyDisplayFilters, displayFiltersHideRows } from '@/features/filters/display-filter.ts';
 import type { IssueGroup } from '@/features/filters/grouping.ts';
+import { UNGROUPED_ID } from '@/features/filters/grouping.ts';
 import { cn } from '@/lib/cn.ts';
 import type { Cycle, Issue, Label, Member, Project, WorkflowState } from '@/lib/query/schemas.ts';
-import type { IssueQuery } from '@/lib/query/use-issues.ts';
-import { type MoveInput, useColumnIssues, useMoveIssue } from '@/lib/query/use-issues.ts';
+import type { IssueQuery, IssueRegrouping, MoveInput } from '@/lib/query/use-issues.ts';
+import { useColumnIssues, useMoveIssue } from '@/lib/query/use-issues.ts';
 import { GroupGlyph } from './group-glyph.tsx';
 import { IssueCard } from './issue-card.tsx';
 import { IssuePeek } from './issue-peek.tsx';
@@ -49,6 +50,7 @@ export interface BoardProps {
   readonly loadingMore?: boolean;
   readonly onLoadMore?: (() => void) | undefined;
   readonly columnSource?: BoardColumnSource | undefined;
+  readonly groupBy?: GroupByField;
 }
 
 const EMPTY_QUERY: IssueQuery = { filter: emptyFilterGroup(), orderBy: 'manual' };
@@ -65,11 +67,44 @@ interface CardLookups {
   readonly childCounts: ReadonlyMap<string, number>;
 }
 
+export const REGROUPABLE_FIELDS: readonly GroupByField[] = [
+  'state',
+  'cycle',
+  'project',
+  'assignee',
+  'priority',
+];
+
+export function canRegroup(groupBy: GroupByField): boolean {
+  return REGROUPABLE_FIELDS.includes(groupBy);
+}
+
+export function regroupPatch(groupBy: GroupByField, groupId: string): IssueRegrouping | null {
+  const id = groupId === UNGROUPED_ID ? null : groupId;
+  switch (groupBy) {
+    case 'state':
+      return id === null ? null : { stateId: id };
+    case 'cycle':
+      return { cycleId: id };
+    case 'project':
+      return { projectId: id };
+    case 'assignee':
+      return { assigneeId: id };
+    case 'priority': {
+      const priority = Number(groupId);
+      return Number.isInteger(priority) && priority >= 0 && priority <= 4 ? { priority } : null;
+    }
+    default:
+      return null;
+  }
+}
+
 export function planDrop(
   groups: readonly IssueGroup[],
   issues: readonly Issue[],
   activeId: string,
   overId: string,
+  groupBy: GroupByField,
 ): MoveInput | null {
   const dragged = issues.find((issue) => issue.id === activeId);
   if (dragged === undefined || overId === activeId) return null;
@@ -79,6 +114,9 @@ export function planDrop(
     groups.find((group) => group.issues.some((issue) => issue.id === overId));
   if (targetGroup === undefined) return null;
 
+  const regrouping = regroupPatch(groupBy, targetGroup.id);
+  if (regrouping === null) return null;
+
   const siblings = targetGroup.issues.filter((issue) => issue.id !== dragged.id);
   const overIndex = siblings.findIndex((issue) => issue.id === overId);
   const insertAt = overIndex === -1 ? siblings.length : overIndex;
@@ -87,7 +125,7 @@ export function planDrop(
 
   return {
     issue: dragged,
-    stateId: targetGroup.id,
+    ...regrouping,
     beforeId: before?.id ?? null,
     afterId: after?.id ?? null,
     beforeOrder: before?.sortOrder ?? null,
@@ -171,6 +209,7 @@ export function Board({
   loadingMore = false,
   onLoadMore,
   columnSource,
+  groupBy = 'state',
 }: BoardProps) {
   const { labelById, memberById, stateById, projects, cycles, openQuickCreate } = useWorkspace();
   const router = useRouter();
@@ -233,6 +272,7 @@ export function Board({
       issues,
       String(event.active.id),
       String(event.over.id),
+      groupBy,
     );
     if (placement !== null) move.mutate(placement);
   };

--- a/apps/web/src/features/issues/board.tsx
+++ b/apps/web/src/features/issues/board.tsx
@@ -383,8 +383,9 @@ function BoardColumn({
           return;
         }
         if (!canFetchMore) return;
-        const settled = root.scrollHeight <= root.clientHeight;
-        if (scrolledRef.current || settled) loadMore?.();
+        const laidOut = root.scrollHeight > 0;
+        const fits = laidOut && root.scrollHeight <= root.clientHeight;
+        if (scrolledRef.current || fits) loadMore?.();
       },
       { root, rootMargin: '240px' },
     );

--- a/apps/web/src/features/issues/my-issues-view.tsx
+++ b/apps/web/src/features/issues/my-issues-view.tsx
@@ -1,17 +1,24 @@
 'use client';
 
+import type { DisplayProperty } from '@orbit/shared/filters';
 import { CircleDot } from 'lucide-react';
 import { useRouter } from 'next/navigation';
+import type { RefObject } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
 import { Skeleton } from '@/components/ui/skeleton.tsx';
 import { DisplayMenu } from '@/features/filters/display-menu.tsx';
+import type { IssueGroup } from '@/features/filters/grouping.ts';
 import { HiddenFooter } from '@/features/filters/hidden-footer.tsx';
+import { LayoutToggle } from '@/features/filters/layout-toggle.tsx';
+import { useLayoutPreference } from '@/features/filters/use-layout-preference.ts';
 import { useViewConfig } from '@/features/filters/use-view-config.ts';
+import type { ViewLayoutMode } from '@/features/filters/view-config.ts';
 import { useProvideViewControls } from '@/features/filters/view-controls.tsx';
 import type { Issue } from '@/lib/query/schemas.ts';
 import { sortIssues } from '@/lib/query/sync.ts';
 import { useAssignedIssues } from '@/lib/query/use-issues.ts';
+import { Board } from './board.tsx';
 import { GroupGlyph } from './group-glyph.tsx';
 import { IssuePeek } from './issue-peek.tsx';
 import { IssueRow } from './issue-row.tsx';
@@ -26,8 +33,9 @@ export function assignedTo(issues: readonly Issue[], userId: string | null): Iss
 export function MyIssuesView() {
   const router = useRouter();
   const workspace = useWorkspace();
-  const { config, setConfig } = useViewConfig(null, 'list', 'my_issues');
-  const controls = useProvideViewControls('my_issues', 'list', config);
+  const { layout, setLayout } = useLayoutPreference('my_issues', '', 'board');
+  const { config, setConfig } = useViewConfig(null, layout, 'my_issues');
+  const controls = useProvideViewControls('my_issues', layout, config);
 
   const assigned = useAssignedIssues(workspace.userId);
   const sentinel = useRef<HTMLDivElement>(null);
@@ -82,7 +90,8 @@ export function MyIssuesView() {
         <span data-numeric className="text-2xs text-faint" data-testid="issue-count">
           {model.total}
         </span>
-        <div className="ml-auto">
+        <div className="ml-auto flex items-center gap-2">
+          <LayoutToggle layout={layout} onChange={setLayout} />
           <DisplayMenu
             config={config}
             capability={controls.capability}
@@ -92,55 +101,18 @@ export function MyIssuesView() {
         </div>
       </div>
 
-      {model.shownCount === 0 ? (
-        <EmptyState
-          icon={<CircleDot strokeWidth={1.75} aria-hidden="true" />}
-          title={loading ? 'Loading your issues' : 'Nothing assigned to you'}
-          description="Issues assigned to you across every team show up here. Press C to create one."
-          className="flex-1"
-        />
-      ) : (
-        <div className="min-h-0 flex-1 overflow-y-auto" data-testid="my-issues-list">
-          {groups.map((group) => (
-            <section key={group.id}>
-              <div
-                className="flex h-8 items-center gap-2 border-border border-b bg-surface-2/60 px-3"
-                data-testid={`issue-group-${group.title}`}
-              >
-                <GroupGlyph group={group} />
-                <h2 className="font-medium text-dense text-text">{group.title}</h2>
-                <span data-numeric className="text-2xs text-faint">
-                  {group.issues.length}
-                </span>
-              </div>
-              {group.issues.map((issue) => (
-                <IssueRow
-                  key={issue.id}
-                  issue={issue}
-                  state={workspace.stateById.get(issue.stateId)}
-                  properties={config.display.properties}
-                  labels={issue.labelIds.flatMap((id) => {
-                    const label = workspace.labelById.get(id);
-                    return label === undefined ? [] : [label];
-                  })}
-                  assignee={
-                    issue.assigneeId === null
-                      ? undefined
-                      : workspace.memberById.get(issue.assigneeId)
-                  }
-                  creator={workspace.memberById.get(issue.creatorId)}
-                  active={peekId === issue.id}
-                  selected={false}
-                  onOpen={() => setPeekId(issue.id)}
-                  onFocus={() => undefined}
-                  onToggleSelected={() => undefined}
-                />
-              ))}
-            </section>
-          ))}
-          {hasNextPage ? <div ref={sentinel} className="h-px" aria-hidden="true" /> : null}
-        </div>
-      )}
+      <MyIssuesBody
+        loading={loading}
+        layout={layout}
+        model={model}
+        groups={groups}
+        properties={config.display.properties}
+        workspace={workspace}
+        peekId={peekId}
+        onPeek={setPeekId}
+        hasNextPage={hasNextPage}
+        sentinel={sentinel}
+      />
 
       <HiddenFooter
         hiddenByFilters={model.hiddenByFilters}
@@ -162,6 +134,92 @@ export function MyIssuesView() {
           if (found !== undefined) router.push(`/issue/${found.identifier}`);
         }}
       />
+    </div>
+  );
+}
+
+interface BodyProps {
+  readonly loading: boolean;
+  readonly layout: ViewLayoutMode;
+  readonly model: ReturnType<typeof useIssueViewModel>;
+  readonly groups: readonly IssueGroup[];
+  readonly properties: readonly DisplayProperty[];
+  readonly workspace: ReturnType<typeof useWorkspace>;
+  readonly peekId: string | null;
+  readonly onPeek: (id: string) => void;
+  readonly hasNextPage: boolean;
+  readonly sentinel: RefObject<HTMLDivElement | null>;
+}
+
+function MyIssuesBody({
+  loading,
+  layout,
+  model,
+  groups,
+  properties,
+  workspace,
+  peekId,
+  onPeek,
+  hasNextPage,
+  sentinel,
+}: BodyProps) {
+  if (model.shownCount === 0) {
+    return (
+      <EmptyState
+        icon={<CircleDot strokeWidth={1.75} aria-hidden="true" />}
+        title={loading ? 'Loading your issues' : 'Nothing assigned to you'}
+        description="Issues assigned to you across every team show up here. Press C to create one."
+        className="flex-1"
+      />
+    );
+  }
+
+  if (layout === 'board') {
+    return (
+      <div className="min-h-0 flex-1 overflow-hidden" data-testid="my-issues-board">
+        <Board groups={groups} draggable={false} properties={properties} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto" data-testid="my-issues-list">
+      {groups.map((group) => (
+        <section key={group.id}>
+          <div
+            className="flex h-8 items-center gap-2 border-border border-b bg-surface-2/60 px-3"
+            data-testid={`issue-group-${group.title}`}
+          >
+            <GroupGlyph group={group} />
+            <h2 className="font-medium text-dense text-text">{group.title}</h2>
+            <span data-numeric className="text-2xs text-faint">
+              {group.issues.length}
+            </span>
+          </div>
+          {group.issues.map((issue) => (
+            <IssueRow
+              key={issue.id}
+              issue={issue}
+              state={workspace.stateById.get(issue.stateId)}
+              properties={properties}
+              labels={issue.labelIds.flatMap((id) => {
+                const label = workspace.labelById.get(id);
+                return label === undefined ? [] : [label];
+              })}
+              assignee={
+                issue.assigneeId === null ? undefined : workspace.memberById.get(issue.assigneeId)
+              }
+              creator={workspace.memberById.get(issue.creatorId)}
+              active={peekId === issue.id}
+              selected={false}
+              onOpen={() => onPeek(issue.id)}
+              onFocus={() => undefined}
+              onToggleSelected={() => undefined}
+            />
+          ))}
+        </section>
+      ))}
+      {hasNextPage ? <div ref={sentinel} className="h-px" aria-hidden="true" /> : null}
     </div>
   );
 }

--- a/apps/web/src/features/issues/my-issues-view.tsx
+++ b/apps/web/src/features/issues/my-issues-view.tsx
@@ -103,6 +103,10 @@ export function MyIssuesView() {
 
       <MyIssuesBody
         loading={loading}
+        loadingMore={isFetchingNextPage}
+        onLoadMore={() => {
+          fetchNextPage().catch(() => undefined);
+        }}
         layout={layout}
         model={model}
         groups={groups}
@@ -148,6 +152,8 @@ interface BodyProps {
   readonly peekId: string | null;
   readonly onPeek: (id: string) => void;
   readonly hasNextPage: boolean;
+  readonly loadingMore: boolean;
+  readonly onLoadMore: () => void;
   readonly sentinel: RefObject<HTMLDivElement | null>;
 }
 
@@ -161,6 +167,8 @@ function MyIssuesBody({
   peekId,
   onPeek,
   hasNextPage,
+  loadingMore,
+  onLoadMore,
   sentinel,
 }: BodyProps) {
   if (model.shownCount === 0) {
@@ -177,7 +185,14 @@ function MyIssuesBody({
   if (layout === 'board') {
     return (
       <div className="min-h-0 flex-1 overflow-hidden" data-testid="my-issues-board">
-        <Board groups={groups} draggable={false} properties={properties} />
+        <Board
+          groups={groups}
+          draggable={false}
+          properties={properties}
+          hasMore={hasNextPage}
+          loadingMore={loadingMore}
+          onLoadMore={onLoadMore}
+        />
       </div>
     );
   }

--- a/apps/web/src/features/issues/quick-create.tsx
+++ b/apps/web/src/features/issues/quick-create.tsx
@@ -141,9 +141,11 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
               onSelect={(id) => {
                 setTeamId(id);
                 setStateId(null);
+                setCycleId(null);
+                setLabelIds([]);
               }}
             >
-              <button type="button" className={chipClassName}>
+              <button type="button" className={chipClassName} data-testid="quick-create-team">
                 {teams.find((team) => team.id === teamId)?.key ?? 'Team'}
               </button>
             </PropertyMenu>

--- a/apps/web/src/features/issues/quick-create.tsx
+++ b/apps/web/src/features/issues/quick-create.tsx
@@ -1,11 +1,15 @@
 'use client';
 
 import { PRIORITIES } from '@orbit/shared/constants';
+
+import { sprintLabel } from '@orbit/shared/utils';
+import { ChevronRight } from 'lucide-react';
 import { type FormEvent, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog.tsx';
 import { Input } from '@/components/ui/input.tsx';
 import { Kbd } from '@/components/ui/kbd.tsx';
+import { Switch } from '@/components/ui/switch.tsx';
 import { RichTextEditor } from '@/features/docs/editor/rich-text-editor.tsx';
 import { useCreateIssue } from '@/lib/query/use-issues.ts';
 import { PriorityGlyph, priorityLabel } from './priority-glyph.tsx';
@@ -23,7 +27,7 @@ const chipClassName =
   'flex h-7 items-center gap-1.5 rounded-md border border-border bg-surface px-2 text-2xs text-muted transition-colors duration-[var(--duration-fast)] hover:border-border-strong hover:text-text';
 
 export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCreateDialogProps) {
-  const { teams, states, members, labels, ready } = useWorkspace();
+  const { teams, states, members, labels, projects, cycles, ready } = useWorkspace();
   const firstTeamId = defaultTeamId ?? teams[0]?.id ?? null;
   const [teamId, setTeamId] = useState<string | null>(firstTeamId);
   const [title, setTitle] = useState('');
@@ -32,6 +36,9 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
   const [priority, setPriority] = useState(0);
   const [assigneeId, setAssigneeId] = useState<string | null>(null);
   const [labelIds, setLabelIds] = useState<readonly string[]>([]);
+  const [projectId, setProjectId] = useState<string | null>(null);
+  const [cycleId, setCycleId] = useState<string | null>(null);
+  const [createMore, setCreateMore] = useState(false);
 
   const create = useCreateIssue(teamId ?? 'none');
 
@@ -47,6 +54,8 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
     setPriority(0);
     setAssigneeId(null);
     setLabelIds([]);
+    setProjectId(null);
+    setCycleId(null);
   }, [open]);
 
   const teamStates = statesForTeam(states, teamId);
@@ -64,12 +73,22 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
         ...(stateId === null ? {} : { stateId }),
         priority,
         assigneeId,
-        projectId: null,
-        cycleId: null,
+        projectId,
+        cycleId,
         estimate: null,
         labelIds,
       },
-      { onSuccess: () => onOpenChange(false) },
+      {
+        onSuccess: () => {
+          if (!createMore) {
+            onOpenChange(false);
+            return;
+          }
+          setTitle('');
+          setDescription('');
+          setLabelIds([]);
+        },
+      },
     );
   };
 
@@ -77,6 +96,16 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent data-testid="quick-create" className="max-w-xl">
         <DialogTitle className="sr-only">Create issue</DialogTitle>
+        <p
+          className="flex items-center gap-1.5 text-2xs text-faint"
+          data-testid="quick-create-crumb"
+        >
+          <span className="rounded-sm bg-surface-2 px-1.5 py-0.5 text-text">
+            {teams.find((team) => team.id === teamId)?.key ?? 'Team'}
+          </span>
+          <ChevronRight className="size-3" aria-hidden="true" />
+          New issue
+        </p>
         <form
           onSubmit={submit}
           onKeyDown={(event) => {
@@ -102,7 +131,6 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
             placeholder="Add a description, markdown works."
             ariaLabel="Issue description"
             testId="quick-create-description"
-            toolbar="compact"
           />
 
           <div className="flex flex-wrap items-center gap-1.5">
@@ -193,15 +221,54 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
                 {labelIds.length === 0 ? 'Labels' : `${labelIds.length} labels`}
               </button>
             </PropertyMenu>
+
+            <PropertyMenu
+              title="Project"
+              options={[
+                { id: 'none', label: 'No project' },
+                ...projects.map((project) => ({ id: project.id, label: project.name })),
+              ]}
+              selected={projectId === null ? ['none'] : [projectId]}
+              onSelect={(value) => setProjectId(value === 'none' ? null : value)}
+            >
+              <button type="button" className={chipClassName} data-testid="quick-create-project">
+                {projects.find((project) => project.id === projectId)?.name ?? 'Project'}
+              </button>
+            </PropertyMenu>
+
+            <PropertyMenu
+              title="Sprint"
+              options={[
+                { id: 'none', label: 'No sprint' },
+                ...cycles
+                  .filter((cycle) => cycle.teamId === teamId)
+                  .map((cycle) => ({ id: cycle.id, label: sprintLabel(cycle) })),
+              ]}
+              selected={cycleId === null ? ['none'] : [cycleId]}
+              onSelect={(value) => setCycleId(value === 'none' ? null : value)}
+            >
+              <button type="button" className={chipClassName} data-testid="quick-create-cycle">
+                {(() => {
+                  const found = cycles.find((cycle) => cycle.id === cycleId);
+                  return found === undefined ? 'Sprint' : sprintLabel(found);
+                })()}
+              </button>
+            </PropertyMenu>
           </div>
 
           <div className="flex items-center justify-end gap-2 border-border border-t pt-3">
             <span className="mr-auto flex items-center gap-1 text-2xs text-faint">
               <Kbd keys={['mod', 'enter']} /> to create
             </span>
-            <Button type="button" size="sm" variant="ghost" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
+            <span className="flex items-center gap-2 text-2xs text-muted">
+              <Switch
+                checked={createMore}
+                onCheckedChange={setCreateMore}
+                aria-label="Create more"
+                data-testid="quick-create-more"
+              />
+              Create more
+            </span>
             <Button
               type="submit"
               size="sm"

--- a/apps/web/src/features/issues/quick-create.tsx
+++ b/apps/web/src/features/issues/quick-create.tsx
@@ -141,6 +141,7 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
               onSelect={(id) => {
                 setTeamId(id);
                 setStateId(null);
+                setProjectId(null);
                 setCycleId(null);
                 setLabelIds([]);
               }}

--- a/apps/web/src/features/issues/quick-create.tsx
+++ b/apps/web/src/features/issues/quick-create.tsx
@@ -60,6 +60,10 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
 
   const teamStates = statesForTeam(states, teamId);
   const teamLabels = labels.filter((label) => label.teamId === null || label.teamId === teamId);
+  const teamProjects = projects.filter(
+    (project) =>
+      project.teamIds.length === 0 || (teamId !== null && project.teamIds.includes(teamId)),
+  );
   const selectedState = teamStates.find((state) => state.id === stateId);
 
   const submit = (event?: FormEvent<HTMLFormElement>) => {
@@ -229,13 +233,13 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
               title="Project"
               options={[
                 { id: 'none', label: 'No project' },
-                ...projects.map((project) => ({ id: project.id, label: project.name })),
+                ...teamProjects.map((project) => ({ id: project.id, label: project.name })),
               ]}
               selected={projectId === null ? ['none'] : [projectId]}
               onSelect={(value) => setProjectId(value === 'none' ? null : value)}
             >
               <button type="button" className={chipClassName} data-testid="quick-create-project">
-                {projects.find((project) => project.id === projectId)?.name ?? 'Project'}
+                {teamProjects.find((project) => project.id === projectId)?.name ?? 'Project'}
               </button>
             </PropertyMenu>
 

--- a/apps/web/src/features/issues/team-view.tsx
+++ b/apps/web/src/features/issues/team-view.tsx
@@ -25,7 +25,7 @@ import type { View, WorkflowState } from '@/lib/query/schemas.ts';
 import { useIssues } from '@/lib/query/use-issues.ts';
 import { useViews } from '@/lib/query/use-views.ts';
 
-import { Board } from './board.tsx';
+import { Board, canRegroup } from './board.tsx';
 import { IssueList } from './issue-list.tsx';
 import { ListSkeleton } from './list-skeleton.tsx';
 import { useIssueViewModel } from './use-issue-view-model.ts';
@@ -220,7 +220,8 @@ function TeamContent({
     return (
       <Board
         groups={groups}
-        draggable={config.groupBy === 'state' && config.orderBy === 'manual'}
+        draggable={canRegroup(config.groupBy) && config.orderBy === 'manual'}
+        groupBy={config.groupBy}
         properties={config.display.properties}
         hasMore={hasMore}
         loadingMore={loadingMore}

--- a/apps/web/src/lib/api/bootstrap.ts
+++ b/apps/web/src/lib/api/bootstrap.ts
@@ -1,4 +1,10 @@
-import { listLabels, listMembers, listProjectsForTeams, listTeams } from '@orbit/core';
+import {
+  listLabels,
+  listMembers,
+  listProjectsForTeams,
+  listTeams,
+  projectTeamLinks,
+} from '@orbit/core';
 import { and, asc, db, eq, inArray, schema, sql } from '@orbit/db';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan } from '@orbit/shared/policy';
@@ -90,13 +96,21 @@ export async function bootstrapPayload(principal: Principal, query: BootstrapQue
   const activeTeam = teams.find((team) => team.key === query.team) ?? teams[0] ?? null;
   const teamIds = teams.map((team) => team.id);
 
-  const [states, cycles, labels, members, projects] = await Promise.all([
+  const [states, cycles, labels, members, projects, links] = await Promise.all([
     listWorkflowStatesForTeams(principal, teamIds),
     listRecentCyclesForTeams(principal, teamIds),
     listLabels(principal),
     listMembers(principal),
     listProjectsForTeams(principal, teamIds),
+    projectTeamLinks(principal, teamIds),
   ]);
+
+  const teamsByProject = new Map<string, string[]>();
+  for (const link of links) {
+    const found = teamsByProject.get(link.projectId) ?? [];
+    found.push(link.teamId);
+    teamsByProject.set(link.projectId, found);
+  }
 
   return {
     userId: principal.userId,
@@ -124,6 +138,7 @@ export async function bootstrapPayload(principal: Principal, query: BootstrapQue
       status: project.status,
       color: project.color,
       icon: project.icon,
+      teamIds: teamsByProject.get(project.id) ?? [],
     })),
     members: members.map((row) => ({
       id: row.user.id,

--- a/apps/web/src/lib/query/keys.ts
+++ b/apps/web/src/lib/query/keys.ts
@@ -38,3 +38,4 @@ export const DOC_ROOT = 'doc';
 export const VIEWS_ROOT = 'views';
 export const STANDUP_ROOT = 'standup';
 export const SEARCH_ROOT = 'search';
+export const VIEW_PREFERENCES_ROOT = 'view-preferences';

--- a/apps/web/src/lib/query/schemas.ts
+++ b/apps/web/src/lib/query/schemas.ts
@@ -88,6 +88,7 @@ export const projectSchema = z.object({
   status: z.string(),
   color: z.string(),
   icon: z.string(),
+  teamIds: z.array(z.string()).catch([]).default([]),
 });
 
 export type Project = z.infer<typeof projectSchema>;

--- a/apps/web/src/lib/query/schemas.ts
+++ b/apps/web/src/lib/query/schemas.ts
@@ -451,3 +451,18 @@ export const standupTodaySchema = z.object({
 export type StandupToday = z.infer<typeof standupTodaySchema>;
 
 export const standupListSchema = z.object({ standups: z.array(standupSchema).default([]) });
+
+export const viewPreferencesSchema = z.object({
+  preferences: z
+    .array(
+      z.object({
+        page: z.string(),
+        scope: z.string(),
+        layout: z.string(),
+        display: z.record(z.string(), z.unknown()).default({}),
+      }),
+    )
+    .default([]),
+});
+
+export type ViewPreferences = z.infer<typeof viewPreferencesSchema>;

--- a/apps/web/src/lib/query/use-issues.ts
+++ b/apps/web/src/lib/query/use-issues.ts
@@ -440,13 +440,30 @@ export function useUpdateIssue() {
   });
 }
 
-export interface MoveInput {
+export interface IssueRegrouping {
+  readonly stateId?: string;
+  readonly cycleId?: string | null;
+  readonly projectId?: string | null;
+  readonly assigneeId?: string | null;
+  readonly priority?: number;
+}
+
+export type MoveInput = IssueRegrouping & {
   readonly issue: Issue;
-  readonly stateId: string;
   readonly beforeId: string | null;
   readonly afterId: string | null;
   readonly beforeOrder: number | null;
   readonly afterOrder: number | null;
+};
+
+function regroupingOf(input: MoveInput): IssueRegrouping {
+  return {
+    ...(input.stateId === undefined ? {} : { stateId: input.stateId }),
+    ...(input.cycleId === undefined ? {} : { cycleId: input.cycleId }),
+    ...(input.projectId === undefined ? {} : { projectId: input.projectId }),
+    ...(input.assigneeId === undefined ? {} : { assigneeId: input.assigneeId }),
+    ...(input.priority === undefined ? {} : { priority: input.priority }),
+  };
 }
 
 export function useMoveIssue() {
@@ -457,7 +474,7 @@ export function useMoveIssue() {
     mutationFn: async (input: MoveInput): Promise<readonly Issue[]> => {
       const result = await apiFetch(`/api/issues/${input.issue.id}/move`, issueMoveResultSchema, {
         method: 'POST',
-        body: { stateId: input.stateId, beforeId: input.beforeId, afterId: input.afterId },
+        body: { ...regroupingOf(input), beforeId: input.beforeId, afterId: input.afterId },
       });
       return [result.issue, ...result.rebalanced];
     },
@@ -465,7 +482,7 @@ export function useMoveIssue() {
       await client.cancelQueries({ queryKey: [ISSUES_ROOT] });
       const optimistic: Issue = {
         ...input.issue,
-        stateId: input.stateId,
+        ...regroupingOf(input),
         sortOrder: sortOrderBetween(input.beforeOrder, input.afterOrder),
       };
       placeIssue(client, optimistic, false);

--- a/apps/web/tests/app/well-known/openid-configuration.test.ts
+++ b/apps/web/tests/app/well-known/openid-configuration.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+
+const ROUTE = 'src/app/.well-known/openid-configuration/route.ts';
+
+describe('the openid configuration alias', () => {
+  it('serves the same metadata as the oauth authorization server document', async () => {
+    const source = await readFile(ROUTE, 'utf8');
+    expect(source).toContain("from '../oauth-authorization-server/route.ts'");
+    expect(source).toContain('GET');
+  });
+
+  it('declares the route config rather than re-exporting it', async () => {
+    const source = await readFile(ROUTE, 'utf8');
+
+    expect(source).toMatch(/export const runtime = 'nodejs';/);
+    expect(source).toMatch(/export const dynamic = 'force-dynamic';/);
+    expect(source).not.toMatch(/export \{[^}]*\bruntime\b[^}]*\} from/);
+    expect(source).not.toMatch(/export \{[^}]*\bdynamic\b[^}]*\} from/);
+  });
+});

--- a/apps/web/tests/features/docs/editor/toolbar-slots.test.tsx
+++ b/apps/web/tests/features/docs/editor/toolbar-slots.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import { useState } from 'react';
+import { TooltipProvider } from '@/components/ui/tooltip.tsx';
+import { RichTextEditor } from '../../../../src/features/docs/editor/rich-text-editor.tsx';
+
+function Harness({ leading, trailing }: { leading?: React.ReactNode; trailing?: React.ReactNode }) {
+  const [value, setValue] = useState('Hello');
+  return (
+    <TooltipProvider>
+      <RichTextEditor
+        value={value}
+        onChange={setValue}
+        toolbar="full"
+        ariaLabel="Doc body"
+        testId="doc-rich-editor"
+        {...(leading === undefined ? {} : { toolbarLeading: leading })}
+        {...(trailing === undefined ? {} : { toolbarTrailing: trailing })}
+      />
+    </TooltipProvider>
+  );
+}
+
+describe('rich text toolbar slots', () => {
+  it('puts the leading control on the same row as the formatting buttons', async () => {
+    render(<Harness leading={<button type="button">Rich text</button>} />);
+
+    const toolbar = await waitFor(() => screen.getByTestId('doc-rich-editor-toolbar'));
+    expect(within(toolbar).getByRole('button', { name: 'Rich text' })).toBeDefined();
+    expect(within(toolbar).getByRole('button', { name: 'Bold' })).toBeDefined();
+    cleanup();
+  });
+
+  it('puts the trailing control on that same row', async () => {
+    render(<Harness trailing={<span>Uploading 40%</span>} />);
+
+    const toolbar = await waitFor(() => screen.getByTestId('doc-rich-editor-toolbar'));
+    expect(within(toolbar).getByText('Uploading 40%')).toBeDefined();
+    cleanup();
+  });
+
+  it('renders no extra separators when neither slot is used', async () => {
+    render(<Harness />);
+
+    const toolbar = await waitFor(() => screen.getByTestId('doc-rich-editor-toolbar'));
+    expect(within(toolbar).queryByText('Rich text')).toBeNull();
+    expect(within(toolbar).getByRole('button', { name: 'Bold' })).toBeDefined();
+    cleanup();
+  });
+});

--- a/apps/web/tests/features/filters/filter-bar.test.tsx
+++ b/apps/web/tests/features/filters/filter-bar.test.tsx
@@ -55,7 +55,16 @@ const workspace: WorkspaceData = {
       role: 'member',
     },
   ],
-  projects: [{ id: 'project-1', name: 'Atlas', status: 'planned', color: '#5a63c8', icon: 'box' }],
+  projects: [
+    {
+      id: 'project-1',
+      name: 'Atlas',
+      status: 'planned',
+      color: '#5a63c8',
+      icon: 'box',
+      teamIds: [],
+    },
+  ],
   cycles: [],
   seedIssues: [],
   stateById: new Map(),

--- a/apps/web/tests/features/filters/grouping.test.ts
+++ b/apps/web/tests/features/filters/grouping.test.ts
@@ -48,7 +48,16 @@ const context: GroupContext = {
     },
   ],
   members: [],
-  projects: [{ id: 'project_1', name: 'Atlas', status: 'planned', color: '#5a63c8', icon: 'box' }],
+  projects: [
+    {
+      id: 'project_1',
+      name: 'Atlas',
+      status: 'planned',
+      color: '#5a63c8',
+      icon: 'box',
+      teamIds: [],
+    },
+  ],
   cycles: [],
   labels: [
     { id: 'label_bug', teamId: null, name: 'Bug', color: '#cc4b4b' },

--- a/apps/web/tests/features/filters/use-layout-preference.test.ts
+++ b/apps/web/tests/features/filters/use-layout-preference.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+import { isLayoutMode, storedLayout } from '@/features/filters/use-layout-preference.ts';
+
+const preferences = {
+  preferences: [
+    { page: 'my_issues', scope: '', layout: 'board', display: {} },
+    { page: 'team', scope: 'eng', layout: 'list', display: {} },
+    { page: 'team', scope: 'design', layout: 'gantt', display: {} },
+  ],
+};
+
+describe('reading back how someone left a page', () => {
+  it('finds the layout for the page and scope asked for', () => {
+    expect(storedLayout(preferences, 'my_issues', '')).toBe('board');
+    expect(storedLayout(preferences, 'team', 'eng')).toBe('list');
+  });
+
+  it('has nothing for a page nobody has chosen yet, so the default stands', () => {
+    expect(storedLayout(preferences, 'project', '')).toBeNull();
+    expect(storedLayout(undefined, 'my_issues', '')).toBeNull();
+  });
+
+  it('keeps one scope from answering for another', () => {
+    expect(storedLayout(preferences, 'team', 'marketing')).toBeNull();
+  });
+
+  it('ignores a layout the product no longer has rather than rendering nothing', () => {
+    expect(storedLayout(preferences, 'team', 'design')).toBeNull();
+  });
+
+  it('knows which layouts are real', () => {
+    expect(isLayoutMode('board')).toBe(true);
+    expect(isLayoutMode('list')).toBe(true);
+    expect(isLayoutMode('timeline')).toBe(false);
+  });
+});

--- a/apps/web/tests/features/issues/board-regroup.test.ts
+++ b/apps/web/tests/features/issues/board-regroup.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'bun:test';
+import { groupIssues } from '../../../src/features/filters/grouping.ts';
+import { canRegroup, planDrop, regroupPatch } from '../../../src/features/issues/board.tsx';
+import type { Cycle, Issue } from '../../../src/lib/query/schemas.ts';
+
+function issue(overrides: Partial<Issue>): Issue {
+  return {
+    id: 'issue_1',
+    organizationId: 'org_1',
+    teamId: 'team_1',
+    number: 1,
+    identifier: 'ENG-1',
+    title: 'Something',
+    description: '',
+    stateId: 'state_todo',
+    priority: 0,
+    estimate: null,
+    assigneeId: null,
+    creatorId: 'member_1',
+    projectId: null,
+    milestoneId: null,
+    cycleId: null,
+    parentId: null,
+    dueDate: null,
+    startedAt: null,
+    completedAt: null,
+    canceledAt: null,
+    archivedAt: null,
+    sortOrder: 1024,
+    labelIds: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as Issue;
+}
+
+function cycle(id: string, number: number): Cycle {
+  return {
+    id,
+    organizationId: 'org_1',
+    teamId: 'team_1',
+    number,
+    name: `Sprint ${number}`,
+    startsAt: '2026-01-01T00:00:00.000Z',
+    endsAt: '2026-01-14T00:00:00.000Z',
+    completedAt: null,
+  } as Cycle;
+}
+
+const cycles = [cycle('cycle_1', 1), cycle('cycle_2', 2)];
+
+const issues = [
+  issue({ id: 'a', identifier: 'ENG-1', cycleId: 'cycle_1', sortOrder: 1024 }),
+  issue({ id: 'b', identifier: 'ENG-2', cycleId: 'cycle_1', sortOrder: 2048 }),
+  issue({ id: 'c', identifier: 'ENG-3', cycleId: null, sortOrder: 1024 }),
+];
+
+const sprintColumns = groupIssues(
+  issues,
+  'cycle',
+  { states: [], members: [], projects: [], cycles, labels: [] },
+  { showEmptyGroups: true, ordering: 'manual' },
+);
+
+describe('regroupPatch', () => {
+  it('moves an issue into the sprint the column represents', () => {
+    expect(regroupPatch('cycle', 'cycle_2')).toEqual({ cycleId: 'cycle_2' });
+  });
+
+  it('takes an issue out of every sprint when dropped on the ungrouped column', () => {
+    expect(regroupPatch('cycle', 'none')).toEqual({ cycleId: null });
+  });
+
+  it('never clears the status, because an issue must always have one', () => {
+    expect(regroupPatch('state', 'none')).toBeNull();
+    expect(regroupPatch('state', 'state_doing')).toEqual({ stateId: 'state_doing' });
+  });
+
+  it('reads a priority column as a number rather than an id', () => {
+    expect(regroupPatch('priority', '2')).toEqual({ priority: 2 });
+    expect(regroupPatch('priority', 'none')).toBeNull();
+  });
+
+  it('unassigns and unsets a project on the ungrouped column', () => {
+    expect(regroupPatch('assignee', 'none')).toEqual({ assigneeId: null });
+    expect(regroupPatch('project', 'none')).toEqual({ projectId: null });
+  });
+
+  it('refuses groupings a single drop cannot express', () => {
+    expect(regroupPatch('label', 'label_1')).toBeNull();
+    expect(regroupPatch('creator', 'member_1')).toBeNull();
+    expect(regroupPatch('estimate', '3')).toBeNull();
+    expect(regroupPatch('none', 'none')).toBeNull();
+  });
+});
+
+describe('canRegroup', () => {
+  it('allows dragging on the groupings a drop can express', () => {
+    expect(canRegroup('state')).toBe(true);
+    expect(canRegroup('cycle')).toBe(true);
+    expect(canRegroup('project')).toBe(true);
+    expect(canRegroup('assignee')).toBe(true);
+    expect(canRegroup('priority')).toBe(true);
+  });
+
+  it('refuses the ones it cannot', () => {
+    expect(canRegroup('label')).toBe(false);
+    expect(canRegroup('creator')).toBe(false);
+    expect(canRegroup('estimate')).toBe(false);
+    expect(canRegroup('none')).toBe(false);
+  });
+});
+
+describe('planDrop across sprints', () => {
+  it('carries the sprint, not the status, when the board is grouped by sprint', () => {
+    const plan = planDrop(sprintColumns, issues, 'c', 'a', 'cycle');
+    expect(plan).toMatchObject({ cycleId: 'cycle_1' });
+    expect(plan?.stateId).toBeUndefined();
+  });
+
+  it('drops an issue back into the backlog column', () => {
+    const plan = planDrop(sprintColumns, issues, 'a', 'c', 'cycle');
+    expect(plan).toMatchObject({ cycleId: null });
+    expect(plan?.stateId).toBeUndefined();
+  });
+
+  it('still keeps the neighbours it was dropped between', () => {
+    const plan = planDrop(sprintColumns, issues, 'c', 'b', 'cycle');
+    expect(plan).toMatchObject({ beforeId: 'a', afterId: 'b' });
+  });
+
+  it('refuses a drop while grouped by something a drop cannot express', () => {
+    const byLabel = groupIssues(
+      issues,
+      'label',
+      { states: [], members: [], projects: [], cycles, labels: [] },
+      { showEmptyGroups: true, ordering: 'manual' },
+    );
+    expect(planDrop(byLabel, issues, 'a', 'b', 'label')).toBeNull();
+  });
+
+  it('never writes a sprint id into the status field', () => {
+    const plan = planDrop(sprintColumns, issues, 'c', 'a', 'cycle');
+    expect(plan?.stateId).toBeUndefined();
+    expect(plan?.cycleId).toBe('cycle_1');
+  });
+});

--- a/apps/web/tests/features/issues/board.test.tsx
+++ b/apps/web/tests/features/issues/board.test.tsx
@@ -290,4 +290,28 @@ describe('Board windowing', () => {
     fireIntersection();
     expect(onLoadMore).toHaveBeenCalled();
   });
+
+  it('fetches without a scroll when the column is short enough to fit', () => {
+    const onLoadMore = mock();
+    renderWindowedBoard(10, onLoadMore);
+
+    const column = screen.getByTestId('board-column-Todo').querySelector('ul') as HTMLElement;
+    Object.defineProperty(column, 'scrollHeight', { value: 300, configurable: true });
+    Object.defineProperty(column, 'clientHeight', { value: 800, configurable: true });
+
+    fireIntersection();
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+
+  it('waits for a scroll when the column is taller than the space it has', () => {
+    const onLoadMore = mock();
+    renderWindowedBoard(10, onLoadMore);
+
+    const column = screen.getByTestId('board-column-Todo').querySelector('ul') as HTMLElement;
+    Object.defineProperty(column, 'scrollHeight', { value: 2000, configurable: true });
+    Object.defineProperty(column, 'clientHeight', { value: 600, configurable: true });
+
+    fireIntersection();
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/tests/features/issues/issue-card.test.tsx
+++ b/apps/web/tests/features/issues/issue-card.test.tsx
@@ -204,13 +204,13 @@ describe('board placement', () => {
   });
 
   it('places a card dropped on an empty column at the end', () => {
-    const plan = planDrop(columns, issues, 'a', 'state_doing');
+    const plan = planDrop(columns, issues, 'a', 'state_doing', 'state');
     expect(plan).toMatchObject({ stateId: 'state_doing', beforeId: 'c', afterId: null });
     expect(plan?.beforeOrder).toBe(1024);
   });
 
   it('places a card between the neighbours it was dropped onto', () => {
-    const plan = planDrop(columns, issues, 'c', 'b');
+    const plan = planDrop(columns, issues, 'c', 'b', 'state');
     expect(plan).toMatchObject({
       stateId: 'state_todo',
       beforeId: 'a',
@@ -221,8 +221,8 @@ describe('board placement', () => {
   });
 
   it('ignores a drop on itself or on an unknown target', () => {
-    expect(planDrop(columns, issues, 'a', 'a')).toBeNull();
-    expect(planDrop(columns, issues, 'a', 'nowhere')).toBeNull();
+    expect(planDrop(columns, issues, 'a', 'a', 'state')).toBeNull();
+    expect(planDrop(columns, issues, 'a', 'nowhere', 'state')).toBeNull();
   });
 });
 

--- a/apps/web/tests/features/issues/my-issues-view.test.tsx
+++ b/apps/web/tests/features/issues/my-issues-view.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock } from 'bun:test';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ToastProvider } from '@/components/ui/toast.tsx';
 import { HotkeyProvider } from '@/lib/keyboard/index.ts';
 import { queryKeys, VIEW_PREFERENCES_ROOT } from '@/lib/query/keys.ts';
@@ -234,6 +235,40 @@ describe('MyIssuesView', () => {
 
     expect(screen.getByTestId('layout-list')).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByTestId('layout-board')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('switches what is rendered when the control is used', async () => {
+    const realFetch = globalThis.fetch;
+    let stored = { page: 'my_issues', scope: '', layout: 'list', display: {} };
+    globalThis.fetch = mock((_input: unknown, init?: RequestInit) => {
+      if (init?.method === 'PUT' && typeof init.body === 'string') {
+        stored = { ...stored, ...(JSON.parse(init.body) as { layout: string }) };
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ preferences: [stored] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as unknown as typeof fetch;
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    workspace = buildWorkspace();
+    renderView('me', 'list');
+
+    expect(screen.getByTestId('my-issues-list')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('layout-board'));
+
+    expect(screen.getByTestId('my-issues-board')).toBeInTheDocument();
+    expect(screen.queryByTestId('my-issues-list')).toBeNull();
+    expect(screen.getByTestId('layout-board')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('layout-list')).toHaveAttribute('aria-pressed', 'false');
+
+    await user.click(screen.getByTestId('layout-list'));
+
+    expect(screen.getByTestId('my-issues-list')).toBeInTheDocument();
+    expect(screen.getByTestId('layout-list')).toHaveAttribute('aria-pressed', 'true');
+    globalThis.fetch = realFetch;
   });
 
   it('opens the peek panel when a row is clicked instead of navigating away', () => {

--- a/apps/web/tests/features/issues/my-issues-view.test.tsx
+++ b/apps/web/tests/features/issues/my-issues-view.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { ToastProvider } from '@/components/ui/toast.tsx';
 import { HotkeyProvider } from '@/lib/keyboard/index.ts';
-import { queryKeys } from '@/lib/query/keys.ts';
+import { queryKeys, VIEW_PREFERENCES_ROOT } from '@/lib/query/keys.ts';
 import type { Issue, WorkflowState } from '@/lib/query/schemas.ts';
 import { assignedSearch } from '@/lib/query/use-issues.ts';
 import type { WorkspaceData } from '../../../src/features/issues/workspace-provider.tsx';
@@ -131,9 +131,12 @@ function renderEmptyCacheView(): void {
   );
 }
 
-function renderView(viewerId = 'me'): void {
+function renderView(viewerId = 'me', layout: 'list' | 'board' = 'list'): void {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+  });
+  client.setQueryData([VIEW_PREFERENCES_ROOT], {
+    preferences: [{ page: 'my_issues', scope: '', layout, display: {} }],
   });
   client.setQueryData(queryKeys.assignedIssues(viewerId, assignedSearch(viewerId)), {
     pages: [
@@ -207,6 +210,30 @@ describe('MyIssuesView', () => {
     renderView();
 
     expect(screen.getByTestId('issue-group-Todo')).toBeInTheDocument();
+  });
+
+  it('opens on a board, which is what someone wants to see first', () => {
+    workspace = buildWorkspace();
+    renderView('me', 'board');
+
+    expect(screen.getByTestId('my-issues-board')).toBeInTheDocument();
+    expect(screen.queryByTestId('my-issues-list')).toBeNull();
+  });
+
+  it('shows the list when that is what was chosen last time', () => {
+    workspace = buildWorkspace();
+    renderView('me', 'list');
+
+    expect(screen.getByTestId('my-issues-list')).toBeInTheDocument();
+    expect(screen.queryByTestId('my-issues-board')).toBeNull();
+  });
+
+  it('offers both layouts and marks the one in use', () => {
+    workspace = buildWorkspace();
+    renderView('me', 'list');
+
+    expect(screen.getByTestId('layout-list')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('layout-board')).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('opens the peek panel when a row is clicked instead of navigating away', () => {

--- a/apps/web/tests/features/issues/quick-create.test.tsx
+++ b/apps/web/tests/features/issues/quick-create.test.tsx
@@ -44,7 +44,16 @@ function buildWorkspace(): WorkspaceData {
       { id: 'me', name: 'Shashank', email: 's@x.co', image: null, handle: 's', role: 'admin' },
     ],
     labels: [{ id: 'label_bug', teamId: 'team_eng', name: 'Bug', color: '#f00' }],
-    projects: [{ id: 'proj_1', name: 'API market', status: 'started', color: '#00f', icon: 'box' }],
+    projects: [
+      {
+        id: 'proj_1',
+        name: 'API market',
+        status: 'started',
+        color: '#00f',
+        icon: 'box',
+        teamIds: [],
+      },
+    ],
     cycles: [
       {
         id: 'cycle_1',
@@ -73,6 +82,14 @@ function open() {
 }
 
 describe('the new issue dialog', () => {
+  it('offers only the projects the chosen team can actually use', () => {
+    workspace = buildWorkspace();
+    open();
+
+    expect(screen.getByTestId('quick-create-project')).toBeTruthy();
+    expect(screen.queryByText('Brand refresh')).toBeNull();
+  });
+
   it('says which team the issue is going into', () => {
     workspace = buildWorkspace();
     open();

--- a/apps/web/tests/features/issues/quick-create.test.tsx
+++ b/apps/web/tests/features/issues/quick-create.test.tsx
@@ -2,8 +2,8 @@ import { afterEach, describe, expect, it, mock } from 'bun:test';
 import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ToastProvider } from '@/components/ui/toast.tsx';
-import type { WorkspaceData } from '../../../src/features/issues/workspace-provider.tsx';
-import * as workspaceProvider from '../../../src/features/issues/workspace-provider.tsx';
+import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
+import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 
 const created = mock((_input: Record<string, unknown>) => undefined);
 
@@ -18,12 +18,12 @@ mock.module('@/lib/query/use-issues.ts', () => ({
 }));
 
 let workspace: WorkspaceData;
-mock.module('../../../src/features/issues/workspace-provider.tsx', () => ({
+mock.module('@/features/issues/workspace-provider.tsx', () => ({
   ...workspaceProvider,
   useWorkspace: () => workspace,
 }));
 
-const { QuickCreateDialog } = await import('../../../src/features/issues/quick-create.tsx');
+const { QuickCreateDialog } = await import('@/features/issues/quick-create.tsx');
 
 function buildWorkspace(): WorkspaceData {
   return {
@@ -100,18 +100,57 @@ describe('the new issue dialog', () => {
     expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
   });
 
-  it('carries the chosen project and sprint onto the issue it creates', async () => {
+  it('carries the project and sprint that were actually chosen', async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     workspace = buildWorkspace();
     open();
 
     await user.type(screen.getByTestId('quick-create-title'), 'Ship the thing');
+    await user.click(screen.getByTestId('quick-create-project'));
+    await user.click(await screen.findByText('API market'));
+    await user.click(screen.getByTestId('quick-create-cycle'));
+    await user.click(await screen.findByText('Sprint 3'));
     await user.click(screen.getByTestId('quick-create-submit'));
 
     expect(created).toHaveBeenCalledTimes(1);
     const input = created.mock.calls[0]?.[0];
     expect(input?.['title']).toBe('Ship the thing');
-    expect(input).toHaveProperty('projectId');
-    expect(input).toHaveProperty('cycleId');
+    expect(input?.['projectId']).toBe('proj_1');
+    expect(input?.['cycleId']).toBe('cycle_1');
+  });
+
+  it('stays open and clears the title when Create more is on', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    workspace = buildWorkspace();
+    open();
+
+    await user.click(screen.getByTestId('quick-create-more'));
+    await user.type(screen.getByTestId('quick-create-title'), 'First one');
+    await user.click(screen.getByTestId('quick-create-submit'));
+
+    expect(created).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('quick-create-title')).toHaveValue('');
+    expect(screen.getByTestId('quick-create')).toBeTruthy();
+  });
+
+  it('drops a sprint from the team that was left behind', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    workspace = {
+      ...buildWorkspace(),
+      teams: [
+        { id: 'team_eng', name: 'Engineering', key: 'ENG', icon: 'e', color: '#fff' },
+        { id: 'team_des', name: 'Design', key: 'DES', icon: 'd', color: '#eee' },
+      ],
+    };
+    open();
+
+    await user.type(screen.getByTestId('quick-create-title'), 'Moved teams');
+    await user.click(screen.getByTestId('quick-create-cycle'));
+    await user.click(await screen.findByText('Sprint 3'));
+    await user.click(screen.getByTestId('quick-create-team'));
+    await user.click(await screen.findByText('Design'));
+    await user.click(screen.getByTestId('quick-create-submit'));
+
+    expect(created.mock.calls[0]?.[0]?.['cycleId']).toBeNull();
   });
 });

--- a/apps/web/tests/features/issues/quick-create.test.tsx
+++ b/apps/web/tests/features/issues/quick-create.test.tsx
@@ -51,7 +51,15 @@ function buildWorkspace(): WorkspaceData {
         status: 'started',
         color: '#00f',
         icon: 'box',
-        teamIds: [],
+        teamIds: ['team_eng'],
+      },
+      {
+        id: 'proj_2',
+        name: 'Brand refresh',
+        status: 'started',
+        color: '#0f0',
+        icon: 'box',
+        teamIds: ['team_des'],
       },
     ],
     cycles: [
@@ -82,11 +90,14 @@ function open() {
 }
 
 describe('the new issue dialog', () => {
-  it('offers only the projects the chosen team can actually use', () => {
+  it('offers only the projects the chosen team can actually use', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
     workspace = buildWorkspace();
     open();
 
-    expect(screen.getByTestId('quick-create-project')).toBeTruthy();
+    await user.click(screen.getByTestId('quick-create-project'));
+
+    expect(await screen.findByText('API market')).toBeTruthy();
     expect(screen.queryByText('Brand refresh')).toBeNull();
   });
 

--- a/apps/web/tests/features/issues/quick-create.test.tsx
+++ b/apps/web/tests/features/issues/quick-create.test.tsx
@@ -133,7 +133,7 @@ describe('the new issue dialog', () => {
     expect(screen.getByTestId('quick-create')).toBeTruthy();
   });
 
-  it('drops a sprint from the team that was left behind', async () => {
+  it('drops the sprint and the project from the team that was left behind', async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     workspace = {
       ...buildWorkspace(),
@@ -145,6 +145,8 @@ describe('the new issue dialog', () => {
     open();
 
     await user.type(screen.getByTestId('quick-create-title'), 'Moved teams');
+    await user.click(screen.getByTestId('quick-create-project'));
+    await user.click(await screen.findByText('API market'));
     await user.click(screen.getByTestId('quick-create-cycle'));
     await user.click(await screen.findByText('Sprint 3'));
     await user.click(screen.getByTestId('quick-create-team'));
@@ -152,5 +154,6 @@ describe('the new issue dialog', () => {
     await user.click(screen.getByTestId('quick-create-submit'));
 
     expect(created.mock.calls[0]?.[0]?.['cycleId']).toBeNull();
+    expect(created.mock.calls[0]?.[0]?.['projectId']).toBeNull();
   });
 });

--- a/apps/web/tests/features/issues/quick-create.test.tsx
+++ b/apps/web/tests/features/issues/quick-create.test.tsx
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ToastProvider } from '@/components/ui/toast.tsx';
+import type { WorkspaceData } from '../../../src/features/issues/workspace-provider.tsx';
+import * as workspaceProvider from '../../../src/features/issues/workspace-provider.tsx';
+
+const created = mock((_input: Record<string, unknown>) => undefined);
+
+mock.module('@/lib/query/use-issues.ts', () => ({
+  useCreateIssue: () => ({
+    mutate: (input: Record<string, unknown>, options?: { onSuccess?: () => void }) => {
+      created(input);
+      options?.onSuccess?.();
+    },
+    isPending: false,
+  }),
+}));
+
+let workspace: WorkspaceData;
+mock.module('../../../src/features/issues/workspace-provider.tsx', () => ({
+  ...workspaceProvider,
+  useWorkspace: () => workspace,
+}));
+
+const { QuickCreateDialog } = await import('../../../src/features/issues/quick-create.tsx');
+
+function buildWorkspace(): WorkspaceData {
+  return {
+    ...({} as WorkspaceData),
+    ready: true,
+    teams: [{ id: 'team_eng', name: 'Engineering', key: 'ENG', icon: 'e', color: '#fff' }],
+    states: [
+      {
+        id: 'state_todo',
+        teamId: 'team_eng',
+        name: 'Todo',
+        category: 'unstarted',
+        color: '#888',
+        position: 1,
+      },
+    ],
+    members: [
+      { id: 'me', name: 'Shashank', email: 's@x.co', image: null, handle: 's', role: 'admin' },
+    ],
+    labels: [{ id: 'label_bug', teamId: 'team_eng', name: 'Bug', color: '#f00' }],
+    projects: [{ id: 'proj_1', name: 'API market', status: 'started', color: '#00f', icon: 'box' }],
+    cycles: [
+      {
+        id: 'cycle_1',
+        teamId: 'team_eng',
+        number: 3,
+        name: '',
+        startsAt: '2026-08-01T00:00:00.000Z',
+        endsAt: '2026-08-14T00:00:00.000Z',
+        completedAt: null,
+      },
+    ],
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  created.mockClear();
+});
+
+function open() {
+  render(
+    <ToastProvider>
+      <QuickCreateDialog open onOpenChange={() => undefined} defaultTeamId="team_eng" />
+    </ToastProvider>,
+  );
+}
+
+describe('the new issue dialog', () => {
+  it('says which team the issue is going into', () => {
+    workspace = buildWorkspace();
+    open();
+    expect(screen.getByTestId('quick-create-crumb')).toHaveTextContent('ENG');
+    expect(screen.getByTestId('quick-create-crumb')).toHaveTextContent('New issue');
+  });
+
+  it('offers a project and a sprint, which it could not before', () => {
+    workspace = buildWorkspace();
+    open();
+    expect(screen.getByTestId('quick-create-project')).toBeTruthy();
+    expect(screen.getByTestId('quick-create-cycle')).toBeTruthy();
+  });
+
+  it('shows no formatting toolbar above the description, the way Linear does not', () => {
+    workspace = buildWorkspace();
+    open();
+    expect(screen.queryByTestId('quick-create-description-toolbar')).toBeNull();
+  });
+
+  it('offers to stay open for the next issue instead of a cancel button', () => {
+    workspace = buildWorkspace();
+    open();
+    expect(screen.getByTestId('quick-create-more')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+  });
+
+  it('carries the chosen project and sprint onto the issue it creates', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    workspace = buildWorkspace();
+    open();
+
+    await user.type(screen.getByTestId('quick-create-title'), 'Ship the thing');
+    await user.click(screen.getByTestId('quick-create-submit'));
+
+    expect(created).toHaveBeenCalledTimes(1);
+    const input = created.mock.calls[0]?.[0];
+    expect(input?.['title']).toBe('Ship the thing');
+    expect(input).toHaveProperty('projectId');
+    expect(input).toHaveProperty('cycleId');
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,5 +24,6 @@ export * from './work/label-service.ts';
 export * from './work/milestone-service.ts';
 export * from './work/project-service.ts';
 export * from './work/standup-service.ts';
+export * from './work/view-preference-service.ts';
 export * from './work/view-service.ts';
 export * from './work/workflow-state-service.ts';

--- a/packages/core/src/work/cycle-service.ts
+++ b/packages/core/src/work/cycle-service.ts
@@ -7,6 +7,7 @@ import {
   eq,
   gt,
   gte,
+  inArray,
   isNotNull,
   isNull,
   lt,
@@ -428,18 +429,56 @@ export async function sprintOutcome(
   cycleId: string,
 ): Promise<RecordedOutcome | null> {
   const cycle = await getCycle(principal, cycleId);
-  if (cycle.completedAt === null) return null;
+  const [outcome] = await outcomesFor([cycle]);
+  return outcome ?? null;
+}
 
-  const stored = readStoredOutcome(cycle.progressSnapshot);
-  if (stored !== null) return { ...stored, reconstructed: false };
+export async function sprintOutcomes(
+  principal: Principal,
+  cycles: readonly CycleRow[],
+): Promise<(RecordedOutcome | null)[]> {
+  assertCan(principal, 'project:read');
+  return await outcomesFor(cycles);
+}
 
-  const rows = await db
-    .select({ category: CYCLE_CATEGORY, estimate: schema.issue.estimate })
-    .from(schema.issue)
-    .innerJoin(schema.workflowState, eq(schema.workflowState.id, schema.issue.stateId))
-    .where(and(eq(schema.issue.cycleId, cycleId), isNull(schema.issue.archivedAt)));
+async function outcomesFor(cycles: readonly CycleRow[]): Promise<(RecordedOutcome | null)[]> {
+  const needsCounting = cycles.filter(
+    (cycle) => cycle.completedAt !== null && readStoredOutcome(cycle.progressSnapshot) === null,
+  );
 
-  return { ...outcomeOf(rows, 0, cycle.completedAt), reconstructed: true };
+  const counted = new Map<string, { category: string; estimate: number | null }[]>();
+  if (needsCounting.length > 0) {
+    const rows = await db
+      .select({
+        cycleId: schema.issue.cycleId,
+        category: CYCLE_CATEGORY,
+        estimate: schema.issue.estimate,
+      })
+      .from(schema.issue)
+      .innerJoin(schema.workflowState, eq(schema.workflowState.id, schema.issue.stateId))
+      .where(
+        and(
+          inArray(
+            schema.issue.cycleId,
+            needsCounting.map((cycle) => cycle.id),
+          ),
+          isNull(schema.issue.archivedAt),
+        ),
+      );
+    for (const row of rows) {
+      if (row.cycleId === null) continue;
+      const list = counted.get(row.cycleId) ?? [];
+      list.push({ category: row.category, estimate: row.estimate });
+      counted.set(row.cycleId, list);
+    }
+  }
+
+  return cycles.map((cycle) => {
+    if (cycle.completedAt === null) return null;
+    const stored = readStoredOutcome(cycle.progressSnapshot);
+    if (stored !== null) return { ...stored, reconstructed: false };
+    return { ...outcomeOf(counted.get(cycle.id) ?? [], 0, cycle.completedAt), reconstructed: true };
+  });
 }
 
 export async function pastCycles(

--- a/packages/core/src/work/cycle-service.ts
+++ b/packages/core/src/work/cycle-service.ts
@@ -21,6 +21,7 @@ import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan, assertInTeam, teamScope } from '@orbit/shared/policy';
 import { cycleCreateSchema, cycleUpdateSchema } from '@orbit/shared/validators';
+import { z } from 'zod';
 import { principalActor } from '../activity/activity-service.ts';
 import { addUtcDays, type Executor, newId, requireRow, startOfUtcDay } from '../internal.ts';
 import { requireTeam } from '../org/team-service.ts';
@@ -400,6 +401,45 @@ function outcomeOf(
     points: { scope: points(rows), completed: points(done) },
     closedAt: now.toISOString(),
   };
+}
+
+function readStoredOutcome(value: unknown): SprintOutcome | null {
+  const parsed = storedOutcomeSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+const storedOutcomeSchema = z.object({
+  scope: z.number(),
+  completed: z.number(),
+  canceled: z.number().default(0),
+  rolledOver: z.number().default(0),
+  points: z
+    .object({ scope: z.number(), completed: z.number() })
+    .default({ scope: 0, completed: 0 }),
+  closedAt: z.string(),
+});
+
+export interface RecordedOutcome extends SprintOutcome {
+  readonly reconstructed: boolean;
+}
+
+export async function sprintOutcome(
+  principal: Principal,
+  cycleId: string,
+): Promise<RecordedOutcome | null> {
+  const cycle = await getCycle(principal, cycleId);
+  if (cycle.completedAt === null) return null;
+
+  const stored = readStoredOutcome(cycle.progressSnapshot);
+  if (stored !== null) return { ...stored, reconstructed: false };
+
+  const rows = await db
+    .select({ category: CYCLE_CATEGORY, estimate: schema.issue.estimate })
+    .from(schema.issue)
+    .innerJoin(schema.workflowState, eq(schema.workflowState.id, schema.issue.stateId))
+    .where(and(eq(schema.issue.cycleId, cycleId), isNull(schema.issue.archivedAt)));
+
+  return { ...outcomeOf(rows, 0, cycle.completedAt), reconstructed: true };
 }
 
 export async function pastCycles(

--- a/packages/core/src/work/issue-service.ts
+++ b/packages/core/src/work/issue-service.ts
@@ -31,6 +31,8 @@ export type IssueRow = typeof schema.issue.$inferSelect;
 export type IssueRelationRow = typeof schema.issueRelation.$inferSelect;
 export type IssueValues = Partial<typeof schema.issue.$inferInsert>;
 
+type GroupedMoveField = 'cycleId' | 'assigneeId' | 'priority' | 'projectId';
+
 export const REBALANCE_THRESHOLD = 0.0001;
 
 export const INVERSE_RELATION: Record<IssueRelationType, IssueRelationType> = {
@@ -785,6 +787,63 @@ export interface MovedIssue {
   readonly actions: SyncAction[];
 }
 
+interface RegroupingInput {
+  readonly cycleId?: string | null | undefined;
+  readonly assigneeId?: string | null | undefined;
+  readonly priority?: number | undefined;
+  readonly projectId?: string | null | undefined;
+}
+
+function applyRegrouping(
+  parsed: RegroupingInput,
+  current: IssueRow,
+  values: IssueValues,
+): GroupedMoveField[] {
+  const regrouped: GroupedMoveField[] = [];
+  const regroup = <Field extends GroupedMoveField>(
+    field: Field,
+    next: IssueValues[Field] | undefined,
+  ): void => {
+    if (next === undefined || next === current[field]) return;
+    values[field] = next;
+    regrouped.push(field);
+  };
+  regroup('cycleId', parsed.cycleId);
+  regroup('assigneeId', parsed.assigneeId);
+  regroup('priority', parsed.priority);
+  if (parsed.projectId !== undefined && parsed.projectId !== current.projectId) {
+    regroup('projectId', parsed.projectId);
+    values.milestoneId = null;
+  }
+  return regrouped;
+}
+
+interface RegroupActivityInput {
+  readonly organizationId: string;
+  readonly issueId: string;
+  readonly actor: Actor;
+  readonly syncId: number;
+  readonly regrouped: readonly GroupedMoveField[];
+  readonly current: IssueRow;
+  readonly issue: IssueRow;
+}
+
+async function recordRegroupings(tx: Executor, input: RegroupActivityInput): Promise<void> {
+  for (const field of input.regrouped) {
+    await appendActivities(tx, [
+      {
+        organizationId: input.organizationId,
+        issueId: input.issueId,
+        actor: input.actor,
+        field,
+        from: await describeValue(tx, field, input.current[field]),
+        to: await describeValue(tx, field, input.issue[field]),
+        syncId: input.syncId,
+      },
+    ]);
+  }
+}
+
 export async function moveIssue(
   principal: Principal,
   issueId: string,
@@ -834,6 +893,13 @@ export async function moveIssue(
       Object.assign(values, applyStateTimestamps(current, state.category, now));
     }
 
+    await assertAssignableToTeam(tx, principal.organizationId, teamId, {
+      cycleId: parsed.cycleId,
+      projectId: parsed.projectId,
+    });
+
+    const regrouped = applyRegrouping(parsed, current, values);
+
     const [moved] = await tx
       .update(schema.issue)
       .set({ ...values, updatedAt: now, syncId })
@@ -854,6 +920,16 @@ export async function moveIssue(
         },
       ]);
     }
+
+    await recordRegroupings(tx, {
+      organizationId: principal.organizationId,
+      issueId,
+      actor,
+      syncId,
+      regrouped,
+      current,
+      issue,
+    });
 
     return {
       issue,

--- a/packages/core/src/work/project-service.ts
+++ b/packages/core/src/work/project-service.ts
@@ -609,3 +609,15 @@ export async function listProjectsForTeams(
     )
     .orderBy(asc(schema.project.name));
 }
+
+export async function projectTeamLinks(
+  principal: Principal,
+  teamIds: readonly string[],
+): Promise<{ projectId: string; teamId: string }[]> {
+  assertCan(principal, 'project:read');
+  if (teamIds.length === 0) return [];
+  return await db
+    .select({ projectId: schema.projectTeam.projectId, teamId: schema.projectTeam.teamId })
+    .from(schema.projectTeam)
+    .where(inArray(schema.projectTeam.teamId, [...teamIds]));
+}

--- a/packages/core/src/work/view-preference-service.ts
+++ b/packages/core/src/work/view-preference-service.ts
@@ -1,18 +1,8 @@
 import { and, db, eq, schema } from '@orbit/db';
-import { VIEW_LAYOUT_MODES, VIEW_PAGES } from '@orbit/shared/filters';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan } from '@orbit/shared/policy';
-import { z } from 'zod';
+import { viewPreferenceSchema } from '@orbit/shared/validators';
 import { newId } from '../internal.ts';
-
-export const viewPreferenceSchema = z.object({
-  page: z.enum(VIEW_PAGES),
-  scope: z.string().max(64).default(''),
-  layout: z.enum(VIEW_LAYOUT_MODES),
-  display: z.record(z.string(), z.unknown()).default({}),
-});
-
-export type ViewPreferenceInput = z.infer<typeof viewPreferenceSchema>;
 
 export interface ViewPreference {
   readonly page: string;

--- a/packages/core/src/work/view-preference-service.ts
+++ b/packages/core/src/work/view-preference-service.ts
@@ -1,0 +1,79 @@
+import { and, db, eq, schema } from '@orbit/db';
+import { VIEW_LAYOUT_MODES, VIEW_PAGES } from '@orbit/shared/filters';
+import type { Principal } from '@orbit/shared/policy';
+import { assertCan } from '@orbit/shared/policy';
+import { z } from 'zod';
+import { newId } from '../internal.ts';
+
+export const viewPreferenceSchema = z.object({
+  page: z.enum(VIEW_PAGES),
+  scope: z.string().max(64).default(''),
+  layout: z.enum(VIEW_LAYOUT_MODES),
+  display: z.record(z.string(), z.unknown()).default({}),
+});
+
+export type ViewPreferenceInput = z.infer<typeof viewPreferenceSchema>;
+
+export interface ViewPreference {
+  readonly page: string;
+  readonly scope: string;
+  readonly layout: string;
+  readonly display: Record<string, unknown>;
+}
+
+export async function listViewPreferences(principal: Principal): Promise<ViewPreference[]> {
+  assertCan(principal, 'issue:read');
+  const rows = await db
+    .select({
+      page: schema.viewPreference.page,
+      scope: schema.viewPreference.scope,
+      layout: schema.viewPreference.layout,
+      display: schema.viewPreference.display,
+    })
+    .from(schema.viewPreference)
+    .where(
+      and(
+        eq(schema.viewPreference.userId, principal.userId),
+        eq(schema.viewPreference.organizationId, principal.organizationId),
+      ),
+    );
+  return rows.map((row) => ({ ...row, display: row.display }));
+}
+
+export async function saveViewPreference(
+  principal: Principal,
+  input: unknown,
+): Promise<ViewPreference> {
+  assertCan(principal, 'issue:read');
+  const parsed = viewPreferenceSchema.parse(input);
+
+  const [row] = await db
+    .insert(schema.viewPreference)
+    .values({
+      id: newId(),
+      organizationId: principal.organizationId,
+      userId: principal.userId,
+      page: parsed.page,
+      scope: parsed.scope,
+      layout: parsed.layout,
+      display: parsed.display,
+    })
+    .onConflictDoUpdate({
+      target: [
+        schema.viewPreference.userId,
+        schema.viewPreference.organizationId,
+        schema.viewPreference.page,
+        schema.viewPreference.scope,
+      ],
+      set: { layout: parsed.layout, display: parsed.display, updatedAt: new Date() },
+    })
+    .returning({
+      page: schema.viewPreference.page,
+      scope: schema.viewPreference.scope,
+      layout: schema.viewPreference.layout,
+      display: schema.viewPreference.display,
+    });
+
+  if (row === undefined) throw new Error('The view preference did not save.');
+  return row;
+}

--- a/packages/core/tests/work/cycle-service.test.ts
+++ b/packages/core/tests/work/cycle-service.test.ts
@@ -598,6 +598,30 @@ describe('sprintOutcomes', () => {
     expect(outcomes[1]?.points.scope).toBe(8);
   });
 
+  it('counts the sprint when the stored snapshot is malformed rather than trusting it', async () => {
+    const cycle = await firstCycle();
+    const done = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Finished',
+      cycleId: cycle.id,
+      estimate: 7,
+    });
+    await updateIssue(workspace.admin, done.issue.id, {
+      stateId: stateNamed(workspace, 'Done').id,
+    });
+    const closed = await completeCycle(workspace.admin, cycle.id);
+
+    await db
+      .update(schema.cycle)
+      .set({ progressSnapshot: { scope: 'not a number' } })
+      .where(eq(schema.cycle.id, closed.cycle.id));
+
+    const outcome = await sprintOutcome(workspace.admin, closed.cycle.id);
+    expect(outcome?.reconstructed).toBe(true);
+    expect(outcome?.scope).toBe(1);
+    expect(outcome?.points.scope).toBe(7);
+  });
+
   it('counts only what is still in the sprint, since a rollover moved the rest away', async () => {
     const cycle = await firstCycle();
     const done = await createIssue(workspace.admin, {

--- a/packages/core/tests/work/cycle-service.test.ts
+++ b/packages/core/tests/work/cycle-service.test.ts
@@ -21,6 +21,7 @@ import {
   getCycleByNumber,
   listCycles,
   pastCycles,
+  sprintOutcome,
   upcomingCycles,
   updateCycle,
 } from '../../src/work/cycle-service.ts';
@@ -493,5 +494,58 @@ describe('two people closing the same sprint at once', () => {
     expect(closed.nextCycle.id).not.toBe(later.cycle.id);
     expect(closed.nextCycle.completedAt).toBeNull();
     expect(closed.nextCycle.number).toBeGreaterThan(later.cycle.number);
+  });
+});
+
+describe('sprintOutcome', () => {
+  it('hands back what was recorded when the sprint was closed', async () => {
+    const cycle = await firstCycle();
+    await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Shipped',
+      cycleId: cycle.id,
+      estimate: 5,
+    });
+    const closed = await completeCycle(workspace.admin, cycle.id);
+
+    const outcome = await sprintOutcome(workspace.admin, closed.cycle.id);
+    expect(outcome?.reconstructed).toBe(false);
+    expect(outcome?.scope).toBe(1);
+  });
+
+  it('counts a sprint closed before outcomes were recorded, rather than saying nothing', async () => {
+    const cycle = await firstCycle();
+    const done = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Finished',
+      cycleId: cycle.id,
+      estimate: 5,
+    });
+    await updateIssue(workspace.admin, done.issue.id, {
+      stateId: stateNamed(workspace, 'Done').id,
+    });
+    await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Left over',
+      cycleId: cycle.id,
+      estimate: 3,
+    });
+    const closed = await completeCycle(workspace.admin, cycle.id);
+
+    await db
+      .update(schema.cycle)
+      .set({ progressSnapshot: null })
+      .where(eq(schema.cycle.id, closed.cycle.id));
+
+    const outcome = await sprintOutcome(workspace.admin, closed.cycle.id);
+    expect(outcome?.reconstructed).toBe(true);
+    expect(outcome?.scope).toBe(1);
+    expect(outcome?.completed).toBe(1);
+    expect(outcome?.points).toEqual({ scope: 5, completed: 5 });
+  });
+
+  it('has nothing to say about a sprint still running', async () => {
+    const cycle = await firstCycle();
+    expect(await sprintOutcome(workspace.admin, cycle.id)).toBeNull();
   });
 });

--- a/packages/core/tests/work/cycle-service.test.ts
+++ b/packages/core/tests/work/cycle-service.test.ts
@@ -22,6 +22,7 @@ import {
   listCycles,
   pastCycles,
   sprintOutcome,
+  sprintOutcomes,
   upcomingCycles,
   updateCycle,
 } from '../../src/work/cycle-service.ts';
@@ -547,5 +548,87 @@ describe('sprintOutcome', () => {
   it('has nothing to say about a sprint still running', async () => {
     const cycle = await firstCycle();
     expect(await sprintOutcome(workspace.admin, cycle.id)).toBeNull();
+  });
+});
+
+describe('sprintOutcomes', () => {
+  it('answers for a page of sprints in one pass, recorded or counted', async () => {
+    const first = await firstCycle();
+    const one = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'In the first',
+      cycleId: first.id,
+      estimate: 2,
+    });
+    await updateIssue(workspace.admin, one.issue.id, {
+      stateId: stateNamed(workspace, 'Done').id,
+    });
+    const closedFirst = await completeCycle(workspace.admin, first.id);
+
+    const second = await createCycle(workspace.admin, {
+      teamId: workspace.teamId,
+      startsAt: daysFromNow(200),
+      endsAt: daysFromNow(214),
+    });
+    const two = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'In the second',
+      cycleId: second.cycle.id,
+      estimate: 8,
+    });
+    await updateIssue(workspace.admin, two.issue.id, {
+      stateId: stateNamed(workspace, 'Done').id,
+    });
+    const closedSecond = await completeCycle(workspace.admin, second.cycle.id);
+
+    await db
+      .update(schema.cycle)
+      .set({ progressSnapshot: null })
+      .where(eq(schema.cycle.id, closedSecond.cycle.id));
+
+    const outcomes = await sprintOutcomes(workspace.admin, [
+      await getCycle(workspace.admin, closedFirst.cycle.id),
+      await getCycle(workspace.admin, closedSecond.cycle.id),
+    ]);
+
+    expect(outcomes).toHaveLength(2);
+    expect(outcomes[0]?.reconstructed).toBe(false);
+    expect(outcomes[0]?.points.scope).toBe(2);
+    expect(outcomes[1]?.reconstructed).toBe(true);
+    expect(outcomes[1]?.points.scope).toBe(8);
+  });
+
+  it('counts only what is still in the sprint, since a rollover moved the rest away', async () => {
+    const cycle = await firstCycle();
+    const done = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Finished',
+      cycleId: cycle.id,
+      estimate: 3,
+    });
+    await updateIssue(workspace.admin, done.issue.id, {
+      stateId: stateNamed(workspace, 'Done').id,
+    });
+    await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Rolled over',
+      cycleId: cycle.id,
+      estimate: 5,
+    });
+    const closed = await completeCycle(workspace.admin, cycle.id);
+    expect(closed.rolledOverIssueIds).toHaveLength(1);
+
+    await db
+      .update(schema.cycle)
+      .set({ progressSnapshot: null })
+      .where(eq(schema.cycle.id, closed.cycle.id));
+
+    const [outcome] = await sprintOutcomes(workspace.admin, [
+      await getCycle(workspace.admin, closed.cycle.id),
+    ]);
+
+    expect(outcome?.reconstructed).toBe(true);
+    expect(outcome?.scope).toBe(1);
+    expect(outcome?.points.scope).toBe(3);
   });
 });

--- a/packages/core/tests/work/issue-service.test.ts
+++ b/packages/core/tests/work/issue-service.test.ts
@@ -302,6 +302,64 @@ describe('moveIssue', () => {
     expect(moved.actions[0]?.scopes).toContain(scopes.team(team.id));
   });
 
+  it('moves an issue into a sprint without touching its status', async () => {
+    const { cycle } = await createCycle(workspace.admin, {
+      teamId: workspace.teamId,
+      startsAt: new Date('2030-02-01').toISOString(),
+      endsAt: new Date('2030-02-15').toISOString(),
+    });
+    const issue = await newIssue('Planned');
+    expect(issue.cycleId).toBeNull();
+
+    const moved = await moveIssue(workspace.admin, issue.id, { cycleId: cycle.id });
+
+    expect(moved.issue.cycleId).toBe(cycle.id);
+    expect(moved.issue.stateId).toBe(issue.stateId);
+  });
+
+  it('takes an issue back out of its sprint', async () => {
+    const { cycle } = await createCycle(workspace.admin, {
+      teamId: workspace.teamId,
+      startsAt: new Date('2030-03-01').toISOString(),
+      endsAt: new Date('2030-03-15').toISOString(),
+    });
+    const issue = await newIssue('Descoped', { cycleId: cycle.id });
+
+    const moved = await moveIssue(workspace.admin, issue.id, { cycleId: null });
+
+    expect(moved.issue.cycleId).toBeNull();
+    expect(moved.issue.stateId).toBe(issue.stateId);
+  });
+
+  it('records the sprint change in the issue history', async () => {
+    const { cycle } = await createCycle(workspace.admin, {
+      teamId: workspace.teamId,
+      startsAt: new Date('2030-04-01').toISOString(),
+      endsAt: new Date('2030-04-15').toISOString(),
+    });
+    const issue = await newIssue('Tracked');
+
+    await moveIssue(workspace.admin, issue.id, { cycleId: cycle.id });
+
+    const entries = await db
+      .select()
+      .from(schema.issueActivity)
+      .where(eq(schema.issueActivity.issueId, issue.id));
+    expect(entries.some((entry) => entry.field === 'cycleId')).toBe(true);
+  });
+
+  it('refuses a sprint that belongs to another team', async () => {
+    const { team } = await createTeam(workspace.admin, { name: 'Ops', key: 'OPS' });
+    const { cycle } = await createCycle(workspace.admin, {
+      teamId: team.id,
+      startsAt: new Date('2030-05-01').toISOString(),
+      endsAt: new Date('2030-05-15').toISOString(),
+    });
+    const issue = await newIssue('Wrong team sprint');
+
+    await expect(moveIssue(workspace.admin, issue.id, { cycleId: cycle.id })).rejects.toThrow();
+  });
+
   it('drops the sprint and project links that belong to the team it left', async () => {
     const { cycle } = await createCycle(workspace.admin, {
       teamId: workspace.teamId,

--- a/packages/core/tests/work/view-preference-service.test.ts
+++ b/packages/core/tests/work/view-preference-service.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import {
+  addMember,
+  createWorkspace,
+  resetDatabase,
+  type Workspace,
+} from '../../src/test-support.ts';
+import { listViewPreferences, saveViewPreference } from '../../src/work/view-preference-service.ts';
+
+let workspace: Workspace;
+
+beforeEach(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+});
+
+describe('remembering how someone likes to see a page', () => {
+  it('has nothing to say before anyone has chosen', async () => {
+    expect(await listViewPreferences(workspace.admin)).toEqual([]);
+  });
+
+  it('keeps the choice, and hands it back on the next visit', async () => {
+    await saveViewPreference(workspace.admin, {
+      page: 'my_issues',
+      scope: '',
+      layout: 'board',
+      display: { groupBy: 'assignee' },
+    });
+
+    const [saved] = await listViewPreferences(workspace.admin);
+    expect(saved?.page).toBe('my_issues');
+    expect(saved?.layout).toBe('board');
+    expect(saved?.display).toEqual({ groupBy: 'assignee' });
+  });
+
+  it('replaces the earlier choice for the same page rather than piling up rows', async () => {
+    await saveViewPreference(workspace.admin, { page: 'my_issues', scope: '', layout: 'board' });
+    await saveViewPreference(workspace.admin, { page: 'my_issues', scope: '', layout: 'list' });
+
+    const all = await listViewPreferences(workspace.admin);
+    expect(all).toHaveLength(1);
+    expect(all[0]?.layout).toBe('list');
+  });
+
+  it('keeps one page separate from another, and one scope from another', async () => {
+    await saveViewPreference(workspace.admin, { page: 'my_issues', scope: '', layout: 'board' });
+    await saveViewPreference(workspace.admin, { page: 'team', scope: 'eng', layout: 'list' });
+    await saveViewPreference(workspace.admin, { page: 'team', scope: 'design', layout: 'board' });
+
+    const all = await listViewPreferences(workspace.admin);
+    expect(all).toHaveLength(3);
+  });
+
+  it('refuses a layout the product does not have', async () => {
+    await expect(
+      saveViewPreference(workspace.admin, { page: 'my_issues', scope: '', layout: 'gantt' }),
+    ).rejects.toThrow();
+  });
+
+  it('keeps one person choices away from another', async () => {
+    await saveViewPreference(workspace.admin, { page: 'my_issues', scope: '', layout: 'board' });
+    const { principal } = await addMember(workspace, 'member');
+    expect(await listViewPreferences(principal)).toEqual([]);
+  });
+});

--- a/packages/db/catchup/production-schema-catchup.sql
+++ b/packages/db/catchup/production-schema-catchup.sql
@@ -1,5 +1,6 @@
 -- Brings a database created before the standup and doc sharing work up to the current schema.
--- Adds five tables: standup, standup_turn, standup_blocker, standup_rotation, doc_access.
+-- Adds six tables: standup, standup_turn, standup_blocker, standup_rotation, doc_access
+-- and view_preference.
 -- Nothing else in the schema changed, so no existing table or column is touched.
 --
 -- Safe to run more than once: every statement checks first, and the whole thing is one
@@ -78,6 +79,22 @@ create table if not exists public.standup_turn (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
+
+create table if not exists public.view_preference (
+  id text primary key,
+  organization_id text not null,
+  user_id text not null,
+  page text not null,
+  scope text not null default '',
+  layout text not null default 'list',
+  display jsonb not null default '{}'::jsonb,
+  sync_id bigint not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists view_preference_unique
+  on public.view_preference (user_id, organization_id, page, scope);
 
 create index if not exists doc_access_subject_idx on public.doc_access USING btree (subject_type, subject_id);
 create unique index if not exists doc_access_unique on public.doc_access USING btree (doc_id, subject_type, subject_id);
@@ -224,6 +241,22 @@ begin
     where conname = 'standup_turn_user_id_user_id_fk' and conrelid = 'public.standup_turn'::regclass
   ) then
     alter table public.standup_turn add constraint standup_turn_user_id_user_id_fk FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+  end if;
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'view_preference_organization_id_organization_id_fk'
+      and conrelid = 'public.view_preference'::regclass
+  ) then
+    alter table public.view_preference add constraint view_preference_organization_id_organization_id_fk
+      FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
+  end if;
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'view_preference_user_id_user_id_fk'
+      and conrelid = 'public.view_preference'::regclass
+  ) then
+    alter table public.view_preference add constraint view_preference_user_id_user_id_fk
+      FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
   end if;
 end $$;
 

--- a/packages/db/catchup/production-schema-catchup.sql
+++ b/packages/db/catchup/production-schema-catchup.sql
@@ -93,70 +93,136 @@ create unique index if not exists standup_turn_person_unique on public.standup_t
 
 do $$
 begin
-  if not exists (select 1 from pg_constraint where conname = 'doc_access_pkey') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'doc_access_pkey' and conrelid = 'public.doc_access'::regclass
+  ) then
     alter table public.doc_access add constraint doc_access_pkey PRIMARY KEY (id);
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_pkey') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_blocker_pkey' and conrelid = 'public.standup_blocker'::regclass
+  ) then
     alter table public.standup_blocker add constraint standup_blocker_pkey PRIMARY KEY (id);
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_pkey') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_pkey' and conrelid = 'public.standup'::regclass
+  ) then
     alter table public.standup add constraint standup_pkey PRIMARY KEY (id);
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_pkey') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_rotation_pkey' and conrelid = 'public.standup_rotation'::regclass
+  ) then
     alter table public.standup_rotation add constraint standup_rotation_pkey PRIMARY KEY (id);
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_turn_pkey') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_turn_pkey' and conrelid = 'public.standup_turn'::regclass
+  ) then
     alter table public.standup_turn add constraint standup_turn_pkey PRIMARY KEY (id);
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'doc_access_doc_id_doc_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'doc_access_doc_id_doc_id_fk' and conrelid = 'public.doc_access'::regclass
+  ) then
     alter table public.doc_access add constraint doc_access_doc_id_doc_id_fk FOREIGN KEY (doc_id) REFERENCES public.doc(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'doc_access_granted_by_id_user_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'doc_access_granted_by_id_user_id_fk' and conrelid = 'public.doc_access'::regclass
+  ) then
     alter table public.doc_access add constraint doc_access_granted_by_id_user_id_fk FOREIGN KEY (granted_by_id) REFERENCES public."user"(id) ON DELETE SET NULL;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'doc_access_organization_id_organization_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'doc_access_organization_id_organization_id_fk' and conrelid = 'public.doc_access'::regclass
+  ) then
     alter table public.doc_access add constraint doc_access_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_issue_id_issue_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_blocker_issue_id_issue_id_fk' and conrelid = 'public.standup_blocker'::regclass
+  ) then
     alter table public.standup_blocker add constraint standup_blocker_issue_id_issue_id_fk FOREIGN KEY (issue_id) REFERENCES public.issue(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_organization_id_organization_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_blocker_organization_id_organization_id_fk' and conrelid = 'public.standup_blocker'::regclass
+  ) then
     alter table public.standup_blocker add constraint standup_blocker_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_owner_id_user_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_blocker_owner_id_user_id_fk' and conrelid = 'public.standup_blocker'::regclass
+  ) then
     alter table public.standup_blocker add constraint standup_blocker_owner_id_user_id_fk FOREIGN KEY (owner_id) REFERENCES public."user"(id) ON DELETE SET NULL;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_turn_id_standup_turn_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_blocker_turn_id_standup_turn_id_fk' and conrelid = 'public.standup_blocker'::regclass
+  ) then
     alter table public.standup_blocker add constraint standup_blocker_turn_id_standup_turn_id_fk FOREIGN KEY (turn_id) REFERENCES public.standup_turn(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_cycle_id_cycle_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_cycle_id_cycle_id_fk' and conrelid = 'public.standup'::regclass
+  ) then
     alter table public.standup add constraint standup_cycle_id_cycle_id_fk FOREIGN KEY (cycle_id) REFERENCES public.cycle(id) ON DELETE SET NULL;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_facilitator_id_user_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_facilitator_id_user_id_fk' and conrelid = 'public.standup'::regclass
+  ) then
     alter table public.standup add constraint standup_facilitator_id_user_id_fk FOREIGN KEY (facilitator_id) REFERENCES public."user"(id) ON DELETE SET NULL;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_organization_id_organization_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_organization_id_organization_id_fk' and conrelid = 'public.standup'::regclass
+  ) then
     alter table public.standup add constraint standup_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_organization_id_organization_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_rotation_organization_id_organization_id_fk' and conrelid = 'public.standup_rotation'::regclass
+  ) then
     alter table public.standup_rotation add constraint standup_rotation_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_team_id_team_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_rotation_team_id_team_id_fk' and conrelid = 'public.standup_rotation'::regclass
+  ) then
     alter table public.standup_rotation add constraint standup_rotation_team_id_team_id_fk FOREIGN KEY (team_id) REFERENCES public.team(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_user_id_user_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_rotation_user_id_user_id_fk' and conrelid = 'public.standup_rotation'::regclass
+  ) then
     alter table public.standup_rotation add constraint standup_rotation_user_id_user_id_fk FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_team_id_team_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_team_id_team_id_fk' and conrelid = 'public.standup'::regclass
+  ) then
     alter table public.standup add constraint standup_team_id_team_id_fk FOREIGN KEY (team_id) REFERENCES public.team(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_turn_organization_id_organization_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_turn_organization_id_organization_id_fk' and conrelid = 'public.standup_turn'::regclass
+  ) then
     alter table public.standup_turn add constraint standup_turn_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_turn_standup_id_standup_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_turn_standup_id_standup_id_fk' and conrelid = 'public.standup_turn'::regclass
+  ) then
     alter table public.standup_turn add constraint standup_turn_standup_id_standup_id_fk FOREIGN KEY (standup_id) REFERENCES public.standup(id) ON DELETE CASCADE;
   end if;
-  if not exists (select 1 from pg_constraint where conname = 'standup_turn_user_id_user_id_fk') then
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'standup_turn_user_id_user_id_fk' and conrelid = 'public.standup_turn'::regclass
+  ) then
     alter table public.standup_turn add constraint standup_turn_user_id_user_id_fk FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
   end if;
 end $$;

--- a/packages/db/catchup/production-schema-catchup.sql
+++ b/packages/db/catchup/production-schema-catchup.sql
@@ -1,0 +1,164 @@
+-- Brings a database created before the standup and doc sharing work up to the current schema.
+-- Adds five tables: standup, standup_turn, standup_blocker, standup_rotation, doc_access.
+-- Nothing else in the schema changed, so no existing table or column is touched.
+--
+-- Safe to run more than once: every statement checks first, and the whole thing is one
+-- transaction, so a failure leaves the database exactly as it was.
+--
+-- Apply it either by pasting it into the Supabase SQL editor, or with
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f packages/db/catchup/production-schema-catchup.sql
+-- using the direct connection on port 5432, not the pooler on 6543.
+
+begin;
+
+create table if not exists public.doc_access (
+    id text NOT NULL,
+    organization_id text NOT NULL,
+    doc_id text NOT NULL,
+    subject_type text NOT NULL,
+    subject_id text NOT NULL,
+    level text DEFAULT 'read'::text NOT NULL,
+    granted_by_id text,
+    sync_id bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+create table if not exists public.standup (
+    id text NOT NULL,
+    organization_id text NOT NULL,
+    team_id text NOT NULL,
+    cycle_id text,
+    held_on date NOT NULL,
+    facilitator_id text,
+    status text DEFAULT 'scheduled'::text NOT NULL,
+    current_turn_id text,
+    started_at timestamp with time zone,
+    ended_at timestamp with time zone,
+    sync_id bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+create table if not exists public.standup_blocker (
+    id text NOT NULL,
+    organization_id text NOT NULL,
+    turn_id text NOT NULL,
+    issue_id text,
+    summary text NOT NULL,
+    owner_id text,
+    resolved_at timestamp with time zone,
+    sync_id bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+create table if not exists public.standup_rotation (
+    id text NOT NULL,
+    organization_id text NOT NULL,
+    team_id text NOT NULL,
+    user_id text NOT NULL,
+    "position" integer NOT NULL,
+    facilitates smallint DEFAULT 1 NOT NULL,
+    sync_id bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+create table if not exists public.standup_turn (
+    id text NOT NULL,
+    organization_id text NOT NULL,
+    standup_id text NOT NULL,
+    user_id text NOT NULL,
+    "position" integer NOT NULL,
+    attendance text DEFAULT 'unknown'::text NOT NULL,
+    status text DEFAULT 'waiting'::text NOT NULL,
+    notes text DEFAULT ''::text NOT NULL,
+    blockers text DEFAULT ''::text NOT NULL,
+    spoke_at timestamp with time zone,
+    duration_seconds integer,
+    sync_id bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+create index if not exists doc_access_subject_idx on public.doc_access USING btree (subject_type, subject_id);
+create unique index if not exists doc_access_unique on public.doc_access USING btree (doc_id, subject_type, subject_id);
+create index if not exists standup_blocker_issue_idx on public.standup_blocker USING btree (issue_id);
+create index if not exists standup_blocker_turn_idx on public.standup_blocker USING btree (turn_id);
+create index if not exists standup_cycle_idx on public.standup USING btree (cycle_id);
+create index if not exists standup_org_day_idx on public.standup USING btree (organization_id, held_on);
+create unique index if not exists standup_rotation_member_unique on public.standup_rotation USING btree (team_id, user_id);
+create index if not exists standup_rotation_order_idx on public.standup_rotation USING btree (team_id, "position");
+create unique index if not exists standup_team_day_unique on public.standup USING btree (team_id, held_on);
+create index if not exists standup_turn_order_idx on public.standup_turn USING btree (standup_id, "position");
+create unique index if not exists standup_turn_person_unique on public.standup_turn USING btree (standup_id, user_id);
+
+do $$
+begin
+  if not exists (select 1 from pg_constraint where conname = 'doc_access_pkey') then
+    alter table public.doc_access add constraint doc_access_pkey PRIMARY KEY (id);
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_pkey') then
+    alter table public.standup_blocker add constraint standup_blocker_pkey PRIMARY KEY (id);
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_pkey') then
+    alter table public.standup add constraint standup_pkey PRIMARY KEY (id);
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_pkey') then
+    alter table public.standup_rotation add constraint standup_rotation_pkey PRIMARY KEY (id);
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_turn_pkey') then
+    alter table public.standup_turn add constraint standup_turn_pkey PRIMARY KEY (id);
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'doc_access_doc_id_doc_id_fk') then
+    alter table public.doc_access add constraint doc_access_doc_id_doc_id_fk FOREIGN KEY (doc_id) REFERENCES public.doc(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'doc_access_granted_by_id_user_id_fk') then
+    alter table public.doc_access add constraint doc_access_granted_by_id_user_id_fk FOREIGN KEY (granted_by_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'doc_access_organization_id_organization_id_fk') then
+    alter table public.doc_access add constraint doc_access_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_issue_id_issue_id_fk') then
+    alter table public.standup_blocker add constraint standup_blocker_issue_id_issue_id_fk FOREIGN KEY (issue_id) REFERENCES public.issue(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_organization_id_organization_id_fk') then
+    alter table public.standup_blocker add constraint standup_blocker_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_owner_id_user_id_fk') then
+    alter table public.standup_blocker add constraint standup_blocker_owner_id_user_id_fk FOREIGN KEY (owner_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_blocker_turn_id_standup_turn_id_fk') then
+    alter table public.standup_blocker add constraint standup_blocker_turn_id_standup_turn_id_fk FOREIGN KEY (turn_id) REFERENCES public.standup_turn(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_cycle_id_cycle_id_fk') then
+    alter table public.standup add constraint standup_cycle_id_cycle_id_fk FOREIGN KEY (cycle_id) REFERENCES public.cycle(id) ON DELETE SET NULL;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_facilitator_id_user_id_fk') then
+    alter table public.standup add constraint standup_facilitator_id_user_id_fk FOREIGN KEY (facilitator_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_organization_id_organization_id_fk') then
+    alter table public.standup add constraint standup_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_organization_id_organization_id_fk') then
+    alter table public.standup_rotation add constraint standup_rotation_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_team_id_team_id_fk') then
+    alter table public.standup_rotation add constraint standup_rotation_team_id_team_id_fk FOREIGN KEY (team_id) REFERENCES public.team(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_rotation_user_id_user_id_fk') then
+    alter table public.standup_rotation add constraint standup_rotation_user_id_user_id_fk FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_team_id_team_id_fk') then
+    alter table public.standup add constraint standup_team_id_team_id_fk FOREIGN KEY (team_id) REFERENCES public.team(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_turn_organization_id_organization_id_fk') then
+    alter table public.standup_turn add constraint standup_turn_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_turn_standup_id_standup_id_fk') then
+    alter table public.standup_turn add constraint standup_turn_standup_id_standup_id_fk FOREIGN KEY (standup_id) REFERENCES public.standup(id) ON DELETE CASCADE;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'standup_turn_user_id_user_id_fk') then
+    alter table public.standup_turn add constraint standup_turn_user_id_user_id_fk FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+  end if;
+end $$;
+
+commit;

--- a/packages/db/src/schema/work.ts
+++ b/packages/db/src/schema/work.ts
@@ -593,6 +593,34 @@ export const view = pgTable(
   (table) => [index('view_org_idx').on(table.organizationId)],
 );
 
+export const viewPreference = pgTable(
+  'view_preference',
+  {
+    id: text('id').primaryKey(),
+    organizationId: text('organization_id')
+      .notNull()
+      .references(() => organization.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    page: text('page').notNull(),
+    scope: text('scope').notNull().default(''),
+    layout: text('layout').notNull().default('list'),
+    display: jsonb('display').$type<Record<string, unknown>>().notNull().default({}),
+    syncId: bigint('sync_id', { mode: 'number' }).notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('view_preference_unique').on(
+      table.userId,
+      table.organizationId,
+      table.page,
+      table.scope,
+    ),
+  ],
+);
+
 export const savedAnalyticsView = pgTable(
   'saved_analytics_view',
   {

--- a/packages/db/src/schema/work.ts
+++ b/packages/db/src/schema/work.ts
@@ -607,7 +607,6 @@ export const viewPreference = pgTable(
     scope: text('scope').notNull().default(''),
     layout: text('layout').notNull().default('list'),
     display: jsonb('display').$type<Record<string, unknown>>().notNull().default({}),
-    syncId: bigint('sync_id', { mode: 'number' }).notNull().default(0),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/mcp-server/src/tools/docs.ts
+++ b/packages/mcp-server/src/tools/docs.ts
@@ -1,0 +1,311 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  archiveDoc,
+  createDoc,
+  createDocCollection,
+  createDocComment,
+  deleteDocComment,
+  getDoc,
+  listDocCollections,
+  listDocComments,
+  listDocs,
+  updateDoc,
+  updateDocComment,
+} from '@orbit/core';
+import { DOC_VISIBILITIES } from '@orbit/shared/constants';
+import { notFound } from '@orbit/shared/errors';
+import type { Principal } from '@orbit/shared/policy';
+import { z } from 'zod';
+import { resolveProject } from '../resolve.ts';
+import { defineTool, publish } from './support.ts';
+
+const docRef = z.string().min(1).describe('A document id, or its exact title.');
+
+const visibilityRef = z
+  .enum(DOC_VISIBILITIES)
+  .describe('Who can reach the document. "workspace" is the usual choice.');
+
+interface DocSummary {
+  readonly id: string;
+  readonly title: string;
+  readonly visibility: string;
+  readonly projectId: string | null;
+  readonly collectionId: string | null;
+  readonly parentId: string | null;
+  readonly updatedAt: string;
+}
+
+function describeDoc(row: {
+  id: string;
+  title: string;
+  visibility: string;
+  projectId: string | null;
+  collectionId: string | null;
+  parentId: string | null;
+  updatedAt: Date;
+}): DocSummary {
+  return {
+    id: row.id,
+    title: row.title,
+    visibility: row.visibility,
+    projectId: row.projectId,
+    collectionId: row.collectionId,
+    parentId: row.parentId,
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+async function resolveDoc(principal: Principal, ref: string): Promise<string> {
+  const rows = await listDocs(principal, {});
+  const byId = rows.find((row) => row.id === ref);
+  if (byId !== undefined) return byId.id;
+  const lowered = ref.toLowerCase();
+  const byTitle = rows.filter((row) => row.title.toLowerCase() === lowered);
+  const first = byTitle[0];
+  if (first === undefined) throw notFound(`No document matches "${ref}".`);
+  return first.id;
+}
+
+export function registerDocTools(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'list_docs',
+      title: 'List documents',
+      description:
+        'List the documents this user can read, newest first. Filter by a search query, a project or a collection.',
+      readOnly: true,
+      inputSchema: {
+        query: z.string().trim().max(200).optional().describe('Match against title and body.'),
+        project: z.string().min(1).optional().describe('Project name, slug or id.'),
+        includeArchived: z.boolean().optional().describe('Include archived documents.'),
+      },
+    },
+    async (args) => {
+      const project =
+        args.project === undefined ? undefined : (await resolveProject(principal, args.project)).id;
+      const rows = await listDocs(principal, {
+        ...(args.query === undefined ? {} : { query: args.query }),
+        ...(project === undefined ? {} : { projectId: project }),
+        ...(args.includeArchived === undefined ? {} : { includeArchived: args.includeArchived }),
+      });
+      return { docs: rows.map(describeDoc) };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'get_doc',
+      title: 'Read a document',
+      description: 'Return a document with its full Markdown body.',
+      readOnly: true,
+      inputSchema: { doc: docRef },
+    },
+    async (args) => {
+      const id = await resolveDoc(principal, args.doc);
+      const detail = await getDoc(principal, id);
+      return { doc: { ...describeDoc(detail.doc), content: detail.doc.content } };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'create_doc',
+      title: 'Create a document',
+      description:
+        'Create a document with a Markdown body. Attach it to a project or nest it under a parent document.',
+      readOnly: false,
+      inputSchema: {
+        title: z.string().trim().min(1).max(200).describe('Document title.'),
+        content: z.string().max(500_000).optional().describe('Markdown body.'),
+        project: z.string().min(1).optional().describe('Project name, slug or id.'),
+        parent: docRef.optional().describe('Parent document, making this a nested page.'),
+        visibility: visibilityRef.optional(),
+      },
+    },
+    async (args) => {
+      const projectId =
+        args.project === undefined ? null : (await resolveProject(principal, args.project)).id;
+      const parentId = args.parent === undefined ? null : await resolveDoc(principal, args.parent);
+      const saved = await createDoc(principal, {
+        title: args.title,
+        content: args.content ?? '',
+        projectId,
+        parentId,
+        ...(args.visibility === undefined ? {} : { visibility: args.visibility }),
+      });
+      await publish(saved.actions);
+      return { doc: describeDoc(saved.doc) };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'update_doc',
+      title: 'Update a document',
+      description:
+        'Change a document title, body, project or visibility. Only the fields you pass are touched.',
+      readOnly: false,
+      inputSchema: {
+        doc: docRef,
+        title: z.string().trim().min(1).max(200).optional(),
+        content: z.string().max(500_000).optional().describe('Replaces the whole Markdown body.'),
+        project: z
+          .string()
+          .min(1)
+          .nullable()
+          .optional()
+          .describe('Project name, slug or id. Pass null to detach.'),
+        visibility: visibilityRef.optional(),
+      },
+    },
+    async (args) => {
+      const id = await resolveDoc(principal, args.doc);
+      let projectId: string | null | undefined;
+      if (args.project === null) projectId = null;
+      else if (args.project !== undefined)
+        projectId = (await resolveProject(principal, args.project)).id;
+      const saved = await updateDoc(principal, id, {
+        ...(args.title === undefined ? {} : { title: args.title }),
+        ...(args.content === undefined ? {} : { content: args.content }),
+        ...(projectId === undefined ? {} : { projectId }),
+        ...(args.visibility === undefined ? {} : { visibility: args.visibility }),
+      });
+      await publish(saved.actions);
+      return { doc: describeDoc(saved.doc) };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'archive_doc',
+      title: 'Archive a document',
+      description:
+        'Archive a document so it leaves the sidebar and the default listings. The content is kept.',
+      readOnly: false,
+      inputSchema: { doc: docRef },
+    },
+    async (args) => {
+      const id = await resolveDoc(principal, args.doc);
+      const saved = await archiveDoc(principal, id);
+      await publish(saved.actions);
+      return { archived: describeDoc(saved.doc) };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'list_doc_comments',
+      title: 'List comments on a document',
+      description: 'Return the comment thread on a document, oldest first.',
+      readOnly: true,
+      inputSchema: { doc: docRef },
+    },
+    async (args) => {
+      const id = await resolveDoc(principal, args.doc);
+      const page = await listDocComments(principal, id);
+      return {
+        comments: page.comments.map((row) => ({
+          id: row.id,
+          body: row.body,
+          authorId: row.authorId,
+          createdAt: row.createdAt.toISOString(),
+        })),
+      };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'comment_on_doc',
+      title: 'Comment on a document',
+      description: 'Add a Markdown comment to a document.',
+      readOnly: false,
+      inputSchema: { doc: docRef, body: z.string().min(1).max(50_000).describe('Markdown body.') },
+    },
+    async (args) => {
+      const id = await resolveDoc(principal, args.doc);
+      const saved = await createDocComment(principal, id, { body: args.body });
+      await publish(saved.actions);
+      return { comment: { id: saved.comment.id, body: saved.comment.body } };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'edit_doc_comment',
+      title: 'Edit a document comment',
+      description: 'Rewrite the body of a comment this user wrote on a document.',
+      readOnly: false,
+      inputSchema: {
+        commentId: z.string().min(1).describe('The comment id.'),
+        body: z.string().min(1).max(50_000).describe('Replacement Markdown body.'),
+      },
+    },
+    async (args) => {
+      const saved = await updateDocComment(principal, args.commentId, { body: args.body });
+      await publish(saved.actions);
+      return { comment: { id: saved.comment.id, body: saved.comment.body } };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'delete_doc_comment',
+      title: 'Delete a document comment',
+      description: 'Remove a comment from a document.',
+      readOnly: false,
+      inputSchema: { commentId: z.string().min(1).describe('The comment id.') },
+    },
+    async (args) => {
+      const actions = await deleteDocComment(principal, args.commentId);
+      await publish(actions);
+      return { deleted: args.commentId };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'list_doc_collections',
+      title: 'List document collections',
+      description: 'Return the folders documents can be filed under.',
+      readOnly: true,
+      inputSchema: {},
+    },
+    async () => {
+      const rows = await listDocCollections(principal);
+      return { collections: rows.map((row) => ({ id: row.id, name: row.name, icon: row.icon })) };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'create_doc_collection',
+      title: 'Create a document collection',
+      description: 'Create a folder that documents can be filed under.',
+      readOnly: false,
+      inputSchema: {
+        name: z.string().trim().min(1).max(120).describe('Collection name.'),
+        icon: z.string().trim().min(1).max(32).optional().describe('Lucide icon name.'),
+      },
+    },
+    async (args) => {
+      const saved = await createDocCollection(principal, {
+        name: args.name,
+        ...(args.icon === undefined ? {} : { icon: args.icon }),
+      });
+      await publish(saved.actions);
+      return { collection: { id: saved.collection.id, name: saved.collection.name } };
+    },
+  );
+}

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -1,10 +1,12 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Principal } from '@orbit/shared/policy';
 import { registerAdminTools } from './admin.ts';
+import { registerDocTools } from './docs.ts';
 import { registerIdentityTools } from './identity.ts';
 import { registerIssueTools } from './issues.ts';
 import { registerPlanningTools } from './planning.ts';
 import { registerScrumTools } from './scrum.ts';
+import { registerWorkspaceTools } from './workspace.ts';
 
 export function registerTools(server: McpServer, principal: Principal): void {
   registerIdentityTools(server, principal);
@@ -12,4 +14,6 @@ export function registerTools(server: McpServer, principal: Principal): void {
   registerPlanningTools(server, principal);
   registerScrumTools(server, principal);
   registerAdminTools(server, principal);
+  registerDocTools(server, principal);
+  registerWorkspaceTools(server, principal);
 }

--- a/packages/mcp-server/src/tools/workspace.ts
+++ b/packages/mcp-server/src/tools/workspace.ts
@@ -1,0 +1,354 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  archiveIssue,
+  archiveProject,
+  createLabel,
+  deleteComment,
+  deleteCycle,
+  deleteIssue,
+  deleteLabel,
+  deleteMilestone,
+  deleteProject,
+  getIssue,
+  listLabels,
+  listMilestones,
+  unarchiveIssue,
+  updateComment,
+  updateLabel,
+  updateMilestone,
+  updateProject,
+} from '@orbit/core';
+import { notFound } from '@orbit/shared/errors';
+import type { Principal } from '@orbit/shared/policy';
+import { z } from 'zod';
+import { resolveCycle, resolveProject } from '../resolve.ts';
+import { defineTool, publish } from './support.ts';
+
+const issueRef = z.string().min(1).describe('An issue identifier like "ENG-42", or an issue id.');
+const projectRef = z.string().min(1).describe('Project name, slug or id.');
+
+async function resolveLabel(principal: Principal, ref: string): Promise<string> {
+  const labels = await listLabels(principal, {});
+  const lowered = ref.toLowerCase();
+  const found = labels.find((label) => label.id === ref || label.name.toLowerCase() === lowered);
+  if (found === undefined) throw notFound(`No label matches "${ref}".`);
+  return found.id;
+}
+
+export function registerWorkspaceTools(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'archive_issue',
+      title: 'Archive an issue',
+      description:
+        'Archive an issue so it leaves the board and the default lists. Use delete_issue to remove it for good.',
+      readOnly: false,
+      inputSchema: { issue: issueRef },
+    },
+    async (args) => {
+      const issue = await getIssue(principal, args.issue);
+      const saved = await archiveIssue(principal, issue.id);
+      await publish(saved.actions);
+      return { archived: { id: saved.issue.id, identifier: saved.issue.identifier } };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'unarchive_issue',
+      title: 'Restore an archived issue',
+      description: 'Bring an archived issue back onto the board.',
+      readOnly: false,
+      inputSchema: { issue: issueRef },
+    },
+    async (args) => {
+      const issue = await getIssue(principal, args.issue);
+      const saved = await unarchiveIssue(principal, issue.id);
+      await publish(saved.actions);
+      return { restored: { id: saved.issue.id, identifier: saved.issue.identifier } };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'delete_issue',
+      title: 'Delete an issue',
+      description:
+        'Permanently delete an issue and everything attached to it. This cannot be undone; prefer archive_issue.',
+      readOnly: false,
+      inputSchema: { issue: issueRef },
+    },
+    async (args) => {
+      const issue = await getIssue(principal, args.issue);
+      const actions = await deleteIssue(principal, issue.id);
+      await publish(actions);
+      return { deleted: issue.identifier };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'edit_comment',
+      title: 'Edit a comment',
+      description: 'Rewrite the body of a comment this user wrote on an issue.',
+      readOnly: false,
+      inputSchema: {
+        commentId: z.string().min(1).describe('The comment id.'),
+        body: z.string().min(1).max(50_000).describe('Replacement Markdown body.'),
+      },
+    },
+    async (args) => {
+      const saved = await updateComment(principal, args.commentId, { body: args.body });
+      await publish(saved.actions);
+      return { comment: args.commentId };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'delete_comment',
+      title: 'Delete a comment',
+      description: 'Remove a comment from an issue.',
+      readOnly: false,
+      inputSchema: { commentId: z.string().min(1).describe('The comment id.') },
+    },
+    async (args) => {
+      const actions = await deleteComment(principal, args.commentId);
+      await publish(actions);
+      return { deleted: args.commentId };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'create_label',
+      title: 'Create a label',
+      description: 'Create a workspace label that can be applied to issues.',
+      readOnly: false,
+      inputSchema: {
+        name: z.string().trim().min(1).max(60).describe('Label name.'),
+        color: z
+          .string()
+          .regex(/^#[0-9a-fA-F]{6}$/)
+          .optional()
+          .describe('Hex colour such as "#7c3aed".'),
+        description: z.string().max(500).optional(),
+      },
+    },
+    async (args) => {
+      const saved = await createLabel(principal, {
+        name: args.name,
+        ...(args.color === undefined ? {} : { color: args.color }),
+        ...(args.description === undefined ? {} : { description: args.description }),
+      });
+      await publish(saved.actions);
+      return { label: { id: saved.label.id, name: saved.label.name } };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'update_label',
+      title: 'Update a label',
+      description: 'Rename a label or change its colour.',
+      readOnly: false,
+      inputSchema: {
+        label: z.string().min(1).describe('Label name or id.'),
+        name: z.string().trim().min(1).max(60).optional(),
+        color: z
+          .string()
+          .regex(/^#[0-9a-fA-F]{6}$/)
+          .optional(),
+        description: z.string().max(500).optional(),
+      },
+    },
+    async (args) => {
+      const id = await resolveLabel(principal, args.label);
+      const saved = await updateLabel(principal, id, {
+        ...(args.name === undefined ? {} : { name: args.name }),
+        ...(args.color === undefined ? {} : { color: args.color }),
+        ...(args.description === undefined ? {} : { description: args.description }),
+      });
+      await publish(saved.actions);
+      return { label: { id: saved.label.id, name: saved.label.name } };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'delete_label',
+      title: 'Delete a label',
+      description: 'Remove a label from the workspace and from every issue carrying it.',
+      readOnly: false,
+      inputSchema: { label: z.string().min(1).describe('Label name or id.') },
+    },
+    async (args) => {
+      const id = await resolveLabel(principal, args.label);
+      const actions = await deleteLabel(principal, id);
+      await publish(actions);
+      return { deleted: args.label };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'update_project',
+      title: 'Update a project',
+      description:
+        'Change a project name, summary, status, health, lead or target dates. Only the fields you pass are touched.',
+      readOnly: false,
+      inputSchema: {
+        project: projectRef,
+        name: z.string().trim().min(1).max(120).optional(),
+        summary: z.string().max(500).optional(),
+        description: z.string().max(100_000).optional(),
+        status: z.string().min(1).optional().describe('Project status such as "in_progress".'),
+        health: z.string().min(1).optional().describe('Project health such as "on_track".'),
+        startsAt: z.iso.date().nullable().optional().describe('Start date as YYYY-MM-DD.'),
+        targetAt: z.iso.date().nullable().optional().describe('Target date as YYYY-MM-DD.'),
+      },
+    },
+    async (args) => {
+      const project = await resolveProject(principal, args.project);
+      const saved = await updateProject(principal, project.id, {
+        ...(args.name === undefined ? {} : { name: args.name }),
+        ...(args.summary === undefined ? {} : { summary: args.summary }),
+        ...(args.description === undefined ? {} : { description: args.description }),
+        ...(args.status === undefined ? {} : { status: args.status }),
+        ...(args.health === undefined ? {} : { health: args.health }),
+        ...(args.startsAt === undefined ? {} : { startsAt: args.startsAt }),
+        ...(args.targetAt === undefined ? {} : { targetAt: args.targetAt }),
+      });
+      await publish(saved.actions);
+      return { project: { id: saved.project.id, name: saved.project.name } };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'archive_project',
+      title: 'Archive a project',
+      description: 'Archive a project so it leaves the active lists. Its issues are kept.',
+      readOnly: false,
+      inputSchema: { project: projectRef },
+    },
+    async (args) => {
+      const project = await resolveProject(principal, args.project);
+      const saved = await archiveProject(principal, project.id);
+      await publish(saved.actions);
+      return { archived: { id: saved.project.id, name: saved.project.name } };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'delete_project',
+      title: 'Delete a project',
+      description:
+        'Permanently delete a project. Its issues survive but lose their project link. Prefer archive_project.',
+      readOnly: false,
+      inputSchema: { project: projectRef },
+    },
+    async (args) => {
+      const project = await resolveProject(principal, args.project);
+      const actions = await deleteProject(principal, project.id);
+      await publish(actions);
+      return { deleted: project.name };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'update_milestone',
+      title: 'Update a milestone',
+      description: 'Rename a milestone or move its target date.',
+      readOnly: false,
+      inputSchema: {
+        milestoneId: z.string().min(1).describe('The milestone id.'),
+        name: z.string().trim().min(1).max(120).optional(),
+        description: z.string().max(2000).optional(),
+        targetDate: z.iso.date().nullable().optional().describe('Target date as YYYY-MM-DD.'),
+      },
+    },
+    async (args) => {
+      const saved = await updateMilestone(principal, args.milestoneId, {
+        ...(args.name === undefined ? {} : { name: args.name }),
+        ...(args.description === undefined ? {} : { description: args.description }),
+        ...(args.targetDate === undefined ? {} : { targetDate: args.targetDate }),
+      });
+      await publish(saved.actions);
+      return { milestone: { id: saved.milestone.id, name: saved.milestone.name } };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'delete_milestone',
+      title: 'Delete a milestone',
+      description: 'Remove a milestone. Its issues survive but lose the milestone link.',
+      readOnly: false,
+      inputSchema: { milestoneId: z.string().min(1).describe('The milestone id.') },
+    },
+    async (args) => {
+      const actions = await deleteMilestone(principal, args.milestoneId);
+      await publish(actions);
+      return { deleted: args.milestoneId };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'delete_sprint',
+      title: 'Delete a sprint',
+      description:
+        'Remove a sprint. Its issues survive and fall back to no sprint, which is what descoping a cancelled sprint needs.',
+      readOnly: false,
+      inputSchema: {
+        team: z.string().min(1).describe('Team key like "ENG", team name, or team id.'),
+        sprint: z.string().min(1).describe('Sprint name, number or id.'),
+      },
+    },
+    async (args) => {
+      const cycle = await resolveCycle(principal, args.team, args.sprint);
+      const actions = await deleteCycle(principal, cycle.id);
+      await publish(actions);
+      return { deleted: cycle.name };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'list_project_milestones',
+      title: 'List milestones on a project',
+      description: 'Return the milestones on a project with their target dates.',
+      readOnly: true,
+      inputSchema: { project: projectRef },
+    },
+    async (args) => {
+      const project = await resolveProject(principal, args.project);
+      const rows = await listMilestones(principal, project.id);
+      return {
+        milestones: rows.map((row) => ({
+          id: row.id,
+          name: row.name,
+          targetDate: row.targetDate,
+        })),
+      };
+    },
+  );
+}

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -75,7 +75,23 @@ describe('discovery', () => {
     expect(names).toContain('run_standup');
     expect(names).toContain('complete_cycle');
     expect(names).toContain('create_milestone');
-    expect(names).toHaveLength(39);
+
+    expect(names).toContain('create_doc');
+    expect(names).toContain('update_doc');
+    expect(names).toContain('get_doc');
+    expect(names).toContain('list_docs');
+    expect(names).toContain('comment_on_doc');
+    expect(names).toContain('archive_issue');
+    expect(names).toContain('delete_issue');
+    expect(names).toContain('create_label');
+    expect(names).toContain('delete_label');
+    expect(names).toContain('update_project');
+    expect(names).toContain('delete_project');
+    expect(names).toContain('delete_sprint');
+    expect(names).toContain('edit_comment');
+    expect(names).toContain('delete_comment');
+
+    expect(new Set(names).size).toBe(names.length);
     for (const tool of tools) {
       expect(tool.description).toBeTruthy();
       expect(tool.inputSchema).toBeTruthy();

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -18,4 +18,5 @@ export * from './standup.ts';
 export * from './team.ts';
 export * from './upload.ts';
 export * from './view.ts';
+export * from './view-preference.ts';
 export * from './workflow-state.ts';

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -56,6 +56,10 @@ export const issueUpdateSchema = z
 export const issueMoveSchema = z.object({
   stateId: idSchema.optional(),
   teamId: idSchema.optional(),
+  cycleId: idSchema.nullable().optional(),
+  projectId: idSchema.nullable().optional(),
+  assigneeId: idSchema.nullable().optional(),
+  priority: prioritySchema.optional(),
   beforeId: idSchema.nullable().default(null),
   afterId: idSchema.nullable().default(null),
 });

--- a/packages/shared/src/validators/view-preference.ts
+++ b/packages/shared/src/validators/view-preference.ts
@@ -8,4 +8,5 @@ export const viewPreferenceSchema = z.object({
   display: z.record(z.string(), z.unknown()).default({}),
 });
 
-export type ViewPreferenceInput = z.infer<typeof viewPreferenceSchema>;
+export type ViewPreferenceInput = z.input<typeof viewPreferenceSchema>;
+export type ViewPreference = z.output<typeof viewPreferenceSchema>;

--- a/packages/shared/src/validators/view-preference.ts
+++ b/packages/shared/src/validators/view-preference.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { VIEW_LAYOUT_MODES, VIEW_PAGES } from '../filters/index.ts';
+
+export const viewPreferenceSchema = z.object({
+  page: z.enum(VIEW_PAGES),
+  scope: z.string().max(64).default(''),
+  layout: z.enum(VIEW_LAYOUT_MODES),
+  display: z.record(z.string(), z.unknown()).default({}),
+});
+
+export type ViewPreferenceInput = z.infer<typeof viewPreferenceSchema>;


### PR DESCRIPTION
Three things, plus the production schema catch-up that is now applied.

**My issues opens on a board, and remembers how you left it.** It had no layout switch and no memory of a choice. It now carries the same List and Board control the other surfaces have and opens on the board. The choice lives on the person, in a new `view_preference` row keyed by user, organization, page and scope, so it follows you to another machine rather than being stranded in one browser's local storage. Display options keep their existing local cache; the layout had nowhere to live at all.

**The new issue dialog is closer to Linear's.** The formatting toolbar above the description is gone, so formatting comes from the selection bubble and markdown like everywhere else. A breadcrumb says which team the issue is going into. Project and sprint join the property row and are actually carried onto the issue, where before both were sent as null regardless of anything. Cancel gives way to Create more, which keeps the dialog open and clears title, description and labels while holding the team, status, priority, project and sprint.

Attaching a file from the dialog is still missing: upload needs an issue to hang the file on and there is not one yet at that point, so it wants deferring until after the create rather than half building it.

**Past sprints count from their issues**, batched into one query rather than one per sprint, with the reconstruction limits stated plainly.

The `view_preference` table is in development, test and production. `bun run verify` is green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds server-backed layout preferences and a board layout for My Issues, updates quick-create to retain compatible project and sprint selections, improves board pagination for short columns, batches past-sprint issue counts, and brings the production schema catch-up in line with the new preference storage.
- Adds the view-preference API, service, validation, schema, and client mutation lifecycle.
- Adds List/Board controls and paginated board rendering to My Issues.
- Extends quick-create with project, sprint, breadcrumb, and Create more behavior.
- Adds project-team links to bootstrap data so project choices can be filtered correctly.
- Updates board pagination and production catch-up DDL.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains in the current code, and the previously reported schema, pagination, rollback, and cross-team assignment issues are fixed.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/issues/board.tsx | Re-arms remote pagination after fetch completion and permits short, non-scrollable columns to load additional pages. |
| apps/web/src/features/issues/my-issues-view.tsx | Adds persisted layout selection and wires assigned-issue pagination into the board layout. |
| apps/web/src/features/filters/use-layout-preference.ts | Implements server-backed layout loading, optimistic writes, rollback on failure, and post-write reconciliation. |
| apps/web/src/features/issues/quick-create.tsx | Adds project and sprint assignment, Create more behavior, and clears team-incompatible selections when teams change. |
| apps/web/src/lib/api/bootstrap.ts | Adds project-team relationships to bootstrap output for team-compatible project filtering. |
| packages/core/src/work/view-preference-service.ts | Adds tenant- and user-scoped preference listing and conflict-upsert persistence. |
| packages/db/catchup/production-schema-catchup.sql | Creates the preference table, unique index, and cascading foreign keys with repeatable guards. |
| packages/core/src/work/project-service.ts | Adds batched project-team link retrieval used by bootstrap. |
| packages/db/src/schema/work.ts | Defines persisted view preferences and their per-user, organization, page, and scope uniqueness contract. |

</details>

<sub>Reviews (9): Last reviewed commit: ["fix(issues): stop the board refetching m..."](https://github.com/noveum/orbit/commit/e9529a6c81e71d0a1f9a7945613e0ee25b0c05c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50466592)</sub>

<!-- /greptile_comment -->