### PR TITLE
Give the sidebar and the command palette one navigation source

### DIFF
--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -54,45 +54,51 @@ export interface NavSection {
 
 const TEAM_SECTION_PREFIX = 'team-';
 
+const WORKSPACE_LINKS: readonly NavLink[] = [
+  { href: '/projects', label: 'Projects', icon: FolderKanban, binding: 'g p' },
+  { href: '/sprints', label: 'Sprints', icon: RefreshCcw },
+  { href: '/standup', label: 'Standup', icon: Users, binding: 'g s' },
+  { href: '/views', label: 'Views', icon: LayoutList, binding: 'g v' },
+  { href: '/analytics', label: 'Analytics', icon: BarChart3, binding: 'g a' },
+  { href: '/docs', label: 'Docs', icon: FileText, binding: 'g d' },
+];
+
+function personalLinks(inboxCount: number): NavLink[] {
+  return [
+    { href: '/inbox', label: 'Inbox', icon: Inbox, binding: 'g i', count: inboxCount },
+    { href: '/my-issues', label: 'My issues', icon: CircleDot, binding: 'g m' },
+    { href: '/pulls', label: 'Pull requests', icon: GitPullRequest, binding: 'g r' },
+  ];
+}
+
+function teamLinks(key: string, openIssues?: number): NavLink[] {
+  return [
+    {
+      href: `/team/${key}/issues`,
+      label: 'Issues',
+      icon: CircleDot,
+      ...(openIssues === undefined ? {} : { count: openIssues }),
+    },
+    { href: `/team/${key}/board`, label: 'Board', icon: Target },
+    { href: `/team/${key}/sprint/active`, label: 'Active sprint', icon: RefreshCcw },
+  ];
+}
+
 export function buildNavigation(teams: readonly ShellTeam[], inboxCount = 0): NavSection[] {
   return [
     {
       id: 'personal',
-      links: [
-        { href: '/inbox', label: 'Inbox', icon: Inbox, binding: 'g i', count: inboxCount },
-        { href: '/my-issues', label: 'My issues', icon: CircleDot, binding: 'g m' },
-        { href: '/pulls', label: 'Pull requests', icon: GitPullRequest, binding: 'g r' },
-      ],
+      links: personalLinks(inboxCount),
     },
     {
       id: 'workspace',
       title: 'Workspace',
-      links: [
-        { href: '/projects', label: 'Projects', icon: FolderKanban, binding: 'g p' },
-        { href: '/sprints', label: 'Sprints', icon: RefreshCcw },
-        { href: '/standup', label: 'Standup', icon: Users, binding: 'g s' },
-        { href: '/views', label: 'Views', icon: LayoutList, binding: 'g v' },
-        { href: '/analytics', label: 'Analytics', icon: BarChart3, binding: 'g a' },
-        { href: '/docs', label: 'Docs', icon: FileText, binding: 'g d' },
-      ],
+      links: WORKSPACE_LINKS,
     },
     ...teams.map((team) => ({
       id: `${TEAM_SECTION_PREFIX}${team.id}`,
       title: team.name,
-      links: [
-        {
-          href: `/team/${team.key.toLowerCase()}/issues`,
-          label: 'Issues',
-          icon: CircleDot,
-          count: team.openIssues,
-        },
-        { href: `/team/${team.key.toLowerCase()}/board`, label: 'Board', icon: Target },
-        {
-          href: `/team/${team.key.toLowerCase()}/sprint/active`,
-          label: 'Active sprint',
-          icon: RefreshCcw,
-        },
-      ],
+      links: teamLinks(team.key.toLowerCase(), team.openIssues),
     })),
   ];
 }
@@ -123,22 +129,11 @@ const DEFAULT_TEAM_COLOR = '#5A63C8';
 
 export function buildSidebarNav(teams: readonly ShellTeam[], inboxCount = 0): SidebarNav {
   return {
-    personal: [
-      { href: '/inbox', label: 'Inbox', icon: Inbox, binding: 'g i', count: inboxCount },
-      { href: '/my-issues', label: 'My issues', icon: CircleDot, binding: 'g m' },
-      { href: '/pulls', label: 'Pull requests', icon: GitPullRequest, binding: 'g r' },
-    ],
+    personal: personalLinks(inboxCount),
     workspace: {
       id: 'workspace',
       title: 'Workspace',
-      links: [
-        { href: '/projects', label: 'Projects', icon: FolderKanban, binding: 'g p' },
-        { href: '/sprints', label: 'Sprints', icon: RefreshCcw },
-        { href: '/standup', label: 'Standup', icon: Users, binding: 'g s' },
-        { href: '/views', label: 'Views', icon: LayoutList, binding: 'g v' },
-        { href: '/analytics', label: 'Analytics', icon: BarChart3, binding: 'g a' },
-        { href: '/docs', label: 'Docs', icon: FileText, binding: 'g d' },
-      ],
+      links: WORKSPACE_LINKS,
     },
     teams: teams.map((team) => {
       const key = team.key.toLowerCase();

--- a/apps/web/tests/lib/navigation.test.ts
+++ b/apps/web/tests/lib/navigation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test';
+import type { NavLink, ShellTeam } from '@/lib/navigation.ts';
+import { buildNavigation, buildSidebarNav } from '@/lib/navigation.ts';
+
+const TEAMS: readonly ShellTeam[] = [
+  { id: 'team_1', key: 'ENG', name: 'Engineering', openIssues: 4 },
+];
+
+function shape(links: readonly NavLink[]): { href: string; binding?: string }[] {
+  return links.map((link) => ({
+    href: link.href,
+    ...(link.binding === undefined ? {} : { binding: link.binding }),
+  }));
+}
+
+function sectionLinks(id: string): readonly NavLink[] {
+  const section = buildNavigation(TEAMS, 2).find((entry) => entry.id === id);
+  if (section === undefined) throw new Error(`no ${id} section`);
+  return section.links;
+}
+
+describe('the command palette and the sidebar read the same navigation', () => {
+  it('offers the same personal links, in the same order, with the same bindings', () => {
+    expect(shape(sectionLinks('personal'))).toEqual(shape(buildSidebarNav(TEAMS, 2).personal));
+  });
+
+  it('offers the same workspace links, in the same order, with the same bindings', () => {
+    expect(shape(sectionLinks('workspace'))).toEqual(
+      shape(buildSidebarNav(TEAMS, 2).workspace.links),
+    );
+  });
+
+  it('offers the same links under a team', () => {
+    const fromSections = sectionLinks('team-team_1');
+    const fromSidebar = buildSidebarNav(TEAMS, 2).teams[0]?.children ?? [];
+
+    expect(shape(fromSections)).toEqual(shape(fromSidebar));
+  });
+});
+
+describe('navigation bindings', () => {
+  it('gives every binding to exactly one destination', () => {
+    const bound = [
+      ...buildSidebarNav(TEAMS, 2).personal,
+      ...buildSidebarNav(TEAMS, 2).workspace.links,
+    ].flatMap((link) => (link.binding === undefined ? [] : [link.binding]));
+
+    expect(new Set(bound).size).toBe(bound.length);
+  });
+
+  it('carries the inbox count through to both surfaces', () => {
+    const fromSections = sectionLinks('personal').find((link) => link.href === '/inbox');
+    const fromSidebar = buildSidebarNav(TEAMS, 7).personal.find((link) => link.href === '/inbox');
+
+    expect(buildSidebarNav(TEAMS, 7).personal[0]?.count).toBe(7);
+    expect(fromSections?.count).toBe(2);
+    expect(fromSidebar?.count).toBe(7);
+  });
+});


### PR DESCRIPTION
`buildNavigation` and `buildSidebarNav` each carried their own copy of the personal links, the workspace links and the per-team links. Every navigation change had to be made in both, and only one copy had test coverage.

This surfaced in review of [#99](https://github.com/Noveum/orbit/pull/99): a contributor adding a Sprints shortcut had to find and edit both tables by hand, and CodeRabbit correctly pointed out that deleting the binding from `buildSidebarNav` would still leave the suite green, because `command-palette.test.tsx` only exercises `buildNavigation`.

Both builders now read the same tables. A test compares the two surfaces link by link, so they cannot drift again, alongside one asserting no binding is claimed by two destinations.

`bun run verify` is green.