### PR TITLE
Close a stored XSS and four cross-team realtime leaks

### DIFF
--- a/apps/web/src/app/api/attachments/presign/route.ts
+++ b/apps/web/src/app/api/attachments/presign/route.ts
@@ -38,7 +38,7 @@ export async function POST(request: Request): Promise<Response> {
       .returning();
     const attachment = requireRow(created, 'That upload could not be registered.');
 
-    const scope = [scopes.organization(attachment.organizationId)];
+    const scope: string[] = [];
     if (attachment.parentType === 'doc') scope.push(scopes.doc(attachment.parentId));
     if (attachment.parentType === 'issue') scope.push(scopes.issue(attachment.parentId));
     if (attachment.parentType === 'project') scope.push(scopes.project(attachment.parentId));
@@ -50,6 +50,7 @@ export async function POST(request: Request): Promise<Response> {
         .limit(1);
       if (comment !== undefined) scope.push(scopes.issue(comment.issueId));
     }
+    if (scope.length === 0) scope.push(scopes.user(attachment.uploadedById));
 
     await publish([
       buildSyncAction({

--- a/packages/core/src/content/attachment-service.ts
+++ b/packages/core/src/content/attachment-service.ts
@@ -9,6 +9,14 @@ import { nextSyncId } from '../sync/sync-id.ts';
 
 export type AttachmentRecord = typeof schema.attachment.$inferSelect;
 
+export function attachmentScopes(
+  row: Pick<AttachmentRecord, 'parentType' | 'parentId' | 'uploadedById'>,
+): string[] {
+  if (row.parentType === 'doc') return [scopes.doc(row.parentId)];
+  if (row.parentType === 'issue') return [scopes.issue(row.parentId)];
+  return [scopes.user(row.uploadedById)];
+}
+
 export interface CompletedAttachment {
   readonly attachment: AttachmentRecord;
   readonly actions: SyncAction[];
@@ -47,9 +55,7 @@ export async function markAttachmentReady(
     if (updated === undefined) throw notFound('That upload was not registered.');
 
     const actor = await principalActor(tx, principal);
-    const scope = [scopes.organization(updated.organizationId)];
-    if (updated.parentType === 'doc') scope.push(scopes.doc(updated.parentId));
-    if (updated.parentType === 'issue') scope.push(scopes.issue(updated.parentId));
+    const scope = attachmentScopes(updated);
 
     return {
       attachment: updated,

--- a/packages/core/src/org/member-service.ts
+++ b/packages/core/src/org/member-service.ts
@@ -10,6 +10,7 @@ import { principalActor } from '../activity/activity-service.ts';
 import { type Executor, requireRow } from '../internal.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
+import { issueScopes } from '../work/issue-service.ts';
 import type { MemberRow } from './organization-service.ts';
 
 export interface MemberWithUser {
@@ -247,11 +248,7 @@ export async function removeMember(
         buildSyncAction({
           syncId,
           organizationId: principal.organizationId,
-          scopes: [
-            scopes.organization(principal.organizationId),
-            scopes.team(row.teamId),
-            scopes.issue(row.id),
-          ],
+          scopes: issueScopes(row),
           action: 'update',
           model: 'issue',
           modelId: row.id,

--- a/packages/core/src/work/cycle-service.ts
+++ b/packages/core/src/work/cycle-service.ts
@@ -671,11 +671,7 @@ export async function completeCycle(
           buildSyncAction({
             syncId,
             organizationId: principal.organizationId,
-            scopes: [
-              scopes.organization(principal.organizationId),
-              scopes.team(row.teamId),
-              scopes.issue(row.id),
-            ],
+            scopes: issueScopes(row),
             action: 'update',
             model: 'issue',
             modelId: row.id,

--- a/packages/realtime-server/src/auth.ts
+++ b/packages/realtime-server/src/auth.ts
@@ -154,6 +154,29 @@ export async function membershipStillValid(principal: ConnectionPrincipal): Prom
   return rows.length > 0;
 }
 
+export async function refreshedPrincipal(
+  principal: ConnectionPrincipal,
+): Promise<ConnectionPrincipal | null> {
+  const rows = await db
+    .select({ role: schema.member.role })
+    .from(schema.member)
+    .where(
+      and(
+        eq(schema.member.organizationId, principal.organizationId),
+        eq(schema.member.userId, principal.userId),
+      ),
+    )
+    .limit(1);
+  const membership = rows[0];
+  if (membership === undefined) return null;
+  const role = roleSchema.parse(membership.role);
+  return {
+    ...principal,
+    role,
+    teamIds: await loadTeamIds(principal.userId, principal.organizationId, role),
+  };
+}
+
 async function issueScopeAllowed(issueId: string, principal: ConnectionPrincipal) {
   const rows = await db
     .select({ organizationId: schema.issue.organizationId, teamId: schema.issue.teamId })

--- a/packages/realtime-server/src/connection.ts
+++ b/packages/realtime-server/src/connection.ts
@@ -30,10 +30,22 @@ export class Connection {
   constructor(
     readonly id: string,
     private readonly socket: RealtimeSocket,
-    readonly principal: ConnectionPrincipal,
+    private current: ConnectionPrincipal,
     private readonly limits: ConnectionLimits,
   ) {
     this.tokens = limits.messageBurst;
+  }
+
+  get principal(): ConnectionPrincipal {
+    return this.current;
+  }
+
+  adoptPrincipal(next: ConnectionPrincipal): void {
+    this.current = next;
+  }
+
+  heldScopes(): string[] {
+    return [...this.scopes];
   }
 
   takeToken(now = Date.now()): boolean {

--- a/packages/realtime-server/src/hub.ts
+++ b/packages/realtime-server/src/hub.ts
@@ -26,6 +26,7 @@ import {
   memberDeleteSchema,
   membershipStillValid,
   readTicketFrame,
+  refreshedPrincipal,
   sessionStillValid,
 } from './auth.ts';
 import { Connection, type SocketState } from './connection.ts';
@@ -209,8 +210,46 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
     }
   }
 
+  async function revalidateReach(connection: Connection): Promise<void> {
+    const next = await refreshedPrincipal(connection.principal);
+    if (next === null) {
+      connections.delete(connection.id);
+      connection.close(ORGANIZATION_FORBIDDEN_CLOSE_CODE, 'membership_revoked');
+      return;
+    }
+    connection.adoptPrincipal(next);
+    const dropped: string[] = [];
+    for (const scope of connection.heldScopes()) {
+      if (await authorizeScope(scope, next)) continue;
+      dropped.push(scope);
+    }
+    if (dropped.length === 0) return;
+    connection.removeScopes(dropped);
+    logger.info('dropped scopes the reader may no longer reach', {
+      connectionId: connection.id,
+      dropped,
+    });
+  }
+
+  function revalidateMembershipReach(action: SyncAction): void {
+    if (action.model !== 'team_member' && action.model !== 'member') return;
+    if (action.model === 'member' && action.action === 'delete') return;
+    for (const connection of connections.values()) {
+      if (connection.organizationId !== action.organizationId) continue;
+      revalidateReach(connection).catch((error: unknown) => {
+        connections.delete(connection.id);
+        connection.close(ORGANIZATION_FORBIDDEN_CLOSE_CODE, 'membership_revoked');
+        logger.error('reach revalidation failed, closing to fail closed', {
+          connectionId: connection.id,
+          ...errorFields(error),
+        });
+      });
+    }
+  }
+
   function revalidateAffected(action: SyncAction): void {
     revalidateDocScopes(action);
+    revalidateMembershipReach(action);
     if (action.model !== 'member' || action.action !== 'delete') return;
     const removed = memberDeleteSchema.safeParse(action.data);
     if (!removed.success) return;

--- a/packages/services/src/markdown/index.ts
+++ b/packages/services/src/markdown/index.ts
@@ -8,7 +8,7 @@ export { decodeEntities, htmlToText, sanitizeHtml } from './sanitize.ts';
 const UNSAFE_URL = /^\s*(javascript|vbscript|file|data):/i;
 const BLOCK_END = /<\/(p|h[1-6]|li|blockquote|pre|tr|table|ul|ol)>/gi;
 const IMAGE_KEYS = ['tokens', 'items', 'rows', 'header', 'cells'] as const;
-const HEADING_TAG = /<h([1-3])((?:\s[^>]*)?)>([\s\S]*?)<\/h\1>/gi;
+const HEADING_TAG = /<h([1-3])((?:[^>"]|"[^"]*")*)>([\s\S]*?)<\/h\1>/gi;
 const EXISTING_ID = /\sid="[^"]*"/gi;
 
 const marked = new Marked({ gfm: true, breaks: false, pedantic: false, async: false });
@@ -38,7 +38,7 @@ function uniqueHeadingId(text: string, used: Map<string, number>): string {
 
 export function renderMarkdownWithHeadingIds(source: string): string {
   const used = new Map<string, number>();
-  return renderMarkdown(source).replace(
+  const withIds = renderMarkdown(source).replace(
     HEADING_TAG,
     (match: string, level: string, attrs: string, inner: string) => {
       const text = decodeEntities(htmlToText(inner)).replace(/\s+/g, ' ').trim();
@@ -47,6 +47,7 @@ export function renderMarkdownWithHeadingIds(source: string): string {
       return `<h${level}${attrs.replace(EXISTING_ID, '')} id="${id}">${inner}</h${level}>`;
     },
   );
+  return sanitizeHtml(withIds);
 }
 
 export function renderPlainText(source: string): string {

--- a/packages/services/src/markdown/sanitize.ts
+++ b/packages/services/src/markdown/sanitize.ts
@@ -150,12 +150,22 @@ function isSafeUrl(raw: string): boolean {
   return SAFE_SCHEMES.has(value.slice(0, colon).toLowerCase());
 }
 
-function keptAttributes(present: readonly (readonly [string, string])[]): Map<string, string> {
+const HEADING_TAGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+
+function attributeAllowed(tag: string, key: string): boolean {
+  if (key === 'id') return HEADING_TAGS.has(tag);
+  return ALLOWED_ATTR.has(key);
+}
+
+function keptAttributes(
+  tag: string,
+  present: readonly (readonly [string, string])[],
+): Map<string, string> {
   const keep = new Map<string, string>();
   for (const [name, value] of present) {
     const key = name.toLowerCase();
     if (keep.has(key)) continue;
-    if (!ALLOWED_ATTR.has(key)) continue;
+    if (!attributeAllowed(tag, key)) continue;
     if (URL_ATTR.has(key) && !isSafeUrl(value)) continue;
     keep.set(key, value);
   }
@@ -186,7 +196,7 @@ function bunSanitizer(): HTMLRewriter {
         for (const attribute of element.attributes) present.push(attribute);
         for (const [name] of present) element.removeAttribute(name);
 
-        const keep = keptAttributes(present);
+        const keep = keptAttributes(tag, present);
         for (const [key, value] of keep) element.setAttribute(key, value);
 
         if (tag !== 'a') return;
@@ -257,7 +267,7 @@ function cleanDomNode(node: ChildNode): void {
     ]);
     for (const [name] of present) element.removeAttribute(name);
 
-    const keep = keptAttributes(present);
+    const keep = keptAttributes(tag, present);
     for (const [key, value] of keep) element.setAttribute(key, value);
 
     if (tag === 'a' && externalLinkTarget(keep)) {

--- a/packages/services/tests/markdown/heading-id-xss.test.ts
+++ b/packages/services/tests/markdown/heading-id-xss.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'bun:test';
+import { parseHTML } from 'linkedom';
+import { renderMarkdownWithHeadingIds } from '../../src/markdown/index.ts';
+
+function rendered(source: string): string {
+  return renderMarkdownWithHeadingIds(source);
+}
+
+function elementsIn(html: string): string[] {
+  const { document } = parseHTML(`<!doctype html><html><body>${html}</body></html>`);
+  return Array.from(document.body.querySelectorAll('*')).map((node) => node.tagName.toLowerCase());
+}
+
+function eventHandlersIn(html: string): string[] {
+  const { document } = parseHTML(`<!doctype html><html><body>${html}</body></html>`);
+  const found: string[] = [];
+  for (const node of Array.from(document.body.querySelectorAll('*'))) {
+    for (const attribute of Array.from(node.attributes)) {
+      if (attribute.name.toLowerCase().startsWith('on')) found.push(attribute.name);
+    }
+  }
+  return found;
+}
+
+describe('renderMarkdownWithHeadingIds', () => {
+  it('still gives every heading an anchor id', () => {
+    const html = rendered('# Release notes\n\n## Breaking changes\n');
+    expect(html).toContain('id="release-notes"');
+    expect(html).toContain('id="breaking-changes"');
+  });
+
+  it('keeps ids unique when two headings share a title', () => {
+    const html = rendered('# Notes\n\n# Notes\n');
+    expect(html).toContain('id="notes"');
+    expect(html).toContain('id="notes-1"');
+  });
+
+  it('does not let an attribute value containing a bracket smuggle an element out', () => {
+    const html = rendered('<h1 title="a><img src=x onerror=alert(1)>">Release notes</h1>');
+    expect(elementsIn(html)).toEqual(['h1']);
+    expect(eventHandlersIn(html)).toEqual([]);
+  });
+
+  it('closes the entity encoded form of the same break out', () => {
+    for (const bracket of ['&gt;', '&#62;', '&#x3e;']) {
+      const html = rendered(`<h2 title="a${bracket}<img src=x onerror=alert(1)>">Plan</h2>`);
+      expect(elementsIn(html)).toEqual(['h2']);
+      expect(eventHandlersIn(html)).toEqual([]);
+    }
+  });
+
+  it('holds for the other attributes the sanitizer keeps', () => {
+    for (const attribute of ['class', 'alt', 'width', 'start', 'rel']) {
+      const html = rendered(`<h3 ${attribute}="a><img src=x onerror=alert(1)>">Q3</h3>`);
+      expect(elementsIn(html)).toEqual(['h3']);
+      expect(eventHandlersIn(html)).toEqual([]);
+    }
+  });
+
+  it('refuses an id the author wrote onto a non heading element', () => {
+    const html = rendered('<p id="body">Text</p>');
+    expect(html).not.toContain('id="body"');
+  });
+
+  it('replaces an id the author put on a heading rather than keeping both', () => {
+    const html = rendered('<h1 id="attacker">Release notes</h1>');
+    expect(html).toContain('id="release-notes"');
+    expect(html).not.toContain('id="attacker"');
+  });
+
+  it('leaves ordinary markdown alone', () => {
+    const html = rendered('# Title\n\nSome **bold** text and a [link](https://example.com).\n');
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('href="https://example.com"');
+  });
+});


### PR DESCRIPTION
Findings from an adversarial security review of `main`. Each was reproduced against the real stack before being fixed.

## Stored XSS in the doc renderer

`renderMarkdownWithHeadingIds` sanitized the markdown and then re-opened the sanitized HTML with a regex to splice in an anchor id:

```
const HEADING_TAG = /<h([1-3])((?:\s[^>]*)?)>([\s\S]*?)<\/h\1>/gi;
return `<h${level}${attrs} id="${id}">${inner}</h${level}>`;
```

`[^>]*` stops at the first bracket, and the sanitizer legitimately keeps attribute values that contain one, because that is spec-legal HTML and neither serializer escapes it. So stored content of the form

```
<h1 title="a><img src=x onerror=alert(1)>">Release notes</h1>
```

survives sanitization as one inert `h1`, and then the splice puts `id="..."` in the middle of the `title` value, closing the quote early. The browser then sees a real `<img>` with a live `onerror`. There is no Content-Security-Policy on the app, so it executes as whoever opened the doc, in the app origin. Any member with `doc:write` could plant it.

Three changes, each sufficient on its own, kept together as layers: the pattern now understands quoted attribute values, the spliced result is sanitized again rather than trusted, and `id` is allowed only on heading elements so the second pass cannot be used to smuggle one onto anything else.

## Four publishers attached an org scope to rows that are not org-wide

The hub authorizes an `org:` scope on organization membership alone, with no role or team test, and every signed-in browser subscribes to it. So an org scope means "everyone in the workspace".

| Publisher | What leaked |
|---|---|
| `completeCycle` | every rolled-over issue, **title and description**, to the whole org instead of the owning team |
| `removeMember` | the same, for every reassigned issue |
| `markAttachmentReady` | file name, size, storage key and parent id for every upload |
| `/api/attachments/presign` | the same, on every upload, including onto **private** docs |

The sprint case is the worst of them: completing a sprint is routine, `cycle:manage` is a member permission rather than an admin one, and every unfinished issue rolls over, so a full sprint of another team's work went out on each close.

All four now use the scopes the rest of the codebase already uses (`issueScopes`, and a new `attachmentScopes` that derives from the parent rather than the organization). The catch-up path had every one of these right, filtering through `visibleToPrincipal` and `readableDocIds`, which is what shows these were bugs rather than intent: only the live publish path skipped the gate.

## A live socket never re-read membership or role

`ConnectionPrincipal.teamIds` and `.role` were captured once at authentication and never refreshed. `revalidateAffected` returned early for everything except a `member` delete.

Two consequences. Someone removed from a team kept receiving that team's issue, comment and reaction deltas for as long as they left the tab open. And an admin demoted to guest kept `role: 'admin'` on the connection, which short-circuits scope authorization for team, project, issue and doc scopes, so they could subscribe to anything in the workspace *after* the demotion, not merely keep what they already had.

The hub now refreshes the principal on any `team_member` or `member` change and re-authorizes every scope the connection holds, dropping the ones that no longer pass. If the refresh throws, the connection closes rather than continuing on stale permissions.

## Not in this PR

Six lower-severity findings from the same review are still open and tracked: team-restricted projects and their milestones carry an org scope, unshared saved views do too, signing out does not close the socket, the `orbit.read` MCP scope is not enforced, presigned uploads carry no server-side size cap, and the analytics CSV export does not escape formula-leading characters. The project and milestone ones need the owning teams computed rather than simply dropping the org scope, or list updates stop arriving, so they want their own change.