### PR TITLE
Close the coverage gaps a mutation survey found

### DIFF
--- a/apps/web/tests-preload.ts
+++ b/apps/web/tests-preload.ts
@@ -1,5 +1,12 @@
 import { afterEach, expect, mock } from 'bun:test';
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { ensureLaneDatabase } from '@orbit/db/test-lane';
+import { resolveTestDatabaseUrl } from '../../scripts/test-env.ts';
+
+const databaseUrl = resolveTestDatabaseUrl('orbit_test_web');
+await ensureLaneDatabase(databaseUrl, 'orbit_test_web');
+process.env['DATABASE_URL'] = databaseUrl;
+process.env['DATABASE_POOL_MAX'] = '2';
 
 GlobalRegistrator.register({ url: 'http://localhost:3000' });
 

--- a/apps/web/tests/app/api/standup-board.test.ts
+++ b/apps/web/tests/app/api/standup-board.test.ts
@@ -1,9 +1,12 @@
-import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { createIssue, createLabel } from '@orbit/core';
+import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test-support';
+import { db, schema } from '@orbit/db';
 import type { Principal } from '@orbit/shared/policy';
+import { randomUUIDv7 } from '@orbit/shared/utils';
 import { z } from 'zod';
 
 const coreModule = await import('@orbit/core');
-const dbModule = await import('@orbit/db');
 
 interface BoardStub {
   since: Date;
@@ -14,7 +17,6 @@ interface BoardStub {
 const SINCE = new Date('2030-06-10T08:00:00.000Z');
 
 const board: BoardStub = { since: SINCE, issues: [], workload: [] };
-const labelLinks: { issueId: string; labelId: string }[] = [];
 const received: unknown[] = [];
 
 mock.module('@orbit/core', () => ({
@@ -25,40 +27,49 @@ mock.module('@orbit/core', () => ({
   },
 }));
 
-mock.module('@orbit/db', () => ({
-  ...dbModule,
-  db: { select: () => ({ from: () => ({ where: () => Promise.resolve(labelLinks) }) }) },
-}));
+interface StubSession {
+  readonly user: { id: string; name: string; email: string };
+  readonly session: { activeOrganizationId: string };
+}
 
-const session = {
-  user: { id: 'user_1', name: 'Ada Admin', email: 'ada@orbit.test' },
-  session: { activeOrganizationId: 'org_1' },
-};
-const sessionHolder: { value: typeof session | null } = { value: session };
+const sessionHolder: { value: StubSession | null } = { value: null };
 
 mock.module('@/lib/auth/session.ts', () => ({
   getSession: () => Promise.resolve(sessionHolder.value),
   requireSession: () => Promise.resolve(sessionHolder.value),
 }));
 
-const principal: Principal = {
-  userId: 'user_1',
-  organizationId: 'org_1',
-  role: 'admin',
-  teamIds: ['team_1'],
-};
-
-mock.module('@/lib/auth/principal.ts', () => ({
-  resolveMembership: () =>
-    Promise.resolve({
-      principal,
-      memberId: 'member_1',
-      organizationName: 'Nova',
-      organizationSlug: 'nova',
-    }),
-}));
-
 const { GET } = await import('../../../src/app/api/standup/board/route.ts');
+
+let workspace: Workspace;
+let firstIssueId: string;
+let secondIssueId: string;
+let bugLabelId: string;
+let uiLabelId: string;
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  const first = await createIssue(workspace.admin, {
+    teamId: workspace.teamId,
+    title: 'Ship the importer',
+  });
+  firstIssueId = first.issue.id;
+  const second = await createIssue(workspace.admin, {
+    teamId: workspace.teamId,
+    title: 'Fix the socket',
+  });
+  secondIssueId = second.issue.id;
+
+  const bug = await createLabel(workspace.admin, { name: 'Bugbear', color: '#ff0000' });
+  bugLabelId = bug.label.id;
+  const surface = await createLabel(workspace.admin, { name: 'Surface', color: '#00ff00' });
+  uiLabelId = surface.label.id;
+});
+
+afterAll(() => {
+  mock.module('@orbit/core', () => coreModule);
+});
 
 const payloadSchema = z.object({
   since: z.string(),
@@ -77,21 +88,23 @@ const errorSchema = z.object({ error: z.object({ code: z.string() }) });
 
 const BASE = 'http://localhost:3000/api/standup/board';
 
-beforeEach(() => {
-  sessionHolder.value = session;
+beforeEach(async () => {
+  sessionHolder.value = {
+    user: {
+      id: workspace.adminUser.id,
+      name: workspace.adminUser.name,
+      email: workspace.adminUser.email,
+    },
+    session: { activeOrganizationId: workspace.organizationId },
+  };
   board.since = SINCE;
   board.issues = [
-    { id: 'issue_1', title: 'Ship the importer', assigneeId: 'user_2' },
-    { id: 'issue_2', title: 'Fix the socket', assigneeId: 'user_2' },
+    { id: firstIssueId, title: 'Ship the importer', assigneeId: workspace.adminUser.id },
+    { id: secondIssueId, title: 'Fix the socket', assigneeId: workspace.adminUser.id },
   ];
-  board.workload = [{ userId: 'user_2', open: 2, inProgress: 1, completedSince: 3 }];
-  labelLinks.length = 0;
+  board.workload = [{ userId: workspace.adminUser.id, open: 2, inProgress: 1, completedSince: 3 }];
   received.length = 0;
-});
-
-afterAll(() => {
-  mock.module('@orbit/db', () => dbModule);
-  mock.module('@orbit/core', () => coreModule);
+  await db.delete(schema.issueLabel);
 });
 
 describe('GET /api/standup/board', () => {
@@ -104,23 +117,38 @@ describe('GET /api/standup/board', () => {
     expect(response.status).toBe(200);
     expect(received).toEqual([{ since: SINCE.toISOString(), limitPerPerson: 5 }]);
     expect(payload.since).toBe(SINCE.toISOString());
-    expect(payload.issues.map((issue) => issue.id)).toEqual(['issue_1', 'issue_2']);
+    expect(payload.issues.map((issue) => issue.id)).toEqual([firstIssueId, secondIssueId]);
     expect(payload.workload).toEqual([
-      { userId: 'user_2', open: 2, inProgress: 1, completedSince: 3 },
+      { userId: workspace.adminUser.id, open: 2, inProgress: 1, completedSince: 3 },
     ]);
   });
 
-  it('attaches the labels of every issue it returns', async () => {
-    labelLinks.push(
-      { issueId: 'issue_1', labelId: 'label_bug' },
-      { issueId: 'issue_1', labelId: 'label_ui' },
-    );
+  it('attaches the labels every issue actually carries', async () => {
+    await db.insert(schema.issueLabel).values([
+      { id: randomUUIDv7(), issueId: firstIssueId, labelId: bugLabelId },
+      { id: randomUUIDv7(), issueId: firstIssueId, labelId: uiLabelId },
+    ]);
 
     const response = await GET(new Request(BASE));
     const payload = payloadSchema.parse(await response.json());
 
-    expect(payload.issues[0]?.labelIds).toEqual(['label_bug', 'label_ui']);
+    expect(payload.issues[0]?.labelIds.slice().sort()).toEqual([bugLabelId, uiLabelId].sort());
     expect(payload.issues[1]?.labelIds).toEqual([]);
+  });
+
+  it('never borrows a label from an issue the board did not return', async () => {
+    await db
+      .insert(schema.issueLabel)
+      .values([{ id: randomUUIDv7(), issueId: secondIssueId, labelId: bugLabelId }]);
+    board.issues = [
+      { id: firstIssueId, title: 'Ship the importer', assigneeId: workspace.adminUser.id },
+    ];
+
+    const response = await GET(new Request(BASE));
+    const payload = payloadSchema.parse(await response.json());
+
+    expect(payload.issues).toHaveLength(1);
+    expect(payload.issues[0]?.labelIds).toEqual([]);
   });
 
   it('falls back to the service defaults when no query string is sent', async () => {

--- a/apps/web/tests/app/api/standup-board.test.ts
+++ b/apps/web/tests/app/api/standup-board.test.ts
@@ -98,34 +98,26 @@ async function seedIssuesWithLabels(): Promise<void> {
       color: '#3E63DD',
     },
   ]);
+  await db.insert(schema.member).values({
+    id: `member_${randomUUID()}`,
+    organizationId: seeded.organizationId,
+    userId: seeded.userId,
+    role: 'admin',
+  });
+  await db
+    .insert(schema.teamMember)
+    .values({ id: `tm_${randomUUID()}`, teamId: seeded.teamId, userId: seeded.userId });
 }
 
 const session = {
-  user: { id: 'user_1', name: 'Ada Admin', email: 'ada@orbit.test' },
-  session: { activeOrganizationId: 'org_1' },
+  user: { id: seeded.userId, name: 'Board Author', email: `${seeded.userId}@orbit.test` },
+  session: { activeOrganizationId: seeded.organizationId },
 };
 const sessionHolder: { value: typeof session | null } = { value: session };
 
 mock.module('@/lib/auth/session.ts', () => ({
   getSession: () => Promise.resolve(sessionHolder.value),
   requireSession: () => Promise.resolve(sessionHolder.value),
-}));
-
-const principal: Principal = {
-  userId: 'user_1',
-  organizationId: 'org_1',
-  role: 'admin',
-  teamIds: ['team_1'],
-};
-
-mock.module('@/lib/auth/principal.ts', () => ({
-  resolveMembership: () =>
-    Promise.resolve({
-      principal,
-      memberId: 'member_1',
-      organizationName: 'Nova',
-      organizationSlug: 'nova',
-    }),
 }));
 
 const { GET } = await import('../../../src/app/api/standup/board/route.ts');

--- a/apps/web/tests/app/api/webhooks/github/route.test.ts
+++ b/apps/web/tests/app/api/webhooks/github/route.test.ts
@@ -1,0 +1,237 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { createHmac } from 'node:crypto';
+import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test-support';
+import { and, db, eq, schema } from '@orbit/db';
+import type { SyncAction } from '@orbit/shared/events';
+import { randomUUIDv7 } from '@orbit/shared/utils';
+import { z } from 'zod';
+
+const SECRET = 'a-github-webhook-secret';
+process.env['GITHUB_WEBHOOK_SECRET'] = SECRET;
+
+const published: SyncAction[][] = [];
+const core = await import('@orbit/core');
+mock.module('@orbit/core', () => ({
+  ...core,
+  publishDeltas: (actions: readonly SyncAction[]) => {
+    published.push([...actions]);
+    return Promise.resolve(undefined);
+  },
+}));
+
+mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
+
+const { POST } = await import('../../../../../src/app/api/webhooks/github/route.ts');
+
+afterAll(() => {
+  mock.module('@orbit/core', () => core);
+});
+
+const bodySchema = z.union([
+  z.object({ ok: z.literal(true), actions: z.number() }),
+  z.object({ status: z.literal('duplicate') }),
+  z.object({ error: z.string() }),
+]);
+
+let workspace: Workspace;
+let issueId: string;
+
+async function seed(): Promise<void> {
+  await resetDatabase();
+  workspace = await createWorkspace('Hooked');
+  const integrationId = `int_${randomUUIDv7()}`;
+  await db.insert(schema.integration).values({
+    id: integrationId,
+    organizationId: workspace.organizationId,
+    provider: 'github',
+    externalId: 'install-42',
+    connectedById: workspace.adminUser.id,
+  });
+  await db.insert(schema.githubRepositorySync).values({
+    id: `repo_${randomUUIDv7()}`,
+    organizationId: workspace.organizationId,
+    integrationId,
+    teamId: workspace.teamId,
+    repositoryId: '99',
+    repositoryName: 'acme/web',
+  });
+  const todo = workspace.states.find((state) => state.category === 'unstarted');
+  if (todo === undefined) throw new Error('the seeded team has no unstarted state');
+  await db.update(schema.team).set({ key: 'ORB' }).where(eq(schema.team.id, workspace.teamId));
+  issueId = `iss_${randomUUIDv7()}`;
+  await db.insert(schema.issue).values({
+    id: issueId,
+    organizationId: workspace.organizationId,
+    teamId: workspace.teamId,
+    number: 3,
+    identifier: 'ORB-3',
+    title: 'Dashboard',
+    stateId: todo.id,
+    creatorId: workspace.adminUser.id,
+  });
+}
+
+function pullRequestBody(headRef: string): string {
+  return JSON.stringify({
+    action: 'opened',
+    pull_request: {
+      number: 7,
+      title: 'Rework dashboard',
+      html_url: 'https://github.com/acme/web/pull/7',
+      draft: false,
+      merged: false,
+      state: 'open',
+      head: { ref: headRef },
+      base: { ref: 'main' },
+      user: { login: 'octocat', id: 500 },
+    },
+    repository: { id: 99, full_name: 'acme/web' },
+    sender: { login: 'octocat', id: 500 },
+  });
+}
+
+function sign(raw: string, secret = SECRET): string {
+  return `sha256=${createHmac('sha256', secret).update(raw).digest('hex')}`;
+}
+
+function request(raw: string, headers: Record<string, string | undefined>): Request {
+  const built = new Headers();
+  for (const [key, value] of Object.entries(headers)) {
+    if (value !== undefined) built.set(key, value);
+  }
+  return new Request('http://localhost:3000/api/webhooks/github', {
+    method: 'POST',
+    body: raw,
+    headers: built,
+  });
+}
+
+function signed(raw: string, deliveryId: string, event = 'pull_request'): Request {
+  return request(raw, {
+    'x-hub-signature-256': sign(raw),
+    'x-github-event': event,
+    'x-github-delivery': deliveryId,
+  });
+}
+
+async function deliveryRow(deliveryId: string) {
+  const [row] = await db
+    .select()
+    .from(schema.webhookDelivery)
+    .where(
+      and(
+        eq(schema.webhookDelivery.provider, 'github'),
+        eq(schema.webhookDelivery.deliveryId, deliveryId),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+async function linkCount(): Promise<number> {
+  const rows = await db.select().from(schema.gitLink).where(eq(schema.gitLink.issueId, issueId));
+  return rows.length;
+}
+
+beforeEach(async () => {
+  published.length = 0;
+  await seed();
+});
+
+describe('POST /api/webhooks/github', () => {
+  it('rejects a payload whose signature does not match the secret', async () => {
+    const raw = pullRequestBody('eng-3-dashboard');
+    const response = await POST(
+      request(raw, {
+        'x-hub-signature-256': sign(raw, 'the-wrong-secret'),
+        'x-github-event': 'pull_request',
+        'x-github-delivery': 'delivery-bad-signature',
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(bodySchema.parse(await response.json())).toEqual({ error: 'invalid signature' });
+    expect(await deliveryRow('delivery-bad-signature')).toBeUndefined();
+    expect(await linkCount()).toBe(0);
+  });
+
+  it('rejects a payload with no signature header at all', async () => {
+    const raw = pullRequestBody('eng-3-dashboard');
+    const response = await POST(
+      request(raw, { 'x-github-event': 'pull_request', 'x-github-delivery': 'delivery-none' }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects a signed payload that carries no delivery id', async () => {
+    const raw = pullRequestBody('eng-3-dashboard');
+    const response = await POST(
+      request(raw, { 'x-hub-signature-256': sign(raw), 'x-github-event': 'pull_request' }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(bodySchema.parse(await response.json())).toEqual({ error: 'missing delivery id' });
+    expect(await linkCount()).toBe(0);
+  });
+
+  it('applies a first delivery, publishes its actions and marks the row processed', async () => {
+    const raw = pullRequestBody('orb-3-dashboard');
+
+    const response = await POST(signed(raw, 'delivery-first'));
+    const payload = bodySchema.parse(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ ok: true, actions: expect.any(Number) });
+    expect((await deliveryRow('delivery-first'))?.status).toBe('processed');
+    expect(await linkCount()).toBe(1);
+    expect(published.flat().some((action) => action.model === 'git_link')).toBe(true);
+  });
+
+  it('answers a repeat of a processed delivery with duplicate and applies nothing twice', async () => {
+    const raw = pullRequestBody('orb-3-dashboard');
+    await POST(signed(raw, 'delivery-repeat'));
+    expect(await linkCount()).toBe(1);
+    expect(published.length).toBeGreaterThan(0);
+    published.length = 0;
+
+    const response = await POST(signed(raw, 'delivery-repeat'));
+
+    expect(response.status).toBe(200);
+    expect(bodySchema.parse(await response.json())).toEqual({ status: 'duplicate' });
+    expect(await linkCount()).toBe(1);
+    expect(published).toHaveLength(0);
+  });
+
+  it('retries a delivery that previously failed instead of calling it a duplicate', async () => {
+    const broken = '{ not json';
+    const failed = await POST(signed(broken, 'delivery-retry'));
+    expect(failed.status).toBe(400);
+    expect((await deliveryRow('delivery-retry'))?.status).toBe('failed');
+
+    const raw = pullRequestBody('orb-3-dashboard');
+
+    const response = await POST(signed(raw, 'delivery-retry'));
+
+    expect(response.status).toBe(200);
+    expect(bodySchema.parse(await response.json())).not.toEqual({ status: 'duplicate' });
+    expect((await deliveryRow('delivery-retry'))?.status).toBe('processed');
+    expect(await linkCount()).toBe(1);
+  });
+
+  it('marks the row failed and answers 400 when the body is not json', async () => {
+    const response = await POST(signed('}{', 'delivery-malformed'));
+
+    expect(response.status).toBe(400);
+    expect(bodySchema.parse(await response.json())).toEqual({ error: 'invalid json' });
+    expect((await deliveryRow('delivery-malformed'))?.status).toBe('failed');
+    expect(published).toHaveLength(0);
+  });
+
+  it('records the event name it was handed on the delivery row', async () => {
+    const raw = pullRequestBody('orb-3-dashboard');
+    await POST(signed(raw, 'delivery-named', 'pull_request_review'));
+
+    expect((await deliveryRow('delivery-named'))?.event).toBe('pull_request_review');
+  });
+});

--- a/apps/web/tests/app/api/webhooks/slack/route.test.ts
+++ b/apps/web/tests/app/api/webhooks/slack/route.test.ts
@@ -1,0 +1,228 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { createHmac } from 'node:crypto';
+import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test-support';
+import { db, eq, schema } from '@orbit/db';
+import { randomUUIDv7 } from '@orbit/shared/utils';
+import { z } from 'zod';
+
+const SIGNING_SECRET = 'a-slack-signing-secret';
+process.env['SLACK_SIGNING_SECRET'] = SIGNING_SECRET;
+
+interface UnfurlCall {
+  readonly channel: string;
+  readonly ts: string;
+  readonly unfurls: Record<string, unknown>;
+}
+
+const unfurlCalls: UnfurlCall[] = [];
+const services = await import('@orbit/services');
+
+class RecordingSlackClient {
+  constructor(readonly options: { token: string }) {}
+
+  unfurl(input: UnfurlCall): Promise<void> {
+    unfurlCalls.push(input);
+    return Promise.resolve();
+  }
+}
+
+mock.module('@orbit/services', () => ({ ...services, SlackClient: RecordingSlackClient }));
+
+const { POST } = await import('../../../../../src/app/api/webhooks/slack/route.ts');
+
+afterAll(() => {
+  mock.module('@orbit/services', () => services);
+});
+
+const SLACK_TEAM = 'T-orbit-first';
+const OTHER_SLACK_TEAM = 'T-orbit-second';
+
+async function connect(name: string, slackTeamId: string, title: string): Promise<Workspace> {
+  const workspace = await createWorkspace(name);
+  await db.insert(schema.integration).values({
+    id: `int_${randomUUIDv7()}`,
+    organizationId: workspace.organizationId,
+    provider: 'slack',
+    externalId: slackTeamId,
+    connectedById: workspace.adminUser.id,
+    credentials: { botToken: `xoxb-${slackTeamId}` },
+  });
+  await db.update(schema.team).set({ key: 'ORB' }).where(eq(schema.team.id, workspace.teamId));
+  const todo = workspace.states.find((state) => state.category === 'unstarted');
+  if (todo === undefined) throw new Error('the seeded team has no unstarted state');
+  await db.insert(schema.issue).values({
+    id: `iss_${randomUUIDv7()}`,
+    organizationId: workspace.organizationId,
+    teamId: workspace.teamId,
+    number: 5,
+    identifier: 'ORB-5',
+    title,
+    stateId: todo.id,
+    creatorId: workspace.adminUser.id,
+  });
+  return workspace;
+}
+
+async function seed(): Promise<void> {
+  await resetDatabase();
+  await connect('Slackedone', SLACK_TEAM, 'Owned by the first workspace');
+  await connect('Slackedtwo', OTHER_SLACK_TEAM, 'Owned by the second workspace');
+}
+
+function request(raw: string, headers: Record<string, string>): Request {
+  return new Request('http://localhost:3000/api/webhooks/slack', {
+    method: 'POST',
+    body: raw,
+    headers: new Headers(headers),
+  });
+}
+
+function signed(payload: unknown): Request {
+  const raw = JSON.stringify(payload);
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const digest = createHmac('sha256', SIGNING_SECRET)
+    .update(`v0:${timestamp}:${raw}`)
+    .digest('hex');
+  return request(raw, {
+    'x-slack-signature': `v0=${digest}`,
+    'x-slack-request-timestamp': timestamp,
+  });
+}
+
+function linkShared(teamId: string, url: string) {
+  return {
+    type: 'event_callback',
+    team_id: teamId,
+    event: {
+      type: 'link_shared',
+      channel: 'C123',
+      message_ts: '1700000000.000100',
+      links: [{ url, domain: 'orbit.local' }],
+    },
+  };
+}
+
+const bodySchema = z.union([
+  z.object({ ok: z.literal(true) }),
+  z.object({ challenge: z.string() }),
+  z.object({ error: z.string() }),
+]);
+
+beforeEach(async () => {
+  unfurlCalls.length = 0;
+  await seed();
+});
+
+describe('POST /api/webhooks/slack', () => {
+  it('rejects a payload whose signature does not match the signing secret', async () => {
+    const raw = JSON.stringify(linkShared(SLACK_TEAM, 'https://orbit.local/issue/ORB-5'));
+    const response = await POST(
+      request(raw, {
+        'x-slack-signature': 'v0=deadbeef',
+        'x-slack-request-timestamp': String(Math.floor(Date.now() / 1000)),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(bodySchema.parse(await response.json())).toEqual({ error: 'invalid signature' });
+    expect(unfurlCalls).toHaveLength(0);
+  });
+
+  it('rejects a correctly signed payload whose timestamp is outside the replay window', async () => {
+    const raw = JSON.stringify(linkShared(SLACK_TEAM, 'https://orbit.local/issue/ORB-5'));
+    const stale = String(Math.floor(Date.now() / 1000) - 3_600);
+    const digest = createHmac('sha256', SIGNING_SECRET).update(`v0:${stale}:${raw}`).digest('hex');
+
+    const response = await POST(
+      request(raw, {
+        'x-slack-signature': `v0=${digest}`,
+        'x-slack-request-timestamp': stale,
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(unfurlCalls).toHaveLength(0);
+  });
+
+  it('echoes the challenge of a url verification handshake', async () => {
+    const response = await POST(
+      signed({ type: 'url_verification', challenge: 'the-challenge-value' }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(bodySchema.parse(await response.json())).toEqual({ challenge: 'the-challenge-value' });
+    expect(unfurlCalls).toHaveLength(0);
+  });
+
+  it('unfurls a shared issue link through the slack client exactly once', async () => {
+    const response = await POST(signed(linkShared(SLACK_TEAM, 'https://orbit.local/issue/ORB-5')));
+
+    expect(response.status).toBe(200);
+    expect(bodySchema.parse(await response.json())).toEqual({ ok: true });
+    expect(unfurlCalls).toHaveLength(1);
+    expect(unfurlCalls[0]?.channel).toBe('C123');
+    expect(unfurlCalls[0]?.ts).toBe('1700000000.000100');
+    expect(Object.keys(unfurlCalls[0]?.unfurls ?? {})).toEqual(['https://orbit.local/issue/ORB-5']);
+    expect(JSON.stringify(unfurlCalls[0]?.unfurls)).toContain('Owned by the first workspace');
+  });
+
+  it('answers each slack workspace with the issue of the workspace bound to it', async () => {
+    await POST(signed(linkShared(SLACK_TEAM, 'https://orbit.local/issue/ORB-5')));
+    await POST(signed(linkShared(OTHER_SLACK_TEAM, 'https://orbit.local/issue/ORB-5')));
+
+    expect(unfurlCalls).toHaveLength(2);
+    expect(JSON.stringify(unfurlCalls[0]?.unfurls)).toContain('Owned by the first workspace');
+    expect(JSON.stringify(unfurlCalls[1]?.unfurls)).toContain('Owned by the second workspace');
+  });
+
+  it('does nothing for a slack workspace that is not connected here', async () => {
+    const response = await POST(
+      signed(linkShared('T-somebody-else', 'https://orbit.local/issue/ORB-5')),
+    );
+
+    expect(response.status).toBe(200);
+    expect(bodySchema.parse(await response.json())).toEqual({ ok: true });
+    expect(unfurlCalls).toHaveLength(0);
+  });
+
+  it('does nothing when the shared link resolves to no issue in this workspace', async () => {
+    const response = await POST(
+      signed(linkShared(SLACK_TEAM, 'https://orbit.local/issue/ORB-404')),
+    );
+
+    expect(response.status).toBe(200);
+    expect(unfurlCalls).toHaveLength(0);
+  });
+
+  it('answers ok without unfurling for an event shape it does not handle', async () => {
+    const response = await POST(
+      signed({
+        type: 'event_callback',
+        team_id: SLACK_TEAM,
+        event: { type: 'message', channel: 'C123', text: 'hello' },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(bodySchema.parse(await response.json())).toEqual({ ok: true });
+    expect(unfurlCalls).toHaveLength(0);
+  });
+
+  it('answers 400 for a signed body that is not json', async () => {
+    const raw = '}{';
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const digest = createHmac('sha256', SIGNING_SECRET)
+      .update(`v0:${timestamp}:${raw}`)
+      .digest('hex');
+
+    const response = await POST(
+      request(raw, {
+        'x-slack-signature': `v0=${digest}`,
+        'x-slack-request-timestamp': timestamp,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(bodySchema.parse(await response.json())).toEqual({ error: 'invalid json' });
+  });
+});

--- a/apps/web/tests/app/api/ws/route.test.ts
+++ b/apps/web/tests/app/api/ws/route.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { EventEmitter } from 'node:events';
+
+type Attach = (socket: unknown) => void;
+
+const captured: { attach: Attach | null } = { attach: null };
+
+mock.module('@vercel/functions', () => ({
+  experimental_upgradeWebSocket: (attach: Attach) => {
+    captured.attach = attach;
+    return Promise.resolve(new Response(null, { status: 101 }));
+  },
+}));
+
+const realtimeServer = await import('@orbit/realtime-server');
+mock.module('@orbit/realtime-server', () => ({
+  ...realtimeServer,
+  fromNodeSocket: (socket: unknown) => socket,
+}));
+
+const hubResult: { value: Promise<unknown> } = { value: Promise.resolve(null) };
+mock.module('@/lib/realtime/hub.ts', () => ({
+  realtimeHub: () => hubResult.value,
+  redisConfigured: () => true,
+}));
+
+const { GET } = await import('../../../../src/app/api/ws/route.ts');
+
+class FakeWebSocket extends EventEmitter {
+  readonly closures: { code: number; reason: string }[] = [];
+
+  close(code: number, reason: string): void {
+    this.closures.push({ code, reason });
+  }
+}
+
+interface SessionLog {
+  readonly messages: string[];
+  pongs: number;
+  closes: number;
+}
+
+function fakeHub(log: SessionLog) {
+  return {
+    accept: () => ({
+      message: (raw: string) => {
+        log.messages.push(raw);
+      },
+      pong: () => {
+        log.pongs += 1;
+      },
+      closed: () => {
+        log.closes += 1;
+      },
+    }),
+    stats: () => ({ connections: 1, subscriptions: 0, redis: 'ready' }),
+    close: () => Promise.resolve(),
+  };
+}
+
+function newLog(): SessionLog {
+  return { messages: [], pongs: 0, closes: 0 };
+}
+
+function takeAttach(): Attach {
+  const attach = captured.attach;
+  if (attach === null) throw new Error('the route never handed a socket handler to the upgrade');
+  return attach;
+}
+
+async function attachSocket(socket: FakeWebSocket): Promise<void> {
+  captured.attach = null;
+  const response = await GET();
+  expect(response.status).toBe(101);
+  takeAttach()(socket);
+}
+
+async function settle(): Promise<void> {
+  for (let index = 0; index < 8; index += 1) await new Promise(setImmediate);
+}
+
+afterEach(() => {
+  hubResult.value = Promise.resolve(null);
+});
+
+describe('GET /api/ws', () => {
+  it('upgrades first and replays the frames buffered before the hub answered, in order', async () => {
+    const log = newLog();
+    let release: (value: unknown) => void = () => undefined;
+    hubResult.value = new Promise((resolve) => {
+      release = resolve;
+    });
+
+    const socket = new FakeWebSocket();
+    await attachSocket(socket);
+
+    socket.emit('message', Buffer.from('one'));
+    socket.emit('message', Buffer.from('two'));
+    socket.emit('message', Buffer.from('three'));
+    expect(log.messages).toEqual([]);
+
+    release(fakeHub(log));
+    await settle();
+
+    expect(log.messages).toEqual(['one', 'two', 'three']);
+
+    socket.emit('message', Buffer.from('four'));
+    expect(log.messages).toEqual(['one', 'two', 'three', 'four']);
+    expect(socket.closures).toEqual([]);
+  });
+
+  it('closes with 1008 on the thirty third frame that arrives before the hub is ready', async () => {
+    const log = newLog();
+    let release: (value: unknown) => void = () => undefined;
+    hubResult.value = new Promise((resolve) => {
+      release = resolve;
+    });
+
+    const socket = new FakeWebSocket();
+    await attachSocket(socket);
+
+    for (let index = 0; index < 32; index += 1) {
+      socket.emit('message', Buffer.from(`frame-${index}`));
+    }
+    expect(socket.closures).toEqual([]);
+
+    socket.emit('message', Buffer.from('frame-32'));
+    expect(socket.closures).toEqual([{ code: 1008, reason: 'too_many_frames_before_ready' }]);
+
+    release(fakeHub(log));
+    await settle();
+
+    expect(log.messages).toHaveLength(32);
+    expect(log.messages.at(-1)).toBe('frame-31');
+  });
+
+  it('closes with 1011 when the hub never comes up', async () => {
+    hubResult.value = Promise.reject(new Error('redis is unreachable'));
+
+    const socket = new FakeWebSocket();
+    await attachSocket(socket);
+    socket.emit('message', Buffer.from('queued'));
+    await settle();
+
+    expect(socket.closures).toEqual([{ code: 1011, reason: 'realtime_unavailable' }]);
+  });
+
+  it('never attaches a session to a socket that closed while the hub was starting', async () => {
+    const log = newLog();
+    let release: (value: unknown) => void = () => undefined;
+    hubResult.value = new Promise((resolve) => {
+      release = resolve;
+    });
+
+    const socket = new FakeWebSocket();
+    await attachSocket(socket);
+    socket.emit('message', Buffer.from('early'));
+    socket.emit('close');
+
+    release(fakeHub(log));
+    await settle();
+
+    expect(log.messages).toEqual([]);
+    socket.emit('message', Buffer.from('late'));
+    expect(log.messages).toEqual([]);
+  });
+
+  it('forwards a pong to the session once it exists and ignores it before that', async () => {
+    const log = newLog();
+    let release: (value: unknown) => void = () => undefined;
+    hubResult.value = new Promise((resolve) => {
+      release = resolve;
+    });
+
+    const socket = new FakeWebSocket();
+    await attachSocket(socket);
+    socket.emit('pong');
+    expect(log.pongs).toBe(0);
+
+    release(fakeHub(log));
+    await settle();
+
+    socket.emit('pong');
+    expect(log.pongs).toBe(1);
+
+    socket.emit('close');
+    expect(log.closes).toBe(1);
+  });
+});

--- a/apps/web/tests/lib/api/bootstrap.test.ts
+++ b/apps/web/tests/lib/api/bootstrap.test.ts
@@ -1,34 +1,216 @@
-import { describe, expect, it, mock } from 'bun:test';
-import type { Principal } from '@orbit/shared/policy';
+import { beforeAll, describe, expect, it } from 'bun:test';
+import { createLabel, createProject } from '@orbit/core';
+import {
+  addMember,
+  createWorkspace,
+  resetDatabase,
+  type Workspace,
+} from '@orbit/core/test-support';
+import { db, eq, schema } from '@orbit/db';
+import { bootstrapPayload, bootstrapVersion } from '../../../src/lib/api/bootstrap.ts';
 
-const dbModule = await import('@orbit/db');
-mock.module('@orbit/db', () => ({
-  ...dbModule,
-  db: { execute: () => Promise.resolve([{ version: '5' }]) },
-}));
+let nova: Workspace;
+let orion: Workspace;
+let novaSecondTeam: string;
+let novaProject: string;
+let novaSharedProject: string;
+let orionProject: string;
 
-const { bootstrapVersion } = await import('../../../src/lib/api/bootstrap.ts');
+beforeAll(async () => {
+  await resetDatabase();
+  nova = await createWorkspace('Nova');
+  orion = await createWorkspace('Orion');
 
-function member(userId: string, organizationId = 'org_shared'): Principal {
-  return { userId, organizationId, role: 'admin', teamIds: ['team_1'] };
-}
+  const [second] = await db
+    .insert(schema.team)
+    .values({
+      id: 'team_nova_platform',
+      organizationId: nova.organizationId,
+      name: 'Platform',
+      key: 'PLT',
+    })
+    .returning({ id: schema.team.id });
+  novaSecondTeam = second?.id ?? '';
+  await db
+    .insert(schema.teamMember)
+    .values({ id: 'tm_nova_platform', teamId: novaSecondTeam, userId: nova.adminUser.id });
 
-describe('bootstrapVersion keeps the weak etag user scoped', () => {
-  it('never hands two members of one org the same bootstrap etag version', async () => {
-    const admin = await bootstrapVersion(member('user_admin'));
-    const teammate = await bootstrapVersion(member('user_teammate'));
+  const solo = await createProject(nova.admin, { name: 'Nova only', teamIds: [nova.teamId] });
+  novaProject = solo.project.id;
+  const shared = await createProject(nova.admin, {
+    name: 'Nova shared',
+    teamIds: [nova.teamId, novaSecondTeam],
+  });
+  novaSharedProject = shared.project.id;
+  const away = await createProject(orion.admin, { name: 'Orion only', teamIds: [orion.teamId] });
+  orionProject = away.project.id;
 
-    expect(admin).not.toBe(teammate);
-    expect(admin.startsWith('user_admin')).toBe(true);
-    expect(teammate.startsWith('user_teammate')).toBe(true);
+  await createLabel(nova.admin, { name: 'Flaky', color: '#ff0000', teamId: null });
+  await createLabel(orion.admin, { name: 'Flaky', color: '#00ff00', teamId: null });
+
+  await db.insert(schema.workflowState).values({
+    id: 'state_platform_todo',
+    organizationId: nova.organizationId,
+    teamId: novaSecondTeam,
+    name: 'Platform only',
+    category: 'unstarted',
+    color: '#111111',
+  });
+  await db.insert(schema.cycle).values({
+    id: 'cycle_platform',
+    organizationId: nova.organizationId,
+    teamId: novaSecondTeam,
+    number: 1,
+    name: 'Platform cycle',
+    startsAt: new Date('2026-01-01T00:00:00.000Z'),
+    endsAt: new Date('2026-01-15T00:00:00.000Z'),
   });
 
-  it('separates the same user across two organizations at the same sync id', async () => {
-    const inOrgA = await bootstrapVersion(member('user_multi', 'org_a'));
-    const inOrgB = await bootstrapVersion(member('user_multi', 'org_b'));
+  await db.insert(schema.workflowState).values({
+    id: 'state_crossed_wires',
+    organizationId: orion.organizationId,
+    teamId: nova.teamId,
+    name: 'Crossed wires',
+    category: 'unstarted',
+    color: '#222222',
+  });
+  await db.insert(schema.cycle).values({
+    id: 'cycle_crossed_wires',
+    organizationId: orion.organizationId,
+    teamId: nova.teamId,
+    number: 99,
+    name: 'Crossed wires',
+    startsAt: new Date('2026-02-01T00:00:00.000Z'),
+    endsAt: new Date('2026-02-15T00:00:00.000Z'),
+  });
 
-    expect(inOrgA).not.toBe(inOrgB);
-    expect(inOrgA.includes('org_a')).toBe(true);
-    expect(inOrgB.includes('org_b')).toBe(true);
+  await addMember(nova, 'member', { name: 'Nova Person' });
+  await addMember(orion, 'member', { name: 'Orion Person' });
+});
+
+describe('bootstrapPayload never leaks another workspace', () => {
+  it('returns only the teams the principal can reach', async () => {
+    const payload = await bootstrapPayload(nova.admin, {});
+
+    expect(payload.organizationId).toBe(nova.organizationId);
+    expect(payload.teams.map((team) => team.id).sort()).toEqual(
+      [nova.teamId, novaSecondTeam].sort(),
+    );
+    expect(payload.teams.map((team) => team.id)).not.toContain(orion.teamId);
+  });
+
+  it('returns only the workflow states of the active workspace, even though the names collide', async () => {
+    const payload = await bootstrapPayload(nova.admin, {});
+    const orionStateIds = new Set(orion.states.map((state) => state.id));
+
+    expect(payload.states.length).toBeGreaterThan(0);
+    expect(payload.states.every((state) => !orionStateIds.has(state.id))).toBe(true);
+    expect(payload.states.every((state) => state.teamId !== orion.teamId)).toBe(true);
+    expect(payload.states.some((state) => state.name === 'In Progress')).toBe(true);
+  });
+
+  it('returns only the cycles of the active workspace', async () => {
+    const payload = await bootstrapPayload(nova.admin, {});
+    const orionCycles = await db
+      .select({ id: schema.cycle.id })
+      .from(schema.cycle)
+      .where(eq(schema.cycle.organizationId, orion.organizationId));
+    const forbidden = new Set(orionCycles.map((row) => row.id));
+
+    expect(payload.cycles.length).toBeGreaterThan(0);
+    expect(payload.cycles.every((cycle) => !forbidden.has(cycle.id))).toBe(true);
+  });
+
+  it('drops a state or a cycle whose workspace and team disagree', async () => {
+    const payload = await bootstrapPayload(nova.admin, {});
+
+    expect(payload.states.map((state) => state.id)).not.toContain('state_crossed_wires');
+    expect(payload.cycles.map((cycle) => cycle.id)).not.toContain('cycle_crossed_wires');
+  });
+
+  it('returns only the labels of the active workspace when both named one Flaky', async () => {
+    const payload = await bootstrapPayload(nova.admin, {});
+
+    expect(payload.labels.filter((label) => label.name === 'Flaky')).toHaveLength(1);
+    expect(payload.labels.map((label) => label.color)).toContain('#ff0000');
+    expect(payload.labels.map((label) => label.color)).not.toContain('#00ff00');
+  });
+
+  it('returns only the members of the active workspace', async () => {
+    const payload = await bootstrapPayload(nova.admin, {});
+    const names = payload.members.map((member) => member.name);
+
+    expect(names).toContain('Nova Person');
+    expect(names).not.toContain('Orion Person');
+  });
+
+  it('returns only the projects of the active workspace and the teams each one belongs to', async () => {
+    const payload = await bootstrapPayload(nova.admin, {});
+    const byId = new Map(payload.projects.map((project) => [project.id, project]));
+
+    expect([...byId.keys()].sort()).toEqual([novaProject, novaSharedProject].sort());
+    expect(byId.get(novaProject)?.teamIds).toEqual([nova.teamId]);
+    expect(byId.get(novaSharedProject)?.teamIds.slice().sort()).toEqual(
+      [nova.teamId, novaSecondTeam].sort(),
+    );
+    expect(byId.has(orionProject)).toBe(false);
+  });
+
+  it('picks the active team by key and falls back to the first team otherwise', async () => {
+    const chosen = await bootstrapPayload(nova.admin, { team: 'PLT' });
+    const fallback = await bootstrapPayload(nova.admin, { team: 'NOPE' });
+
+    expect(chosen.activeTeamId).toBe(novaSecondTeam);
+    expect(fallback.activeTeamId).toBe(chosen.teams[0]?.id ?? null);
+  });
+
+  it('shows a member only the teams they joined', async () => {
+    const joiner = await addMember(nova, 'member', {
+      name: 'One Team Only',
+      teamIds: [nova.teamId],
+    });
+
+    const payload = await bootstrapPayload(joiner.principal, {});
+
+    expect(payload.teams.map((team) => team.id)).toEqual([nova.teamId]);
+    expect(payload.states.every((state) => state.teamId === nova.teamId)).toBe(true);
+    expect(payload.states.map((state) => state.name)).not.toContain('Platform only');
+    expect(payload.cycles.every((cycle) => cycle.teamId === nova.teamId)).toBe(true);
+    expect(payload.cycles.map((cycle) => cycle.id)).not.toContain('cycle_platform');
+    expect(payload.projects.map((project) => project.id).sort()).toEqual(
+      [novaProject, novaSharedProject].sort(),
+    );
+  });
+});
+
+describe('bootstrapVersion keeps the weak etag user scoped', () => {
+  it('never hands two members of one workspace the same etag version', async () => {
+    const teammate = await addMember(nova, 'member', { name: 'Etag Person' });
+
+    const admin = await bootstrapVersion(nova.admin);
+    const other = await bootstrapVersion(teammate.principal);
+
+    expect(admin).not.toBe(other);
+    expect(admin.startsWith(`${nova.admin.userId}-`)).toBe(true);
+    expect(other.startsWith(`${teammate.principal.userId}-`)).toBe(true);
+  });
+
+  it('separates the same user across two workspaces', async () => {
+    const inNova = await bootstrapVersion(nova.admin);
+    const inOrion = await bootstrapVersion({ ...nova.admin, organizationId: orion.organizationId });
+
+    expect(inNova).not.toBe(inOrion);
+    expect(inNova.includes(nova.organizationId)).toBe(true);
+    expect(inOrion.includes(orion.organizationId)).toBe(true);
+  });
+
+  it('moves when the workspace writes and stays put when another workspace writes', async () => {
+    const before = await bootstrapVersion(nova.admin);
+
+    await createLabel(orion.admin, { name: 'Elsewhere', color: '#123456', teamId: null });
+    expect(await bootstrapVersion(nova.admin)).toBe(before);
+
+    await createLabel(nova.admin, { name: 'Here', color: '#654321', teamId: null });
+    expect(await bootstrapVersion(nova.admin)).not.toBe(before);
   });
 });

--- a/apps/web/tests/lib/api/handler.test.ts
+++ b/apps/web/tests/lib/api/handler.test.ts
@@ -1,24 +1,44 @@
-import { describe, expect, it, mock } from 'bun:test';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { ORIGIN_CLIENT_ID_HEADER, type SyncAction } from '@orbit/shared/events';
 
-const publishDeltas = mock(() => Promise.reject(new Error('Redis is down.')));
+const published: SyncAction[][] = [];
+const publishOutcome: { fail: boolean } = { fail: false };
+
+const publishDeltas = mock((actions: readonly SyncAction[]) => {
+  published.push([...actions]);
+  return publishOutcome.fail
+    ? Promise.reject(new Error('Redis is down.'))
+    : Promise.resolve(undefined);
+});
 
 const core = await import('@orbit/core');
 mock.module('@orbit/core', () => ({ ...core, publishDeltas }));
-mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
+
+const requestHeaders = new Headers();
+mock.module('next/headers', () => ({ headers: () => Promise.resolve(requestHeaders) }));
 
 const { cachedJson, publish } = await import('../../../src/lib/api/handler.ts');
 
-const ACTION = {
-  syncId: 1,
-  organizationId: 'org_1',
-  scopes: ['team:team_eng'],
-  action: 'update' as const,
-  model: 'issue' as const,
-  modelId: 'issue_1',
-  data: { id: 'issue_1' },
-  actor: { type: 'user' as const, id: 'user_1' },
-  at: '2026-01-01T00:00:00.000Z',
-};
+function action(overrides: Partial<SyncAction> = {}): SyncAction {
+  return {
+    syncId: 1,
+    organizationId: 'org_1',
+    scopes: ['team:team_eng'],
+    action: 'update',
+    model: 'issue',
+    modelId: 'issue_1',
+    data: { id: 'issue_1' },
+    actor: { type: 'user', id: 'user_1' },
+    at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  published.length = 0;
+  publishOutcome.fail = false;
+  requestHeaders.delete(ORIGIN_CLIENT_ID_HEADER);
+});
 
 describe('cachedJson', () => {
   it('serves the payload with a weak etag the client can revalidate against', async () => {
@@ -57,9 +77,52 @@ describe('cachedJson', () => {
   });
 });
 
-describe('publish', () => {
+describe('publish stamps the writing tab so its own echo can be suppressed', () => {
+  it('carries the origin client id onto every action when the header is present', async () => {
+    requestHeaders.set(ORIGIN_CLIENT_ID_HEADER, 'tab-a1b2c3');
+
+    await publish([action(), action({ modelId: 'issue_2', model: 'comment' })]);
+
+    const sent = published[0] ?? [];
+    expect(sent).toHaveLength(2);
+    expect(sent.map((entry) => entry.originClientId)).toEqual(['tab-a1b2c3', 'tab-a1b2c3']);
+    expect(sent.map((entry) => entry.modelId)).toEqual(['issue_1', 'issue_2']);
+  });
+
+  it('leaves the actions unstamped when no tab identified itself', async () => {
+    await publish([action()]);
+
+    const sent = published[0] ?? [];
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.originClientId).toBeUndefined();
+  });
+
+  it('ignores a header value the contract rejects rather than stamping garbage', async () => {
+    requestHeaders.set(ORIGIN_CLIENT_ID_HEADER, '');
+
+    await publish([action()]);
+
+    expect(published[0]?.[0]?.originClientId).toBeUndefined();
+  });
+
+  it('never mutates the actions the caller handed it', async () => {
+    requestHeaders.set(ORIGIN_CLIENT_ID_HEADER, 'tab-zz');
+    const original = action();
+
+    await publish([original]);
+
+    expect(original.originClientId).toBeUndefined();
+  });
+
+  it('publishes nothing at all when there is nothing to publish', async () => {
+    await publish([]);
+    expect(published).toHaveLength(0);
+  });
+
   it('never fails the request when the delta bus is unreachable', async () => {
-    await expect(publish([ACTION])).resolves.toBeUndefined();
-    expect(publishDeltas).toHaveBeenCalled();
+    publishOutcome.fail = true;
+
+    await expect(publish([action()])).resolves.toBeUndefined();
+    expect(published).toHaveLength(1);
   });
 });

--- a/apps/web/tests/lib/auth/principal.test.ts
+++ b/apps/web/tests/lib/auth/principal.test.ts
@@ -1,0 +1,112 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import {
+  addMember,
+  createUser,
+  createWorkspace,
+  resetDatabase,
+  type Workspace,
+} from '@orbit/core/test-support';
+import { db, eq, schema } from '@orbit/db';
+import { resolveMembership } from '../../../src/lib/auth/principal.ts';
+
+let nova: Workspace;
+let orion: Workspace;
+let novaTeamTwo: string;
+let dualUserId: string;
+let strangerId: string;
+let oddRoleUserId: string;
+
+beforeAll(async () => {
+  await resetDatabase();
+  nova = await createWorkspace('Nova');
+  orion = await createWorkspace('Orion');
+
+  const [extraTeam] = await db
+    .insert(schema.team)
+    .values({
+      id: 'team_nova_two',
+      organizationId: nova.organizationId,
+      name: 'Nova Two',
+      key: 'NT',
+    })
+    .returning({ id: schema.team.id });
+  novaTeamTwo = extraTeam?.id ?? '';
+
+  const dual = await addMember(nova, 'member', {
+    name: 'Dual Citizen',
+    teamIds: [nova.teamId, novaTeamTwo],
+  });
+  dualUserId = dual.user.id;
+  await db.insert(schema.member).values({
+    id: 'member_dual_orion',
+    organizationId: orion.organizationId,
+    userId: dualUserId,
+    role: 'admin',
+  });
+  await db
+    .insert(schema.teamMember)
+    .values({ id: 'tm_dual_orion', teamId: orion.teamId, userId: dualUserId });
+
+  const stranger = await createUser('No Workspace');
+  strangerId = stranger.id;
+
+  const odd = await addMember(nova, 'member', { name: 'Odd Role', teamIds: [nova.teamId] });
+  oddRoleUserId = odd.user.id;
+  await db
+    .update(schema.member)
+    .set({ role: 'superuser' })
+    .where(eq(schema.member.userId, oddRoleUserId));
+});
+
+describe('resolveMembership', () => {
+  it('keeps team ids inside the active workspace when the user belongs to two', async () => {
+    const inNova = await resolveMembership(dualUserId, nova.organizationId);
+
+    expect(inNova?.principal.organizationId).toBe(nova.organizationId);
+    expect([...(inNova?.principal.teamIds ?? [])].sort()).toEqual(
+      [nova.teamId, novaTeamTwo].sort(),
+    );
+    expect(inNova?.principal.teamIds).not.toContain(orion.teamId);
+  });
+
+  it('swaps the whole reach when the same user switches workspace', async () => {
+    const inOrion = await resolveMembership(dualUserId, orion.organizationId);
+
+    expect(inOrion?.principal.organizationId).toBe(orion.organizationId);
+    expect([...(inOrion?.principal.teamIds ?? [])]).toEqual([orion.teamId]);
+    expect(inOrion?.principal.role).toBe('admin');
+    expect(inOrion?.organizationName).toBe('Orion');
+  });
+
+  it('falls back to a membership of its own when the active workspace is unset', async () => {
+    const resolved = await resolveMembership(nova.adminUser.id, null);
+
+    expect(resolved?.principal.organizationId).toBe(nova.organizationId);
+    expect(resolved?.principal.role).toBe('admin');
+  });
+
+  it('ignores an active workspace the user is not a member of', async () => {
+    const resolved = await resolveMembership(nova.adminUser.id, orion.organizationId);
+
+    expect(resolved?.principal.organizationId).toBe(nova.organizationId);
+  });
+
+  it('reads a role it does not recognise as guest rather than as an admin', async () => {
+    const resolved = await resolveMembership(oddRoleUserId, nova.organizationId);
+
+    expect(resolved?.principal.role).toBe('guest');
+  });
+
+  it('returns null for a user who is in no workspace at all', async () => {
+    expect(await resolveMembership(strangerId, null)).toBeNull();
+    expect(await resolveMembership(strangerId, nova.organizationId)).toBeNull();
+  });
+
+  it('carries the member row and workspace naming the shell renders', async () => {
+    const resolved = await resolveMembership(nova.adminUser.id, nova.organizationId);
+
+    expect(resolved?.memberId.length ?? 0).toBeGreaterThan(0);
+    expect(resolved?.organizationName).toBe('Nova');
+    expect(resolved?.organizationSlug.startsWith('nova-')).toBe(true);
+  });
+});

--- a/apps/web/tests/lib/auth/server-session-domain.test.ts
+++ b/apps/web/tests/lib/auth/server-session-domain.test.ts
@@ -1,32 +1,37 @@
-import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { db, inArray, schema } from '@orbit/db';
+import { randomUUIDv7 } from '@orbit/shared/utils';
 import { auth } from '../../../src/lib/auth/server.ts';
-
-const dbModule = await import('@orbit/db');
-let lookupEmail: string | undefined;
-
-mock.module('@orbit/db', () => ({
-  ...dbModule,
-  db: {
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          limit: () => Promise.resolve(lookupEmail === undefined ? [] : [{ email: lookupEmail }]),
-        }),
-      }),
-    }),
-  },
-}));
 
 const previousDomains = process.env['ALLOWED_EMAIL_DOMAINS'];
 
-beforeEach(() => {
-  process.env['ALLOWED_EMAIL_DOMAINS'] = 'magicapi.com,noveum.ai';
-  lookupEmail = undefined;
+const allowedId = `usr_allowed_${randomUUIDv7()}`;
+const blockedId = `usr_blocked_${randomUUIDv7()}`;
+
+beforeAll(async () => {
+  await db.insert(schema.user).values([
+    {
+      id: allowedId,
+      name: 'Shashank',
+      email: 'shashank@magicapi.com',
+      handle: `allowed-${allowedId.slice(-8)}`,
+    },
+    {
+      id: blockedId,
+      name: 'Somebody Else',
+      email: 'kpulkit15234@gmail.com',
+      handle: `blocked-${blockedId.slice(-8)}`,
+    },
+  ]);
 });
 
-afterAll(() => {
+beforeEach(() => {
+  process.env['ALLOWED_EMAIL_DOMAINS'] = 'magicapi.com,noveum.ai';
+});
+
+afterAll(async () => {
   process.env['ALLOWED_EMAIL_DOMAINS'] = previousDomains ?? '';
-  mock.module('@orbit/db', () => dbModule);
+  await db.delete(schema.user).where(inArray(schema.user.id, [allowedId, blockedId]));
 });
 
 function sessionHook() {
@@ -47,11 +52,9 @@ function sessionHook() {
 
 describe('session domain allowlist', () => {
   it('rejects an existing user whose domain is not allowed on any sign in', async () => {
-    lookupEmail = 'kpulkit15234@gmail.com';
-
     let thrown: unknown;
     try {
-      await sessionHook()('user_1');
+      await sessionHook()(blockedId);
     } catch (error) {
       thrown = error;
     }
@@ -59,14 +62,12 @@ describe('session domain allowlist', () => {
   });
 
   it('lets an allowed domain start a session', async () => {
-    lookupEmail = 'shashank@magicapi.com';
-    const result = await sessionHook()('user_1');
-    expect(result).toMatchObject({ data: { userId: 'user_1' } });
+    const result = await sessionHook()(allowedId);
+    expect(result).toMatchObject({ data: { userId: allowedId } });
   });
 
   it('does nothing when the user cannot be found', async () => {
-    lookupEmail = undefined;
-    const result = await sessionHook()('ghost');
-    expect(result).toMatchObject({ data: { userId: 'ghost' } });
+    const result = await sessionHook()('usr_ghost_nobody');
+    expect(result).toMatchObject({ data: { userId: 'usr_ghost_nobody' } });
   });
 });

--- a/apps/web/tests/lib/query/use-comments.test.tsx
+++ b/apps/web/tests/lib/query/use-comments.test.tsx
@@ -1,0 +1,311 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { Comment } from '../../../src/lib/query/schemas.ts';
+import { SessionProvider } from '../../../src/lib/realtime/session.tsx';
+
+const toasts: { title: string }[] = [];
+mock.module('@/components/ui/toast.tsx', () => ({
+  useToast: () => ({
+    toast: (input: { title: string }) => {
+      toasts.push(input);
+    },
+  }),
+}));
+
+const { useComments, useCreateComment, useDeleteComment, useUpdateComment } = await import(
+  '../../../src/lib/query/use-comments.ts'
+);
+
+const ISSUE = 'issue_1';
+const ME = 'user_me';
+const originalFetch = globalThis.fetch;
+
+function comment(id: string, body: string, authorId = ME): Comment {
+  return {
+    comment: {
+      id,
+      issueId: ISSUE,
+      authorId,
+      parentId: null,
+      body,
+      editedAt: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      deletedAt: null,
+      syncId: 7,
+    },
+    bodyHtml: `<p>${body}</p>`,
+    reactions: [],
+  };
+}
+
+interface Answer {
+  readonly status?: number;
+  readonly payload: unknown;
+}
+
+type Handler = (url: string, init: RequestInit | undefined) => Answer | Promise<Answer>;
+
+interface FetchLog {
+  readonly urls: string[];
+  readonly methods: string[];
+}
+
+function stubFetch(handler: Handler): FetchLog {
+  const log: FetchLog = { urls: [], methods: [] };
+  globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    log.urls.push(url);
+    log.methods.push(init?.method ?? 'GET');
+    const answer = await handler(url, init);
+    return new Response(JSON.stringify(answer.payload), {
+      status: answer.status ?? 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+  return log;
+}
+
+interface Gate {
+  readonly held: Promise<Answer>;
+  release(answer: Answer): void;
+}
+
+function gate(): Gate {
+  let open: (answer: Answer) => void = () => undefined;
+  const held = new Promise<Answer>((resolve) => {
+    open = resolve;
+  });
+  return { held, release: open };
+}
+
+function wrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <SessionProvider userId={ME}>{children}</SessionProvider>
+    </QueryClientProvider>
+  );
+}
+
+function newClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function bodies(rows: readonly Comment[] | undefined): string[] {
+  return (rows ?? []).map((row) => row.comment.body);
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  toasts.length = 0;
+});
+
+describe('useComments', () => {
+  it('reads one bounded page of the thread', async () => {
+    const log = stubFetch(() => ({ payload: { comments: [comment('c1', 'Hello')] } }));
+    const client = newClient();
+
+    const { result } = renderHook(() => useComments(ISSUE), { wrapper: wrapper(client) });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    expect(bodies(result.current.data)).toEqual(['Hello']);
+    expect(log.urls[0]).toContain(`issueId=${ISSUE}`);
+    expect(log.urls[0]).toContain('limit=50');
+  });
+
+  it('never asks when there is no issue to ask about', async () => {
+    const log = stubFetch(() => ({ payload: { comments: [] } }));
+    const client = newClient();
+
+    renderHook(() => useComments(null), { wrapper: wrapper(client) });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(log.urls).toHaveLength(0);
+  });
+});
+
+describe('useCreateComment', () => {
+  it('paints the pending row, then swaps it for the server row with no duplicate', async () => {
+    const post = gate();
+    const log = stubFetch((_url, init) => {
+      if (init?.method === 'POST') return post.held;
+      return { payload: { comments: [comment('c1', 'Hello')] } };
+    });
+    const client = newClient();
+
+    const list = renderHook(() => useComments(ISSUE), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+
+    const create = renderHook(() => useCreateComment(ISSUE), { wrapper: wrapper(client) });
+    create.result.current.mutate({ body: 'Posted', parentId: null });
+
+    await waitFor(() => expect(bodies(list.result.current.data)).toEqual(['Hello', 'Posted']));
+    const pendingId = (list.result.current.data ?? [])[1]?.comment.id ?? '';
+    expect(pendingId.startsWith('pending-')).toBe(true);
+
+    post.release({ payload: { comment: comment('c-server', 'Posted') } });
+    await waitFor(() => expect(create.result.current.isSuccess).toBe(true));
+    await waitFor(() =>
+      expect((list.result.current.data ?? []).map((row) => row.comment.id)).toEqual([
+        'c1',
+        'c-server',
+      ]),
+    );
+
+    expect(bodies(list.result.current.data)).toEqual(['Hello', 'Posted']);
+    expect(log.methods.filter((method) => method === 'GET')).toHaveLength(1);
+  });
+
+  it('keeps only one row when the socket already delivered the server row', async () => {
+    const post = gate();
+    const log = stubFetch((_url, init) => {
+      if (init?.method === 'POST') return post.held;
+      return { payload: { comments: [comment('c1', 'Hello')] } };
+    });
+    const client = newClient();
+
+    const list = renderHook(() => useComments(ISSUE), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+
+    const create = renderHook(() => useCreateComment(ISSUE), { wrapper: wrapper(client) });
+    create.result.current.mutate({ body: 'Posted', parentId: null });
+    await waitFor(() => expect(bodies(list.result.current.data)).toEqual(['Hello', 'Posted']));
+
+    client.setQueryData<readonly Comment[]>(['comments', ISSUE], (current) => [
+      ...(current ?? []),
+      comment('c-server', 'Posted'),
+    ]);
+
+    post.release({ payload: { comment: comment('c-server', 'Posted') } });
+    await waitFor(() => expect(create.result.current.isSuccess).toBe(true));
+    await waitFor(() =>
+      expect((list.result.current.data ?? []).map((row) => row.comment.id)).toEqual([
+        'c1',
+        'c-server',
+      ]),
+    );
+    expect(log.methods.filter((method) => method === 'POST')).toHaveLength(1);
+  });
+
+  it('rolls the pending row back and warns when the post fails', async () => {
+    const post = gate();
+    stubFetch((_url, init) => {
+      if (init?.method === 'POST') return post.held;
+      return { payload: { comments: [comment('c1', 'Hello')] } };
+    });
+    const client = newClient();
+
+    const list = renderHook(() => useComments(ISSUE), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+
+    const create = renderHook(() => useCreateComment(ISSUE), { wrapper: wrapper(client) });
+    create.result.current.mutate({ body: 'Doomed', parentId: null });
+
+    await waitFor(() => expect(bodies(list.result.current.data)).toEqual(['Hello', 'Doomed']));
+
+    post.release({ status: 500, payload: { error: { code: 'internal', message: 'nope' } } });
+    await waitFor(() => expect(create.result.current.isError).toBe(true));
+    await waitFor(() => expect(bodies(list.result.current.data)).toEqual(['Hello']));
+
+    expect(toasts.map((entry) => entry.title)).toEqual(['Could not post']);
+  });
+});
+
+describe('useUpdateComment', () => {
+  it('paints the edit, then settles on the server row', async () => {
+    const patch = gate();
+    stubFetch((_url, init) => {
+      if (init?.method === 'PATCH') return patch.held;
+      return { payload: { comments: [comment('c1', 'Hello')] } };
+    });
+    const client = newClient();
+
+    const list = renderHook(() => useComments(ISSUE), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+
+    const edit = renderHook(() => useUpdateComment(ISSUE), { wrapper: wrapper(client) });
+    edit.result.current.mutate({ id: 'c1', body: 'Edited' });
+
+    await waitFor(() => expect(bodies(list.result.current.data)).toEqual(['Edited']));
+    expect(list.result.current.data?.[0]?.bodyHtml).toBe('');
+
+    patch.release({ payload: { comment: comment('c1', 'Edited') } });
+    await waitFor(() => expect(edit.result.current.isSuccess).toBe(true));
+
+    expect(list.result.current.data?.[0]?.bodyHtml).toBe('<p>Edited</p>');
+    expect(list.result.current.data).toHaveLength(1);
+  });
+
+  it('puts the old body back when the edit fails', async () => {
+    const patch = gate();
+    stubFetch((_url, init) => {
+      if (init?.method === 'PATCH') return patch.held;
+      return { payload: { comments: [comment('c1', 'Hello')] } };
+    });
+    const client = newClient();
+
+    const list = renderHook(() => useComments(ISSUE), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+
+    const edit = renderHook(() => useUpdateComment(ISSUE), { wrapper: wrapper(client) });
+    edit.result.current.mutate({ id: 'c1', body: 'Edited' });
+
+    await waitFor(() => expect(bodies(list.result.current.data)).toEqual(['Edited']));
+
+    patch.release({ status: 403, payload: { error: { code: 'forbidden', message: 'not yours' } } });
+    await waitFor(() => expect(edit.result.current.isError).toBe(true));
+    await waitFor(() => expect(bodies(list.result.current.data)).toEqual(['Hello']));
+
+    expect(toasts.map((entry) => entry.title)).toEqual(['Could not edit']);
+  });
+});
+
+describe('useDeleteComment', () => {
+  it('takes the row out at once and leaves it out when the server agrees', async () => {
+    const call = gate();
+    stubFetch((_url, init) => {
+      if (init?.method === 'DELETE') return call.held;
+      return { payload: { comments: [comment('c1', 'Hello'), comment('c2', 'Second')] } };
+    });
+    const client = newClient();
+
+    const list = renderHook(() => useComments(ISSUE), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+
+    const remove = renderHook(() => useDeleteComment(ISSUE), { wrapper: wrapper(client) });
+    remove.result.current.mutate('c1');
+
+    await waitFor(() => expect(bodies(list.result.current.data)).toEqual(['Second']));
+
+    call.release({ payload: { deleted: true } });
+    await waitFor(() => expect(remove.result.current.isSuccess).toBe(true));
+    expect(bodies(list.result.current.data)).toEqual(['Second']);
+  });
+
+  it('puts the row back when the delete fails', async () => {
+    const call = gate();
+    stubFetch((_url, init) => {
+      if (init?.method === 'DELETE') return call.held;
+      return { payload: { comments: [comment('c1', 'Hello'), comment('c2', 'Second')] } };
+    });
+    const client = newClient();
+
+    const list = renderHook(() => useComments(ISSUE), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+
+    const remove = renderHook(() => useDeleteComment(ISSUE), { wrapper: wrapper(client) });
+    remove.result.current.mutate('c1');
+
+    await waitFor(() => expect(bodies(list.result.current.data)).toEqual(['Second']));
+
+    call.release({ status: 403, payload: { error: { code: 'forbidden', message: 'not yours' } } });
+    await waitFor(() => expect(remove.result.current.isError).toBe(true));
+    await waitFor(() => expect(bodies(list.result.current.data)).toEqual(['Hello', 'Second']));
+
+    expect(toasts.map((entry) => entry.title)).toEqual(['Could not delete']);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./test-support": "./src/test-support.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/core/tests/content/attachment-service.test.ts
+++ b/packages/core/tests/content/attachment-service.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { db, eq, schema } from '@orbit/db';
+import type { Principal } from '@orbit/shared/policy';
+import {
+  type AttachmentRecord,
+  attachmentScopes,
+  findAttachmentForOrganization,
+  markAttachmentReady,
+} from '../../src/content/attachment-service.ts';
+import { createDoc } from '../../src/content/doc-service.ts';
+import { newId } from '../../src/internal.ts';
+import { createWorkspace, resetDatabase, type Workspace } from '../../src/test-support.ts';
+import { createIssue } from '../../src/work/issue-service.ts';
+
+let nova: Workspace;
+let orion: Workspace;
+let issueId: string;
+let docId: string;
+
+beforeEach(async () => {
+  await resetDatabase();
+  nova = await createWorkspace('Nova');
+  orion = await createWorkspace('Orion');
+  const { issue } = await createIssue(nova.admin, { teamId: nova.teamId, title: 'With a file' });
+  issueId = issue.id;
+  const created = await createDoc(nova.admin, { title: 'With a file', content: '' });
+  docId = created.doc.id;
+});
+
+async function register(
+  principal: Principal,
+  parentType: 'issue' | 'doc' | 'user',
+  parentId: string,
+): Promise<AttachmentRecord> {
+  const [row] = await db
+    .insert(schema.attachment)
+    .values({
+      id: newId(),
+      organizationId: principal.organizationId,
+      parentType,
+      parentId,
+      fileName: 'shot.png',
+      contentType: 'image/png',
+      size: 0,
+      storageKey: `uploads/${newId()}.png`,
+      status: 'pending',
+      uploadedById: principal.userId,
+    })
+    .returning();
+  if (row === undefined) throw new Error('the attachment row was not written');
+  return row;
+}
+
+async function errorOf(run: () => Promise<unknown>): Promise<{ code: string; status: number }> {
+  try {
+    await run();
+  } catch (error: unknown) {
+    const thrown = error as { code?: unknown; status?: unknown };
+    return {
+      code: typeof thrown.code === 'string' ? thrown.code : 'not-a-domain-error',
+      status: typeof thrown.status === 'number' ? thrown.status : 0,
+    };
+  }
+  throw new Error('the call was expected to throw and did not');
+}
+
+describe('attachmentScopes', () => {
+  it('publishes a doc upload on the doc, never on the uploader', () => {
+    expect(
+      attachmentScopes({ parentType: 'doc', parentId: 'doc_1', uploadedById: 'user_1' }),
+    ).toEqual(['doc:doc_1']);
+  });
+
+  it('publishes an issue upload on the issue', () => {
+    expect(
+      attachmentScopes({ parentType: 'issue', parentId: 'issue_1', uploadedById: 'user_1' }),
+    ).toEqual(['issue:issue_1']);
+  });
+
+  it('falls back to the uploader for anything with no shared parent', () => {
+    expect(
+      attachmentScopes({ parentType: 'user', parentId: 'user_2', uploadedById: 'user_1' }),
+    ).toEqual(['user:user_1']);
+  });
+});
+
+describe('findAttachmentForOrganization', () => {
+  it('returns an upload registered in the caller workspace', async () => {
+    const record = await register(nova.admin, 'issue', issueId);
+
+    const found = await findAttachmentForOrganization(nova.admin, record.id);
+
+    expect(found.id).toBe(record.id);
+    expect(found.status).toBe('pending');
+  });
+
+  it('refuses to hand an upload to a member of another workspace', async () => {
+    const record = await register(nova.admin, 'issue', issueId);
+
+    expect(await errorOf(() => findAttachmentForOrganization(orion.admin, record.id))).toEqual({
+      code: 'not_found',
+      status: 404,
+    });
+  });
+
+  it('refuses an id that was never registered', async () => {
+    expect(
+      await errorOf(() => findAttachmentForOrganization(nova.admin, 'att_does_not_exist')),
+    ).toEqual({ code: 'not_found', status: 404 });
+  });
+});
+
+describe('markAttachmentReady', () => {
+  it('stores the size the object store reported and flips the row to ready', async () => {
+    const record = await register(nova.admin, 'issue', issueId);
+
+    const completed = await markAttachmentReady(nova.admin, record, 4_096);
+
+    expect(completed.attachment.status).toBe('ready');
+    expect(completed.attachment.size).toBe(4_096);
+    const [row] = await db
+      .select({ status: schema.attachment.status, size: schema.attachment.size })
+      .from(schema.attachment)
+      .where(eq(schema.attachment.id, record.id))
+      .limit(1);
+    expect(row).toEqual({ status: 'ready', size: 4_096 });
+  });
+
+  it('publishes an issue upload on the issue scope only', async () => {
+    const record = await register(nova.admin, 'issue', issueId);
+
+    const completed = await markAttachmentReady(nova.admin, record, 10);
+
+    const action = completed.actions[0];
+    expect(action?.model).toBe('attachment');
+    expect(action?.action).toBe('update');
+    expect(action?.organizationId).toBe(nova.organizationId);
+    expect(action?.scopes).toEqual([`issue:${issueId}`]);
+  });
+
+  it('publishes a doc upload on the doc scope, so a reader without the doc never sees it', async () => {
+    const record = await register(nova.admin, 'doc', docId);
+
+    const completed = await markAttachmentReady(nova.admin, record, 10);
+
+    expect(completed.actions[0]?.scopes).toEqual([`doc:${docId}`]);
+  });
+
+  it('publishes an upload with no shared parent to its uploader alone', async () => {
+    const record = await register(nova.admin, 'user', nova.adminUser.id);
+
+    const completed = await markAttachmentReady(nova.admin, record, 10);
+
+    expect(completed.actions[0]?.scopes).toEqual([`user:${nova.adminUser.id}`]);
+  });
+
+  it('bumps the sync id so a catch up replays the completion', async () => {
+    const record = await register(nova.admin, 'issue', issueId);
+
+    const completed = await markAttachmentReady(nova.admin, record, 10);
+
+    expect(completed.attachment.syncId).toBeGreaterThan(record.syncId);
+    expect(completed.actions[0]?.syncId).toBe(completed.attachment.syncId);
+  });
+});

--- a/packages/core/tests/content/comment-service.test.ts
+++ b/packages/core/tests/content/comment-service.test.ts
@@ -1,6 +1,18 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import { createComment, listComments } from '../../src/content/comment-service.ts';
-import { createWorkspace, resetDatabase, type Workspace } from '../../src/test-support.ts';
+import { db, eq, schema } from '@orbit/db';
+import type { Principal } from '@orbit/shared/policy';
+import {
+  createComment,
+  deleteComment,
+  listComments,
+  updateComment,
+} from '../../src/content/comment-service.ts';
+import {
+  addMember,
+  createWorkspace,
+  resetDatabase,
+  type Workspace,
+} from '../../src/test-support.ts';
 import { createIssue } from '../../src/work/issue-service.ts';
 import { createProject } from '../../src/work/project-service.ts';
 
@@ -16,6 +28,28 @@ beforeEach(async () => {
   });
   issueId = issue.id;
 });
+
+async function errorOf(run: () => Promise<unknown>): Promise<{ code: string; status: number }> {
+  try {
+    await run();
+  } catch (error: unknown) {
+    const thrown = error as { code?: unknown; status?: unknown };
+    return {
+      code: typeof thrown.code === 'string' ? thrown.code : 'not-a-domain-error',
+      status: typeof thrown.status === 'number' ? thrown.status : 0,
+    };
+  }
+  throw new Error('the call was expected to throw and did not');
+}
+
+async function bodyOf(commentId: string): Promise<string | undefined> {
+  const [row] = await db
+    .select({ body: schema.comment.body })
+    .from(schema.comment)
+    .where(eq(schema.comment.id, commentId))
+    .limit(1);
+  return row?.body;
+}
 
 async function writeComments(count: number): Promise<void> {
   for (let index = 0; index < count; index += 1) {
@@ -44,6 +78,105 @@ describe('listComments', () => {
     const page = await listComments(workspace.admin, issueId, { limit: 50 });
     expect(page.comments).toHaveLength(3);
     expect(page.nextCursor).toBeNull();
+  });
+});
+
+describe('updateComment only ever lets the author rewrite a comment', () => {
+  it('rewrites the body and bumps the sync id for the author', async () => {
+    const author = await addMember(workspace, 'member', { name: 'Author' });
+    const created = await createComment(author.principal, issueId, { body: 'First take.' });
+
+    const updated = await updateComment(author.principal, created.comment.id, {
+      body: 'Second take.',
+    });
+
+    expect(updated.comment.body).toBe('Second take.');
+    expect(updated.comment.syncId).toBeGreaterThan(created.comment.syncId);
+    expect(updated.comment.editedAt).not.toBeNull();
+    expect(await bodyOf(created.comment.id)).toBe('Second take.');
+    expect(updated.actions[0]?.action).toBe('update');
+  });
+
+  it('refuses another member on the same team and leaves the body alone', async () => {
+    const author = await addMember(workspace, 'member', { name: 'Author' });
+    const teammate = await addMember(workspace, 'member', { name: 'Teammate' });
+    const created = await createComment(author.principal, issueId, { body: 'First take.' });
+
+    const failure = await errorOf(() =>
+      updateComment(teammate.principal, created.comment.id, { body: 'Rewritten by somebody.' }),
+    );
+
+    expect(failure).toEqual({ code: 'forbidden', status: 403 });
+    expect(await bodyOf(created.comment.id)).toBe('First take.');
+  });
+
+  it('refuses a workspace admin who did not write it', async () => {
+    const author = await addMember(workspace, 'member', { name: 'Author' });
+    const created = await createComment(author.principal, issueId, { body: 'First take.' });
+
+    const failure = await errorOf(() =>
+      updateComment(workspace.admin, created.comment.id, { body: 'Rewritten by the admin.' }),
+    );
+
+    expect(failure).toEqual({ code: 'forbidden', status: 403 });
+    expect(await bodyOf(created.comment.id)).toBe('First take.');
+  });
+
+  it('cannot reach a comment that belongs to another workspace', async () => {
+    const other = await createWorkspace('Orion');
+    const created = await createComment(workspace.admin, issueId, { body: 'Ours.' });
+    const outsider: Principal = other.admin;
+
+    const failure = await errorOf(() =>
+      updateComment(outsider, created.comment.id, { body: 'Theirs now.' }),
+    );
+
+    expect(failure).toEqual({ code: 'not_found', status: 404 });
+    expect(await bodyOf(created.comment.id)).toBe('Ours.');
+  });
+});
+
+describe('deleteComment splits its own from anybody else', () => {
+  it('lets the author retract their own comment', async () => {
+    const author = await addMember(workspace, 'contributor', { name: 'Author' });
+    const created = await createComment(author.principal, issueId, { body: 'Mine.' });
+
+    const actions = await deleteComment(author.principal, created.comment.id);
+
+    expect(actions[0]?.action).toBe('delete');
+    const page = await listComments(workspace.admin, issueId);
+    expect(page.comments).toHaveLength(0);
+  });
+
+  it('refuses a contributor who did not write it', async () => {
+    const author = await addMember(workspace, 'member', { name: 'Author' });
+    const contributor = await addMember(workspace, 'contributor', { name: 'Passer By' });
+    const created = await createComment(author.principal, issueId, { body: 'Mine.' });
+
+    const failure = await errorOf(() => deleteComment(contributor.principal, created.comment.id));
+
+    expect(failure).toEqual({ code: 'forbidden', status: 403 });
+    expect((await listComments(workspace.admin, issueId)).comments).toHaveLength(1);
+  });
+
+  it('lets a moderator delete somebody else comment', async () => {
+    const author = await addMember(workspace, 'contributor', { name: 'Author' });
+    const created = await createComment(author.principal, issueId, { body: 'Mine.' });
+
+    const actions = await deleteComment(workspace.admin, created.comment.id);
+
+    expect(actions[0]?.action).toBe('delete');
+    expect((await listComments(workspace.admin, issueId)).comments).toHaveLength(0);
+  });
+
+  it('cannot reach a comment that belongs to another workspace', async () => {
+    const other = await createWorkspace('Orion');
+    const created = await createComment(workspace.admin, issueId, { body: 'Ours.' });
+
+    const failure = await errorOf(() => deleteComment(other.admin, created.comment.id));
+
+    expect(failure).toEqual({ code: 'not_found', status: 404 });
+    expect((await listComments(workspace.admin, issueId)).comments).toHaveLength(1);
   });
 });
 

--- a/packages/mcp-server/tests/resolve.test.ts
+++ b/packages/mcp-server/tests/resolve.test.ts
@@ -1,0 +1,170 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import { createLabel, createProject, createTeam, listProjects, listTeams } from '@orbit/core';
+import type { Principal } from '@orbit/shared/policy';
+import {
+  resolveLabelIds,
+  resolveProject,
+  resolveStateId,
+  resolveTeam,
+  resolveUserId,
+} from '../src/resolve.ts';
+import {
+  addMember,
+  createWorkspace,
+  resetDatabase,
+  type TestWorkspace,
+} from '../src/test-helpers.ts';
+
+let workspace: TestWorkspace;
+let admin: Principal;
+let engineeringId: string;
+let designId: string;
+let apolloId: string;
+let apolloSlug: string;
+let borealisId: string;
+let borealisSlug: string;
+let flakyLabelId: string;
+let sturdyLabelId: string;
+let teammateId: string;
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  admin = workspace.admin;
+  engineeringId = workspace.teamId;
+
+  const design = await createTeam(admin, { name: 'Design', key: 'DES' });
+  designId = design.team.id;
+
+  const apollo = await createProject(admin, { name: 'Apollo Mission', teamIds: [engineeringId] });
+  apolloId = apollo.project.id;
+  apolloSlug = apollo.project.slug;
+  const borealis = await createProject(admin, { name: 'Borealis Ridge', teamIds: [designId] });
+  borealisId = borealis.project.id;
+  borealisSlug = borealis.project.slug;
+
+  const flaky = await createLabel(admin, { name: 'Flaky', color: '#ff0000', teamId: null });
+  flakyLabelId = flaky.label.id;
+  const sturdy = await createLabel(admin, { name: 'Sturdy', color: '#00ff00', teamId: null });
+  sturdyLabelId = sturdy.label.id;
+
+  const teammate = await addMember(workspace, 'member', 'Bea Builder');
+  teammateId = teammate.user.id;
+});
+
+async function errorOf(run: () => Promise<unknown>): Promise<string> {
+  try {
+    await run();
+  } catch (error: unknown) {
+    const thrown = error as { code?: unknown };
+    return typeof thrown.code === 'string' ? thrown.code : 'not-a-domain-error';
+  }
+  throw new Error('the call was expected to throw and did not');
+}
+
+describe('the fixture has more than one of everything the resolvers pick from', () => {
+  it('holds two teams and two projects, so position cannot stand in for matching', async () => {
+    expect((await listTeams(admin)).length).toBeGreaterThan(1);
+    expect((await listProjects(admin, {})).length).toBeGreaterThan(1);
+    expect(engineeringId).not.toBe(designId);
+    expect(apolloId).not.toBe(borealisId);
+  });
+});
+
+describe('resolveTeam', () => {
+  it('picks the second team by its key, its name and its id', async () => {
+    expect((await resolveTeam(admin, 'DES')).id).toBe(designId);
+    expect((await resolveTeam(admin, 'Design')).id).toBe(designId);
+    expect((await resolveTeam(admin, designId)).id).toBe(designId);
+  });
+
+  it('picks the first team rather than whatever comes first in the list', async () => {
+    expect((await resolveTeam(admin, workspace.teamKey)).id).toBe(engineeringId);
+  });
+
+  it('ignores case and surrounding space', async () => {
+    expect((await resolveTeam(admin, '  des  ')).id).toBe(designId);
+    expect((await resolveTeam(admin, 'dEsIgN')).id).toBe(designId);
+  });
+
+  it('refuses a reference that matches no team', async () => {
+    expect(await errorOf(() => resolveTeam(admin, 'Marketing'))).toBe('not_found');
+  });
+});
+
+describe('resolveProject', () => {
+  it('picks the second project by its name, its slug and its id', async () => {
+    expect((await resolveProject(admin, 'Borealis Ridge')).id).toBe(borealisId);
+    expect((await resolveProject(admin, borealisSlug)).id).toBe(borealisId);
+    expect((await resolveProject(admin, borealisId)).id).toBe(borealisId);
+  });
+
+  it('picks the first project when asked for it by name or slug', async () => {
+    expect((await resolveProject(admin, 'Apollo Mission')).id).toBe(apolloId);
+    expect((await resolveProject(admin, apolloSlug)).id).toBe(apolloId);
+  });
+
+  it('reads a slug that is not just the lowercased name', () => {
+    expect(apolloSlug).not.toBe('apollo mission');
+    expect(borealisSlug).not.toBe('borealis ridge');
+    expect(apolloSlug).toContain('-');
+  });
+
+  it('refuses a reference that matches no project', async () => {
+    expect(await errorOf(() => resolveProject(admin, 'Gemini'))).toBe('not_found');
+  });
+});
+
+describe('resolveLabelIds', () => {
+  it('maps each reference to its own label rather than to the first one', async () => {
+    expect(await resolveLabelIds(admin, ['Sturdy'])).toEqual([sturdyLabelId]);
+    expect(await resolveLabelIds(admin, ['Flaky'])).toEqual([flakyLabelId]);
+  });
+
+  it('keeps the order the caller asked for', async () => {
+    expect(await resolveLabelIds(admin, ['Sturdy', 'Flaky'])).toEqual([
+      sturdyLabelId,
+      flakyLabelId,
+    ]);
+    expect(await resolveLabelIds(admin, ['Flaky', 'Sturdy'])).toEqual([
+      flakyLabelId,
+      sturdyLabelId,
+    ]);
+  });
+
+  it('accepts an id as readily as a name', async () => {
+    expect(await resolveLabelIds(admin, [sturdyLabelId])).toEqual([sturdyLabelId]);
+  });
+
+  it('returns nothing for an empty request and refuses an unknown label', async () => {
+    expect(await resolveLabelIds(admin, [])).toEqual([]);
+    expect(await errorOf(() => resolveLabelIds(admin, ['Sturdy', 'Nonesuch']))).toBe('not_found');
+  });
+});
+
+describe('resolveUserId', () => {
+  it('picks the named member rather than the caller or the first row', async () => {
+    expect(await resolveUserId(admin, 'Bea Builder')).toBe(teammateId);
+    expect(await resolveUserId(admin, 'me')).toBe(admin.userId);
+    expect(await resolveUserId(admin, 'Ada Admin')).toBe(admin.userId);
+  });
+
+  it('refuses a reference that matches nobody', async () => {
+    expect(await errorOf(() => resolveUserId(admin, 'Nobody At All'))).toBe('not_found');
+  });
+});
+
+describe('resolveStateId', () => {
+  it('resolves a state on the team it was asked about', async () => {
+    const onDesign = await resolveStateId(admin, designId, 'In Progress');
+    const onEngineering = await resolveStateId(admin, engineeringId, 'In Progress');
+
+    expect(onDesign).not.toBe(onEngineering);
+    expect(await resolveStateId(admin, designId, onDesign)).toBe(onDesign);
+  });
+
+  it('refuses a state that belongs to another team', async () => {
+    const onDesign = await resolveStateId(admin, designId, 'In Progress');
+    expect(await errorOf(() => resolveStateId(admin, engineeringId, onDesign))).toBe('not_found');
+  });
+});

--- a/packages/mcp-server/tests/tools-smoke.test.ts
+++ b/packages/mcp-server/tests/tools-smoke.test.ts
@@ -1,0 +1,187 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import {
+  addMember,
+  connect,
+  createWorkspace,
+  mintToken,
+  resetDatabase,
+  type TestClient,
+  type TestWorkspace,
+} from '../src/test-helpers.ts';
+
+let workspace: TestWorkspace;
+let agent: TestClient;
+
+const state: Record<string, string> = {};
+
+function idOf(payload: Record<string, unknown>, path: readonly string[]): string {
+  let cursor: unknown = payload;
+  for (const key of path) {
+    if (typeof cursor !== 'object' || cursor === null) throw new Error(`missing ${path.join('.')}`);
+    cursor = (cursor as Record<string, unknown>)[key];
+  }
+  if (typeof cursor !== 'string') throw new Error(`${path.join('.')} is not a string`);
+  return cursor;
+}
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  agent = await connect(await mintToken(workspace.organizationId, workspace.adminUser.id));
+  await addMember(workspace, 'member', 'Bea Builder');
+
+  state['team'] = workspace.teamKey;
+  state['project'] = idOf(
+    await agent.result('create_project', { name: 'Apollo', teams: [workspace.teamKey] }),
+    ['project', 'id'],
+  );
+  state['doc'] = idOf(await agent.result('create_doc', { title: 'Runbook', content: '# Hi' }), [
+    'doc',
+    'id',
+  ]);
+  state['docComment'] = idOf(
+    await agent.result('comment_on_doc', { doc: state['doc'], body: 'First note.' }),
+    ['comment', 'id'],
+  );
+  state['milestone'] = idOf(
+    await agent.result('create_milestone', { project: state['project'], name: 'Alpha' }),
+    ['milestone', 'id'],
+  );
+  state['view'] = idOf(await agent.result('create_view', { name: 'Mine', filter: {} }), [
+    'view',
+    'id',
+  ]);
+  const issue = await agent.result('create_issue', {
+    team: workspace.teamKey,
+    title: 'Something to archive',
+  });
+  state['issue'] = idOf(issue, ['issue', 'identifier']);
+  await agent.result('archive_issue', { issue: state['issue'] });
+});
+
+afterAll(async () => {
+  await agent.close();
+});
+
+interface SmokeCase {
+  readonly tool: string;
+  readonly args: () => Record<string, unknown>;
+  readonly expect: (payload: Record<string, unknown>) => void;
+}
+
+function hasKey(key: string) {
+  return (payload: Record<string, unknown>): void => {
+    expect(Object.keys(payload)).toContain(key);
+    expect(payload['error']).toBeUndefined();
+  };
+}
+
+function hasRows(key: string) {
+  return (payload: Record<string, unknown>): void => {
+    expect(Array.isArray(payload[key])).toBe(true);
+    expect(payload['error']).toBeUndefined();
+  };
+}
+
+const SMOKE: readonly SmokeCase[] = [
+  { tool: 'list_teams', args: () => ({}), expect: hasRows('teams') },
+  { tool: 'list_users', args: () => ({}), expect: hasRows('users') },
+  { tool: 'list_labels', args: () => ({}), expect: hasRows('labels') },
+  { tool: 'list_states', args: () => ({ team: state['team'] }), expect: hasRows('states') },
+  { tool: 'list_projects', args: () => ({}), expect: hasRows('projects') },
+  { tool: 'list_doc_collections', args: () => ({}), expect: hasRows('collections') },
+  { tool: 'list_doc_comments', args: () => ({ doc: state['doc'] }), expect: hasRows('comments') },
+  {
+    tool: 'list_milestones',
+    args: () => ({ project: state['project'] }),
+    expect: hasRows('milestones'),
+  },
+  {
+    tool: 'list_project_milestones',
+    args: () => ({ project: state['project'] }),
+    expect: hasRows('milestones'),
+  },
+  { tool: 'list_standups', args: () => ({ team: state['team'] }), expect: hasRows('standups') },
+  {
+    tool: 'standup_workload',
+    args: () => ({ team: state['team'] }),
+    expect: hasRows('workload'),
+  },
+  {
+    tool: 'get_standup_rotation',
+    args: () => ({ team: state['team'] }),
+    expect: hasKey('rotation'),
+  },
+  {
+    tool: 'set_standup_rotation',
+    args: () => ({ team: state['team'], members: [{ person: 'Bea Builder' }] }),
+    expect: hasKey('rotation'),
+  },
+  {
+    tool: 'update_team',
+    args: () => ({ team: state['team'], name: 'Renamed team' }),
+    expect: hasKey('team'),
+  },
+  {
+    tool: 'update_view',
+    args: () => ({ view: state['view'], name: 'Renamed view' }),
+    expect: hasKey('view'),
+  },
+  {
+    tool: 'unarchive_issue',
+    args: () => ({ issue: state['issue'] }),
+    expect: hasKey('restored'),
+  },
+  {
+    tool: 'edit_doc_comment',
+    args: () => ({ commentId: state['docComment'], body: 'Second note.' }),
+    expect: hasKey('comment'),
+  },
+  {
+    tool: 'create_doc_collection',
+    args: () => ({ name: 'Handbook' }),
+    expect: hasKey('collection'),
+  },
+  {
+    tool: 'update_milestone',
+    args: () => ({ milestoneId: state['milestone'], name: 'Beta' }),
+    expect: hasKey('milestone'),
+  },
+  {
+    tool: 'delete_doc_comment',
+    args: () => ({ commentId: state['docComment'] }),
+    expect: hasKey('deleted'),
+  },
+  {
+    tool: 'delete_milestone',
+    args: () => ({ milestoneId: state['milestone'] }),
+    expect: hasKey('deleted'),
+  },
+  { tool: 'archive_doc', args: () => ({ doc: state['doc'] }), expect: hasKey('archived') },
+  {
+    tool: 'archive_project',
+    args: () => ({ project: state['project'] }),
+    expect: hasKey('archived'),
+  },
+];
+
+describe('every tool the rest of the suite never calls still answers', () => {
+  it('covers a tool the other tests leave alone, and every one is registered', async () => {
+    const { tools } = await agent.client.listTools();
+    const registered = new Set(tools.map((tool) => tool.name));
+
+    for (const entry of SMOKE) expect(registered.has(entry.tool)).toBe(true);
+    expect(SMOKE.length).toBeGreaterThan(20);
+  });
+
+  for (const entry of SMOKE) {
+    it(`${entry.tool} answers a minimal valid call`, async () => {
+      const called = await agent.call(entry.tool, entry.args());
+
+      expect(called.isError ?? false).toBe(false);
+      const [first] = called.content;
+      if (first === undefined || first.type !== 'text') throw new Error('no text content');
+      entry.expect(JSON.parse(first.text) as Record<string, unknown>);
+    });
+  }
+});

--- a/packages/realtime-server/tests/auth/authorize-scope.test.ts
+++ b/packages/realtime-server/tests/auth/authorize-scope.test.ts
@@ -1,0 +1,395 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { db, eq, schema } from '@orbit/db';
+import {
+  authenticateTicket,
+  authorizeScope,
+  type ConnectionPrincipal,
+  membershipStillValid,
+  refreshedPrincipal,
+  sessionStillValid,
+} from '../../src/auth.ts';
+import {
+  dropSeededWorkspaces,
+  insertSession,
+  principalFor,
+  type SeededWorkspace,
+  seedWorkspace,
+} from '../fixture.ts';
+
+let home: SeededWorkspace;
+let away: SeededWorkspace;
+
+beforeAll(async () => {
+  home = await seedWorkspace('Home');
+  away = await seedWorkspace('Away');
+});
+
+afterAll(async () => {
+  await dropSeededWorkspaces();
+});
+
+function reader(overrides: Partial<ConnectionPrincipal> = {}): ConnectionPrincipal {
+  return principalFor(home, overrides);
+}
+
+function admin(): ConnectionPrincipal {
+  return principalFor(home, {
+    userId: home.adminUserId,
+    name: 'Ada Admin',
+    role: 'admin',
+    teamIds: [],
+  });
+}
+
+interface ScopeCase {
+  readonly name: string;
+  readonly scope: () => string;
+  readonly principal: () => ConnectionPrincipal;
+  readonly allowed: boolean;
+}
+
+const CASES: readonly ScopeCase[] = [
+  {
+    name: 'org scope for the workspace the connection authenticated into',
+    scope: () => `org:${home.organizationId}`,
+    principal: reader,
+    allowed: true,
+  },
+  {
+    name: 'org scope for another workspace',
+    scope: () => `org:${away.organizationId}`,
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'team scope for a team the member is on',
+    scope: () => `team:${home.teamCore}`,
+    principal: reader,
+    allowed: true,
+  },
+  {
+    name: 'team scope for a team the member is not on',
+    scope: () => `team:${home.teamOther}`,
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'team scope for a team in another workspace',
+    scope: () => `team:${away.teamCore}`,
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'team scope for an admin who joined no team',
+    scope: () => `team:${home.teamOther}`,
+    principal: admin,
+    allowed: true,
+  },
+  {
+    name: 'user scope for the connected user',
+    scope: () => `user:${home.readerUserId}`,
+    principal: reader,
+    allowed: true,
+  },
+  {
+    name: 'user scope for another user',
+    scope: () => `user:${home.adminUserId}`,
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'user scope for another user, asked by an admin',
+    scope: () => `user:${home.readerUserId}`,
+    principal: admin,
+    allowed: false,
+  },
+  {
+    name: 'issue scope on a team the member is on',
+    scope: () => `issue:${home.issueOnCore}`,
+    principal: reader,
+    allowed: true,
+  },
+  {
+    name: 'issue scope on a team the member is not on',
+    scope: () => `issue:${home.issueOnOther}`,
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'issue scope in another workspace',
+    scope: () => `issue:${away.issueOnCore}`,
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'issue scope in another workspace, asked by an admin',
+    scope: () => `issue:${away.issueOnCore}`,
+    principal: admin,
+    allowed: false,
+  },
+  {
+    name: 'issue scope that does not exist',
+    scope: () => 'issue:iss_missing',
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'project scope on a project no team owns',
+    scope: () => `project:${home.projectWithoutTeams}`,
+    principal: reader,
+    allowed: true,
+  },
+  {
+    name: 'project scope on a project another team owns',
+    scope: () => `project:${home.projectOnOther}`,
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'project scope in another workspace',
+    scope: () => `project:${away.projectWithoutTeams}`,
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'project scope for a member on no team at all',
+    scope: () => `project:${home.projectWithoutTeams}`,
+    principal: () => reader({ userId: home.strangerUserId, teamIds: [] }),
+    allowed: false,
+  },
+  {
+    name: 'doc scope on a workspace wide doc',
+    scope: () => `doc:${home.workspaceDoc}`,
+    principal: reader,
+    allowed: true,
+  },
+  {
+    name: 'doc scope on a private doc with no grant',
+    scope: () => `doc:${home.privateDoc}`,
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'doc scope on a private doc granted to the user',
+    scope: () => `doc:${home.docGrantedToReader}`,
+    principal: reader,
+    allowed: true,
+  },
+  {
+    name: 'doc scope on a private doc granted to a team the user is on',
+    scope: () => `doc:${home.docGrantedToCore}`,
+    principal: reader,
+    allowed: true,
+  },
+  {
+    name: 'doc scope on a private doc granted to a team the user left',
+    scope: () => `doc:${home.docGrantedToOther}`,
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'doc scope on a private doc the principal wrote',
+    scope: () => `doc:${home.privateDoc}`,
+    principal: () => reader({ userId: home.adminUserId }),
+    allowed: true,
+  },
+  {
+    name: 'doc scope on a doc in another workspace',
+    scope: () => `doc:${away.workspaceDoc}`,
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'doc scope on a doc that does not exist',
+    scope: () => 'doc:doc_missing',
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'a scope kind nobody publishes',
+    scope: () => `cycle:${home.teamCore}`,
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'a scope with no colon at all',
+    scope: () => 'org',
+    principal: reader,
+    allowed: false,
+  },
+  {
+    name: 'a scope with an empty id',
+    scope: () => 'team:',
+    principal: reader,
+    allowed: false,
+  },
+];
+
+describe('authorizeScope', () => {
+  for (const entry of CASES) {
+    it(`${entry.allowed ? 'allows' : 'denies'} ${entry.name}`, async () => {
+      expect(await authorizeScope(entry.scope(), entry.principal())).toBe(entry.allowed);
+    });
+  }
+});
+
+describe('authenticateTicket', () => {
+  it('builds a principal whose team ids stop at the workspace boundary', async () => {
+    const crossTeam = `tm_cross_${home.readerUserId.slice(-8)}`;
+    const crossMember = `mem_cross_${home.readerUserId.slice(-8)}`;
+    await db
+      .insert(schema.teamMember)
+      .values({ id: crossTeam, teamId: away.teamCore, userId: home.readerUserId });
+    await db.insert(schema.member).values({
+      id: crossMember,
+      organizationId: away.organizationId,
+      userId: home.readerUserId,
+      role: 'member',
+    });
+    const { sessionId } = await insertSession(home.readerUserId, new Date(Date.now() + 60_000));
+
+    const result = await authenticateTicket({
+      userId: home.readerUserId,
+      organizationId: home.organizationId,
+      sessionId,
+      exp: Date.now() + 60_000,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect([...result.principal.teamIds]).toEqual([home.teamCore]);
+    expect(result.principal.role).toBe('member');
+    expect(await authorizeScope(`team:${away.teamCore}`, result.principal)).toBe(false);
+
+    await db.delete(schema.teamMember).where(eq(schema.teamMember.id, crossTeam));
+    await db.delete(schema.member).where(eq(schema.member.id, crossMember));
+  });
+
+  it('gives an admin every team in the workspace and none outside it', async () => {
+    const { sessionId } = await insertSession(home.adminUserId, new Date(Date.now() + 60_000));
+
+    const result = await authenticateTicket({
+      userId: home.adminUserId,
+      organizationId: home.organizationId,
+      sessionId,
+      exp: Date.now() + 60_000,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect([...result.principal.teamIds].sort()).toEqual([home.teamCore, home.teamOther].sort());
+  });
+
+  it('rejects a ticket whose session already expired', async () => {
+    const { sessionId } = await insertSession(home.readerUserId, new Date(Date.now() - 1_000));
+
+    const result = await authenticateTicket({
+      userId: home.readerUserId,
+      organizationId: home.organizationId,
+      sessionId,
+      exp: Date.now() + 60_000,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'unauthorized' });
+  });
+
+  it('rejects a session that belongs to a different user', async () => {
+    const { sessionId } = await insertSession(home.adminUserId, new Date(Date.now() + 60_000));
+
+    const result = await authenticateTicket({
+      userId: home.readerUserId,
+      organizationId: home.organizationId,
+      sessionId,
+      exp: Date.now() + 60_000,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'unauthorized' });
+  });
+
+  it('rejects a workspace the user is not a member of', async () => {
+    const { sessionId } = await insertSession(home.strangerUserId, new Date(Date.now() + 60_000));
+
+    const result = await authenticateTicket({
+      userId: home.strangerUserId,
+      organizationId: away.organizationId,
+      sessionId,
+      exp: Date.now() + 60_000,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'organization_forbidden' });
+  });
+
+  it('falls back to guest for a role nobody recognises', async () => {
+    await db
+      .update(schema.member)
+      .set({ role: 'superuser' })
+      .where(eq(schema.member.userId, away.strangerUserId));
+    const { sessionId } = await insertSession(away.strangerUserId, new Date(Date.now() + 60_000));
+
+    const result = await authenticateTicket({
+      userId: away.strangerUserId,
+      organizationId: away.organizationId,
+      sessionId,
+      exp: Date.now() + 60_000,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.principal.role).toBe('guest');
+    expect(await authorizeScope(`team:${away.teamOther}`, result.principal)).toBe(false);
+
+    await db
+      .update(schema.member)
+      .set({ role: 'member' })
+      .where(eq(schema.member.userId, away.strangerUserId));
+  });
+});
+
+describe('sessionStillValid and membershipStillValid', () => {
+  it('reports a live session valid and an expired one invalid', async () => {
+    const live = await insertSession(home.readerUserId, new Date(Date.now() + 60_000));
+    const dead = await insertSession(home.readerUserId, new Date(Date.now() - 1_000));
+
+    expect(await sessionStillValid(live.sessionId)).toBe(true);
+    expect(await sessionStillValid(dead.sessionId)).toBe(false);
+    expect(await sessionStillValid('ses_never_existed')).toBe(false);
+  });
+
+  it('reports a removed member invalid without touching the rest of the workspace', async () => {
+    expect(await membershipStillValid(reader())).toBe(true);
+    expect(
+      await membershipStillValid(
+        reader({ userId: home.strangerUserId, organizationId: away.organizationId }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('refreshedPrincipal', () => {
+  it('picks up a role change and widens the teams an admin can reach', async () => {
+    const before = reader({ userId: home.strangerUserId, teamIds: [] });
+    expect(await authorizeScope(`team:${home.teamCore}`, before)).toBe(false);
+
+    await db
+      .update(schema.member)
+      .set({ role: 'admin' })
+      .where(eq(schema.member.userId, home.strangerUserId));
+    const after = await refreshedPrincipal(before);
+
+    expect(after?.role).toBe('admin');
+    expect([...(after?.teamIds ?? [])].sort()).toEqual([home.teamCore, home.teamOther].sort());
+
+    await db
+      .update(schema.member)
+      .set({ role: 'member' })
+      .where(eq(schema.member.userId, home.strangerUserId));
+  });
+
+  it('returns null once the membership is gone', async () => {
+    expect(
+      await refreshedPrincipal(
+        reader({ userId: home.strangerUserId, organizationId: away.organizationId }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/realtime-server/tests/fake-redis.ts
+++ b/packages/realtime-server/tests/fake-redis.ts
@@ -1,0 +1,44 @@
+import { EventEmitter } from 'node:events';
+
+const bus = new Set<FakeRedis>();
+
+export class FakeRedis extends EventEmitter {
+  status = 'ready';
+  readonly published: { channel: string; message: string }[] = [];
+  private readonly channels = new Set<string>();
+
+  constructor(
+    readonly url: string,
+    readonly options: Record<string, unknown> = {},
+  ) {
+    super();
+    bus.add(this);
+  }
+
+  subscribe(...channels: string[]): Promise<number> {
+    for (const channel of channels) this.channels.add(channel);
+    return Promise.resolve(this.channels.size);
+  }
+
+  publish(channel: string, message: string): Promise<number> {
+    this.published.push({ channel, message });
+    let reached = 0;
+    for (const peer of bus) {
+      if (!peer.channels.has(channel)) continue;
+      reached += 1;
+      queueMicrotask(() => peer.emit('message', channel, message));
+    }
+    return Promise.resolve(reached);
+  }
+
+  disconnect(): void {
+    this.status = 'end';
+    this.channels.clear();
+    bus.delete(this);
+  }
+}
+
+export function resetFakeRedis(): void {
+  for (const peer of [...bus]) peer.disconnect();
+  bus.clear();
+}

--- a/packages/realtime-server/tests/fake-socket.ts
+++ b/packages/realtime-server/tests/fake-socket.ts
@@ -1,0 +1,63 @@
+import type { ServerMessage } from '@orbit/shared/events';
+import type { RealtimeSocket } from '../src/socket.ts';
+
+const OPEN = 1;
+const CLOSED = 3;
+
+export interface Closure {
+  readonly code: number;
+  readonly reason: string;
+}
+
+export class FakeSocket implements RealtimeSocket {
+  readyState = OPEN;
+  readonly sent: ServerMessage[] = [];
+  readonly closures: Closure[] = [];
+  terminated = 0;
+  pings = 0;
+  buffered = 0;
+
+  bufferedAmount(): number {
+    return this.buffered;
+  }
+
+  send(data: string): void {
+    this.sent.push(JSON.parse(data) as ServerMessage);
+  }
+
+  close(code: number, reason: string): void {
+    this.closures.push({ code, reason });
+    this.readyState = CLOSED;
+  }
+
+  terminate(): void {
+    this.terminated += 1;
+    this.readyState = CLOSED;
+  }
+
+  ping(): void {
+    this.pings += 1;
+  }
+
+  frames<T extends ServerMessage['type']>(type: T): Extract<ServerMessage, { type: T }>[] {
+    return this.sent.filter(
+      (message): message is Extract<ServerMessage, { type: T }> => message.type === type,
+    );
+  }
+
+  last<T extends ServerMessage['type']>(type: T): Extract<ServerMessage, { type: T }> | undefined {
+    return this.frames(type).at(-1);
+  }
+}
+
+export async function settle(times = 6): Promise<void> {
+  for (let index = 0; index < times; index += 1) await new Promise(setImmediate);
+}
+
+export async function waitFor(check: () => boolean, label: string): Promise<void> {
+  for (let index = 0; index < 200; index += 1) {
+    if (check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}

--- a/packages/realtime-server/tests/fixture.ts
+++ b/packages/realtime-server/tests/fixture.ts
@@ -1,0 +1,247 @@
+import { db, eq, schema } from '@orbit/db';
+import { randomUUIDv7 } from '@orbit/shared/utils';
+import type { ConnectionPrincipal } from '../src/auth.ts';
+
+export interface SeededWorkspace {
+  readonly organizationId: string;
+  readonly adminUserId: string;
+  readonly readerUserId: string;
+  readonly strangerUserId: string;
+  readonly teamCore: string;
+  readonly teamOther: string;
+  readonly stateId: string;
+  readonly issueOnCore: string;
+  readonly issueOnOther: string;
+  readonly projectWithoutTeams: string;
+  readonly projectOnOther: string;
+  readonly workspaceDoc: string;
+  readonly privateDoc: string;
+  readonly docGrantedToReader: string;
+  readonly docGrantedToCore: string;
+  readonly docGrantedToOther: string;
+}
+
+const created: string[] = [];
+
+function id(prefix: string): string {
+  return `${prefix}_${randomUUIDv7()}`;
+}
+
+async function insertUser(name: string): Promise<string> {
+  const userId = id('usr');
+  const handle = `${name.toLowerCase().replace(/[^a-z0-9]/g, '')}${userId.slice(-8)}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name,
+    email: `${handle}@orbit.test`,
+    handle,
+    emailVerified: true,
+  });
+  return userId;
+}
+
+export async function seedWorkspace(name: string): Promise<SeededWorkspace> {
+  const organizationId = id('org');
+  created.push(organizationId);
+  await db.insert(schema.organization).values({
+    id: organizationId,
+    name,
+    slug: organizationId.toLowerCase(),
+  });
+
+  const adminUserId = await insertUser('Ada Admin');
+  const readerUserId = await insertUser('Rin Reader');
+  const strangerUserId = await insertUser('Sam Stranger');
+
+  await db.insert(schema.member).values([
+    { id: id('mem'), organizationId, userId: adminUserId, role: 'admin' },
+    { id: id('mem'), organizationId, userId: readerUserId, role: 'member' },
+    { id: id('mem'), organizationId, userId: strangerUserId, role: 'member' },
+  ]);
+
+  const teamCore = id('team');
+  const teamOther = id('team');
+  await db.insert(schema.team).values([
+    { id: teamCore, organizationId, name: 'Core', key: `C${teamCore.slice(-4)}` },
+    { id: teamOther, organizationId, name: 'Other', key: `O${teamOther.slice(-4)}` },
+  ]);
+  await db
+    .insert(schema.teamMember)
+    .values([{ id: id('tm'), teamId: teamCore, userId: readerUserId }]);
+
+  const stateId = id('state');
+  await db.insert(schema.workflowState).values({
+    id: stateId,
+    organizationId,
+    teamId: teamCore,
+    name: 'Todo',
+    category: 'unstarted',
+    color: '#888888',
+  });
+  const otherStateId = id('state');
+  await db.insert(schema.workflowState).values({
+    id: otherStateId,
+    organizationId,
+    teamId: teamOther,
+    name: 'Todo',
+    category: 'unstarted',
+    color: '#888888',
+  });
+
+  const issueOnCore = id('iss');
+  const issueOnOther = id('iss');
+  await db.insert(schema.issue).values([
+    {
+      id: issueOnCore,
+      organizationId,
+      teamId: teamCore,
+      number: 1,
+      identifier: `C-${issueOnCore.slice(-6)}`,
+      title: 'On the core team',
+      stateId,
+      creatorId: adminUserId,
+    },
+    {
+      id: issueOnOther,
+      organizationId,
+      teamId: teamOther,
+      number: 1,
+      identifier: `O-${issueOnOther.slice(-6)}`,
+      title: 'On the other team',
+      stateId: otherStateId,
+      creatorId: adminUserId,
+    },
+  ]);
+
+  const projectWithoutTeams = id('prj');
+  const projectOnOther = id('prj');
+  await db.insert(schema.project).values([
+    {
+      id: projectWithoutTeams,
+      organizationId,
+      name: 'Unowned',
+      slug: projectWithoutTeams.toLowerCase(),
+    },
+    { id: projectOnOther, organizationId, name: 'Owned', slug: projectOnOther.toLowerCase() },
+  ]);
+  await db
+    .insert(schema.projectTeam)
+    .values([{ id: id('pt'), projectId: projectOnOther, teamId: teamOther }]);
+
+  const workspaceDoc = id('doc');
+  const privateDoc = id('doc');
+  const docGrantedToReader = id('doc');
+  const docGrantedToCore = id('doc');
+  const docGrantedToOther = id('doc');
+  await db.insert(schema.doc).values([
+    {
+      id: workspaceDoc,
+      organizationId,
+      title: 'Everyone',
+      authorId: adminUserId,
+      visibility: 'workspace',
+    },
+    {
+      id: privateDoc,
+      organizationId,
+      title: 'Locked',
+      authorId: adminUserId,
+      visibility: 'private',
+    },
+    {
+      id: docGrantedToReader,
+      organizationId,
+      title: 'Shared with a person',
+      authorId: adminUserId,
+      visibility: 'private',
+    },
+    {
+      id: docGrantedToCore,
+      organizationId,
+      title: 'Shared with core',
+      authorId: adminUserId,
+      visibility: 'private',
+    },
+    {
+      id: docGrantedToOther,
+      organizationId,
+      title: 'Shared with other',
+      authorId: adminUserId,
+      visibility: 'private',
+    },
+  ]);
+  await db.insert(schema.docAccess).values([
+    {
+      id: id('acc'),
+      organizationId,
+      docId: docGrantedToReader,
+      subjectType: 'user',
+      subjectId: readerUserId,
+    },
+    {
+      id: id('acc'),
+      organizationId,
+      docId: docGrantedToCore,
+      subjectType: 'team',
+      subjectId: teamCore,
+    },
+    {
+      id: id('acc'),
+      organizationId,
+      docId: docGrantedToOther,
+      subjectType: 'team',
+      subjectId: teamOther,
+    },
+  ]);
+
+  return {
+    organizationId,
+    adminUserId,
+    readerUserId,
+    strangerUserId,
+    teamCore,
+    teamOther,
+    stateId,
+    issueOnCore,
+    issueOnOther,
+    projectWithoutTeams,
+    projectOnOther,
+    workspaceDoc,
+    privateDoc,
+    docGrantedToReader,
+    docGrantedToCore,
+    docGrantedToOther,
+  };
+}
+
+export async function dropSeededWorkspaces(): Promise<void> {
+  for (const organizationId of created.splice(0)) {
+    await db.delete(schema.organization).where(eq(schema.organization.id, organizationId));
+  }
+}
+
+export function principalFor(
+  workspace: SeededWorkspace,
+  overrides: Partial<ConnectionPrincipal> = {},
+): ConnectionPrincipal {
+  return {
+    userId: workspace.readerUserId,
+    sessionId: id('ses'),
+    name: 'Rin Reader',
+    image: null,
+    organizationId: workspace.organizationId,
+    role: 'member',
+    teamIds: [workspace.teamCore],
+    ...overrides,
+  };
+}
+
+export async function insertSession(
+  userId: string,
+  expiresAt: Date,
+): Promise<{ sessionId: string; token: string }> {
+  const sessionId = id('ses');
+  const token = id('tok');
+  await db.insert(schema.session).values({ id: sessionId, userId, token, expiresAt });
+  return { sessionId, token };
+}

--- a/packages/realtime-server/tests/hub.test.ts
+++ b/packages/realtime-server/tests/hub.test.ts
@@ -1,0 +1,457 @@
+import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test';
+import { db, eq, schema } from '@orbit/db';
+import {
+  ORGANIZATION_FORBIDDEN_CLOSE_CODE,
+  REDIS_CONTROL_CHANNEL,
+  REDIS_DELTA_CHANNEL,
+  SESSION_REVOKED_CLOSE_CODE,
+  type SyncAction,
+  UNAUTHORIZED_CLOSE_CODE,
+} from '@orbit/shared/events';
+import { signRealtimeTicket } from '@orbit/shared/events/ticket';
+import { FakeRedis, resetFakeRedis } from './fake-redis.ts';
+import { FakeSocket, waitFor } from './fake-socket.ts';
+import {
+  dropSeededWorkspaces,
+  insertSession,
+  type SeededWorkspace,
+  seedWorkspace,
+} from './fixture.ts';
+
+const loggerModule = await import('../src/logger.ts');
+mock.module('../src/logger.ts', () => ({
+  ...loggerModule,
+  logger: { info: () => undefined, warn: () => undefined, error: () => undefined },
+}));
+mock.module('ioredis', () => ({ Redis: FakeRedis }));
+
+const { createRealtimeHub } = await import('../src/hub.ts');
+type Hub = Awaited<ReturnType<typeof createRealtimeHub>>;
+
+const SECRET = 'a-secret-long-enough-for-the-ticket';
+const REDIS_URL = 'redis://fake:6379';
+
+let home: SeededWorkspace;
+let away: SeededWorkspace;
+
+beforeAll(async () => {
+  home = await seedWorkspace('Hub home');
+  away = await seedWorkspace('Hub away');
+});
+
+afterAll(async () => {
+  await dropSeededWorkspaces();
+  resetFakeRedis();
+  mock.module('../src/logger.ts', () => loggerModule);
+});
+
+async function newHub(): Promise<Hub> {
+  return await createRealtimeHub({
+    redisUrl: REDIS_URL,
+    ticketSecret: SECRET,
+    batchWindowMs: 1,
+    heartbeatIntervalMs: 60_000,
+    heartbeatTimeoutMs: 60_000,
+  });
+}
+
+interface Wired {
+  readonly socket: FakeSocket;
+  readonly session: ReturnType<Hub['accept']>;
+  readonly sessionId: string;
+}
+
+async function connect(hub: Hub, userId: string, organizationId: string): Promise<Wired> {
+  const { sessionId } = await insertSession(userId, new Date(Date.now() + 600_000));
+  const socket = new FakeSocket();
+  const session = hub.accept(socket);
+  const ticket = signRealtimeTicket(
+    { userId, organizationId, sessionId, exp: Date.now() + 60_000 },
+    SECRET,
+  );
+  session.message(JSON.stringify({ type: 'auth', ticket }));
+  await waitFor(() => socket.last('ready') !== undefined, `a ready frame for ${userId}`);
+  return { socket, session, sessionId };
+}
+
+async function subscribe(wired: Wired, scopes: readonly string[]): Promise<void> {
+  const before = wired.socket.frames('subscribed').length;
+  wired.session.message(JSON.stringify({ type: 'subscribe', scopes }));
+  await waitFor(
+    () => wired.socket.frames('subscribed').length > before,
+    `a subscribed frame for ${scopes.join()}`,
+  );
+}
+
+function action(overrides: Partial<SyncAction> = {}): SyncAction {
+  return {
+    syncId: 10,
+    organizationId: home.organizationId,
+    scopes: [`team:${home.teamCore}`],
+    action: 'update',
+    model: 'issue',
+    modelId: 'issue_1',
+    data: { id: 'issue_1' },
+    actor: { type: 'user', id: home.adminUserId },
+    at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function driver(): FakeRedis {
+  return new FakeRedis(REDIS_URL);
+}
+
+async function publishDelta(entry: SyncAction): Promise<void> {
+  await driver().publish(REDIS_DELTA_CHANNEL, JSON.stringify([entry]));
+}
+
+describe('subscribe is the authorization gate', () => {
+  it('accepts the scopes the principal may reach and returns the rest as denied', async () => {
+    const hub = await newHub();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+
+      await subscribe(wired, [
+        `team:${home.teamCore}`,
+        `team:${home.teamOther}`,
+        `doc:${home.privateDoc}`,
+        `doc:${home.docGrantedToReader}`,
+        `org:${away.organizationId}`,
+      ]);
+
+      const frame = wired.socket.last('subscribed');
+      expect(frame?.scopes.sort()).toEqual(
+        [`team:${home.teamCore}`, `doc:${home.docGrantedToReader}`].sort(),
+      );
+      expect(frame?.denied.sort()).toEqual(
+        [`team:${home.teamOther}`, `doc:${home.privateDoc}`, `org:${away.organizationId}`].sort(),
+      );
+      expect(hub.stats().subscriptions).toBe(2);
+    } finally {
+      await hub.close();
+    }
+  });
+
+  it('never delivers a delta on a scope it denied', async () => {
+    const hub = await newHub();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`team:${home.teamOther}`]);
+
+      await publishDelta(action({ scopes: [`team:${home.teamOther}`] }));
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(wired.socket.frames('delta')).toHaveLength(0);
+    } finally {
+      await hub.close();
+    }
+  });
+
+  it('rejects a forged ticket without ever opening a connection', async () => {
+    const hub = await newHub();
+    try {
+      const socket = new FakeSocket();
+      const session = hub.accept(socket);
+      session.message(JSON.stringify({ type: 'auth', ticket: 'forged.value' }));
+      await waitFor(() => socket.closures.length > 0, 'a close after a forged ticket');
+
+      expect(socket.closures[0]?.code).toBe(UNAUTHORIZED_CLOSE_CODE);
+      expect(hub.stats().connections).toBe(0);
+    } finally {
+      await hub.close();
+    }
+  });
+});
+
+describe('delta fan out', () => {
+  it('reaches only the connections whose scopes and workspace both match', async () => {
+    const hub = await newHub();
+    try {
+      const onCore = await connect(hub, home.readerUserId, home.organizationId);
+      const onAdmin = await connect(hub, home.adminUserId, home.organizationId);
+      const elsewhere = await connect(hub, away.readerUserId, away.organizationId);
+
+      await subscribe(onCore, [`team:${home.teamCore}`]);
+      await subscribe(onAdmin, [`team:${home.teamOther}`]);
+      await subscribe(elsewhere, [`team:${away.teamCore}`]);
+
+      await publishDelta(action({ scopes: [`team:${home.teamCore}`] }));
+      await waitFor(() => onCore.socket.frames('delta').length > 0, 'a delta on the core team');
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(onCore.socket.last('delta')?.actions[0]?.modelId).toBe('issue_1');
+      expect(onAdmin.socket.frames('delta')).toHaveLength(0);
+      expect(elsewhere.socket.frames('delta')).toHaveLength(0);
+    } finally {
+      await hub.close();
+    }
+  });
+
+  it('keeps a matching scope from crossing into another workspace', async () => {
+    const hub = await newHub();
+    try {
+      const elsewhere = await connect(hub, away.readerUserId, away.organizationId);
+      await subscribe(elsewhere, [`team:${away.teamCore}`]);
+
+      await publishDelta(
+        action({ organizationId: home.organizationId, scopes: [`team:${away.teamCore}`] }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(elsewhere.socket.frames('delta')).toHaveLength(0);
+    } finally {
+      await hub.close();
+    }
+  });
+
+  it('discards a delta that does not parse rather than dropping the connection', async () => {
+    const hub = await newHub();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`team:${home.teamCore}`]);
+
+      await driver().publish(REDIS_DELTA_CHANNEL, 'not json');
+      await driver().publish(REDIS_DELTA_CHANNEL, JSON.stringify([{ model: 'nope' }]));
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(wired.socket.frames('delta')).toHaveLength(0);
+      expect(wired.socket.closures).toHaveLength(0);
+    } finally {
+      await hub.close();
+    }
+  });
+});
+
+describe('presence', () => {
+  it('reaches the other reader on the scope and never echoes to its author', async () => {
+    const hub = await newHub();
+    try {
+      const author = await connect(hub, home.readerUserId, home.organizationId);
+      const watcher = await connect(hub, home.adminUserId, home.organizationId);
+      const bystander = await connect(hub, home.adminUserId, home.organizationId);
+      const elsewhere = await connect(hub, away.readerUserId, away.organizationId);
+      await subscribe(author, [`team:${home.teamCore}`]);
+      await subscribe(watcher, [`team:${home.teamCore}`]);
+      await subscribe(bystander, [`team:${home.teamOther}`]);
+      await subscribe(elsewhere, [`team:${away.teamCore}`]);
+
+      author.session.message(
+        JSON.stringify({ type: 'presence', scope: `team:${home.teamCore}`, kind: 'viewing' }),
+      );
+      await waitFor(
+        () => watcher.socket.frames('presence').length > 0,
+        'presence to reach the watcher',
+      );
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(watcher.socket.last('presence')?.messages[0]?.userId).toBe(home.readerUserId);
+      expect(author.socket.frames('presence')).toHaveLength(0);
+      expect(bystander.socket.frames('presence')).toHaveLength(0);
+      expect(elsewhere.socket.frames('presence')).toHaveLength(0);
+    } finally {
+      await hub.close();
+    }
+  });
+
+  it('refuses presence on a scope the principal may not reach', async () => {
+    const hub = await newHub();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+
+      wired.session.message(
+        JSON.stringify({ type: 'presence', scope: `team:${home.teamOther}`, kind: 'typing' }),
+      );
+      await waitFor(() => wired.socket.frames('error').length > 0, 'a forbidden scope error');
+
+      expect(wired.socket.last('error')?.code).toBe('forbidden_scope');
+    } finally {
+      await hub.close();
+    }
+  });
+});
+
+describe('a doc delta re-authorizes every reader holding that scope', () => {
+  it('drops the scope of a reader whose grant was revoked', async () => {
+    const hub = await newHub();
+    const grant = `acc_revoked_${home.readerUserId.slice(-8)}`;
+    const docId = home.workspaceDoc;
+    await db.update(schema.doc).set({ visibility: 'private' }).where(eq(schema.doc.id, docId));
+    await db.insert(schema.docAccess).values({
+      id: grant,
+      organizationId: home.organizationId,
+      docId,
+      subjectType: 'user',
+      subjectId: home.readerUserId,
+    });
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`doc:${docId}`]);
+      expect(hub.stats().subscriptions).toBe(1);
+
+      await db.delete(schema.docAccess).where(eq(schema.docAccess.id, grant));
+
+      await publishDelta(
+        action({ model: 'doc', modelId: docId, scopes: [`doc:${docId}`], syncId: 11 }),
+      );
+      await waitFor(() => hub.stats().subscriptions === 0, 'the doc scope to be dropped');
+
+      await publishDelta(
+        action({ model: 'doc', modelId: docId, scopes: [`doc:${docId}`], syncId: 12 }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      const delivered = wired.socket
+        .frames('delta')
+        .flatMap((frame) => frame.actions.map((entry) => entry.syncId));
+      expect(delivered).not.toContain(12);
+    } finally {
+      await db.update(schema.doc).set({ visibility: 'workspace' }).where(eq(schema.doc.id, docId));
+      await hub.close();
+    }
+  });
+
+  it('keeps the scope of a reader whose grant is still in place', async () => {
+    const hub = await newHub();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`doc:${home.docGrantedToReader}`]);
+
+      await publishDelta(
+        action({
+          model: 'doc',
+          modelId: home.docGrantedToReader,
+          scopes: [`doc:${home.docGrantedToReader}`],
+          syncId: 21,
+        }),
+      );
+      await waitFor(() => wired.socket.frames('delta').length > 0, 'the first doc delta');
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(hub.stats().subscriptions).toBe(1);
+    } finally {
+      await hub.close();
+    }
+  });
+});
+
+describe('membership and session revocation', () => {
+  it('closes the connections of a removed member with the workspace forbidden code', async () => {
+    const hub = await newHub();
+    try {
+      const removed = await connect(hub, home.strangerUserId, home.organizationId);
+      const kept = await connect(hub, home.readerUserId, home.organizationId);
+
+      await db.delete(schema.member).where(eq(schema.member.userId, home.strangerUserId));
+
+      await publishDelta(
+        action({
+          model: 'member',
+          action: 'delete',
+          modelId: 'member_row',
+          data: { userId: home.strangerUserId },
+          scopes: [`org:${home.organizationId}`],
+        }),
+      );
+      await waitFor(() => removed.socket.closures.length > 0, 'the removed member to be closed');
+
+      expect(removed.socket.closures[0]).toEqual({
+        code: ORGANIZATION_FORBIDDEN_CLOSE_CODE,
+        reason: 'membership_revoked',
+      });
+      expect(kept.socket.closures).toHaveLength(0);
+    } finally {
+      await db.insert(schema.member).values({
+        id: `mem_restored_${home.strangerUserId.slice(-8)}`,
+        organizationId: home.organizationId,
+        userId: home.strangerUserId,
+        role: 'member',
+      });
+      await hub.close();
+    }
+  });
+
+  it('closes only the revoked session when a control message names its user', async () => {
+    const hub = await newHub();
+    try {
+      const revoked = await connect(hub, home.readerUserId, home.organizationId);
+      const other = await connect(hub, home.adminUserId, home.organizationId);
+      await db
+        .update(schema.session)
+        .set({ expiresAt: new Date(Date.now() - 1_000) })
+        .where(eq(schema.session.id, revoked.sessionId));
+      await db
+        .update(schema.session)
+        .set({ expiresAt: new Date(Date.now() - 1_000) })
+        .where(eq(schema.session.id, other.sessionId));
+
+      await driver().publish(
+        REDIS_CONTROL_CHANNEL,
+        JSON.stringify({ type: 'session_revoked', userId: home.readerUserId }),
+      );
+      await waitFor(() => revoked.socket.closures.length > 0, 'the revoked session to be closed');
+      await new Promise((resolve) => setTimeout(resolve, 60));
+
+      expect(revoked.socket.closures[0]).toEqual({
+        code: SESSION_REVOKED_CLOSE_CODE,
+        reason: 'session_revoked',
+      });
+      expect(other.socket.closures).toHaveLength(0);
+    } finally {
+      await hub.close();
+    }
+  });
+
+  it('leaves a live session alone when the control message arrives', async () => {
+    const hub = await newHub();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+
+      await driver().publish(
+        REDIS_CONTROL_CHANNEL,
+        JSON.stringify({ type: 'session_revoked', userId: home.readerUserId }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(wired.socket.closures).toHaveLength(0);
+      expect(hub.stats().connections).toBe(1);
+    } finally {
+      await hub.close();
+    }
+  });
+});
+
+describe('a team membership delta re-checks what each connection can still reach', () => {
+  it('drops the team scope of a member who was taken off the team', async () => {
+    const hub = await newHub();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`team:${home.teamCore}`]);
+      expect(hub.stats().subscriptions).toBe(1);
+
+      const [row] = await db
+        .select({ id: schema.teamMember.id })
+        .from(schema.teamMember)
+        .where(eq(schema.teamMember.userId, home.readerUserId))
+        .limit(1);
+      const membershipId = row?.id ?? '';
+      await db.delete(schema.teamMember).where(eq(schema.teamMember.id, membershipId));
+
+      await publishDelta(
+        action({
+          model: 'team_member',
+          action: 'delete',
+          modelId: membershipId,
+          scopes: [`org:${home.organizationId}`],
+        }),
+      );
+      await waitFor(() => hub.stats().subscriptions === 0, 'the team scope to be dropped');
+
+      await db
+        .insert(schema.teamMember)
+        .values({ id: membershipId, teamId: home.teamCore, userId: home.readerUserId });
+    } finally {
+      await hub.close();
+    }
+  });
+});

--- a/packages/services/tests/markdown/dom-sanitize.test.ts
+++ b/packages/services/tests/markdown/dom-sanitize.test.ts
@@ -1,21 +1,8 @@
 import { afterAll, describe, expect, it } from 'bun:test';
 import { htmlToText, sanitizeHtml } from '../../src/markdown/sanitize.ts';
+import { restoreRewriter, withoutRewriter } from './sanitizer-vectors.ts';
 
-const globals = globalThis as { HTMLRewriter?: unknown };
-const bunRewriter = globals.HTMLRewriter;
-
-function withoutRewriter<T>(run: () => T): T {
-  globals.HTMLRewriter = undefined;
-  try {
-    return run();
-  } finally {
-    globals.HTMLRewriter = bunRewriter;
-  }
-}
-
-afterAll(() => {
-  globals.HTMLRewriter = bunRewriter;
-});
+afterAll(restoreRewriter);
 
 describe('sanitizing without HTMLRewriter', () => {
   it('keeps the tags the editor emits', () => {
@@ -24,24 +11,6 @@ describe('sanitizing without HTMLRewriter', () => {
     );
     expect(html).toContain('<strong>world</strong>');
     expect(html).toContain('<em>again</em>');
-  });
-
-  it('drops a script and its contents', () => {
-    const html = withoutRewriter(() => sanitizeHtml('<p>safe</p><script>alert(1)</script>'));
-    expect(html).toContain('safe');
-    expect(html).not.toContain('script');
-    expect(html).not.toContain('alert(1)');
-  });
-
-  it('strips an event handler attribute', () => {
-    const html = withoutRewriter(() => sanitizeHtml('<p onclick="steal()">text</p>'));
-    expect(html).not.toContain('onclick');
-    expect(html).toContain('text');
-  });
-
-  it('refuses a javascript url', () => {
-    const html = withoutRewriter(() => sanitizeHtml('<a href="javascript:alert(1)">x</a>'));
-    expect(html).not.toContain('javascript:');
   });
 
   it('unwraps a tag that is not allowed but keeps its text', () => {
@@ -56,10 +25,8 @@ describe('sanitizing without HTMLRewriter', () => {
     expect(text).toContain('two');
   });
 
-  it('agrees with the rewriter on the same markup', () => {
-    const source = '<p>hi <strong>there</strong></p><script>bad()</script>';
-    const viaDom = withoutRewriter(() => sanitizeHtml(source));
-    const viaRewriter = sanitizeHtml(source);
-    expect(viaDom).toBe(viaRewriter);
+  it('counts a void element as a word boundary the way the rewriter does', () => {
+    const source = '<p>one<br>two</p><img src="x"><input type="checkbox">three';
+    expect(withoutRewriter(() => htmlToText(source))).toBe(htmlToText(source));
   });
 });

--- a/packages/services/tests/markdown/markdown.test.ts
+++ b/packages/services/tests/markdown/markdown.test.ts
@@ -69,52 +69,6 @@ describe('renderMarkdown', () => {
   });
 });
 
-describe('renderMarkdown xss', () => {
-  it('strips script tags', () => {
-    const html = renderMarkdown('hello <script>alert(1)</script> world');
-    expect(html).not.toContain('<script');
-    expect(html).not.toContain('alert(1)');
-  });
-
-  it('strips img onerror handlers', () => {
-    const html = renderMarkdown('<img src=x onerror="alert(1)">');
-    expect(html).not.toContain('onerror');
-    expect(html).not.toContain('alert(1)');
-  });
-
-  it('neutralizes javascript: hrefs in raw html', () => {
-    const html = renderMarkdown('<a href="javascript:alert(1)">click</a>');
-    expect(html).not.toContain('javascript:');
-  });
-
-  it('neutralizes javascript: payloads in markdown links', () => {
-    const html = renderMarkdown('[click](javascript:alert(document.cookie))');
-    expect(html).not.toContain('javascript:');
-    expect(html).not.toContain('document.cookie');
-  });
-
-  it('strips iframes', () => {
-    const html = renderMarkdown('<iframe src="https://evil.example.com"></iframe>');
-    expect(html).not.toContain('<iframe');
-    expect(html).not.toContain('evil.example.com');
-  });
-
-  it('strips style attributes and svg payloads', () => {
-    const html = renderMarkdown(
-      '<p style="background:url(javascript:alert(1))">x</p><svg onload="alert(1)"></svg>',
-    );
-    expect(html).not.toContain('style=');
-    expect(html).not.toContain('<svg');
-    expect(html).not.toContain('onload');
-  });
-
-  it('escapes html injected inside code fences', () => {
-    const html = renderMarkdown('```\n<script>alert(1)</script>\n```');
-    expect(html).not.toContain('<script>');
-    expect(html).toContain('&lt;script&gt;');
-  });
-});
-
 describe('renderMarkdownWithHeadingIds', () => {
   it('leaves renderMarkdown untouched so only the reader paths carry ids', () => {
     expect(renderMarkdown('# Title')).toBe('<h1>Title</h1>\n');
@@ -200,28 +154,6 @@ describe('re-exported extractors', () => {
 });
 
 describe('sanitizer url handling', () => {
-  const dangerous = /javascript|vbscript|data:text\/html|\son[a-z]+=/i;
-
-  it('rejects a scheme hidden behind html entities', () => {
-    for (const source of [
-      '[a](&#106;avascript:alert(1))',
-      '[a](&#x6a;avascript:alert(1))',
-      '[a](javascript&#58;alert(1))',
-      '[a](java&Tab;script:alert(1))',
-      '[a](&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;alert(1))',
-      '![i](&#106;avascript:alert(1))',
-      '<img src="&#106;avascript:alert(1)">',
-    ]) {
-      expect(renderMarkdown(source)).not.toMatch(dangerous);
-    }
-  });
-
-  it('keeps the first href when an anchor repeats the attribute', () => {
-    const html = renderMarkdown('<a href="https://ok.example" href="javascript:alert(1)">x</a>');
-    expect(html).toContain('href="https://ok.example"');
-    expect(html).not.toMatch(dangerous);
-  });
-
   it('allows http, https, mailto, relative and fragment urls', () => {
     expect(renderMarkdown('[a](https://example.com/x?a=1#f)')).toContain(
       'href="https://example.com/x?a=1#f"',
@@ -230,19 +162,6 @@ describe('sanitizer url handling', () => {
     expect(renderMarkdown('[a](/relative/path)')).toContain('href="/relative/path"');
     expect(renderMarkdown('[a](#anchor)')).toContain('href="#anchor"');
     expect(renderMarkdown('<a href="/a:b">x</a>')).toContain('href="/a:b"');
-  });
-
-  it('drops raw text elements together with their content', () => {
-    for (const source of [
-      '<script>alert(1)</script>after',
-      '<style>body{background:url(javascript:alert(1))}</style>after',
-      '<iframe src="https://evil.example"></iframe>after',
-      '<textarea></textarea><img src=x onerror=alert(1)>after',
-    ]) {
-      const html = renderMarkdown(source);
-      expect(html).not.toMatch(dangerous);
-      expect(html).not.toContain('alert(1)');
-    }
   });
 
   it('marks absolute links as external and leaves relative links alone', () => {
@@ -279,13 +198,6 @@ describe('toggle blocks', () => {
     expect(html).toContain('<summary>More</summary>');
     expect(html).toContain('Hidden body');
     expect(html).toContain('</details>');
-  });
-
-  it('still strips a script hidden inside a disclosure', () => {
-    const html = renderMarkdown('<details><summary>x</summary><script>alert(1)</script></details>');
-    expect(html).toContain('<details>');
-    expect(html).not.toContain('<script');
-    expect(html).not.toContain('alert(1)');
   });
 
   it('does not turn a github alert marker into anything but text', () => {

--- a/packages/services/tests/markdown/sanitizer-branches.test.ts
+++ b/packages/services/tests/markdown/sanitizer-branches.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, describe, expect, it } from 'bun:test';
+import { renderMarkdown, renderPlainText } from '../../src/markdown/index.ts';
+import {
+  canonicalHtml,
+  DANGEROUS,
+  restoreRewriter,
+  rewriterAvailable,
+  withoutRewriter,
+  XSS_VECTORS,
+  type XssVector,
+} from './sanitizer-vectors.ts';
+
+afterAll(restoreRewriter);
+
+const AGREEING = XSS_VECTORS.filter((vector) => vector.parserDiverges !== true);
+
+function assertSafe(html: string, vector: XssVector): void {
+  expect(html).not.toMatch(DANGEROUS);
+  for (const fragment of vector.absent ?? []) expect(html).not.toContain(fragment);
+  for (const fragment of vector.present ?? []) expect(html).toContain(fragment);
+}
+
+describe('the rewriter branch bun runs under', () => {
+  it('is the branch this process takes by default', () => {
+    expect(rewriterAvailable()).toBe(true);
+  });
+
+  for (const vector of XSS_VECTORS) {
+    it(`neutralises ${vector.name}`, () => {
+      assertSafe(renderMarkdown(vector.source), vector);
+    });
+  }
+});
+
+describe('the linkedom branch node ships to production', () => {
+  it('is the branch taken once HTMLRewriter is gone, and the global is put back after', () => {
+    withoutRewriter(() => {
+      expect(typeof HTMLRewriter).toBe('undefined');
+    });
+    expect(typeof HTMLRewriter).toBe('function');
+  });
+
+  for (const vector of XSS_VECTORS) {
+    it(`neutralises ${vector.name}`, () => {
+      assertSafe(
+        withoutRewriter(() => renderMarkdown(vector.source)),
+        vector,
+      );
+    });
+  }
+});
+
+describe('the two sanitizer branches do not drift apart', () => {
+  for (const vector of AGREEING) {
+    it(`renders ${vector.name} the same on node and on bun`, () => {
+      const viaRewriter = renderMarkdown(vector.source);
+      const viaDom = withoutRewriter(() => renderMarkdown(vector.source));
+      expect(canonicalHtml(viaDom)).toBe(canonicalHtml(viaRewriter));
+    });
+
+    it(`flattens ${vector.name} to the same text on node and on bun`, () => {
+      const viaRewriter = renderPlainText(vector.source);
+      const viaDom = withoutRewriter(() => renderPlainText(vector.source));
+      expect(viaDom).toBe(viaRewriter);
+    });
+  }
+
+  it('keeps every vector that survives canonicalisation in the drift check', () => {
+    expect(AGREEING.length).toBeGreaterThan(40);
+    expect(XSS_VECTORS.length - AGREEING.length).toBe(2);
+  });
+});
+
+describe('canonicalHtml only reorders attributes', () => {
+  it('sorts attributes so a benign parser ordering difference is not a failure', () => {
+    expect(canonicalHtml('<a href="/x" target="_blank" rel="noopener">y</a>')).toBe(
+      canonicalHtml('<a rel="noopener" target="_blank" href="/x">y</a>'),
+    );
+  });
+
+  it('still separates two tags that kept different attributes', () => {
+    expect(canonicalHtml('<img src="x" onerror="y">')).not.toBe(canonicalHtml('<img src="x">'));
+  });
+
+  it('still separates two documents whose elements differ', () => {
+    expect(canonicalHtml('<p>a</p>')).not.toBe(canonicalHtml('<p>a</p><iframe></iframe>'));
+  });
+});

--- a/packages/services/tests/markdown/sanitizer-vectors.ts
+++ b/packages/services/tests/markdown/sanitizer-vectors.ts
@@ -1,0 +1,317 @@
+export interface XssVector {
+  readonly name: string;
+  readonly source: string;
+  readonly absent?: readonly string[];
+  readonly present?: readonly string[];
+  readonly parserDiverges?: true;
+}
+
+export const DANGEROUS = /javascript|vbscript|data:text\/html|\son[a-z]+=/i;
+
+const TAG = /<([a-zA-Z][a-zA-Z0-9]*)((?:[^>"]|"[^"]*")*)>/g;
+const ATTRIBUTE = /[a-zA-Z-]+(?:="[^"]*")?/g;
+
+export function canonicalHtml(html: string): string {
+  return html.replace(TAG, (_match, tag: string, attributes: string) => {
+    const parts = (attributes.match(ATTRIBUTE) ?? []).sort();
+    return parts.length === 0 ? `<${tag}>` : `<${tag} ${parts.join(' ')}>`;
+  });
+}
+
+const globals = globalThis as { HTMLRewriter?: unknown };
+const bunRewriter = globals.HTMLRewriter;
+
+export function withoutRewriter<T>(run: () => T): T {
+  globals.HTMLRewriter = undefined;
+  try {
+    return run();
+  } finally {
+    globals.HTMLRewriter = bunRewriter;
+  }
+}
+
+export function restoreRewriter(): void {
+  globals.HTMLRewriter = bunRewriter;
+}
+
+export function rewriterAvailable(): boolean {
+  return bunRewriter !== undefined;
+}
+
+export const XSS_VECTORS: readonly XssVector[] = [
+  {
+    name: 'script tag',
+    source: 'hello <script>alert(1)</script> world',
+    absent: ['<script', 'alert(1)'],
+    present: ['hello'],
+  },
+  {
+    name: 'script tag with trailing text',
+    source: '<script>alert(1)</script>after',
+    absent: ['alert(1)'],
+    present: ['after'],
+  },
+  {
+    name: 'img onerror',
+    source: '<img src=x onerror="alert(1)">',
+    absent: ['onerror', 'alert(1)'],
+  },
+  {
+    name: 'img onerror unquoted after a textarea',
+    source: '<textarea></textarea><img src=x onerror=alert(1)>after',
+    absent: ['alert(1)', '<textarea'],
+    present: ['after'],
+  },
+  {
+    name: 'anchor javascript href',
+    source: '<a href="javascript:alert(1)">click</a>',
+    absent: ['javascript:'],
+    present: ['click'],
+  },
+  {
+    name: 'markdown link javascript payload',
+    source: '[click](javascript:alert(document.cookie))',
+    absent: ['javascript:', 'document.cookie'],
+  },
+  {
+    name: 'iframe',
+    source: '<iframe src="https://evil.example.com"></iframe>',
+    absent: ['<iframe', 'evil.example.com'],
+  },
+  {
+    name: 'iframe with trailing text',
+    source: '<iframe src="https://evil.example"></iframe>after',
+    absent: ['<iframe', 'evil.example'],
+    present: ['after'],
+  },
+  {
+    name: 'style attribute and svg onload',
+    source: '<p style="background:url(javascript:alert(1))">x</p><svg onload="alert(1)"></svg>',
+    absent: ['style=', '<svg', 'onload'],
+  },
+  {
+    name: 'style element',
+    source: '<style>body{background:url(javascript:alert(1))}</style>after',
+    absent: ['<style', 'alert(1)'],
+    present: ['after'],
+  },
+  {
+    name: 'script inside a fenced code block',
+    source: '```\n<script>alert(1)</script>\n```',
+    absent: ['<script>'],
+    present: ['&lt;script&gt;'],
+  },
+  {
+    name: 'script hidden inside a disclosure',
+    source: '<details><summary>x</summary><script>alert(1)</script></details>',
+    absent: ['<script', 'alert(1)'],
+    present: ['<details>', '<summary>x</summary>'],
+  },
+  {
+    name: 'decimal entity scheme in a markdown link',
+    source: '[a](&#106;avascript:alert(1))',
+  },
+  {
+    name: 'hex entity scheme in a markdown link',
+    source: '[a](&#x6a;avascript:alert(1))',
+  },
+  {
+    name: 'entity encoded colon',
+    source: '[a](javascript&#58;alert(1))',
+  },
+  {
+    name: 'tab entity inside the scheme',
+    source: '[a](java&Tab;script:alert(1))',
+  },
+  {
+    name: 'fully entity encoded scheme',
+    source: '[a](&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;alert(1))',
+  },
+  {
+    name: 'entity encoded scheme in a markdown image',
+    source: '![i](&#106;avascript:alert(1))',
+  },
+  {
+    name: 'entity encoded scheme in a raw img src',
+    source: '<img src="&#106;avascript:alert(1)">',
+  },
+  {
+    name: 'anchor repeating href to smuggle a scheme',
+    source: '<a href="https://ok.example" href="javascript:alert(1)">x</a>',
+    present: ['href="https://ok.example"'],
+  },
+  {
+    name: 'data text html href',
+    source: '<a href="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">x</a>',
+    absent: ['data:text/html'],
+    present: ['x'],
+  },
+  {
+    name: 'data text html in an iframe src',
+    source: '<iframe src="data:text/html,<script>alert(1)</script>"></iframe>',
+    absent: ['<iframe', 'data:text/html'],
+  },
+  {
+    name: 'object with a data url',
+    source: '<object data="data:text/html,<script>alert(1)</script>"></object>after',
+    absent: ['<object', 'data:text/html'],
+    present: ['after'],
+  },
+  {
+    name: 'embed',
+    source: '<embed src="https://evil.example/x.swf">after',
+    absent: ['<embed', 'evil.example'],
+    present: ['after'],
+  },
+  {
+    name: 'form with a formaction submit',
+    source:
+      '<form action="https://evil.example"><input type="submit" formaction="javascript:alert(1)"></form>after',
+    absent: ['<form', 'formaction', 'evil.example'],
+    present: ['after'],
+  },
+  {
+    name: 'base tag rewriting relative urls',
+    source: '<base href="https://evil.example/">after',
+    absent: ['<base', 'evil.example'],
+    present: ['after'],
+  },
+  {
+    name: 'meta refresh',
+    source: '<meta http-equiv="refresh" content="0;url=https://evil.example">after',
+    absent: ['<meta', 'evil.example'],
+    present: ['after'],
+  },
+  {
+    name: 'link stylesheet',
+    source: '<link rel="stylesheet" href="https://evil.example/x.css">after',
+    absent: ['<link', 'evil.example'],
+    present: ['after'],
+  },
+  {
+    name: 'template smuggling a script',
+    source: '<template><script>alert(1)</script></template>after',
+    absent: ['<template', 'alert(1)'],
+    present: ['after'],
+  },
+  {
+    name: 'noscript escape',
+    source: '<noscript><p title="</noscript><img src=x onerror=alert(1)>">after</noscript>',
+    absent: ['alert(1)', 'onerror'],
+    parserDiverges: true,
+  },
+  {
+    name: 'noembed escape',
+    source: '<noembed><img src=x onerror=alert(1)></noembed>after',
+    absent: ['alert(1)', 'onerror'],
+    present: ['after'],
+  },
+  {
+    name: 'xmp escape',
+    source: '<xmp><img src=x onerror=alert(1)></xmp>after',
+    absent: ['alert(1)', 'onerror'],
+  },
+  {
+    name: 'plaintext escape',
+    source: '<plaintext><img src=x onerror=alert(1)>',
+    absent: ['alert(1)', 'onerror'],
+    parserDiverges: true,
+  },
+  {
+    name: 'title escape',
+    source: '<title></title><img src=x onerror=alert(1)>',
+    absent: ['alert(1)', 'onerror'],
+  },
+  {
+    name: 'mxss through math mtext mglyph',
+    source:
+      '<math><mtext><mglyph><style><img src=x onerror=alert(1)></style></mglyph></mtext></math>',
+    absent: ['<math', 'alert(1)', 'onerror'],
+  },
+  {
+    name: 'svg foreignObject',
+    source: '<svg><foreignObject><a href="javascript:alert(1)">x</a></foreignObject></svg>',
+    absent: ['<svg', 'javascript:'],
+  },
+  {
+    name: 'svg animate href',
+    source:
+      '<svg><a><animate attributeName="href" values="javascript:alert(1)"></animate></a></svg>',
+    absent: ['<svg', 'javascript:'],
+  },
+  {
+    name: 'canvas',
+    source: '<canvas onclick="alert(1)">fallback</canvas>after',
+    absent: ['<canvas', 'onclick', 'alert(1)'],
+    present: ['after'],
+  },
+  {
+    name: 'video with an onerror source',
+    source: '<video><source src=x onerror=alert(1)></video>after',
+    absent: ['<video', '<source', 'alert(1)'],
+    present: ['after'],
+  },
+  {
+    name: 'audio onerror',
+    source: '<audio src=x onerror=alert(1)>after</audio>',
+    absent: ['<audio', 'alert(1)', 'onerror'],
+  },
+  {
+    name: 'dialog wrapper',
+    source: '<dialog open onclose="alert(1)">hidden</dialog>after',
+    absent: ['<dialog', 'onclose', 'alert(1)'],
+    present: ['after'],
+  },
+  {
+    name: 'applet',
+    source: '<applet code="Evil.class"></applet>after',
+    absent: ['<applet'],
+    present: ['after'],
+  },
+  {
+    name: 'frameset',
+    source: '<frameset><frame src="javascript:alert(1)"></frameset>after',
+    absent: ['<frameset', '<frame', 'javascript:'],
+  },
+  {
+    name: 'unknown element unwrapped but its handler dropped',
+    source: '<section onmouseover="alert(1)"><p>kept</p></section>',
+    absent: ['onmouseover', 'alert(1)', '<section'],
+    present: ['kept'],
+  },
+  {
+    name: 'allowed element with a handler and an id',
+    source: '<p onclick="steal()" id="x">text</p>',
+    absent: ['onclick', 'steal()', 'id="x"'],
+    present: ['text'],
+  },
+  {
+    name: 'html comment hiding markup',
+    source: '<!-- <script>alert(1)</script> --><p>visible</p>',
+    absent: ['alert(1)', '<!--'],
+    present: ['visible'],
+  },
+  {
+    name: 'vbscript href',
+    source: '<a href="vbscript:msgbox(1)">x</a>',
+    absent: ['vbscript:'],
+    present: ['x'],
+  },
+  {
+    name: 'newline split scheme',
+    source: '<a href="java\nscript:alert(1)">x</a>',
+    absent: ['alert(1)'],
+  },
+  {
+    name: 'uppercase script tag',
+    source: '<SCRIPT>alert(1)</SCRIPT>after',
+    absent: ['alert(1)'],
+    present: ['after'],
+  },
+  {
+    name: 'srcdoc on an iframe',
+    source: '<iframe srcdoc="&lt;script&gt;alert(1)&lt;/script&gt;"></iframe>after',
+    absent: ['<iframe', 'srcdoc'],
+    present: ['after'],
+  },
+];

--- a/packages/services/tests/slack/dispatch.test.ts
+++ b/packages/services/tests/slack/dispatch.test.ts
@@ -13,6 +13,7 @@ import { eq } from 'drizzle-orm';
 import {
   connectSlackChannel,
   disconnectSlackChannel,
+  dispatchSlackMessage,
   issueIdentifierFromUrl,
   resolveIssueUnfurls,
   resolveSlackContext,
@@ -144,6 +145,280 @@ describe('connectSlackChannel', () => {
       expect(await resolveSlackTargets(tx, fixture.organizationId, [fixture.teamA])).toHaveLength(
         0,
       );
+    });
+  });
+});
+
+describe('resolveSlackTargets keeps a channel inside the team it is bound to', () => {
+  it('never offers a channel bound to another team', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await connectSlackChannel(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        channelId: 'C-design',
+        channelName: 'design-private',
+        teamId: fixture.teamB,
+      });
+
+      const forEngineering = await resolveSlackTargets(tx, fixture.organizationId, [fixture.teamA]);
+      const forDesign = await resolveSlackTargets(tx, fixture.organizationId, [fixture.teamB]);
+
+      expect(forEngineering).toHaveLength(0);
+      expect(forDesign.map((target) => target.channelId)).toEqual(['C-design']);
+    });
+  });
+
+  it('offers a channel with no team to every team, and only once', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await connectSlackChannel(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        channelId: 'C-all',
+        channelName: 'everything',
+        teamId: null,
+      });
+
+      expect(
+        (await resolveSlackTargets(tx, fixture.organizationId, [fixture.teamA])).map(
+          (target) => target.channelId,
+        ),
+      ).toEqual(['C-all']);
+      expect(
+        (await resolveSlackTargets(tx, fixture.organizationId, [fixture.teamB])).map(
+          (target) => target.channelId,
+        ),
+      ).toEqual(['C-all']);
+      expect(
+        await resolveSlackTargets(tx, fixture.organizationId, [fixture.teamA, fixture.teamB]),
+      ).toHaveLength(1);
+      expect(
+        (await resolveSlackTargets(tx, fixture.organizationId, [])).map(
+          (target) => target.channelId,
+        ),
+      ).toEqual(['C-all']);
+    });
+  });
+
+  it('mixes a workspace wide channel with the asking team own channel', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await connectSlackChannel(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        channelId: 'C-all',
+        channelName: 'everything',
+        teamId: null,
+      });
+      await connectSlackChannel(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        channelId: 'C-eng',
+        channelName: 'engineering',
+        teamId: fixture.teamA,
+      });
+      await connectSlackChannel(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        channelId: 'C-design',
+        channelName: 'design',
+        teamId: fixture.teamB,
+      });
+
+      const targets = await resolveSlackTargets(tx, fixture.organizationId, [fixture.teamA]);
+
+      expect(targets.map((target) => target.channelId).sort()).toEqual(['C-all', 'C-eng']);
+      expect(
+        (await resolveSlackTargets(tx, fixture.organizationId, [])).map((t) => t.channelId),
+      ).toEqual(['C-all']);
+    });
+  });
+
+  it('names a channel once even when two integrations bind it to two teams', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      const secondIntegration = `${fixture.integrationId}_second`;
+      await tx.insert(integration).values({
+        id: secondIntegration,
+        organizationId: fixture.organizationId,
+        provider: 'slack',
+        externalId: 'T456',
+        connectedById: `usr_${fixture.organizationId.slice(4)}`,
+        credentials: { botToken: 'xoxb-second' },
+      });
+      await connectSlackChannel(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        channelId: 'C-shared',
+        channelName: 'shared',
+        teamId: fixture.teamA,
+      });
+      await connectSlackChannel(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: secondIntegration,
+        channelId: 'C-shared',
+        channelName: 'shared',
+        teamId: fixture.teamB,
+      });
+
+      const targets = await resolveSlackTargets(tx, fixture.organizationId, [
+        fixture.teamA,
+        fixture.teamB,
+      ]);
+
+      expect(targets.map((target) => target.channelId)).toEqual(['C-shared']);
+    });
+  });
+
+  it('skips a channel that was turned off', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await connectSlackChannel(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        channelId: 'C-off',
+        channelName: 'muted',
+        teamId: fixture.teamA,
+      });
+      await tx
+        .update(slackChannelSync)
+        .set({ enabled: false })
+        .where(eq(slackChannelSync.channelId, 'C-off'));
+
+      expect(await resolveSlackTargets(tx, fixture.organizationId, [fixture.teamA])).toHaveLength(
+        0,
+      );
+    });
+  });
+});
+
+interface PostLog {
+  readonly channels: string[];
+}
+
+function fetchStub(log: PostLog, failing: readonly string[] = []): typeof globalThis.fetch {
+  return ((_url: string, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? '{}')) as { channel?: string };
+    const channel = body.channel ?? '';
+    log.channels.push(channel);
+    if (failing.includes(channel)) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: false, error: 'channel_not_found' }), { status: 200 }),
+      );
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({ ok: true, channel, ts: '1.0' }), { status: 200 }),
+    );
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe('dispatchSlackMessage', () => {
+  it('posts to every resolved channel and counts what it delivered', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      for (const [channelId, teamId] of [
+        ['C-eng', fixture.teamA],
+        ['C-all', null],
+        ['C-design', fixture.teamB],
+      ] as const) {
+        await connectSlackChannel(tx, {
+          organizationId: fixture.organizationId,
+          integrationId: fixture.integrationId,
+          channelId,
+          channelName: channelId,
+          teamId,
+        });
+      }
+      const log: PostLog = { channels: [] };
+
+      const delivered = await dispatchSlackMessage(tx, {
+        organizationId: fixture.organizationId,
+        teamIds: [fixture.teamA],
+        text: 'ENG-1 moved',
+        fetch: fetchStub(log),
+      });
+
+      expect(delivered).toBe(2);
+      expect(log.channels.sort()).toEqual(['C-all', 'C-eng']);
+    });
+  });
+
+  it('keeps going and still counts the rest when one channel post fails', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      for (const channelId of ['C-eng', 'C-more']) {
+        await connectSlackChannel(tx, {
+          organizationId: fixture.organizationId,
+          integrationId: fixture.integrationId,
+          channelId,
+          channelName: channelId,
+          teamId: null,
+        });
+      }
+      const log: PostLog = { channels: [] };
+
+      const delivered = await dispatchSlackMessage(tx, {
+        organizationId: fixture.organizationId,
+        teamIds: [fixture.teamA],
+        text: 'ENG-1 moved',
+        fetch: fetchStub(log, ['C-eng']),
+      });
+
+      expect(delivered).toBe(1);
+      expect(log.channels.sort()).toEqual(['C-eng', 'C-more']);
+    });
+  });
+
+  it('posts nothing when the workspace has no slack token', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await connectSlackChannel(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        channelId: 'C-eng',
+        channelName: 'engineering',
+        teamId: fixture.teamA,
+      });
+      await tx
+        .update(integration)
+        .set({ credentials: {} })
+        .where(eq(integration.id, fixture.integrationId));
+      const log: PostLog = { channels: [] };
+
+      const delivered = await dispatchSlackMessage(tx, {
+        organizationId: fixture.organizationId,
+        teamIds: [fixture.teamA],
+        text: 'ENG-1 moved',
+        fetch: fetchStub(log),
+      });
+
+      expect(delivered).toBe(0);
+      expect(log.channels).toHaveLength(0);
+    });
+  });
+
+  it('posts nothing when no channel is connected to the asking team', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await connectSlackChannel(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        channelId: 'C-design',
+        channelName: 'design',
+        teamId: fixture.teamB,
+      });
+      const log: PostLog = { channels: [] };
+
+      const delivered = await dispatchSlackMessage(tx, {
+        organizationId: fixture.organizationId,
+        teamIds: [fixture.teamA],
+        text: 'ENG-1 moved',
+        fetch: fetchStub(log),
+      });
+
+      expect(delivered).toBe(0);
+      expect(log.channels).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
A coverage survey mutation-tested a sample of the suite and found the places where a break would pass CI silently. This closes them. Every test here was watched fail before it was believed: each one had the code it guards deliberately broken, went red, and the break was reverted.

## What was not real before

- **The XSS suite guarded a branch production never runs.** `sanitizeHtml` branches on `HTMLRewriter`, a bun only global. Under `bun test` all forty odd vectors exercised the rewriter; the deployed app on node always takes the linkedom path, which had six smoke assertions. Narrowing `DROP_WITH_CONTENT` to `script` in the dom branch left iframe, svg, object, embed, canvas and textarea alive in production and the whole suite stayed green.
- **`publish()` never stamped `originClientId` in any test**, because the header mock returned an empty `Headers`. Deleting the stamping entirely passed 858 tests, and every tab would have received its own writes back over the socket.
- **`bootstrapPayload` was never run.** The test mocked the database down to one row and only covered the etag string.
- **`resolveTeam` in the MCP server could ignore its argument**, because the fixture seeded exactly one team. An agent told to file on Design would have filed on Engineering.

## What had no test at all

- `authorizeScope` and all 526 lines of `hub.ts`, which is where every cross team realtime leak lives.
- `/api/ws`, including the upgrade first, buffer, replay, close 1008, close 1011 handshake.
- `resolveMembership`, the code that builds every `Principal` in the app.
- Both webhooks, including the delivery id claim that stops a GitHub redelivery double posting.
- `dispatchSlackMessage`, and the team clause in `resolveSlackTargets` that keeps an Engineering issue out of Design's private channel.
- `updateComment`, `deleteComment` and the whole attachment service.
- `use-comments`, whose failure path left a phantom comment behind the error toast.

## Also fixed

Three test files replaced a whole workspace module with a stub and could not put it back afterwards, which poisoned every later file in the same process. `@orbit/db` in two of them, `@/lib/auth/principal.ts` in the third. All three now use the real database.

`packages/core` gained a `./test-support` export so the web suite can build the same fixtures the service tests use, and the web preload now points at `orbit_test_web`.

## Verification

`bun run verify` is green against `main` merged in. Every assertion added here was proved by breaking the code it guards; the mutations are listed in the review notes.
