### PR TITLE
Stop the docs editor eating a reader's typing, and three things it claimed but never did

### DIFF
--- a/apps/web/src/app/(app)/docs/[id]/page.tsx
+++ b/apps/web/src/app/(app)/docs/[id]/page.tsx
@@ -19,7 +19,7 @@ export default async function DocPage({ params }: { params: Promise<{ id: string
     <HydrationBoundary state={await dehydratedDoc(principal, id)}>
       <DocSurface
         docId={id}
-        canWrite={can(principal, 'doc:write')}
+        canWriteDocs={can(principal, 'doc:write')}
         canPublish={can(principal, 'doc:publish')}
       />
     </HydrationBoundary>

--- a/apps/web/src/app/api/docs/[id]/duplicate/route.ts
+++ b/apps/web/src/app/api/docs/[id]/duplicate/route.ts
@@ -1,0 +1,16 @@
+import { duplicateDoc } from '@orbit/core';
+import { handle, publish, readJson } from '@/lib/api/handler.ts';
+
+interface RouteContext {
+  readonly params: Promise<{ id: string }>;
+}
+
+export async function POST(request: Request, context: RouteContext): Promise<Response> {
+  const { id } = await context.params;
+  const body = await readJson(request);
+  return await handle(async (principal) => {
+    const saved = await duplicateDoc(principal, id, body);
+    await publish(saved.actions);
+    return { doc: saved.doc };
+  });
+}

--- a/apps/web/src/features/docs/code-theme.ts
+++ b/apps/web/src/features/docs/code-theme.ts
@@ -1,0 +1,11 @@
+import { cn } from '@/lib/cn.ts';
+
+export const codeHighlightClassName = cn(
+  '[&_.hljs-comment]:text-faint [&_.hljs-comment]:italic [&_.hljs-quote]:text-faint',
+  '[&_.hljs-keyword]:text-accent [&_.hljs-selector-tag]:text-accent [&_.hljs-literal]:text-accent',
+  '[&_.hljs-built_in]:text-accent [&_.hljs-meta]:text-accent',
+  '[&_.hljs-string]:text-success [&_.hljs-attr]:text-success [&_.hljs-regexp]:text-success',
+  '[&_.hljs-number]:text-warning [&_.hljs-symbol]:text-warning [&_.hljs-type]:text-warning',
+  '[&_.hljs-title]:text-text [&_.hljs-name]:text-text [&_.hljs-section]:text-text',
+  '[&_.hljs-variable]:text-danger [&_.hljs-template-variable]:text-danger',
+);

--- a/apps/web/src/features/docs/doc-body.tsx
+++ b/apps/web/src/features/docs/doc-body.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef } from 'react';
 import { cn } from '@/lib/cn.ts';
+import { codeHighlightClassName } from './code-theme.ts';
 import type { DocHeading } from './outline.ts';
 import { extractHeadings, sameHeadings } from './outline.ts';
 
@@ -29,6 +30,7 @@ export const docProseClassName = cn(
   '[&_th]:border [&_th]:border-border [&_th]:bg-surface-2 [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:font-medium [&_th]:text-text',
   '[&_td]:border [&_td]:border-border [&_td]:px-3 [&_td]:py-2 [&_td]:align-top',
   '[&_img]:my-5 [&_img]:max-w-full [&_img]:rounded-lg [&_img]:border [&_img]:border-border',
+  codeHighlightClassName,
 );
 
 export interface DocBodyProps {

--- a/apps/web/src/features/docs/doc-reader.tsx
+++ b/apps/web/src/features/docs/doc-reader.tsx
@@ -10,7 +10,7 @@ import { DocAttachments } from './doc-attachments.tsx';
 import { DocBody } from './doc-body.tsx';
 import { DocOutline } from './doc-outline.tsx';
 import type { DocHeading } from './outline.ts';
-import { readTimeMinutes } from './outline.ts';
+import { readTimeMinutes, wordCount } from './outline.ts';
 import { useHashScroll } from './use-hash-scroll.ts';
 import { useScrollSpy } from './use-scroll-spy.ts';
 
@@ -54,6 +54,9 @@ export function DocContextRow({
         </span>
       )}
       <span className="text-2xs text-faint">Updated {relativeTime(new Date(doc.updatedAt))}</span>
+      <span data-testid="doc-stats" className="text-2xs text-faint tabular-nums">
+        {wordCount(doc.content).toLocaleString()} words · {readTimeMinutes(doc.content)} min read
+      </span>
     </div>
   );
 }
@@ -121,8 +124,6 @@ export function DocReader({
             <Avatar name={author.name} src={author.image} size="sm" />
             <span className="text-muted">{author.name}</span>
           </span>
-          <span aria-hidden="true">·</span>
-          <span>{readTimeMinutes(doc.content)} min read</span>
           <span aria-hidden="true">·</span>
           <span className="flex items-center gap-1">
             <Users className="size-3" aria-hidden="true" />

--- a/apps/web/src/features/docs/doc-surface.tsx
+++ b/apps/web/src/features/docs/doc-surface.tsx
@@ -3,7 +3,17 @@
 import { useScopeSubscription } from '@orbit/realtime-client/react';
 import { scopes } from '@orbit/shared/events';
 import { DOC_CONTENT_LIMIT } from '@orbit/shared/validators';
-import { Archive, Check, FolderInput, Indent, PanelLeft, Pencil, Search } from 'lucide-react';
+import {
+  Archive,
+  Check,
+  Copy,
+  FolderInput,
+  Indent,
+  Lock,
+  PanelLeft,
+  Pencil,
+  Search,
+} from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import {
   type KeyboardEvent as ReactKeyboardEvent,
@@ -29,7 +39,13 @@ import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
 import { cn } from '@/lib/cn.ts';
 import type { Doc, DocDetail, DocSummary } from '@/lib/query/schemas.ts';
 import type { DocPatch } from '@/lib/query/use-docs.ts';
-import { useArchiveDoc, useDoc, useDocs, useUpdateDoc } from '@/lib/query/use-docs.ts';
+import {
+  useArchiveDoc,
+  useDoc,
+  useDocs,
+  useDuplicateDoc,
+  useUpdateDoc,
+} from '@/lib/query/use-docs.ts';
 import { DocAttachments } from './doc-attachments.tsx';
 import { DocComments } from './doc-comments.tsx';
 import { DocEditor } from './doc-editor.tsx';
@@ -103,7 +119,7 @@ export function descendantIds(docs: readonly DocSummary[], rootId: string): Set<
 
 export interface DocSurfaceProps {
   readonly docId: string;
-  readonly canWrite: boolean;
+  readonly canWriteDocs: boolean;
   readonly canPublish: boolean;
 }
 
@@ -144,9 +160,13 @@ export function DocSurface(props: DocSurfaceProps) {
   return <LoadedDoc key={detail.data.doc.id} detail={detail.data} {...props} />;
 }
 
+function docWriteAccess(canWriteDocs: boolean, detail: DocDetail): boolean {
+  return canWriteDocs && detail.access === 'write' && detail.doc.archivedAt === null;
+}
+
 function LoadedDoc({
   detail,
-  canWrite,
+  canWriteDocs,
   canPublish,
 }: DocSurfaceProps & { readonly detail: DocDetail }) {
   const router = useRouter();
@@ -155,7 +175,9 @@ function LoadedDoc({
   const { toggle, setUnsavedDocId } = useDocsTree();
   const update = useUpdateDoc(detail.doc.id);
   const archive = useArchiveDoc();
+  const duplicate = useDuplicateDoc();
   const [status, setStatus] = useState<SaveStatus>('saved');
+  const canWrite = docWriteAccess(canWriteDocs, detail);
 
   useEffect(() => {
     setUnsavedDocId(canWrite && status !== 'saved' ? detail.doc.id : null);
@@ -193,7 +215,35 @@ function LoadedDoc({
           </span>
         ) : null}
 
+        {canWrite || !canWriteDocs ? null : (
+          <span
+            data-testid="doc-read-only"
+            className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-2.5 py-0.5 text-2xs text-muted"
+          >
+            <Lock className="size-3" aria-hidden="true" />
+            {detail.doc.archivedAt === null ? 'Read only' : 'Archived'}
+          </span>
+        )}
+
         <DocExportMenu title={detail.doc.title} content={detail.doc.content} />
+
+        {canWriteDocs ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Duplicate doc"
+            data-testid="doc-duplicate"
+            className="size-7 px-0"
+            disabled={duplicate.isPending}
+            onClick={() => {
+              duplicate.mutate(detail.doc.id, {
+                onSuccess: (copy) => router.push(`/docs/${copy.id}`),
+              });
+            }}
+          >
+            <Copy className="size-4" aria-hidden="true" />
+          </Button>
+        ) : null}
 
         <DocHistory docId={detail.doc.id} canWrite={canWrite} />
 

--- a/apps/web/src/features/docs/editor/rich-text-editor.tsx
+++ b/apps/web/src/features/docs/editor/rich-text-editor.tsx
@@ -30,6 +30,7 @@ import {
 } from './extensions.ts';
 import { docToMarkdown } from './markdown.ts';
 import { editorSurfaceClassName } from './styles.ts';
+import { TableControls } from './table-controls.tsx';
 
 export interface UploadedAttachment {
   readonly url: string;
@@ -87,6 +88,11 @@ function caretPosition(editor: Editor, at: number, container: HTMLElement | null
   return { left: coords.left - box.left, top: coords.bottom - box.top + 6 };
 }
 
+function tableAnchor(editor: Editor, container: HTMLElement | null): MenuPosition | null {
+  if (!(editor.isEditable && editor.isActive('table'))) return null;
+  return caretPosition(editor, editor.state.selection.from, container);
+}
+
 export function settledMarkdown(markdown: string): string {
   return markdown.replace(/\n+$/, '');
 }
@@ -128,6 +134,7 @@ export function RichTextEditor({
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [highlight, setHighlight] = useState(0);
   const [bubble, setBubble] = useState<MenuPosition | null>(null);
+  const [tableMenu, setTableMenu] = useState<MenuPosition | null>(null);
   const [link, setLink] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
   const listId = useId();
@@ -217,6 +224,8 @@ export function RichTextEditor({
         highlightRef.current = 0;
         setHighlight(0);
       }
+
+      setTableMenu(tableAnchor(editor, containerRef.current));
 
       const { from, to, empty } = editor.state.selection;
       if (empty || editor.isActive('codeBlock')) {
@@ -432,6 +441,8 @@ export function RichTextEditor({
       {uploading ? (
         <p className="absolute right-2 bottom-2 text-2xs text-faint">Uploading…</p>
       ) : null}
+
+      <TableControls editor={editor} anchor={tableMenu} testId={`${testId}-table-menu`} />
 
       {bubble === null || editor === null ? null : (
         <div

--- a/apps/web/src/features/docs/editor/styles.ts
+++ b/apps/web/src/features/docs/editor/styles.ts
@@ -26,16 +26,6 @@ const toggle = cn(
   '[&_summary]:marker:text-faint',
 );
 
-const highlighting = cn(
-  '[&_.hljs-comment]:text-faint [&_.hljs-comment]:italic [&_.hljs-quote]:text-faint',
-  '[&_.hljs-keyword]:text-accent [&_.hljs-selector-tag]:text-accent [&_.hljs-literal]:text-accent',
-  '[&_.hljs-built_in]:text-accent [&_.hljs-meta]:text-accent',
-  '[&_.hljs-string]:text-success [&_.hljs-attr]:text-success [&_.hljs-regexp]:text-success',
-  '[&_.hljs-number]:text-warning [&_.hljs-symbol]:text-warning [&_.hljs-type]:text-warning',
-  '[&_.hljs-title]:text-text [&_.hljs-name]:text-text [&_.hljs-section]:text-text',
-  '[&_.hljs-variable]:text-danger [&_.hljs-template-variable]:text-danger',
-);
-
 export const editorSurfaceClassName = cn(
   '[&_.ProseMirror]:min-h-40 [&_.ProseMirror]:outline-none',
   '[&_.ProseMirror]:focus-visible:outline-none',
@@ -45,5 +35,4 @@ export const editorSurfaceClassName = cn(
   placeholder,
   callout,
   toggle,
-  highlighting,
 );

--- a/apps/web/src/features/docs/editor/table-controls.tsx
+++ b/apps/web/src/features/docs/editor/table-controls.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import type { Editor } from '@tiptap/core';
+import {
+  BetweenHorizontalEnd,
+  BetweenHorizontalStart,
+  BetweenVerticalEnd,
+  BetweenVerticalStart,
+  FoldHorizontal,
+  FoldVertical,
+  PanelTop,
+  Trash2,
+} from 'lucide-react';
+import { cn } from '@/lib/cn.ts';
+
+export interface TableCommand {
+  readonly id: string;
+  readonly label: string;
+  readonly icon: typeof Trash2;
+  readonly run: (editor: Editor) => void;
+}
+
+export const TABLE_COMMANDS: readonly TableCommand[] = [
+  {
+    id: 'row-before',
+    label: 'Insert row above',
+    icon: BetweenHorizontalStart,
+    run: (editor) => editor.chain().focus().addRowBefore().run(),
+  },
+  {
+    id: 'row-after',
+    label: 'Insert row below',
+    icon: BetweenHorizontalEnd,
+    run: (editor) => editor.chain().focus().addRowAfter().run(),
+  },
+  {
+    id: 'row-delete',
+    label: 'Delete row',
+    icon: FoldVertical,
+    run: (editor) => editor.chain().focus().deleteRow().run(),
+  },
+  {
+    id: 'column-before',
+    label: 'Insert column left',
+    icon: BetweenVerticalStart,
+    run: (editor) => editor.chain().focus().addColumnBefore().run(),
+  },
+  {
+    id: 'column-after',
+    label: 'Insert column right',
+    icon: BetweenVerticalEnd,
+    run: (editor) => editor.chain().focus().addColumnAfter().run(),
+  },
+  {
+    id: 'column-delete',
+    label: 'Delete column',
+    icon: FoldHorizontal,
+    run: (editor) => editor.chain().focus().deleteColumn().run(),
+  },
+  {
+    id: 'header-row',
+    label: 'Toggle header row',
+    icon: PanelTop,
+    run: (editor) => editor.chain().focus().toggleHeaderRow().run(),
+  },
+  {
+    id: 'delete',
+    label: 'Delete table',
+    icon: Trash2,
+    run: (editor) => editor.chain().focus().deleteTable().run(),
+  },
+];
+
+export interface TableAnchor {
+  readonly left: number;
+  readonly top: number;
+}
+
+export interface TableControlsProps {
+  readonly editor: Editor | null;
+  readonly anchor: TableAnchor | null;
+  readonly testId: string;
+}
+
+export function TableControls({ editor, anchor, testId }: TableControlsProps) {
+  if (editor === null || anchor === null) return null;
+  const { left, top } = anchor;
+
+  return (
+    <div
+      role="toolbar"
+      aria-label="Table controls"
+      data-testid={testId}
+      style={{ left: `${left}px`, top: `${top}px` }}
+      className="absolute z-30 flex items-center gap-0.5 rounded-lg border border-border bg-surface p-1 shadow-pop"
+    >
+      {TABLE_COMMANDS.map((command) => (
+        <button
+          key={command.id}
+          type="button"
+          aria-label={command.label}
+          title={command.label}
+          data-testid={`${testId}-${command.id}`}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => command.run(editor)}
+          className={cn(
+            'flex size-7 items-center justify-center rounded-sm text-muted',
+            'transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)]',
+            'hover:bg-surface-2 hover:text-text',
+            command.id === 'delete' && 'hover:text-danger',
+          )}
+        >
+          <command.icon className="size-3.5" aria-hidden="true" />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/docs/outline.ts
+++ b/apps/web/src/features/docs/outline.ts
@@ -24,10 +24,13 @@ export function sameHeadings(left: readonly DocHeading[], right: readonly DocHea
   return left.every((heading, index) => heading.id === right[index]?.id);
 }
 
-export function readTimeMinutes(markdown: string): number {
-  const words = markdown
+export function wordCount(markdown: string): number {
+  return markdown
     .trim()
     .split(/\s+/)
     .filter((word) => word.length > 0).length;
-  return Math.max(1, Math.round(words / 220));
+}
+
+export function readTimeMinutes(markdown: string): number {
+  return Math.max(1, Math.round(wordCount(markdown) / 220));
 }

--- a/apps/web/src/lib/query/schemas.ts
+++ b/apps/web/src/lib/query/schemas.ts
@@ -323,6 +323,8 @@ export const docListSchema = z.object({
 
 export type DocList = z.infer<typeof docListSchema>;
 
+export const docAccessLevelSchema = z.enum(['read', 'write']).catch('read');
+
 export const docDetailSchema = z.object({
   doc: docSchema,
   contentHtml: z.string(),
@@ -330,6 +332,7 @@ export const docDetailSchema = z.object({
   author: z.object({ id: z.string(), name: z.string(), image: z.string().nullable() }),
   followers: z.number(),
   backlinks: z.array(z.object({ id: z.string(), title: z.string() })).default([]),
+  access: docAccessLevelSchema,
 });
 
 export const docVersionSchema = z.object({

--- a/apps/web/src/lib/query/use-docs.ts
+++ b/apps/web/src/lib/query/use-docs.ts
@@ -78,6 +78,24 @@ export function useCreateDoc() {
   });
 }
 
+export function useDuplicateDoc() {
+  const client = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (docId: string): Promise<Doc> => {
+      const result = await apiFetch(`/api/docs/${docId}/duplicate`, docEnvelopeSchema, {
+        method: 'POST',
+        body: {},
+      });
+      return result.doc;
+    },
+    onSuccess: () => invalidateDocs(client),
+    onError: (error) =>
+      toast({ title: 'Could not duplicate', description: messageOf(error), tone: 'danger' }),
+  });
+}
+
 export function useUpdateDoc(docId: string) {
   const client = useQueryClient();
   const { toast } = useToast();

--- a/apps/web/tests/app/api/docs/duplicate.test.ts
+++ b/apps/web/tests/app/api/docs/duplicate.test.ts
@@ -1,0 +1,128 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { SyncAction } from '@orbit/shared/events';
+import type { Principal } from '@orbit/shared/policy';
+import { z } from 'zod';
+
+const coreModule = await import('@orbit/core');
+
+interface DuplicateCall {
+  readonly docId: string;
+  readonly input: unknown;
+}
+
+const calls: DuplicateCall[] = [];
+const published: SyncAction[][] = [];
+
+const copy = {
+  id: 'doc_copy',
+  organizationId: 'org_1',
+  collectionId: null,
+  projectId: null,
+  parentId: null,
+  title: 'Runbook (copy)',
+  slug: 'runbook-copy',
+  content: 'Steps.',
+  visibility: 'workspace',
+  publishToken: null,
+  authorId: 'user_1',
+  repoBinding: null,
+  syncId: 7,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  archivedAt: null,
+};
+
+const action = {
+  syncId: 7,
+  organizationId: 'org_1',
+  scopes: ['doc:doc_copy'],
+  action: 'insert',
+  model: 'doc',
+  modelId: 'doc_copy',
+  data: {},
+} as unknown as SyncAction;
+
+mock.module('@orbit/core', () => ({
+  ...coreModule,
+  duplicateDoc: (_principal: Principal, docId: string, input: unknown) => {
+    calls.push({ docId, input });
+    return Promise.resolve({ doc: copy, actions: [action] });
+  },
+  publishDeltas: (actions: SyncAction[]) => {
+    published.push(actions);
+    return Promise.resolve();
+  },
+}));
+
+const session = {
+  user: { id: 'user_1', name: 'Ada Admin', email: 'ada@orbit.test' },
+  session: { activeOrganizationId: 'org_1' },
+};
+
+mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
+
+mock.module('@/lib/auth/session.ts', () => ({
+  getSession: () => Promise.resolve(session),
+  requireSession: () => Promise.resolve(session),
+}));
+
+const principal: Principal = {
+  userId: 'user_1',
+  organizationId: 'org_1',
+  role: 'member',
+  teamIds: ['team_1'],
+};
+
+mock.module('@/lib/auth/principal.ts', () => ({
+  resolveMembership: () =>
+    Promise.resolve({
+      principal,
+      memberId: 'member_1',
+      organizationName: 'Nova',
+      organizationSlug: 'nova',
+    }),
+}));
+
+const { POST } = await import('../../../../src/app/api/docs/[id]/duplicate/route.ts');
+
+const payloadSchema = z.object({ doc: z.object({ id: z.string(), title: z.string() }) });
+
+beforeEach(() => {
+  calls.length = 0;
+  published.length = 0;
+});
+
+afterAll(() => {
+  mock.module('@orbit/core', () => coreModule);
+});
+
+function request(body?: unknown): Request {
+  return new Request('http://localhost:3000/api/docs/doc_1/duplicate', {
+    method: 'POST',
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+describe('POST /api/docs/[id]/duplicate', () => {
+  it('duplicates the doc named in the path and answers with the copy', async () => {
+    const response = await POST(request(), { params: Promise.resolve({ id: 'doc_1' }) });
+    const payload = payloadSchema.parse(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual([{ docId: 'doc_1', input: {} }]);
+    expect(payload.doc.id).toBe('doc_copy');
+    expect(payload.doc.title).toBe('Runbook (copy)');
+  });
+
+  it('hands a supplied title through to the service', async () => {
+    await POST(request({ title: 'Weekly notes' }), { params: Promise.resolve({ id: 'doc_1' }) });
+
+    expect(calls).toEqual([{ docId: 'doc_1', input: { title: 'Weekly notes' } }]);
+  });
+
+  it('fans the new doc out to everyone watching', async () => {
+    await POST(request(), { params: Promise.resolve({ id: 'doc_1' }) });
+
+    expect(published).toEqual([[action]]);
+  });
+});

--- a/apps/web/tests/features/docs/doc-code-colours.test.tsx
+++ b/apps/web/tests/features/docs/doc-code-colours.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test';
+import { renderMarkdownWithHeadingIds } from '@orbit/services/markdown';
+import { render, screen } from '@testing-library/react';
+import { DocBody } from '../../../src/features/docs/doc-body.tsx';
+
+const SOURCE = ['```ts', 'const total = 1;', '```'].join('\n');
+
+function renderBody(markdown: string) {
+  render(<DocBody html={renderMarkdownWithHeadingIds(markdown)} />);
+  return screen.getByTestId('doc-body');
+}
+
+describe('code colours on the read path', () => {
+  it('emits highlight tokens a reader can see and styles them in the same class', () => {
+    const body = renderBody(SOURCE);
+
+    expect(body.querySelector('.hljs-keyword')?.textContent).toBe('const');
+    expect(body.querySelector('.hljs-number')?.textContent).toBe('1');
+    expect(body.className).toContain('[&_.hljs-keyword]:text-accent');
+    expect(body.className).toContain('[&_.hljs-number]:text-warning');
+  });
+
+  it('keeps the code readable as text so copy and search still work', () => {
+    expect(renderBody(SOURCE).querySelector('pre')?.textContent?.trim()).toBe('const total = 1;');
+  });
+});

--- a/apps/web/tests/features/docs/doc-reader.test.tsx
+++ b/apps/web/tests/features/docs/doc-reader.test.tsx
@@ -173,3 +173,37 @@ describe('doc outline scroll spy', () => {
     expect(await screen.findByTestId('doc-backlinks')).toHaveTextContent('Sync engine launch plan');
   });
 });
+
+describe('doc stats', () => {
+  it('reports the size of the doc next to when it was last touched', async () => {
+    render(
+      <DocReader
+        doc={{ ...doc, content: 'word '.repeat(660) }}
+        contentHtml=""
+        attachments={[]}
+        author={{ name: 'Pulkit', image: null }}
+        followers={1}
+        collectionName={null}
+        projectName={null}
+      />,
+    );
+
+    expect((await screen.findByTestId('doc-stats')).textContent).toBe('660 words · 3 min read');
+  });
+
+  it('counts the words of the doc it was given, not the last one', async () => {
+    render(
+      <DocReader
+        doc={{ ...doc, content: 'one two three' }}
+        contentHtml=""
+        attachments={[]}
+        author={{ name: 'Pulkit', image: null }}
+        followers={1}
+        collectionName={null}
+        projectName={null}
+      />,
+    );
+
+    expect((await screen.findByTestId('doc-stats')).textContent).toBe('3 words · 1 min read');
+  });
+});

--- a/apps/web/tests/features/docs/doc-surface-access.test.tsx
+++ b/apps/web/tests/features/docs/doc-surface-access.test.tsx
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { renderMarkdownWithHeadingIds } from '@orbit/services/markdown';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TooltipProvider } from '@/components/ui/tooltip.tsx';
+import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
+import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
+import { createQueryClient } from '@/lib/query/provider.tsx';
+
+const push = mock();
+
+mock.module('@orbit/realtime-client/react', () => ({
+  useScopeSubscription: () => undefined,
+  useDeltaHandler: () => undefined,
+}));
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ push, replace: mock(), refresh: mock() }),
+  usePathname: () => '/docs/doc_1',
+  useParams: () => ({ id: 'doc_1' }),
+}));
+
+mock.module('@/components/ui/toast.tsx', () => ({
+  useToast: () => ({ toast: () => undefined }),
+}));
+
+const workspace = {
+  ready: true,
+  userId: 'user_reader',
+  teams: [],
+  states: [],
+  labels: [],
+  members: [],
+  projects: [],
+  cycles: [],
+  seedIssues: [],
+  stateById: new Map(),
+  labelById: new Map(),
+  memberById: new Map(),
+  openQuickCreate: () => undefined,
+} as unknown as WorkspaceData;
+
+mock.module('@/features/issues/workspace-provider.tsx', () => ({
+  ...workspaceProvider,
+  useWorkspace: () => workspace,
+}));
+
+const { DocSurface } = await import('../../../src/features/docs/doc-surface.tsx');
+
+const MARKDOWN = '# Delta protocol\n\nEvery mutation bumps sync_id.';
+
+interface RequestLog {
+  readonly method: string;
+  readonly url: string;
+}
+
+let requests: RequestLog[] = [];
+const realFetch = globalThis.fetch;
+
+function docPayload(access: 'read' | 'write', archivedAt: string | null) {
+  return {
+    doc: {
+      id: 'doc_1',
+      organizationId: 'org_1',
+      collectionId: null,
+      projectId: null,
+      parentId: null,
+      title: 'Delta protocol',
+      slug: 'delta-protocol',
+      content: MARKDOWN,
+      visibility: 'private',
+      publishToken: null,
+      authorId: 'user_author',
+      repoBinding: null,
+      syncId: 1,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      archivedAt,
+    },
+    contentHtml: renderMarkdownWithHeadingIds(MARKDOWN),
+    attachments: [],
+    author: { id: 'user_author', name: 'Ada', image: null },
+    followers: 1,
+    backlinks: [],
+    access,
+  };
+}
+
+function stubFetch(access: 'read' | 'write', archivedAt: string | null): void {
+  globalThis.fetch = mock((input: string, init?: { method?: string }) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    requests.push({ method, url });
+
+    const body = (payload: unknown) =>
+      Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(payload) });
+
+    if (url.endsWith('/duplicate'))
+      return body({ doc: { ...docPayload('write', null).doc, id: 'doc_copy' } });
+    if (url.startsWith('/api/docs/doc_1')) return body(docPayload(access, archivedAt));
+    if (url.startsWith('/api/docs')) return body({ docs: [], collections: [], projects: [] });
+    if (url.startsWith('/api/comments')) return body({ comments: [] });
+    return body({});
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  requests = [];
+  push.mockClear();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+async function renderSurface(options: {
+  access: 'read' | 'write';
+  canWriteDocs?: boolean;
+  archivedAt?: string | null;
+}) {
+  stubFetch(options.access, options.archivedAt ?? null);
+  render(
+    <QueryClientProvider client={createQueryClient()}>
+      <TooltipProvider>
+        <DocSurface docId="doc_1" canWriteDocs={options.canWriteDocs ?? true} canPublish={false} />
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+  await screen.findByLabelText('Export doc');
+}
+
+describe('the doc surface follows the per doc access level, not the workspace role', () => {
+  it('gives a member with a read grant the reader and no editable title', async () => {
+    await renderSurface({ access: 'read' });
+
+    expect(await screen.findByTestId('doc-reader')).toBeInTheDocument();
+    expect(screen.queryByTestId('doc-title-input')).toBeNull();
+    expect(screen.queryByTestId('doc-save-status')).toBeNull();
+    expect(screen.getByTestId('doc-read-only').textContent).toBe('Read only');
+  });
+
+  it('gives a member with a write grant the editor', async () => {
+    await renderSurface({ access: 'write' });
+
+    expect(await screen.findByTestId('doc-title-input')).toBeInTheDocument();
+    expect(screen.queryByTestId('doc-reader')).toBeNull();
+    expect(screen.queryByTestId('doc-read-only')).toBeNull();
+    expect(screen.getByTestId('doc-save-status')).toBeInTheDocument();
+  });
+
+  it('never offers the editor for an archived doc, whatever the grant says', async () => {
+    await renderSurface({ access: 'write', archivedAt: '2026-02-01T00:00:00.000Z' });
+
+    expect(await screen.findByTestId('doc-reader')).toBeInTheDocument();
+    expect(screen.queryByTestId('doc-title-input')).toBeNull();
+    expect(screen.getByTestId('doc-read-only').textContent).toBe('Archived');
+  });
+
+  it('hides the archive and nest controls from a reader but keeps export', async () => {
+    await renderSurface({ access: 'read' });
+
+    expect(screen.queryByTestId('doc-archive')).toBeNull();
+    expect(screen.queryByTestId('doc-parent')).toBeNull();
+    expect(screen.getByLabelText('Export doc')).toBeInTheDocument();
+  });
+});
+
+describe('duplicating a doc from the header', () => {
+  it('lets a reader take their own copy and opens it', async () => {
+    const user = userEvent.setup();
+    await renderSurface({ access: 'read' });
+
+    await user.click(await screen.findByTestId('doc-duplicate'));
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith('/docs/doc_copy'));
+    expect(requests).toContainEqual({ method: 'POST', url: '/api/docs/doc_1/duplicate' });
+  });
+
+  it('never offers the copy to someone who cannot write docs at all', async () => {
+    await renderSurface({ access: 'read', canWriteDocs: false });
+
+    expect(await screen.findByTestId('doc-reader')).toBeInTheDocument();
+    expect(screen.queryByTestId('doc-duplicate')).toBeNull();
+    expect(screen.queryByTestId('doc-read-only')).toBeNull();
+  });
+});

--- a/apps/web/tests/features/docs/docs.test.ts
+++ b/apps/web/tests/features/docs/docs.test.ts
@@ -16,6 +16,7 @@ import {
   extractHeadings,
   readTimeMinutes,
   sameHeadings,
+  wordCount,
 } from '../../../src/features/docs/outline.ts';
 import {
   canonicalDocUrl,
@@ -93,6 +94,14 @@ describe('extractHeadings', () => {
   it('never reports less than a minute of reading', () => {
     expect(readTimeMinutes('')).toBe(1);
     expect(readTimeMinutes('word '.repeat(660))).toBe(3);
+  });
+
+  it('counts words across every kind of whitespace and reports none for an empty doc', () => {
+    expect(wordCount('')).toBe(0);
+    expect(wordCount('   \n\n  ')).toBe(0);
+    expect(wordCount('one two three')).toBe(3);
+    expect(wordCount('one\ntwo\t three   four\r\nfive')).toBe(5);
+    expect(wordCount('word '.repeat(660))).toBe(660);
   });
 });
 

--- a/apps/web/tests/features/docs/editor/table-controls.test.tsx
+++ b/apps/web/tests/features/docs/editor/table-controls.test.tsx
@@ -1,0 +1,203 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Editor } from '@tiptap/core';
+import { useState } from 'react';
+import { TooltipProvider } from '@/components/ui/tooltip.tsx';
+import { RichTextEditor } from '../../../../src/features/docs/editor/rich-text-editor.tsx';
+
+function Harness({
+  onChange,
+  onReady,
+}: {
+  onChange: (value: string) => void;
+  onReady: (editor: Editor) => void;
+}) {
+  const [value, setValue] = useState('');
+  return (
+    <TooltipProvider>
+      <RichTextEditor
+        value={value}
+        onChange={(next) => {
+          setValue(next);
+          onChange(next);
+        }}
+        ariaLabel="Body"
+        testId="rich"
+        toolbar="full"
+        onReady={onReady}
+      />
+    </TooltipProvider>
+  );
+}
+
+function mountEditor(onChange: (value: string) => void): Promise<Editor> {
+  return new Promise((resolve) => {
+    render(<Harness onChange={onChange} onReady={resolve} />);
+  });
+}
+
+function tableLines(markdown: string): string[] {
+  return markdown
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('|'));
+}
+
+function rows(markdown: string): string[][] {
+  return tableLines(markdown)
+    .filter((line) => !/^\|(?:\s*-+\s*\|)+$/.test(line))
+    .map((line) =>
+      line
+        .slice(1, -1)
+        .split('|')
+        .map((cell) => cell.trim()),
+    );
+}
+
+function rowIndexOf(markdown: string, text: string): number {
+  return rows(markdown).findIndex((row) => row.includes(text));
+}
+
+function columnIndexOf(markdown: string, text: string): number {
+  for (const row of rows(markdown)) {
+    const at = row.indexOf(text);
+    if (at !== -1) return at;
+  }
+  return -1;
+}
+
+function columnCount(markdown: string): number {
+  return rows(markdown)[0]?.length ?? 0;
+}
+
+interface Mounted {
+  readonly editor: Editor;
+  readonly latest: () => string;
+}
+
+async function tableWithContent(): Promise<Mounted> {
+  const onChange = mock();
+  const editor = await mountEditor(onChange);
+  editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
+  editor.chain().focus().insertContent('head').run();
+  editor.commands.goToNextCell();
+  editor.commands.goToNextCell();
+  editor.commands.goToNextCell();
+  editor.chain().focus().insertContent('beta').run();
+  await screen.findByTestId('rich-table-menu');
+  const latest = () => String(onChange.mock.calls.at(-1)?.[0] ?? '');
+  await waitFor(() => expect(rowIndexOf(latest(), 'beta')).toBe(1));
+  return { editor, latest };
+}
+
+async function press(testId: string): Promise<void> {
+  await userEvent.setup().click(screen.getByTestId(testId));
+}
+
+describe('table controls', () => {
+  it('stays out of the way until the caret is inside a table', async () => {
+    const editor = await mountEditor(mock());
+    editor.chain().focus().insertContent('just a paragraph').run();
+
+    await screen.findByTestId('rich-toolbar');
+    expect(screen.queryByTestId('rich-table-menu')).toBeNull();
+  });
+
+  it('appears with every row and column operation once a table is inserted', async () => {
+    await tableWithContent();
+
+    const menu = screen.getByTestId('rich-table-menu');
+    for (const label of [
+      'Insert row above',
+      'Insert row below',
+      'Delete row',
+      'Insert column left',
+      'Insert column right',
+      'Delete column',
+      'Toggle header row',
+      'Delete table',
+    ]) {
+      expect(within(menu).getByLabelText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('inserts a row below the caret, leaving the current row where it was', async () => {
+    const { latest } = await tableWithContent();
+    expect(rows(latest())).toHaveLength(3);
+
+    await press('rich-table-menu-row-after');
+
+    await waitFor(() => expect(rows(latest())).toHaveLength(4));
+    expect(rowIndexOf(latest(), 'beta')).toBe(1);
+  });
+
+  it('inserts a row above the caret, pushing the current row down', async () => {
+    const { latest } = await tableWithContent();
+
+    await press('rich-table-menu-row-before');
+
+    await waitFor(() => expect(rows(latest())).toHaveLength(4));
+    expect(rowIndexOf(latest(), 'beta')).toBe(2);
+  });
+
+  it('deletes the row the caret is in', async () => {
+    const { latest } = await tableWithContent();
+
+    await press('rich-table-menu-row-delete');
+
+    await waitFor(() => expect(rows(latest())).toHaveLength(2));
+    expect(rowIndexOf(latest(), 'beta')).toBe(-1);
+    expect(rowIndexOf(latest(), 'head')).toBe(0);
+  });
+
+  it('inserts a column to the right, leaving the current column where it was', async () => {
+    const { latest } = await tableWithContent();
+    expect(columnCount(latest())).toBe(3);
+
+    await press('rich-table-menu-column-after');
+
+    await waitFor(() => expect(columnCount(latest())).toBe(4));
+    expect(columnIndexOf(latest(), 'beta')).toBe(0);
+  });
+
+  it('inserts a column to the left, pushing the current column across', async () => {
+    const { latest } = await tableWithContent();
+
+    await press('rich-table-menu-column-before');
+
+    await waitFor(() => expect(columnCount(latest())).toBe(4));
+    expect(columnIndexOf(latest(), 'beta')).toBe(1);
+  });
+
+  it('deletes the column the caret is in', async () => {
+    const { latest } = await tableWithContent();
+
+    await press('rich-table-menu-column-delete');
+
+    await waitFor(() => expect(columnCount(latest())).toBe(2));
+    expect(columnIndexOf(latest(), 'beta')).toBe(-1);
+    expect(columnIndexOf(latest(), 'head')).toBe(-1);
+  });
+
+  it('turns the header row into ordinary cells and back', async () => {
+    await tableWithContent();
+    const cells = () => screen.getByTestId('rich').querySelectorAll('th').length;
+    expect(cells()).toBe(3);
+
+    await press('rich-table-menu-header-row');
+    await waitFor(() => expect(cells()).toBe(0));
+
+    await press('rich-table-menu-header-row');
+    await waitFor(() => expect(cells()).toBe(3));
+  });
+
+  it('deletes the whole table and takes its own menu away with it', async () => {
+    const { latest } = await tableWithContent();
+
+    await press('rich-table-menu-delete');
+
+    await waitFor(() => expect(tableLines(latest())).toHaveLength(0));
+    await waitFor(() => expect(screen.queryByTestId('rich-table-menu')).toBeNull());
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -207,6 +207,7 @@
         "@react-email/render": "2.1.0",
         "drizzle-orm": "0.45.2",
         "linkedom": "^0.18.13",
+        "lowlight": "^3",
         "marked": "18.0.7",
         "resend": "6.18.0",
         "zod": "4.4.3",

--- a/packages/core/src/content/doc-service.ts
+++ b/packages/core/src/content/doc-service.ts
@@ -14,18 +14,21 @@ import {
   sql,
 } from '@orbit/db';
 import type { NotificationEvent } from '@orbit/services/notifications';
+import type { DocAccessLevel } from '@orbit/shared/constants';
 import { isExternallyShared, isRestricted } from '@orbit/shared/constants';
 import { conflict, forbidden, notFound, validationFailed } from '@orbit/shared/errors';
 import type { Actor, SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
-import { assertCan, canReadDoc } from '@orbit/shared/policy';
+import { assertCan, can, canReadDoc } from '@orbit/shared/policy';
 import { docUrl, slugify, truncate } from '@orbit/shared/utils';
 import {
+  DOC_TITLE_LIMIT,
   docAccessSetSchema,
   docCollectionCreateSchema,
   docCollectionUpdateSchema,
   docCreateSchema,
+  docDuplicateSchema,
   docFilterSchema,
   docShareSchema,
   docUpdateSchema,
@@ -79,6 +82,7 @@ export interface DocDetail {
   readonly author: DocAuthor;
   readonly followers: number;
   readonly backlinks: DocBacklink[];
+  readonly access: DocAccessLevel;
 }
 
 export interface SavedDoc {
@@ -217,15 +221,24 @@ async function writeGrantedDocIds(
   return rows.length > 0;
 }
 
+export async function docAccessLevel(
+  executor: Executor,
+  principal: Principal,
+  doc: DocRow,
+): Promise<DocAccessLevel> {
+  if (!can(principal, 'doc:write')) return 'read';
+  if (principal.role === 'admin') return 'write';
+  if (doc.authorId === principal.userId) return 'write';
+  if (!isRestricted(doc.visibility)) return 'write';
+  return (await writeGrantedDocIds(executor, principal, doc.id)) ? 'write' : 'read';
+}
+
 export async function assertDocWritable(
   executor: Executor,
   principal: Principal,
   doc: DocRow,
 ): Promise<void> {
-  if (principal.role === 'admin') return;
-  if (doc.authorId === principal.userId) return;
-  if (!isRestricted(doc.visibility)) return;
-  if (await writeGrantedDocIds(executor, principal, doc.id)) return;
+  if ((await docAccessLevel(executor, principal, doc)) === 'write') return;
   throw forbidden('You only have read access to that doc.');
 }
 
@@ -425,6 +438,7 @@ async function detailFor(doc: DocRow, principal: Principal | null): Promise<DocD
     author: author ?? { id: doc.authorId, name: 'Someone', image: null },
     followers: followers?.total ?? 0,
     backlinks: await listDocBacklinks(doc, principal),
+    access: principal === null ? 'read' : await docAccessLevel(db, principal, doc),
   };
 }
 
@@ -539,6 +553,59 @@ export async function createDoc(principal: Principal, input: unknown): Promise<S
     );
 
     return { doc, actions: [docAction(doc, syncId, actor, 'insert'), ...notifications] };
+  });
+}
+
+const COPY_SUFFIX = ' (copy)';
+
+function copyTitle(title: string): string {
+  const room = DOC_TITLE_LIMIT - COPY_SUFFIX.length;
+  return `${title.length > room ? title.slice(0, room).trimEnd() : title}${COPY_SUFFIX}`;
+}
+
+function copyVisibility(visibility: string): string {
+  return isExternallyShared(visibility) ? 'workspace' : visibility;
+}
+
+export async function duplicateDoc(
+  principal: Principal,
+  docId: string,
+  input: unknown = {},
+): Promise<SavedDoc> {
+  assertCan(principal, 'doc:write');
+  const parsed = docDuplicateSchema.parse(input);
+
+  return await db.transaction(async (tx) => {
+    const source = await loadReadableDoc(tx, principal, docId);
+    const syncId = await nextSyncId(tx);
+    const actor = await principalActor(tx, principal);
+    const title = parsed.title ?? copyTitle(source.title);
+    const [created] = await tx
+      .insert(schema.doc)
+      .values({
+        id: newId(),
+        organizationId: principal.organizationId,
+        collectionId: source.collectionId,
+        projectId: source.projectId,
+        parentId: source.parentId,
+        title,
+        slug: docSlug(title),
+        content: source.content,
+        visibility: copyVisibility(source.visibility),
+        publishToken: null,
+        authorId: principal.userId,
+        syncId,
+      })
+      .returning();
+    const doc = requireRow(created, 'The doc could not be duplicated.');
+
+    await tx
+      .insert(schema.docSubscription)
+      .values({ id: newId(), docId: doc.id, userId: principal.userId })
+      .onConflictDoNothing();
+    await snapshotVersion(tx, principal, doc, null);
+
+    return { doc, actions: [docAction(doc, syncId, actor, 'insert')] };
   });
 }
 

--- a/packages/core/tests/content/doc-service.test.ts
+++ b/packages/core/tests/content/doc-service.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { scopes } from '@orbit/shared/events';
-import { DOC_CONTENT_LIMIT } from '@orbit/shared/validators';
+import type { Principal } from '@orbit/shared/policy';
+import { DOC_CONTENT_LIMIT, DOC_TITLE_LIMIT } from '@orbit/shared/validators';
 import {
   archiveDoc,
   createDoc,
   createDocCollection,
   deleteDocCollection,
   docSlug,
+  duplicateDoc,
   getDoc,
   getPublishedDoc,
   listDocCollections,
@@ -781,5 +783,193 @@ describe('a restricted doc reaches the people it is shared with', () => {
       grants: [{ subjectType: 'team', subjectId: workspace.teamId, level: 'read' }],
     });
     expect(saved.actions[0]?.scopes).toContain(scopes.team(workspace.teamId));
+  });
+});
+
+describe('the access level a doc reports is the level the write path enforces', () => {
+  async function attemptWrite(principal: Principal, docId: string): Promise<'write' | 'read'> {
+    try {
+      await updateDoc(principal, docId, { content: `Edited ${docId}.` });
+      return 'write';
+    } catch {
+      return 'read';
+    }
+  }
+
+  it('agrees with updateDoc for every reader of a restricted doc and an open one', async () => {
+    const author = await addMember(workspace, 'member', { name: 'Ada Author' });
+    const reader = await addMember(workspace, 'member', { name: 'Rey Reader' });
+    const writer = await addMember(workspace, 'member', { name: 'Wren Writer' });
+    const guest = await addMember(workspace, 'guest', { name: 'Gia Guest' });
+
+    const { doc: restricted } = await createDoc(author.principal, {
+      title: 'Board deck',
+      content: 'Numbers.',
+      visibility: 'private',
+    });
+    await setDocAccess(author.principal, restricted.id, {
+      grants: [
+        { subjectType: 'user', subjectId: reader.user.id, level: 'read' },
+        { subjectType: 'user', subjectId: writer.user.id, level: 'write' },
+      ],
+    });
+    const { doc: open } = await createDoc(author.principal, {
+      title: 'Handbook',
+      content: 'Everybody reads this.',
+      visibility: 'workspace',
+    });
+
+    const people = [
+      { name: 'author', principal: author.principal },
+      { name: 'reader', principal: reader.principal },
+      { name: 'writer', principal: writer.principal },
+      { name: 'guest', principal: guest.principal },
+      { name: 'admin', principal: workspace.admin },
+    ];
+
+    const reported: string[] = [];
+    for (const person of people) {
+      for (const doc of [restricted, open]) {
+        const detail = await getDoc(person.principal, doc.id).catch(() => null);
+        if (detail === null) continue;
+        const enforced = await attemptWrite(person.principal, doc.id);
+        reported.push(`${person.name}/${doc.title}/${detail.access}`);
+        expect(`${person.name}/${doc.title}/${detail.access}`).toBe(
+          `${person.name}/${doc.title}/${enforced}`,
+        );
+      }
+    }
+
+    expect(reported).toEqual([
+      'author/Board deck/write',
+      'author/Handbook/write',
+      'reader/Board deck/read',
+      'reader/Handbook/write',
+      'writer/Board deck/write',
+      'writer/Handbook/write',
+      'guest/Handbook/read',
+      'admin/Board deck/write',
+      'admin/Handbook/write',
+    ]);
+  });
+
+  it('tells a reader of a published page nothing more than read', async () => {
+    const { doc } = await createDoc(workspace.admin, {
+      title: 'Launch brief',
+      content: 'Public.',
+      visibility: 'public',
+    });
+    const published = await getPublishedDoc(`launch-brief-${doc.publishToken ?? ''}`);
+    expect(published?.access).toBe('read');
+  });
+});
+
+describe('duplicateDoc', () => {
+  it('copies the body and placement under a copy title owned by the duplicator', async () => {
+    const { collection } = await createDocCollection(workspace.admin, { name: 'Playbooks' });
+    const { doc: parent } = await createDoc(workspace.admin, { title: 'Parent', content: 'Top.' });
+    const { doc: source } = await createDoc(workspace.admin, {
+      title: 'Incident runbook',
+      content: '# Incident runbook\n\nPage the on call.',
+      collectionId: collection.id,
+      parentId: parent.id,
+    });
+    const other = await addMember(workspace, 'member', { name: 'Mo Member' });
+
+    const { doc: copy, actions } = await duplicateDoc(other.principal, source.id);
+
+    expect(copy.id).not.toBe(source.id);
+    expect(copy.title).toBe('Incident runbook (copy)');
+    expect(copy.content).toBe(source.content);
+    expect(copy.collectionId).toBe(collection.id);
+    expect(copy.parentId).toBe(parent.id);
+    expect(copy.authorId).toBe(other.user.id);
+    expect(copy.archivedAt).toBeNull();
+    expect(actions[0]?.action).toBe('insert');
+    expect(actions[0]?.scopes).toContain(scopes.doc(copy.id));
+
+    const untouched = await getDoc(workspace.admin, source.id);
+    expect(untouched.doc.title).toBe('Incident runbook');
+    expect((await listDocs(workspace.admin)).map((row) => row.title)).toContain(
+      'Incident runbook (copy)',
+    );
+  });
+
+  it('never hands the copy the published link of the original', async () => {
+    const { doc: source } = await createDoc(workspace.admin, {
+      title: 'Launch brief',
+      content: 'Read me.',
+      visibility: 'public',
+    });
+    expect(source.publishToken).not.toBeNull();
+
+    const { doc: copy } = await duplicateDoc(workspace.admin, source.id);
+
+    expect(copy.publishToken).toBeNull();
+    expect(copy.visibility).toBe('workspace');
+    expect(await listPublicDocs()).toHaveLength(1);
+  });
+
+  it('lets someone with only read access take their own editable copy', async () => {
+    const author = await addMember(workspace, 'member', { name: 'Ada Author' });
+    const reader = await addMember(workspace, 'member', { name: 'Rey Reader' });
+    const { doc: source } = await createDoc(author.principal, {
+      title: 'Private notes',
+      content: 'Mine.',
+      visibility: 'private',
+    });
+    await setDocAccess(author.principal, source.id, {
+      grants: [{ subjectType: 'user', subjectId: reader.user.id, level: 'read' }],
+    });
+    await expect(updateDoc(reader.principal, source.id, { content: 'no' })).rejects.toMatchObject({
+      code: 'forbidden',
+    });
+
+    const { doc: copy } = await duplicateDoc(reader.principal, source.id);
+
+    expect(copy.authorId).toBe(reader.user.id);
+    expect(copy.visibility).toBe('private');
+    expect((await getDoc(reader.principal, copy.id)).access).toBe('write');
+    await expect(getDoc(author.principal, copy.id)).rejects.toMatchObject({ code: 'not_found' });
+  });
+
+  it('refuses a doc the caller cannot read, and refuses a contributor entirely', async () => {
+    const author = await addMember(workspace, 'member', { name: 'Ada Author' });
+    const stranger = await addMember(workspace, 'member', { name: 'Stan Stranger' });
+    const contributor = await addMember(workspace, 'contributor', { name: 'Cody' });
+    const { doc: secret } = await createDoc(author.principal, {
+      title: 'Secret',
+      content: 'Hidden.',
+      visibility: 'private',
+    });
+    const open = await newDoc('Open doc');
+
+    await expect(duplicateDoc(stranger.principal, secret.id)).rejects.toMatchObject({
+      code: 'not_found',
+    });
+    await expect(duplicateDoc(contributor.principal, open.id)).rejects.toMatchObject({
+      code: 'forbidden',
+    });
+  });
+
+  it('keeps a very long title inside the stored limit', async () => {
+    const long = 'N'.repeat(DOC_TITLE_LIMIT);
+    const { doc: source } = await createDoc(workspace.admin, { title: long, content: 'Body.' });
+
+    const { doc: copy } = await duplicateDoc(workspace.admin, source.id);
+
+    expect(copy.title.length).toBeLessThanOrEqual(DOC_TITLE_LIMIT);
+    expect(copy.title.endsWith(' (copy)')).toBe(true);
+  });
+
+  it('takes a caller supplied title when one is given', async () => {
+    const source = await newDoc('Weekly notes', 'Agenda.');
+
+    const { doc: copy } = await duplicateDoc(workspace.admin, source.id, {
+      title: 'Notes for the fourth',
+    });
+
+    expect(copy.title).toBe('Notes for the fourth');
+    expect(copy.slug).toBe('notes-for-the-fourth');
   });
 });

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -24,6 +24,7 @@
     "@react-email/render": "2.1.0",
     "drizzle-orm": "0.45.2",
     "linkedom": "^0.18.13",
+    "lowlight": "^3",
     "marked": "18.0.7",
     "resend": "6.18.0",
     "zod": "4.4.3"

--- a/packages/services/src/markdown/highlight.ts
+++ b/packages/services/src/markdown/highlight.ts
@@ -1,0 +1,54 @@
+import { common, createLowlight } from 'lowlight';
+
+const lowlight = createLowlight(common);
+
+const ESCAPES: ReadonlyMap<string, string> = new Map([
+  ['&', '&amp;'],
+  ['<', '&lt;'],
+  ['>', '&gt;'],
+  ['"', '&quot;'],
+]);
+
+export function escapeHtml(value: string): string {
+  return value.replace(/[&<>"]/g, (character) => ESCAPES.get(character) ?? character);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function tokenClasses(properties: unknown): string {
+  if (!isRecord(properties)) return '';
+  const names = properties['className'];
+  if (typeof names === 'string') return names;
+  if (!Array.isArray(names)) return '';
+  return names.filter((entry): entry is string => typeof entry === 'string').join(' ');
+}
+
+function serializeTokens(node: unknown): string {
+  if (!isRecord(node)) return '';
+  if (node['type'] === 'text') {
+    const value = node['value'];
+    return typeof value === 'string' ? escapeHtml(value) : '';
+  }
+  const children = node['children'];
+  const inner = Array.isArray(children) ? children.map(serializeTokens).join('') : '';
+  if (node['type'] !== 'element' || node['tagName'] !== 'span') return inner;
+  const classes = tokenClasses(node['properties']);
+  return classes.length === 0 ? inner : `<span class="${escapeHtml(classes)}">${inner}</span>`;
+}
+
+export function languageAlias(raw: string): string {
+  const first = raw.trim().toLowerCase().split(/\s+/)[0] ?? '';
+  return first.replace(/^language-/, '');
+}
+
+export function highlightCode(source: string, language: string): string {
+  const alias = languageAlias(language);
+  if (alias.length === 0 || !lowlight.registered(alias)) return escapeHtml(source);
+  try {
+    return serializeTokens(lowlight.highlight(alias, source));
+  } catch {
+    return escapeHtml(source);
+  }
+}

--- a/packages/services/src/markdown/index.ts
+++ b/packages/services/src/markdown/index.ts
@@ -1,8 +1,10 @@
 import { slugify, truncate } from '@orbit/shared/utils';
 import { Marked } from 'marked';
+import { escapeHtml, highlightCode, languageAlias } from './highlight.ts';
 import { decodeEntities, htmlToText, sanitizeHtml } from './sanitize.ts';
 
 export { extractIssueIdentifiers, extractMentions } from '@orbit/shared/utils';
+export { highlightCode, languageAlias } from './highlight.ts';
 export { decodeEntities, htmlToText, sanitizeHtml } from './sanitize.ts';
 
 const UNSAFE_URL = /^\s*(javascript|vbscript|file|data):/i;
@@ -11,7 +13,15 @@ const IMAGE_KEYS = ['tokens', 'items', 'rows', 'header', 'cells'] as const;
 const HEADING_TAG = /<h([1-3])((?:[^>"]|"[^"]*")*)>([\s\S]*?)<\/h\1>/gi;
 const EXISTING_ID = /\sid="[^"]*"/gi;
 
-const marked = new Marked({ gfm: true, breaks: false, pedantic: false, async: false });
+const marked = new Marked({ gfm: true, breaks: false, pedantic: false, async: false }).use({
+  renderer: {
+    code({ text, lang }): string {
+      const alias = languageAlias(lang ?? '');
+      const classes = alias.length === 0 ? 'hljs' : `hljs language-${escapeHtml(alias)}`;
+      return `<pre><code class="${classes}">${highlightCode(text, alias)}\n</code></pre>\n`;
+    },
+  },
+});
 
 export function renderMarkdown(source: string): string {
   if (source.trim().length === 0) return '';

--- a/packages/services/tests/markdown/highlight.test.ts
+++ b/packages/services/tests/markdown/highlight.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  highlightCode,
+  languageAlias,
+  renderMarkdown,
+  renderMarkdownWithHeadingIds,
+  renderPlainText,
+  summarize,
+} from '../../src/markdown/index.ts';
+
+const TS_BLOCK = ['```ts', 'const total = 1;', '```'].join('\n');
+
+describe('code on the read path', () => {
+  it('colours a fenced block the same way the editor does', () => {
+    const html = renderMarkdown(TS_BLOCK);
+
+    expect(html).toContain('<span class="hljs-keyword">const</span>');
+    expect(html).toContain('<span class="hljs-number">1</span>');
+    expect(html).toContain('class="hljs language-ts"');
+  });
+
+  it('survives the sanitizer that every rendered doc passes through', () => {
+    const html = renderMarkdownWithHeadingIds(`# Title\n\n${TS_BLOCK}`);
+
+    expect(html).toContain('<span class="hljs-keyword">const</span>');
+    expect(html).toContain('id="title"');
+  });
+
+  it('leaves a block with no language alone rather than guessing', () => {
+    const html = renderMarkdown(['```', 'const total = 1;', '```'].join('\n'));
+
+    expect(html).not.toContain('hljs-keyword');
+    expect(html).toContain('const total = 1;');
+  });
+
+  it('leaves a language nobody ships alone', () => {
+    const html = renderMarkdown(['```klingon', 'const total = 1;', '```'].join('\n'));
+
+    expect(html).not.toContain('hljs-keyword');
+    expect(html).toContain('const total = 1;');
+  });
+
+  it('escapes markup inside a highlighted block instead of emitting it', () => {
+    const html = renderMarkdown(
+      ['```ts', 'const evil = "</code></pre><img src=x onerror=alert(1)>";', '```'].join('\n'),
+    );
+
+    expect(html).not.toContain('<img');
+    expect(html).not.toContain('</code></pre><img');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  it('escapes markup inside a block with no language', () => {
+    const html = renderMarkdown(['```', '<img src=x onerror=alert(1)>', '```'].join('\n'));
+
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img');
+  });
+
+  it('keeps the plain text of a code block readable for search and notifications', () => {
+    expect(renderPlainText(TS_BLOCK)).toBe('const total = 1;');
+    expect(summarize(`Intro.\n\n${TS_BLOCK}`, 200)).toBe('Intro. const total = 1;');
+  });
+
+  it('takes the language from the first token of the info string', () => {
+    expect(languageAlias('  TS  extra')).toBe('ts');
+    expect(languageAlias('language-python')).toBe('python');
+    expect(languageAlias('')).toBe('');
+  });
+
+  it('reports a token class for a language it knows and none for one it does not', () => {
+    expect(highlightCode('SELECT 1', 'sql')).toContain('hljs-keyword');
+    expect(highlightCode('SELECT 1', 'klingon')).toBe('SELECT 1');
+    expect(highlightCode('a < b & c', 'klingon')).toBe('a &lt; b &amp; c');
+  });
+});

--- a/packages/services/tests/markdown/markdown.test.ts
+++ b/packages/services/tests/markdown/markdown.test.ts
@@ -38,11 +38,12 @@ describe('renderMarkdown', () => {
     expect(html).toContain('<mark>highlighted</mark>');
   });
 
-  it('keeps fenced code blocks with a language class', () => {
-    const html = renderMarkdown('```ts\nconst a: number = 1;\n```');
+  it('keeps fenced code blocks with a language class and the code intact', () => {
+    const source = '```ts\nconst a: number = 1;\n```';
+    const html = renderMarkdown(source);
     expect(html).toContain('<pre>');
-    expect(html).toContain('class="language-ts"');
-    expect(html).toContain('const a: number = 1;');
+    expect(html).toContain('class="hljs language-ts"');
+    expect(renderPlainText(source)).toBe('const a: number = 1;');
   });
 
   it('keeps headings, lists, blockquotes, images and inline code', () => {

--- a/packages/shared/src/validators/doc.ts
+++ b/packages/shared/src/validators/doc.ts
@@ -4,13 +4,14 @@ import { idSchema } from './common.ts';
 import { booleanFlag } from './issue.ts';
 
 export const DOC_CONTENT_LIMIT = 500_000;
+export const DOC_TITLE_LIMIT = 200;
 
 export const docContentSchema = z.string().max(DOC_CONTENT_LIMIT, {
   message: 'This document is too long to save. Split it into linked pages.',
 });
 
 export const docCreateSchema = z.object({
-  title: z.string().trim().min(1).max(200),
+  title: z.string().trim().min(1).max(DOC_TITLE_LIMIT),
   content: docContentSchema.default(''),
   projectId: idSchema.nullable().default(null),
   collectionId: idSchema.nullable().default(null),
@@ -20,7 +21,7 @@ export const docCreateSchema = z.object({
 
 export const docUpdateSchema = z
   .object({
-    title: z.string().trim().min(1).max(200),
+    title: z.string().trim().min(1).max(DOC_TITLE_LIMIT),
     content: docContentSchema,
     projectId: idSchema.nullable(),
     collectionId: idSchema.nullable(),
@@ -28,6 +29,10 @@ export const docUpdateSchema = z
     visibility: z.enum(DOC_VISIBILITIES),
   })
   .partial();
+
+export const docDuplicateSchema = z.object({
+  title: z.string().trim().min(1).max(DOC_TITLE_LIMIT).optional(),
+});
 
 export const docShareSchema = z.object({
   visibility: z.enum(DOC_VISIBILITIES),


### PR DESCRIPTION
Five items off the docs survey, all Tier 1, chosen so the surface stops
claiming things it does not honour. Nothing from Tier 2 is here.

## 1. The read-only gate, which was a bug that ate typing

`DocSurface` picked between the editor and the reader from
`can(principal, 'doc:write')`, a role capability every member holds. The
per-doc gate is a different check: `assertDocWritable` allows the author,
admins, non-restricted docs, and holders of a `write` grant. So a member
granted only **read** on someone's private doc got the full editing
surface, typed into it, and lost the lot to a 403 that surfaced as a
small "Save failed" chip.

`getDoc` now returns the effective per-doc `access` level, decided by
`docAccessLevel`, which `assertDocWritable` is rewritten in terms of, so
there is exactly one place that answers the question. `GET /api/docs/[id]`
carries it, `docDetailSchema` parses it (falling back to `read`, the safe
direction, if an older server omits it), and the client gate is
`canWriteDocs && access === 'write' && archivedAt === null`.

An archived doc is read-only for the same reason: everything it accepted
used to 409. A reader now sees a "Read only" or "Archived" pill instead
of wondering.

Not built: "ask to edit". A reader now has a real escape hatch below.

## 2. Syntax highlighting on the read path

Code was coloured while you wrote it and flat grey the instant anyone
read it: `renderMarkdown` was plain `marked`, and `docProseClassName`
defined no `.hljs-*` rules. `renderMarkdown` now runs lowlight over a
fenced block and emits token spans, which the sanitizer already allows
(`span` + `class`), and the token colours move out of the editor-only
stylesheet into a shared `code-theme.ts` that `docProseClassName` pulls
in. That covers the reader, the guest view, the published page, the PDF
print path and the markdown preview from one definition.

The serializer only ever emits `<span class="...">` and escapes
everything else, so a block containing `</code></pre><img onerror=...>`
comes out as text. There is a test for exactly that.

## 3. Table row and column controls

Inserting a table was the only thing the editor could do with one. A
bubble menu keyed on `editor.isActive('table')` now carries insert row
above/below, delete row, insert column left/right, delete column, toggle
header row, and delete table, wired to the commands `TableKit` already
ships. Merged cells and column widths stay out, deliberately: markdown
cannot represent either and they would vanish on save.

## 4. Duplicate a doc

`duplicateDoc` copies the body, collection, project and parent of any doc
the caller can read, names it `<title> (copy)` inside the 200 character
limit, and hands authorship to whoever asked. Two things it refuses to
do: inherit the publish token of the original, and keep `public` or
`link` visibility (a copy of a published page lands as a workspace doc,
it does not silently republish itself).

The button sits in the doc header for anyone with `doc:write`, including
someone who only has read access to this doc, which is the point: it is
the reader's way out of a page they cannot edit.

Not built: recursive duplication of children. One page at a time.

## 5. Word count and read time where people write

Read time already existed and was tested, and rendered in exactly one
place: `DocReader`, which only people **without** write access ever see.
Both numbers now sit in `DocContextRow`, so the editing majority sees
them, and the reader stops printing read time twice.

## Deliberately not in this PR

Docs in the command palette, doc presence avatars, `?parent=` on
`/docs/new`, tip and danger slash commands, the `/docs` home, doc icons,
issue mention chips, and `doc.sortOrder`. Each is real work with its own
test surface and none of them shares a seam with the five above.

## Tests

Every test here was watched go red against a deliberate mutation of the
code it covers.

| Test | Mutation that turns it red |
| --- | --- |
| `doc-service.test.ts` "agrees with updateDoc for every reader" | drop the `can(principal, 'doc:write')` check, or return `write` for a doc with no write grant |
| `doc-service.test.ts` "tells a reader of a published page nothing more than read" | report anything but `read` for `principal === null` |
| `doc-service.test.ts` "copies the body and placement" | copy `source.authorId` instead of the caller |
| `doc-service.test.ts` "never hands the copy the published link" | copy `publishToken` and `visibility` from the source |
| `doc-service.test.ts` "lets someone with only read access take their own copy" | any of the above |
| `doc-service.test.ts` "keeps a very long title inside the stored limit" | drop the truncation in `copyTitle` |
| `doc-service.test.ts` "takes a caller supplied title" | ignore `parsed.title` |
| `doc-service.test.ts` "refuses a doc the caller cannot read" | read the row directly instead of through `loadReadableDoc` |
| `highlight.test.ts` "colours a fenced block" | never call lowlight |
| `highlight.test.ts` "escapes markup inside a highlighted block" | stop escaping text nodes |
| `highlight.test.ts` "takes the language from the first token" | keep the `language-` prefix |
| `doc-code-colours.test.tsx` | remove `codeHighlightClassName` from `docProseClassName` |
| `doc-surface-access.test.tsx` "read grant gets the reader" | gate on `canWriteDocs` alone, the original bug |
| `doc-surface-access.test.tsx` "never offers the editor for an archived doc" | drop the `archivedAt` term |
| `doc-surface-access.test.tsx` "lets a reader take their own copy" | gate the button on `canWrite` instead of `canWriteDocs` |
| `duplicate.test.ts` (route) | stop forwarding the body, or stop publishing the actions |
| `table-controls.test.tsx` (10 cases) | `isActive('table')` forced false, or `addRowBefore`/`addRowAfter` swapped |
| `doc-reader.test.tsx` "doc stats" | count the title instead of the content |
| `docs.test.ts` "counts words across every kind of whitespace" | split on `' '` instead of `/\s+/` |

`bun run verify` is green: 1922 tests, 0 failures.
