### PR TITLE
Close four cross-workspace leaks and the project, ordering and update bugs

### DIFF
--- a/apps/web/src/app/api/integrations/git-links/route.ts
+++ b/apps/web/src/app/api/integrations/git-links/route.ts
@@ -1,3 +1,4 @@
+import { getIssue } from '@orbit/core';
 import { and, db, desc, eq, schema } from '@orbit/db';
 import { assertCan } from '@orbit/shared/policy';
 import { gitLinksQuerySchema } from '@orbit/shared/validators';
@@ -8,6 +9,7 @@ export async function GET(request: Request): Promise<Response> {
     const { principal } = await apiContext();
     assertCan(principal, 'issue:read');
     const { issueId } = gitLinksQuerySchema.parse(searchParamsOf(request));
+    const issue = await getIssue(principal, issueId);
     const pulls = await db
       .select({
         id: schema.gitLink.id,
@@ -24,7 +26,7 @@ export async function GET(request: Request): Promise<Response> {
       .where(
         and(
           eq(schema.gitLink.organizationId, principal.organizationId),
-          eq(schema.gitLink.issueId, issueId),
+          eq(schema.gitLink.issueId, issue.id),
           eq(schema.gitLink.kind, 'pull_request'),
         ),
       )

--- a/apps/web/src/features/issues/my-issues-view.tsx
+++ b/apps/web/src/features/issues/my-issues-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { DisplayProperty } from '@orbit/shared/filters';
+import type { DisplayProperty, IssueOrdering } from '@orbit/shared/filters';
 import { CircleDot } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import type { RefObject } from 'react';
@@ -25,9 +25,14 @@ import { IssueRow } from './issue-row.tsx';
 import { useIssueViewModel } from './use-issue-view-model.ts';
 import { useWorkspace } from './workspace-provider.tsx';
 
-export function assignedTo(issues: readonly Issue[], userId: string | null): Issue[] {
+export function assignedTo(
+  issues: readonly Issue[],
+  userId: string | null,
+  ordering: IssueOrdering = 'manual',
+): Issue[] {
   if (userId === null) return [];
-  return sortIssues(issues.filter((issue) => issue.assigneeId === userId));
+  const mine = issues.filter((issue) => issue.assigneeId === userId);
+  return ordering === 'manual' ? sortIssues(mine) : mine;
 }
 
 export function MyIssuesView() {
@@ -37,7 +42,10 @@ export function MyIssuesView() {
   const { config, setConfig } = useViewConfig(null, layout, 'my_issues');
   const controls = useProvideViewControls('my_issues', layout, config);
 
-  const assigned = useAssignedIssues(workspace.userId);
+  const assigned = useAssignedIssues(workspace.userId, {
+    filter: config.filter,
+    orderBy: config.orderBy,
+  });
   const sentinel = useRef<HTMLDivElement>(null);
   const [peekId, setPeekId] = useState<string | null>(null);
 
@@ -56,8 +64,8 @@ export function MyIssuesView() {
 
   const loading = assigned.isPending;
   const mine = useMemo(
-    () => assignedTo(assigned.data ?? [], workspace.userId),
-    [assigned.data, workspace.userId],
+    () => assignedTo(assigned.data ?? [], workspace.userId, config.orderBy),
+    [assigned.data, workspace.userId, config.orderBy],
   );
 
   const scope = useMemo(

--- a/apps/web/src/features/projects/data.ts
+++ b/apps/web/src/features/projects/data.ts
@@ -174,15 +174,13 @@ export async function getProjectDetail(principal: Principal, slug: string): Prom
       scope: milestoneProgress.get(milestone.id)?.scope ?? 0,
       completed: milestoneProgress.get(milestone.id)?.completed ?? 0,
     })),
-    updates: updates
-      .map((update) => ({
-        id: update.id,
-        health: toHealth(update.health),
-        body: renderPlainText(update.body),
-        createdAt: update.createdAt.toISOString(),
-        author: people.get(update.authorId) ?? null,
-      }))
-      .reverse(),
+    updates: updates.map((update) => ({
+      id: update.id,
+      health: toHealth(update.health),
+      body: renderPlainText(update.body),
+      createdAt: update.createdAt.toISOString(),
+      author: people.get(update.authorId) ?? null,
+    })),
     series,
   };
 }

--- a/apps/web/src/lib/api/docs.ts
+++ b/apps/web/src/lib/api/docs.ts
@@ -1,4 +1,4 @@
-import { listDocCollections, listDocs } from '@orbit/core';
+import { listDocCollections, listDocs, visibleProjectFilter } from '@orbit/core';
 import { and, db, eq, isNull, schema } from '@orbit/db';
 import { summarize } from '@orbit/services/markdown';
 import type { Principal } from '@orbit/shared/policy';
@@ -17,6 +17,7 @@ export async function docListPayload(principal: Principal, filter?: DocFilterInp
         and(
           eq(schema.project.organizationId, principal.organizationId),
           isNull(schema.project.archivedAt),
+          visibleProjectFilter(principal),
         ),
       ),
   ]);

--- a/apps/web/src/lib/query/issue-search.ts
+++ b/apps/web/src/lib/query/issue-search.ts
@@ -63,8 +63,8 @@ export function facetsSearch(
   return params.toString();
 }
 
-export function assignedSearch(userId: string): string {
-  const params = searchParams({ ...DEFAULT_ISSUE_QUERY, orderBy: 'updated' });
+export function assignedSearch(userId: string, query?: IssueQuery): string {
+  const params = searchParams(query ?? { ...DEFAULT_ISSUE_QUERY, orderBy: 'updated' });
   params.set('assigneeId', userId);
   return params.toString();
 }

--- a/apps/web/src/lib/query/use-issues.ts
+++ b/apps/web/src/lib/query/use-issues.ts
@@ -204,8 +204,8 @@ export function useProjectIssues(
   });
 }
 
-export function useAssignedIssues(userId: string | null) {
-  const search = userId === null ? '' : assignedSearch(userId);
+export function useAssignedIssues(userId: string | null, query?: IssueQuery) {
+  const search = userId === null ? '' : assignedSearch(userId, query);
   return useInfiniteQuery({
     ...pagedIssueOptions(queryKeys.assignedIssues(userId ?? 'none', search), search),
     enabled: userId !== null,

--- a/apps/web/tests/features/issues/my-issues-view.test.tsx
+++ b/apps/web/tests/features/issues/my-issues-view.test.tsx
@@ -6,7 +6,7 @@ import { ToastProvider } from '@/components/ui/toast.tsx';
 import { HotkeyProvider } from '@/lib/keyboard/index.ts';
 import { queryKeys, VIEW_PREFERENCES_ROOT } from '@/lib/query/keys.ts';
 import type { Issue, WorkflowState } from '@/lib/query/schemas.ts';
-import { assignedSearch } from '@/lib/query/use-issues.ts';
+import { assignedSearch, DEFAULT_ISSUE_QUERY } from '@/lib/query/use-issues.ts';
 import type { WorkspaceData } from '../../../src/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '../../../src/features/issues/workspace-provider.tsx';
 
@@ -85,6 +85,44 @@ describe('assignedTo', () => {
   it('returns nothing before the viewer is known', () => {
     expect(assignedTo([issue({ assigneeId: 'me' })], null)).toEqual([]);
   });
+
+  it('keeps the order the server sent when the viewer picked one', () => {
+    const rows = assignedTo(
+      [
+        issue({ id: 'a', identifier: 'ENG-1', assigneeId: 'me', sortOrder: 200 }),
+        issue({
+          id: 'c',
+          identifier: 'DES-2',
+          teamId: 'team_des',
+          assigneeId: 'me',
+          sortOrder: 10,
+        }),
+      ],
+      'me',
+      'updated',
+    );
+
+    expect(rows.map((row) => row.identifier)).toEqual(['ENG-1', 'DES-2']);
+  });
+
+  it('falls back to the manual order only when the ordering is manual', () => {
+    const rows = assignedTo(
+      [
+        issue({ id: 'a', identifier: 'ENG-1', assigneeId: 'me', sortOrder: 200 }),
+        issue({
+          id: 'c',
+          identifier: 'DES-2',
+          teamId: 'team_des',
+          assigneeId: 'me',
+          sortOrder: 10,
+        }),
+      ],
+      'me',
+      'manual',
+    );
+
+    expect(rows.map((row) => row.identifier)).toEqual(['DES-2', 'ENG-1']);
+  });
 });
 
 const todo: WorkflowState = {
@@ -139,30 +177,33 @@ function renderView(viewerId = 'me', layout: 'list' | 'board' = 'list'): void {
   client.setQueryData([VIEW_PREFERENCES_ROOT], {
     preferences: [{ page: 'my_issues', scope: '', layout, display: {} }],
   });
-  client.setQueryData(queryKeys.assignedIssues(viewerId, assignedSearch(viewerId)), {
-    pages: [
-      {
-        issues: [
-          issue({ id: 'a', identifier: 'ENG-1', assigneeId: 'me', sortOrder: 200 }),
-          issue({ id: 'b', identifier: 'ENG-2', assigneeId: 'you' }),
-        ],
-        nextCursor: null,
-      },
-      {
-        issues: [
-          issue({
-            id: 'c',
-            identifier: 'DES-9',
-            teamId: 'team_des',
-            assigneeId: 'me',
-            sortOrder: 10,
-          }),
-        ],
-        nextCursor: null,
-      },
-    ],
-    pageParams: [null, 'cursor-1'],
-  });
+  client.setQueryData(
+    queryKeys.assignedIssues(viewerId, assignedSearch(viewerId, DEFAULT_ISSUE_QUERY)),
+    {
+      pages: [
+        {
+          issues: [
+            issue({ id: 'a', identifier: 'ENG-1', assigneeId: 'me', sortOrder: 200 }),
+            issue({ id: 'b', identifier: 'ENG-2', assigneeId: 'you' }),
+          ],
+          nextCursor: null,
+        },
+        {
+          issues: [
+            issue({
+              id: 'c',
+              identifier: 'DES-9',
+              teamId: 'team_des',
+              assigneeId: 'me',
+              sortOrder: 10,
+            }),
+          ],
+          nextCursor: null,
+        },
+      ],
+      pageParams: [null, 'cursor-1'],
+    },
+  );
   render(
     <QueryClientProvider client={client}>
       <ToastProvider>

--- a/packages/core/src/realtime/backfill.ts
+++ b/packages/core/src/realtime/backfill.ts
@@ -475,8 +475,17 @@ const LOADERS: Record<SyncModel, Loader> = {
   reaction: async (principal, since, limit) =>
     (
       await db
-        .select()
+        .select({
+          row: schema.reaction,
+          teamId: schema.issue.teamId,
+          issueId: schema.issue.id,
+        })
         .from(schema.reaction)
+        .leftJoin(schema.comment, eq(schema.comment.id, schema.reaction.commentId))
+        .innerJoin(
+          schema.issue,
+          eq(schema.issue.id, sql`coalesce(${schema.comment.issueId}, ${schema.reaction.issueId})`),
+        )
         .where(
           and(
             eq(schema.reaction.organizationId, principal.organizationId),
@@ -485,13 +494,10 @@ const LOADERS: Record<SyncModel, Loader> = {
         )
         .orderBy(asc(schema.reaction.syncId))
         .limit(limit)
-    ).map((row) => ({
+    ).map(({ row, teamId, issueId }) => ({
       modelId: row.id,
       syncId: row.syncId,
-      scopes:
-        row.issueId === null
-          ? [scopes.organization(row.organizationId)]
-          : [scopes.organization(row.organizationId), scopes.issue(row.issueId)],
+      scopes: [scopes.organization(row.organizationId), scopes.team(teamId), scopes.issue(issueId)],
       data: row,
     })),
 

--- a/packages/core/src/work/issue-service.ts
+++ b/packages/core/src/work/issue-service.ts
@@ -520,6 +520,20 @@ async function projectFitsTeam(
   return rows.some((row) => row.teamId === teamId);
 }
 
+async function assertMemberOfWorkspace(
+  executor: Executor,
+  organizationId: string,
+  userId: string | null | undefined,
+): Promise<void> {
+  if (userId === undefined || userId === null) return;
+  const [row] = await executor
+    .select({ id: schema.member.id })
+    .from(schema.member)
+    .where(and(eq(schema.member.organizationId, organizationId), eq(schema.member.userId, userId)))
+    .limit(1);
+  if (row === undefined) throw validationFailed('That person is not in this workspace.');
+}
+
 async function assertAssignableToTeam(
   executor: Executor,
   organizationId: string,
@@ -553,6 +567,7 @@ export async function createIssue(principal: Principal, input: unknown): Promise
     if (state.teamId !== team.id) {
       throw validationFailed('That status belongs to another team.');
     }
+    await assertMemberOfWorkspace(tx, principal.organizationId, parsed.assigneeId);
     await assertAssignableToTeam(tx, principal.organizationId, team.id, {
       cycleId: parsed.cycleId,
       projectId: parsed.projectId,
@@ -673,6 +688,7 @@ async function applyIssueUpdates(
       }
       Object.assign(values, applyStateTimestamps(current, state.category, now));
     }
+    await assertMemberOfWorkspace(tx, principal.organizationId, values.assigneeId);
     await assertAssignableToTeam(tx, principal.organizationId, current.teamId, values);
     pending.push({ current, values, changes });
   }
@@ -917,6 +933,7 @@ export async function moveIssue(
       Object.assign(values, applyStateTimestamps(current, state.category, now));
     }
 
+    await assertMemberOfWorkspace(tx, principal.organizationId, parsed.assigneeId);
     await assertAssignableToTeam(tx, principal.organizationId, teamId, {
       cycleId: parsed.cycleId,
       projectId: parsed.projectId,

--- a/packages/core/src/work/project-service.ts
+++ b/packages/core/src/work/project-service.ts
@@ -1,4 +1,17 @@
-import { and, asc, count, db, eq, inArray, isNull, schema, sql } from '@orbit/db';
+import {
+  and,
+  asc,
+  count,
+  db,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  notExists,
+  or,
+  schema,
+  sql,
+} from '@orbit/db';
 import { conflict, notFound } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
@@ -498,7 +511,7 @@ export async function listProjectUpdates(
         eq(schema.projectUpdate.organizationId, principal.organizationId),
       ),
     )
-    .orderBy(asc(schema.projectUpdate.createdAt))
+    .orderBy(desc(schema.projectUpdate.createdAt))
     .limit(limit);
 }
 
@@ -591,20 +604,31 @@ export async function listProjectsForTeams(
   teamIds: readonly string[],
 ): Promise<ProjectRow[]> {
   assertCan(principal, 'project:read');
-  if (teamIds.length === 0) return [];
+  const linkedToATeam =
+    teamIds.length === 0
+      ? undefined
+      : inArray(
+          schema.project.id,
+          db
+            .select({ id: schema.projectTeam.projectId })
+            .from(schema.projectTeam)
+            .where(inArray(schema.projectTeam.teamId, [...teamIds])),
+        );
+  const ownedByNobody = notExists(
+    db
+      .select({ id: schema.projectTeam.projectId })
+      .from(schema.projectTeam)
+      .where(eq(schema.projectTeam.projectId, schema.project.id)),
+  );
+  const reachable = linkedToATeam === undefined ? ownedByNobody : or(linkedToATeam, ownedByNobody);
   return await db
     .select()
     .from(schema.project)
     .where(
       and(
         eq(schema.project.organizationId, principal.organizationId),
-        inArray(
-          schema.project.id,
-          db
-            .select({ id: schema.projectTeam.projectId })
-            .from(schema.projectTeam)
-            .where(inArray(schema.projectTeam.teamId, [...teamIds])),
-        ),
+        isNull(schema.project.archivedAt),
+        reachable,
       ),
     )
     .orderBy(asc(schema.project.name));

--- a/packages/core/tests/realtime/backfill.test.ts
+++ b/packages/core/tests/realtime/backfill.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { db, schema } from '@orbit/db';
 import { SYNC_MODELS } from '@orbit/shared/events';
+import { createComment, toggleReaction } from '../../src/content/comment-service.ts';
 import { createDoc, createDocCollection, setDocAccess } from '../../src/content/doc-service.ts';
 import { newId } from '../../src/internal.ts';
 import { createInvite } from '../../src/org/invite-service.ts';
@@ -282,5 +283,52 @@ describe('catch up respects document access', () => {
     });
     const result = await catchUp(guest, 0);
     expect(result.actions.some((action) => action.modelId === doc.id)).toBe(true);
+  });
+});
+
+describe('catch up scopes reactions to the team that owns the issue', () => {
+  it('hides a reaction on another team issue from a member', async () => {
+    const outsider = await createTeam(workspace.admin, { name: 'Design', key: teamKey() });
+    const { principal: member } = await addMember(workspace, 'member', {
+      teamIds: [workspace.teamId],
+    });
+
+    const theirs = await createIssue(workspace.admin, {
+      teamId: outsider.team.id,
+      title: 'Confidential to Design',
+    });
+    const comment = await createComment(workspace.admin, theirs.issue.id, {
+      body: 'Only Design should see this thread.',
+    });
+    const reaction = await toggleReaction(workspace.admin, comment.comment.id, { emoji: '🚀' });
+
+    const result = await catchUp(member, 0);
+    const ids = new Set(result.actions.map((action) => action.modelId));
+
+    for (const action of reaction.actions) {
+      expect(ids.has(action.modelId)).toBe(false);
+    }
+  });
+
+  it('still gives a reaction on the member own team issue', async () => {
+    const { principal: member } = await addMember(workspace, 'member', {
+      teamIds: [workspace.teamId],
+    });
+
+    const mine = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Ours',
+    });
+    const comment = await createComment(workspace.admin, mine.issue.id, { body: 'Nice work.' });
+    const reaction = await toggleReaction(workspace.admin, comment.comment.id, { emoji: '🚀' });
+
+    const result = await catchUp(member, 0);
+    const ids = new Set(result.actions.map((action) => action.modelId));
+
+    const reacted = reaction.actions.filter((action) => action.model === 'reaction');
+    expect(reacted.length).toBeGreaterThan(0);
+    for (const action of reacted) {
+      expect(ids.has(action.modelId)).toBe(true);
+    }
   });
 });

--- a/packages/core/tests/work/issue-service.test.ts
+++ b/packages/core/tests/work/issue-service.test.ts
@@ -232,6 +232,56 @@ describe('updateIssue', () => {
   });
 });
 
+describe('assignee membership', () => {
+  it('refuses to create an issue assigned to somebody outside the workspace', async () => {
+    const outside = await createWorkspace('Elsewhere');
+
+    await expect(
+      createIssue(workspace.admin, {
+        teamId: workspace.teamId,
+        title: 'Assigned to a stranger',
+        assigneeId: outside.admin.userId,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('refuses to reassign an issue to somebody outside the workspace', async () => {
+    const outside = await createWorkspace('Elsewhere');
+    const issue = await newIssue('Ours');
+
+    await expect(
+      updateIssue(workspace.admin, issue.id, { assigneeId: outside.admin.userId }),
+    ).rejects.toThrow();
+  });
+
+  it('refuses to move an issue onto somebody outside the workspace', async () => {
+    const outside = await createWorkspace('Elsewhere');
+    const issue = await newIssue('Ours');
+
+    await expect(
+      moveIssue(workspace.admin, issue.id, { assigneeId: outside.admin.userId }),
+    ).rejects.toThrow();
+  });
+
+  it('still accepts a member of the same workspace', async () => {
+    const { user } = await addMember(workspace, 'member', { name: 'Colleague' });
+    const issue = await newIssue('Ours');
+
+    const updated = await updateIssue(workspace.admin, issue.id, { assigneeId: user.id });
+
+    expect(updated.issue.assigneeId).toBe(user.id);
+  });
+
+  it('still accepts clearing the assignee', async () => {
+    const { user } = await addMember(workspace, 'member', { name: 'Colleague' });
+    const issue = await newIssue('Ours', { assigneeId: user.id });
+
+    const cleared = await updateIssue(workspace.admin, issue.id, { assigneeId: null });
+
+    expect(cleared.issue.assigneeId).toBeNull();
+  });
+});
+
 describe('label deltas', () => {
   async function starterLabel() {
     const [label] = await db

--- a/packages/core/tests/work/project-service.test.ts
+++ b/packages/core/tests/work/project-service.test.ts
@@ -16,9 +16,11 @@ import {
 } from '../../src/work/milestone-service.ts';
 import {
   addProjectTeam,
+  archiveProject,
   createProject,
   getProject,
   listProjects,
+  listProjectsForTeams,
   listProjectTeams,
   listProjectUpdates,
   postProjectUpdate,
@@ -285,5 +287,60 @@ describe('a project stays inside the teams it belongs to', () => {
       (await postProjectUpdate(lead, project.id, { health: 'on_track', body: 'All good.' })).update
         .body,
     ).toBe('All good.');
+  });
+});
+
+describe('the payload the client boots from', () => {
+  it('shows the newest project updates, not the first ever written', async () => {
+    const { project } = await createProject(workspace.admin, {
+      name: 'Long running',
+      teamIds: [workspace.teamId],
+    });
+    for (const week of ['One', 'Two', 'Three', 'Four', 'Five']) {
+      await postProjectUpdate(workspace.admin, project.id, {
+        health: 'on_track',
+        body: `Week ${week}`,
+      });
+    }
+
+    const latest = await listProjectUpdates(workspace.admin, project.id, 2);
+
+    expect(latest).toHaveLength(2);
+    expect(latest[0]?.body).toBe('Week Five');
+    expect(latest[1]?.body).toBe('Week Four');
+  });
+
+  it('keeps a project that belongs to no team in particular', async () => {
+    const { project } = await createProject(workspace.admin, {
+      name: 'Company wiki',
+      teamIds: [],
+    });
+
+    const forTeams = await listProjectsForTeams(workspace.admin, [workspace.teamId]);
+
+    expect(forTeams.map((row) => row.id)).toContain(project.id);
+  });
+
+  it('drops an archived project so it leaves the picker', async () => {
+    const { project } = await createProject(workspace.admin, {
+      name: 'Finished work',
+      teamIds: [workspace.teamId],
+    });
+    await archiveProject(workspace.admin, project.id);
+
+    const forTeams = await listProjectsForTeams(workspace.admin, [workspace.teamId]);
+
+    expect(forTeams.map((row) => row.id)).not.toContain(project.id);
+  });
+
+  it('still returns the team projects a member can reach', async () => {
+    const { project } = await createProject(workspace.admin, {
+      name: 'Team work',
+      teamIds: [workspace.teamId],
+    });
+
+    const forTeams = await listProjectsForTeams(workspace.admin, [workspace.teamId]);
+
+    expect(forTeams.map((row) => row.id)).toContain(project.id);
   });
 });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -14,6 +14,7 @@ export {
   lte,
   ne,
   not,
+  notExists,
   or,
   type SQL,
   sql,


### PR DESCRIPTION
Second wave from the adversarial audit. Every finding here survived a refutation pass, and each fix carries a test that fails without it.

## Security

**An issue's assignee was never checked for workspace membership.** `createIssue` wrote `assigneeId` straight from the body and `applyIssueUpdates` validated only cycle, project and milestone. A plain `PATCH /api/issues/{id}` with a user id from another workspace was accepted, and that person's name then surfaced in the activity feed, the assignee facet and the avatar. Create, update and move now require a `member` row; clearing the assignee still works.

**`GET /api/integrations/git-links` never loaded the issue.** It asserted `issue:read` and then queried by the caller-supplied `issueId`, so the team check never ran and anybody could read the pull requests attached to any issue in the workspace. It resolves the issue through `getIssue` first now.

**Sync catch-up returned every reaction in the workspace.** The loader emitted no `team:` scope, and `visibleToPrincipal` treats a row without one as visible to everybody. Reactions now carry the team owning the issue they belong to, resolved through the comment when threaded and directly when left on the issue.

**`GET /api/docs` named every project in the workspace.** It built its own project query that omitted `visibleProjectFilter`, which `listProjects` applies to the same table.

## Correctness

**A project's updates were ordered oldest first before the limit.** Past twenty updates, the query returned the first twenty ever written and every new update landed in a window nobody could see; the page then reversed that stale window. Ordered newest first at the source, compensating reverse removed.

**`listProjectsForTeams` disagreed with `visibleProjectFilter` in two ways.** It never excluded archived projects, so an archived project stayed in the workspace picker forever and could still be attached to a new issue, and it required a `project_team` row, so a project belonging to no team was invisible everywhere the client reads the bootstrap payload even though the projects page listed it for everybody.

**My Issues ignored the ordering you picked.** All seven orderings were offered; the query hardcoded `updated` so the choice never reached the server, and the view re-sorted by `sortOrder` afterwards which destroyed whatever came back. The filter and ordering now reach the server, and the client only applies its manual sort when the ordering is manual.

`bun run verify` is green.