### PR TITLE
Stop a dead websocket from logging everyone out of production

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,9 @@
+.env
+.env.*
+!.env.example
+
+extras
+uploads
+recordings
+test-results
+playwright-report

--- a/apps/web/src/lib/realtime/provider.tsx
+++ b/apps/web/src/lib/realtime/provider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { RealtimeProvider } from '@orbit/realtime-client/react';
-import { SESSION_REVOKED_CLOSE_CODE, UNAUTHORIZED_CLOSE_CODE } from '@orbit/shared/events';
+import { SESSION_REVOKED_CLOSE_CODE } from '@orbit/shared/events';
 import type { ReactNode } from 'react';
 import { useCallback } from 'react';
 import { authClient } from '@/lib/auth/client.ts';
@@ -11,10 +11,33 @@ import { SessionProvider } from './session.tsx';
 import { fetchRealtimeTicket } from './ticket.ts';
 import { resolveRealtimeUrl } from './url.ts';
 
-const SIGNED_OUT_CLOSE_CODES: readonly number[] = [
-  SESSION_REVOKED_CLOSE_CODE,
-  UNAUTHORIZED_CLOSE_CODE,
-];
+export interface SessionGate {
+  readonly getSession: (options: {
+    readonly query: { readonly disableCookieCache: true };
+  }) => Promise<unknown>;
+  readonly signOut: () => Promise<unknown>;
+}
+
+function serverHasNoSession(result: unknown): boolean {
+  if (result === null || typeof result !== 'object') return false;
+  const answer = result as { data?: unknown; error?: unknown };
+  return answer.error == null && answer.data == null;
+}
+
+export async function endSessionIfRevoked(gate: SessionGate = authClient): Promise<boolean> {
+  const current = await gate
+    .getSession({ query: { disableCookieCache: true } })
+    .catch(() => undefined);
+  if (!serverHasNoSession(current)) return false;
+  await gate.signOut().catch(() => undefined);
+  window.location.href = '/login';
+  return true;
+}
+
+export function handleTerminalClose(code: number, gate: SessionGate = authClient): void {
+  if (code !== SESSION_REVOKED_CLOSE_CODE) return;
+  endSessionIfRevoked(gate).catch(() => undefined);
+}
 
 export interface WorkspaceRealtimeProps {
   readonly url: string;
@@ -31,12 +54,7 @@ export function WorkspaceRealtime({
   teamIds,
   children,
 }: WorkspaceRealtimeProps) {
-  const handleTerminal = useCallback((code: number) => {
-    if (!SIGNED_OUT_CLOSE_CODES.includes(code)) return;
-    authClient.signOut().finally(() => {
-      window.location.href = '/login';
-    });
-  }, []);
+  const handleTerminal = useCallback((code: number) => handleTerminalClose(code), []);
 
   const fetchTicket = useCallback(() => fetchRealtimeTicket(organizationId), [organizationId]);
 

--- a/apps/web/src/lib/realtime/provider.tsx
+++ b/apps/web/src/lib/realtime/provider.tsx
@@ -4,6 +4,7 @@ import { RealtimeProvider } from '@orbit/realtime-client/react';
 import { SESSION_REVOKED_CLOSE_CODE } from '@orbit/shared/events';
 import type { ReactNode } from 'react';
 import { useCallback } from 'react';
+import { z } from 'zod';
 import { authClient } from '@/lib/auth/client.ts';
 import { ConnectionBanner } from './connection-banner.tsx';
 import { DeltaBridge } from './delta-bridge.tsx';
@@ -18,10 +19,13 @@ export interface SessionGate {
   readonly signOut: () => Promise<unknown>;
 }
 
+const noSessionSchema = z.object({
+  data: z.null(),
+  error: z.null().optional(),
+});
+
 function serverHasNoSession(result: unknown): boolean {
-  if (result === null || typeof result !== 'object') return false;
-  const answer = result as { data?: unknown; error?: unknown };
-  return answer.error == null && answer.data == null;
+  return noSessionSchema.safeParse(result).success;
 }
 
 export async function endSessionIfRevoked(gate: SessionGate = authClient): Promise<boolean> {

--- a/apps/web/src/lib/realtime/url.ts
+++ b/apps/web/src/lib/realtime/url.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 
 const REALTIME_PATH = '/api/ws';
 
-const LOCAL_HOSTNAMES: readonly string[] = ['localhost', '127.0.0.1', '[::1]', '::1'];
+const LOCAL_HOSTNAMES: readonly string[] = ['localhost', '[::1]', '::1'];
+
+const IPV4_LOOPBACK = /^127\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
 
 const socketUrlSchema = z
   .url()
@@ -16,9 +18,16 @@ export function configuredRealtimeUrl(): string {
   return socketUrlSchema.parse(configured);
 }
 
+function loopbackAddress(hostname: string): boolean {
+  const octets = IPV4_LOOPBACK.exec(hostname);
+  if (octets === null) return false;
+  return octets.slice(1).every((octet) => Number(octet) <= 255);
+}
+
 function servedLocally(origin: string): boolean {
   try {
-    return LOCAL_HOSTNAMES.includes(new URL(origin).hostname);
+    const { hostname } = new URL(origin);
+    return LOCAL_HOSTNAMES.includes(hostname) || loopbackAddress(hostname);
   } catch {
     return false;
   }

--- a/apps/web/src/lib/realtime/url.ts
+++ b/apps/web/src/lib/realtime/url.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 
 const REALTIME_PATH = '/api/ws';
 
+const LOCAL_HOSTNAMES: readonly string[] = ['localhost', '127.0.0.1', '[::1]', '::1'];
+
 const socketUrlSchema = z
   .url()
   .refine((value) => value.startsWith('ws://') || value.startsWith('wss://'))
@@ -14,9 +16,17 @@ export function configuredRealtimeUrl(): string {
   return socketUrlSchema.parse(configured);
 }
 
+function servedLocally(origin: string): boolean {
+  try {
+    return LOCAL_HOSTNAMES.includes(new URL(origin).hostname);
+  } catch {
+    return false;
+  }
+}
+
 export function resolveRealtimeUrl(configured: string, origin: string): string {
-  if (configured.length > 0) return configured;
   if (origin.length === 0) return '';
+  if (configured.length > 0 && servedLocally(origin)) return configured;
   const url = new URL(REALTIME_PATH, origin);
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
   return url.toString();

--- a/apps/web/tests/lib/realtime/provider.test.ts
+++ b/apps/web/tests/lib/realtime/provider.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { SESSION_REVOKED_CLOSE_CODE, UNAUTHORIZED_CLOSE_CODE } from '@orbit/shared/events';
+import type { SessionGate } from '../../../src/lib/realtime/provider.tsx';
+import { endSessionIfRevoked, handleTerminalClose } from '../../../src/lib/realtime/provider.tsx';
+
+const HERE = 'https://orbit.example/my-issues';
+
+const location = { href: HERE };
+const savedWindow = Reflect.getOwnPropertyDescriptor(globalThis, 'window');
+
+interface Recorder {
+  readonly gate: SessionGate;
+  readonly calls: { sessions: unknown[]; signOuts: number };
+}
+
+function gateReturning(answer: () => Promise<unknown>): Recorder {
+  const calls = { sessions: [] as unknown[], signOuts: 0 };
+  return {
+    calls,
+    gate: {
+      getSession: (options) => {
+        calls.sessions.push(options);
+        return answer();
+      },
+      signOut: () => {
+        calls.signOuts += 1;
+        return Promise.resolve(undefined);
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  location.href = HERE;
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { location },
+  });
+});
+
+afterEach(() => {
+  if (savedWindow === undefined) Reflect.deleteProperty(globalThis, 'window');
+  else Object.defineProperty(globalThis, 'window', savedWindow);
+});
+
+describe('endSessionIfRevoked', () => {
+  it('signs out and leaves for the login page when the server has no session left', async () => {
+    const { gate, calls } = gateReturning(async () => ({ data: null }));
+
+    expect(await endSessionIfRevoked(gate)).toBe(true);
+    expect(calls.signOuts).toBe(1);
+    expect(location.href).toBe('/login');
+  });
+
+  it('bypasses the cookie cache so a stale cached session cannot mask a revocation', async () => {
+    const { gate, calls } = gateReturning(async () => ({ data: null }));
+
+    await endSessionIfRevoked(gate);
+
+    expect(calls.sessions).toEqual([{ query: { disableCookieCache: true } }]);
+  });
+
+  it('keeps the user signed in when the server still has the session', async () => {
+    const { gate, calls } = gateReturning(async () => ({ data: { session: { id: 'live' } } }));
+
+    expect(await endSessionIfRevoked(gate)).toBe(false);
+    expect(calls.signOuts).toBe(0);
+    expect(location.href).toBe(HERE);
+  });
+
+  it('keeps the user signed in when the session check throws', async () => {
+    const { gate, calls } = gateReturning(() => Promise.reject(new Error('offline')));
+
+    expect(await endSessionIfRevoked(gate)).toBe(false);
+    expect(calls.signOuts).toBe(0);
+    expect(location.href).toBe(HERE);
+  });
+
+  it('keeps the user signed in when the session check answers with an error', async () => {
+    const { gate, calls } = gateReturning(async () => ({ data: null, error: { status: 500 } }));
+
+    expect(await endSessionIfRevoked(gate)).toBe(false);
+    expect(calls.signOuts).toBe(0);
+    expect(location.href).toBe(HERE);
+  });
+});
+
+describe('handleTerminalClose', () => {
+  it('does not touch the session when the socket merely fails to authenticate', async () => {
+    const { gate, calls } = gateReturning(async () => ({ data: null }));
+
+    handleTerminalClose(UNAUTHORIZED_CLOSE_CODE, gate);
+    await Promise.resolve();
+
+    expect(calls.sessions).toEqual([]);
+    expect(calls.signOuts).toBe(0);
+    expect(location.href).toBe(HERE);
+  });
+
+  it('ignores an ordinary transport close', async () => {
+    const { gate, calls } = gateReturning(async () => ({ data: null }));
+
+    handleTerminalClose(1006, gate);
+    await Promise.resolve();
+
+    expect(calls.sessions).toEqual([]);
+    expect(location.href).toBe(HERE);
+  });
+
+  it('checks with the server when the hub reports the session was revoked', async () => {
+    const { gate, calls } = gateReturning(async () => ({ data: { session: { id: 'live' } } }));
+
+    handleTerminalClose(SESSION_REVOKED_CLOSE_CODE, gate);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(calls.sessions).toHaveLength(1);
+    expect(calls.signOuts).toBe(0);
+    expect(location.href).toBe(HERE);
+  });
+});

--- a/apps/web/tests/lib/realtime/url.test.ts
+++ b/apps/web/tests/lib/realtime/url.test.ts
@@ -2,8 +2,20 @@ import { afterEach, describe, expect, it } from 'bun:test';
 import { configuredRealtimeUrl, resolveRealtimeUrl } from '../../../src/lib/realtime/url.ts';
 
 describe('resolveRealtimeUrl', () => {
-  it('prefers an explicitly configured url', () => {
+  it('honours a configured url while the page is served locally', () => {
+    expect(resolveRealtimeUrl('ws://localhost:3100', 'http://localhost:3000')).toBe(
+      'ws://localhost:3100',
+    );
+  });
+
+  it('ignores a configured url once the page is served from a deployed origin', () => {
     expect(resolveRealtimeUrl('ws://localhost:3100', 'https://orbit.example')).toBe(
+      'wss://orbit.example/api/ws',
+    );
+  });
+
+  it('treats a loopback address as local too', () => {
+    expect(resolveRealtimeUrl('ws://localhost:3100', 'http://127.0.0.1:3000')).toBe(
       'ws://localhost:3100',
     );
   });

--- a/apps/web/tests/lib/realtime/url.test.ts
+++ b/apps/web/tests/lib/realtime/url.test.ts
@@ -20,6 +20,30 @@ describe('resolveRealtimeUrl', () => {
     );
   });
 
+  it('treats the whole 127.0.0.0/8 range as loopback', () => {
+    expect(resolveRealtimeUrl('ws://localhost:3100', 'http://127.0.0.2:3000')).toBe(
+      'ws://localhost:3100',
+    );
+    expect(resolveRealtimeUrl('ws://localhost:3100', 'http://127.255.255.254:3000')).toBe(
+      'ws://localhost:3100',
+    );
+  });
+
+  it('treats the IPv6 loopback as local', () => {
+    expect(resolveRealtimeUrl('ws://localhost:3100', 'http://[::1]:3000')).toBe(
+      'ws://localhost:3100',
+    );
+  });
+
+  it('does not mistake a hostname that merely looks like loopback for the real thing', () => {
+    expect(resolveRealtimeUrl('ws://localhost:3100', 'https://127.0.0.1.orbit.example')).toBe(
+      'wss://127.0.0.1.orbit.example/api/ws',
+    );
+    expect(resolveRealtimeUrl('ws://localhost:3100', 'https://localhost.orbit.example')).toBe(
+      'wss://localhost.orbit.example/api/ws',
+    );
+  });
+
   it('falls back to the same origin over tls', () => {
     expect(resolveRealtimeUrl('', 'https://orbit.example')).toBe('wss://orbit.example/api/ws');
   });


### PR DESCRIPTION
## What was happening

Signing in to production worked, and then a few seconds later the app threw you back to the login page. Both Google and the magic link behaved the same way.

The session was never the problem. Two bugs compounded:

**The deployed page opened its websocket against `ws://localhost:3100`.** That value comes from `NEXT_PUBLIC_REALTIME_URL` in the repository `.env`, and the build inlines it. The guard meant to stop this read `NODE_ENV`, which is also inlined at build time and so cannot describe where the page is actually served. Captured from the live RSC payload on production:

```
{"url":"ws://localhost:3100","userId":"..."}
```

**A websocket that cannot authenticate was treated as proof the session was gone.** `handleTerminal` ran `authClient.signOut()` and a hard redirect to `/login` on close code 4001. The hub sends 4001 for *any* connection it cannot authenticate, including a plain auth timeout.

Together: production loads, the socket dials the developer's own machine, that hub cannot find the session in its local database, it closes 4001, and the client destroys a valid session. If nothing is listening on 3100 the browser blocks the connection instead and the app just retries forever behind a "Reconnecting to live updates" banner.

## The fix

Decide the socket URL from the page origin, which is only known in the browser and cannot be baked in wrong. The override is honoured only while the page itself is served from localhost or a loopback address; every other origin follows the app's own origin to `/api/ws`. This holds no matter what `NODE_ENV` or `NEXT_PUBLIC_REALTIME_URL` end up as at build time.

Treat the socket as what it is: a transport, not the authority on whether a session exists. 4001 is ignored and realtime simply stays closed, which the connection banner already reports. 4002 is a claim of genuine revocation, so it is confirmed against the server with the cookie cache bypassed, and the user is only signed out when the server agrees. A check that throws or answers with an error leaves the user where they are.

## Tests

`apps/web/tests/lib/realtime/url.test.ts` covers the origin rule in both directions, including that a deployed origin ignores a configured localhost socket.

`apps/web/tests/lib/realtime/provider.test.ts` covers the close-code handling: 4001 and ordinary closes never touch the session, 4002 checks the server first, and a failed or errored check keeps the user signed in. The dependency is injected rather than mocked with `mock.module`, which is global in Bun and leaks across suites.

`bun run verify` is green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents deployment-time websocket configuration from directing production browsers to localhost and stops unauthenticated socket closures from destroying otherwise valid sessions.
- Resolves deployed websocket URLs against the browser’s origin while retaining loopback-only development overrides.
- Confirms session-revocation close events against the auth server before signing out.
- Adds focused tests for URL selection and terminal-close handling.
- Excludes local environment files and generated artifacts from Vercel deployments.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/realtime/provider.tsx | Replaces socket-authoritative logout behavior with a fresh server session check for revocation events. |
| apps/web/src/lib/realtime/url.ts | Restricts configured websocket overrides to loopback-served pages and otherwise derives a same-origin websocket URL. |
| apps/web/tests/lib/realtime/provider.test.ts | Covers unauthorized closes, revocation confirmation, server errors, and confirmed session removal. |
| apps/web/tests/lib/realtime/url.test.ts | Covers deployed, loopback IPv4, IPv6, and misleading-hostname URL resolution. |
| .vercelignore | Prevents local environment files and generated development artifacts from entering Vercel deployments. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Hub as Realtime hub
    participant Client as Browser client
    participant Auth as Auth server
    Hub-->>Client: Close websocket
    alt Code 4001 or ordinary transport close
        Client->>Client: Keep current session
    else Code 4002 (session revoked)
        Client->>Auth: "getSession(disableCookieCache=true)"
        alt Server confirms no session
            Client->>Auth: signOut()
            Client->>Client: Redirect to /login
        else Session exists or check fails
            Client->>Client: Keep current session
        end
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(realtime): recognise the whole loopb..."](https://github.com/noveum/orbit/commit/94f93c08a91a352985315b450e823cf8f9adea13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50522465)</sub>

<!-- /greptile_comment -->