### PR TITLE
refactor(policy): decide doc read access in one place

### DIFF
--- a/packages/core/src/content/doc-service.ts
+++ b/packages/core/src/content/doc-service.ts
@@ -19,7 +19,7 @@ import { conflict, forbidden, notFound, validationFailed } from '@orbit/shared/e
 import type { Actor, SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
-import { assertCan } from '@orbit/shared/policy';
+import { assertCan, canReadDoc } from '@orbit/shared/policy';
 import { docUrl, slugify, truncate } from '@orbit/shared/utils';
 import {
   docAccessSetSchema,
@@ -156,13 +156,6 @@ export function docReadFilter(principal: Principal): SQL {
     inArray(schema.doc.id, grants),
   );
   return clause ?? sql`false`;
-}
-
-export function canReadDoc(principal: Principal, doc: DocRow, grants: readonly string[]): boolean {
-  if (principal.role === 'admin') return true;
-  if (doc.authorId === principal.userId) return true;
-  if (!isRestricted(doc.visibility)) return true;
-  return grants.includes(doc.id);
 }
 
 async function grantedDocIds(

--- a/packages/realtime-server/src/auth.ts
+++ b/packages/realtime-server/src/auth.ts
@@ -1,7 +1,8 @@
 import { and, db, eq, gt, inArray, or, schema, sql } from '@orbit/db';
-import { isRestricted, ORG_ROLES, type OrgRole } from '@orbit/shared/constants';
+import { ORG_ROLES, type OrgRole } from '@orbit/shared/constants';
 import { authMessageSchema } from '@orbit/shared/events';
 import { type RealtimeTicketPayload, verifyRealtimeTicket } from '@orbit/shared/events/ticket';
+import { canReadDoc } from '@orbit/shared/policy';
 import { z } from 'zod';
 
 export interface ConnectionPrincipal {
@@ -184,6 +185,7 @@ async function projectScopeAllowed(projectId: string, principal: ConnectionPrinc
 async function docScopeAllowed(docId: string, principal: ConnectionPrincipal) {
   const rows = await db
     .select({
+      id: schema.doc.id,
       organizationId: schema.doc.organizationId,
       visibility: schema.doc.visibility,
       authorId: schema.doc.authorId,
@@ -192,10 +194,8 @@ async function docScopeAllowed(docId: string, principal: ConnectionPrincipal) {
     .where(eq(schema.doc.id, docId))
     .limit(1);
   const doc = rows[0];
-  if (doc === undefined || doc.organizationId !== principal.organizationId) return false;
-  if (principal.role === 'admin') return true;
-  if (doc.authorId === principal.userId) return true;
-  if (!isRestricted(doc.visibility)) return true;
+  if (doc === undefined) return false;
+  if (canReadDoc(principal, doc, [])) return true;
 
   const grants = await db
     .select({ docId: schema.docAccess.docId })
@@ -218,7 +218,11 @@ async function docScopeAllowed(docId: string, principal: ConnectionPrincipal) {
       ),
     )
     .limit(1);
-  return grants.length > 0;
+  return canReadDoc(
+    principal,
+    doc,
+    grants.map((row) => row.docId),
+  );
 }
 
 export async function authorizeScope(

--- a/packages/shared/src/policy/index.ts
+++ b/packages/shared/src/policy/index.ts
@@ -1,4 +1,4 @@
-import { ORG_ROLE_RANK, type OrgRole } from '../constants/index.ts';
+import { isRestricted, ORG_ROLE_RANK, type OrgRole } from '../constants/index.ts';
 import { forbidden, notFound } from '../errors/index.ts';
 
 export const PERMISSIONS = [
@@ -131,4 +131,29 @@ export function atLeast(role: OrgRole, minimum: OrgRole): boolean {
 
 export function canAssignRole(actorRole: OrgRole, targetRole: OrgRole): boolean {
   return actorRole === 'admin' && ORG_ROLE_RANK[targetRole] <= ORG_ROLE_RANK.admin;
+}
+
+export interface ReadableDocRow {
+  readonly id: string;
+  readonly organizationId: string;
+  readonly authorId: string;
+  readonly visibility: string;
+}
+
+export interface DocReader {
+  readonly userId: string;
+  readonly organizationId: string;
+  readonly role: OrgRole;
+}
+
+export function canReadDoc(
+  principal: DocReader,
+  doc: ReadableDocRow,
+  grantedDocIds: readonly string[],
+): boolean {
+  if (doc.organizationId !== principal.organizationId) return false;
+  if (principal.role === 'admin') return true;
+  if (doc.authorId === principal.userId) return true;
+  if (!isRestricted(doc.visibility)) return true;
+  return grantedDocIds.includes(doc.id);
 }

--- a/packages/shared/tests/policy/can-read-doc.test.ts
+++ b/packages/shared/tests/policy/can-read-doc.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'bun:test';
+import { canReadDoc, type DocReader, type ReadableDocRow } from '../../src/policy/index.ts';
+
+const ORG = 'org_1';
+
+function reader(overrides: Partial<DocReader> = {}): DocReader {
+  return { userId: 'user_reader', organizationId: ORG, role: 'member', ...overrides };
+}
+
+function doc(overrides: Partial<ReadableDocRow> = {}): ReadableDocRow {
+  return {
+    id: 'doc_1',
+    organizationId: ORG,
+    authorId: 'user_author',
+    visibility: 'workspace',
+    ...overrides,
+  };
+}
+
+describe('canReadDoc', () => {
+  it('refuses a doc in another workspace, whatever the role', () => {
+    const other = doc({ organizationId: 'org_2' });
+    expect(canReadDoc(reader({ role: 'admin' }), other, [])).toBe(false);
+    expect(canReadDoc(reader({ userId: 'user_author', role: 'admin' }), other, ['doc_1'])).toBe(
+      false,
+    );
+  });
+
+  it('lets an org admin read anything in their own workspace', () => {
+    expect(canReadDoc(reader({ role: 'admin' }), doc({ visibility: 'private' }), [])).toBe(true);
+  });
+
+  it('lets the author read their own restricted doc', () => {
+    expect(canReadDoc(reader({ userId: 'user_author' }), doc({ visibility: 'private' }), [])).toBe(
+      true,
+    );
+  });
+
+  it('lets anyone in the workspace read an unrestricted doc', () => {
+    for (const visibility of ['workspace', 'link', 'public']) {
+      expect(canReadDoc(reader(), doc({ visibility }), [])).toBe(true);
+    }
+  });
+
+  it('refuses a restricted doc without a grant', () => {
+    for (const visibility of ['private', 'team']) {
+      expect(canReadDoc(reader(), doc({ visibility }), [])).toBe(false);
+      expect(canReadDoc(reader(), doc({ visibility }), ['doc_other'])).toBe(false);
+    }
+  });
+
+  it('allows a restricted doc once the grant names it', () => {
+    expect(canReadDoc(reader(), doc({ visibility: 'private' }), ['doc_1'])).toBe(true);
+    expect(canReadDoc(reader(), doc({ visibility: 'team' }), ['doc_1'])).toBe(true);
+  });
+
+  it('treats an unknown visibility as unrestricted, matching isRestricted', () => {
+    expect(canReadDoc(reader(), doc({ visibility: 'something_new' }), [])).toBe(true);
+  });
+});


### PR DESCRIPTION
The rule that decides who may read a doc was written twice: `canReadDoc` in `packages/core/src/content/doc-service.ts`, and again inline inside `docScopeAllowed` in the realtime hub's scope authorization.

Two copies of an authorization rule is one copy that can drift, and these had already started to: the hub compared the organization by hand as a separate step, while core relied on its caller having filtered by organization first. Same intent, two different shapes, and nothing forcing them to stay in agreement.

`canReadDoc` now lives in `packages/shared/src/policy`, which is where the project's own rule says authorization belongs, and both callers use it. Each keeps its own grant query, because one runs inside a Drizzle transaction and the other on a socket connection, but the decision they feed it is now literally the same function.

The shared version folds the organization check into the decision rather than trusting the caller to have filtered. That can only refuse more than before, never less: core's one caller already filtered by organization in the query, so it is a no-op there and defence in depth everywhere else.

Seven tests in `packages/shared/tests/policy/can-read-doc.test.ts` pin the rule down, including the cross-workspace case that an admin must still be refused, and the behaviour on a visibility string the enum does not know about.