### PR TITLE
Close the twelve mutations that still survived the suite

### DIFF
--- a/apps/web/tests/app/api/webhooks/slack/route.test.ts
+++ b/apps/web/tests/app/api/webhooks/slack/route.test.ts
@@ -8,10 +8,14 @@ import { z } from 'zod';
 const SIGNING_SECRET = 'a-slack-signing-secret';
 process.env['SLACK_SIGNING_SECRET'] = SIGNING_SECRET;
 
-interface UnfurlCall {
+interface UnfurlInput {
   readonly channel: string;
   readonly ts: string;
   readonly unfurls: Record<string, unknown>;
+}
+
+interface UnfurlCall extends UnfurlInput {
+  readonly token: string;
 }
 
 const unfurlCalls: UnfurlCall[] = [];
@@ -20,8 +24,8 @@ const services = await import('@orbit/services');
 class RecordingSlackClient {
   constructor(readonly options: { token: string }) {}
 
-  unfurl(input: UnfurlCall): Promise<void> {
-    unfurlCalls.push(input);
+  unfurl(input: UnfurlInput): Promise<void> {
+    unfurlCalls.push({ ...input, token: this.options.token });
     return Promise.resolve();
   }
 }
@@ -36,17 +40,26 @@ afterAll(() => {
 
 const SLACK_TEAM = 'T-orbit-first';
 const OTHER_SLACK_TEAM = 'T-orbit-second';
+const SECOND_SLACK_TEAM_OF_FIRST = 'T-orbit-first-annex';
 
-async function connect(name: string, slackTeamId: string, title: string): Promise<Workspace> {
-  const workspace = await createWorkspace(name);
+function botTokenFor(slackTeamId: string): string {
+  return `xoxb-${slackTeamId}`;
+}
+
+async function addSlackIntegration(workspace: Workspace, slackTeamId: string): Promise<void> {
   await db.insert(schema.integration).values({
     id: `int_${randomUUIDv7()}`,
     organizationId: workspace.organizationId,
     provider: 'slack',
     externalId: slackTeamId,
     connectedById: workspace.adminUser.id,
-    credentials: { botToken: `xoxb-${slackTeamId}` },
+    credentials: { botToken: botTokenFor(slackTeamId) },
   });
+}
+
+async function connect(name: string, slackTeamId: string, title: string): Promise<Workspace> {
+  const workspace = await createWorkspace(name);
+  await addSlackIntegration(workspace, slackTeamId);
   await db.update(schema.team).set({ key: 'ORB' }).where(eq(schema.team.id, workspace.teamId));
   const todo = workspace.states.find((state) => state.category === 'unstarted');
   if (todo === undefined) throw new Error('the seeded team has no unstarted state');
@@ -65,7 +78,8 @@ async function connect(name: string, slackTeamId: string, title: string): Promis
 
 async function seed(): Promise<void> {
   await resetDatabase();
-  await connect('Slackedone', SLACK_TEAM, 'Owned by the first workspace');
+  const first = await connect('Slackedone', SLACK_TEAM, 'Owned by the first workspace');
+  await addSlackIntegration(first, SECOND_SLACK_TEAM_OF_FIRST);
   await connect('Slackedtwo', OTHER_SLACK_TEAM, 'Owned by the second workspace');
 }
 
@@ -164,6 +178,26 @@ describe('POST /api/webhooks/slack', () => {
     expect(unfurlCalls[0]?.ts).toBe('1700000000.000100');
     expect(Object.keys(unfurlCalls[0]?.unfurls ?? {})).toEqual(['https://orbit.local/issue/ORB-5']);
     expect(JSON.stringify(unfurlCalls[0]?.unfurls)).toContain('Owned by the first workspace');
+  });
+
+  it('answers with the bot token of the slack workspace the event came from', async () => {
+    await POST(signed(linkShared(SLACK_TEAM, 'https://orbit.local/issue/ORB-5')));
+    await POST(signed(linkShared(SECOND_SLACK_TEAM_OF_FIRST, 'https://orbit.local/issue/ORB-5')));
+
+    expect(unfurlCalls.map((call) => call.token)).toEqual([
+      botTokenFor(SLACK_TEAM),
+      botTokenFor(SECOND_SLACK_TEAM_OF_FIRST),
+    ]);
+  });
+
+  it('signs a second slack workspace unfurl with that other workspace token', async () => {
+    await POST(signed(linkShared(OTHER_SLACK_TEAM, 'https://orbit.local/issue/ORB-5')));
+    await POST(signed(linkShared(SLACK_TEAM, 'https://orbit.local/issue/ORB-5')));
+
+    expect(unfurlCalls.map((call) => call.token)).toEqual([
+      botTokenFor(OTHER_SLACK_TEAM),
+      botTokenFor(SLACK_TEAM),
+    ]);
   });
 
   it('answers each slack workspace with the issue of the workspace bound to it', async () => {

--- a/apps/web/tests/lib/query/use-comments.test.tsx
+++ b/apps/web/tests/lib/query/use-comments.test.tsx
@@ -14,15 +14,20 @@ mock.module('@/components/ui/toast.tsx', () => ({
   }),
 }));
 
-const { useComments, useCreateComment, useDeleteComment, useUpdateComment } = await import(
-  '../../../src/lib/query/use-comments.ts'
-);
+const { useComments, useCreateComment, useDeleteComment, useToggleReaction, useUpdateComment } =
+  await import('../../../src/lib/query/use-comments.ts');
 
 const ISSUE = 'issue_1';
 const ME = 'user_me';
+const SOMEONE_ELSE = 'user_them';
 const originalFetch = globalThis.fetch;
 
-function comment(id: string, body: string, authorId = ME): Comment {
+function comment(
+  id: string,
+  body: string,
+  authorId = ME,
+  reactions: Comment['reactions'] = [],
+): Comment {
   return {
     comment: {
       id,
@@ -37,8 +42,12 @@ function comment(id: string, body: string, authorId = ME): Comment {
       syncId: 7,
     },
     bodyHtml: `<p>${body}</p>`,
-    reactions: [],
+    reactions,
   };
+}
+
+function reaction(id: string, commentId: string, userId: string, emoji: string) {
+  return { id, commentId, userId, emoji };
 }
 
 interface Answer {
@@ -51,14 +60,16 @@ type Handler = (url: string, init: RequestInit | undefined) => Answer | Promise<
 interface FetchLog {
   readonly urls: string[];
   readonly methods: string[];
+  readonly payloads: string[];
 }
 
 function stubFetch(handler: Handler): FetchLog {
-  const log: FetchLog = { urls: [], methods: [] };
+  const log: FetchLog = { urls: [], methods: [], payloads: [] };
   globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
     const url = String(input);
     log.urls.push(url);
     log.methods.push(init?.method ?? 'GET');
+    log.payloads.push(String(init?.body ?? ''));
     const answer = await handler(url, init);
     return new Response(JSON.stringify(answer.payload), {
       status: answer.status ?? 200,
@@ -307,5 +318,126 @@ describe('useDeleteComment', () => {
     await waitFor(() => expect(bodies(list.result.current.data)).toEqual(['Hello', 'Second']));
 
     expect(toasts.map((entry) => entry.title)).toEqual(['Could not delete']);
+  });
+});
+
+function emojiOn(rows: readonly Comment[] | undefined, id: string): string[] {
+  const entry = (rows ?? []).find((row) => row.comment.id === id);
+  return (entry?.reactions ?? []).map((row) => `${row.userId}:${row.emoji}`).sort();
+}
+
+const PARTY = '\u{1F389}';
+const EYES = '\u{1F440}';
+
+describe('useToggleReaction', () => {
+  it('paints my reaction on the named comment and posts it to that comment endpoint', async () => {
+    const post = gate();
+    const log = stubFetch((_url, init) => {
+      if (init?.method === 'POST') return post.held;
+      return {
+        payload: {
+          comments: [
+            comment('c1', 'Hello', ME, [reaction('r1', 'c1', SOMEONE_ELSE, EYES)]),
+            comment('c2', 'Second'),
+          ],
+        },
+      };
+    });
+    const client = newClient();
+
+    const list = renderHook(() => useComments(ISSUE), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+
+    const react = renderHook(() => useToggleReaction(ISSUE), { wrapper: wrapper(client) });
+    react.result.current.mutate({ commentId: 'c1', emoji: PARTY });
+
+    await waitFor(() =>
+      expect(emojiOn(list.result.current.data, 'c1')).toEqual([
+        `${ME}:${PARTY}`,
+        `${SOMEONE_ELSE}:${EYES}`,
+      ]),
+    );
+    expect(emojiOn(list.result.current.data, 'c2')).toEqual([]);
+
+    post.release({ payload: { emoji: PARTY, active: true } });
+    await waitFor(() => expect(react.result.current.isSuccess).toBe(true));
+
+    const posted = log.urls.filter((_url, index) => log.methods[index] === 'POST');
+    expect(posted).toEqual(['/api/comments/c1/reactions']);
+    expect(
+      log.payloads
+        .filter((_payload, index) => log.methods[index] === 'POST')
+        .map((payload) => JSON.parse(payload) as unknown),
+    ).toEqual([{ emoji: PARTY }]);
+    expect(emojiOn(list.result.current.data, 'c1')).toEqual([
+      `${ME}:${PARTY}`,
+      `${SOMEONE_ELSE}:${EYES}`,
+    ]);
+  });
+
+  it('takes my own reaction back off and leaves the same emoji from someone else', async () => {
+    const post = gate();
+    stubFetch((_url, init) => {
+      if (init?.method === 'POST') return post.held;
+      return {
+        payload: {
+          comments: [
+            comment('c1', 'Hello', ME, [
+              reaction('mine', 'c1', ME, PARTY),
+              reaction('theirs', 'c1', SOMEONE_ELSE, PARTY),
+            ]),
+          ],
+        },
+      };
+    });
+    const client = newClient();
+
+    const list = renderHook(() => useComments(ISSUE), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+
+    const react = renderHook(() => useToggleReaction(ISSUE), { wrapper: wrapper(client) });
+    react.result.current.mutate({ commentId: 'c1', emoji: PARTY });
+
+    await waitFor(() =>
+      expect(emojiOn(list.result.current.data, 'c1')).toEqual([`${SOMEONE_ELSE}:${PARTY}`]),
+    );
+
+    post.release({ payload: { emoji: PARTY, active: false } });
+    await waitFor(() => expect(react.result.current.isSuccess).toBe(true));
+    expect(emojiOn(list.result.current.data, 'c1')).toEqual([`${SOMEONE_ELSE}:${PARTY}`]);
+  });
+
+  it('puts the reactions back and warns when the server refuses', async () => {
+    const post = gate();
+    stubFetch((_url, init) => {
+      if (init?.method === 'POST') return post.held;
+      return {
+        payload: {
+          comments: [comment('c1', 'Hello', ME, [reaction('theirs', 'c1', SOMEONE_ELSE, EYES)])],
+        },
+      };
+    });
+    const client = newClient();
+
+    const list = renderHook(() => useComments(ISSUE), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+
+    const react = renderHook(() => useToggleReaction(ISSUE), { wrapper: wrapper(client) });
+    react.result.current.mutate({ commentId: 'c1', emoji: PARTY });
+
+    await waitFor(() =>
+      expect(emojiOn(list.result.current.data, 'c1')).toEqual([
+        `${ME}:${PARTY}`,
+        `${SOMEONE_ELSE}:${EYES}`,
+      ]),
+    );
+
+    post.release({ status: 403, payload: { error: { code: 'forbidden', message: 'no' } } });
+    await waitFor(() => expect(react.result.current.isError).toBe(true));
+    await waitFor(() =>
+      expect(emojiOn(list.result.current.data, 'c1')).toEqual([`${SOMEONE_ELSE}:${EYES}`]),
+    );
+
+    expect(toasts.map((entry) => entry.title)).toEqual(['Could not react']);
   });
 });

--- a/packages/core/tests/work/label-service.test.ts
+++ b/packages/core/tests/work/label-service.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { createWorkspace, resetDatabase, type Workspace } from '../../src/test-support.ts';
+import {
+  createLabel,
+  deleteLabel,
+  getLabel,
+  type LabelRow,
+  listLabels,
+  updateLabel,
+} from '../../src/work/label-service.ts';
+
+let nova: Workspace;
+let orion: Workspace;
+let novaLabel: LabelRow;
+let orionLabel: LabelRow;
+
+beforeEach(async () => {
+  await resetDatabase();
+  nova = await createWorkspace('Nova');
+  orion = await createWorkspace('Orion');
+  novaLabel = (await createLabel(nova.admin, { name: 'Regression', color: '#EF4444' })).label;
+  orionLabel = (await createLabel(orion.admin, { name: 'Regression', color: '#22C55E' })).label;
+});
+
+async function errorOf(run: () => Promise<unknown>): Promise<string> {
+  try {
+    await run();
+  } catch (error: unknown) {
+    const thrown = error as { code?: unknown };
+    return typeof thrown.code === 'string' ? thrown.code : 'not-a-domain-error';
+  }
+  throw new Error('the call was expected to throw and did not');
+}
+
+async function labelById(workspace: Workspace, labelId: string): Promise<LabelRow | undefined> {
+  return (await listLabels(workspace.admin)).find((row) => row.id === labelId);
+}
+
+describe('the label fixture puts a same named label in each workspace', () => {
+  it('holds two workspaces whose Regression labels are different rows', () => {
+    expect(nova.organizationId).not.toBe(orion.organizationId);
+    expect(novaLabel.id).not.toBe(orionLabel.id);
+    expect(novaLabel.name).toBe(orionLabel.name);
+  });
+});
+
+describe('getLabel stops at the workspace boundary', () => {
+  it('reads its own label and refuses the one next door', async () => {
+    expect((await getLabel(nova.admin, novaLabel.id)).color).toBe('#EF4444');
+    expect(await errorOf(() => getLabel(nova.admin, orionLabel.id))).toBe('not_found');
+    expect(await errorOf(() => getLabel(orion.admin, novaLabel.id))).toBe('not_found');
+  });
+});
+
+describe('updateLabel stops at the workspace boundary', () => {
+  it('refuses to rename a label in another workspace and leaves it untouched', async () => {
+    expect(await errorOf(() => updateLabel(nova.admin, orionLabel.id, { name: 'Stolen' }))).toBe(
+      'not_found',
+    );
+
+    const survivor = await labelById(orion, orionLabel.id);
+    expect(survivor?.name).toBe('Regression');
+    expect(survivor?.color).toBe('#22C55E');
+  });
+
+  it('refuses to move a foreign label onto a team of the asking workspace', async () => {
+    expect(
+      await errorOf(() => updateLabel(nova.admin, orionLabel.id, { teamId: nova.teamId })),
+    ).toBe('not_found');
+
+    expect((await labelById(orion, orionLabel.id))?.teamId).toBeNull();
+  });
+
+  it('still renames a label the asking workspace owns', async () => {
+    const renamed = await updateLabel(nova.admin, novaLabel.id, { name: 'Flake' });
+
+    expect(renamed.label.name).toBe('Flake');
+    expect((await labelById(nova, novaLabel.id))?.name).toBe('Flake');
+    expect((await labelById(orion, orionLabel.id))?.name).toBe('Regression');
+  });
+});
+
+describe('deleteLabel stops at the workspace boundary', () => {
+  it('refuses to delete a label in another workspace and leaves the row behind', async () => {
+    expect(await errorOf(() => deleteLabel(nova.admin, orionLabel.id))).toBe('not_found');
+
+    expect(await labelById(orion, orionLabel.id)).toBeDefined();
+  });
+
+  it('still deletes a label the asking workspace owns, and only that one', async () => {
+    const actions = await deleteLabel(nova.admin, novaLabel.id);
+
+    expect(actions[0]?.action).toBe('delete');
+    expect(await labelById(nova, novaLabel.id)).toBeUndefined();
+    expect(await labelById(orion, orionLabel.id)).toBeDefined();
+  });
+});

--- a/packages/mcp-server/tests/resolve.test.ts
+++ b/packages/mcp-server/tests/resolve.test.ts
@@ -1,7 +1,17 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
-import { createLabel, createProject, createTeam, listProjects, listTeams } from '@orbit/core';
+import {
+  completeCycle,
+  createCycle,
+  createLabel,
+  createProject,
+  createTeam,
+  listCycles,
+  listProjects,
+  listTeams,
+} from '@orbit/core';
 import type { Principal } from '@orbit/shared/policy';
 import {
+  resolveCycle,
   resolveLabelIds,
   resolveProject,
   resolveStateId,
@@ -26,6 +36,15 @@ let borealisSlug: string;
 let flakyLabelId: string;
 let sturdyLabelId: string;
 let teammateId: string;
+let operationsId: string;
+let engineeringSprintOne: string;
+let engineeringSprintTwo: string;
+let engineeringSprintThree: string;
+let designSprintOne: string;
+
+function daysFromNow(days: number): Date {
+  return new Date(Date.now() + days * 86_400_000);
+}
 
 beforeAll(async () => {
   await resetDatabase();
@@ -50,6 +69,33 @@ beforeAll(async () => {
 
   const teammate = await addMember(workspace, 'member', 'Bea Builder');
   teammateId = teammate.user.id;
+
+  const operations = await createTeam(admin, { name: 'Operations', key: 'OPS' });
+  operationsId = operations.team.id;
+
+  const [bootstrapEngineering] = await listCycles(admin, engineeringId);
+  if (bootstrapEngineering === undefined) throw new Error('the engineering team has no cycle');
+  engineeringSprintOne = bootstrapEngineering.id;
+  const [bootstrapDesign] = await listCycles(admin, designId);
+  if (bootstrapDesign === undefined) throw new Error('the design team has no cycle');
+  designSprintOne = bootstrapDesign.id;
+
+  const sprintTwo = await createCycle(admin, {
+    teamId: engineeringId,
+    startsAt: daysFromNow(20),
+    endsAt: daysFromNow(34),
+  });
+  engineeringSprintTwo = sprintTwo.cycle.id;
+  const sprintThree = await createCycle(admin, {
+    teamId: engineeringId,
+    startsAt: daysFromNow(40),
+    endsAt: daysFromNow(54),
+  });
+  engineeringSprintThree = sprintThree.cycle.id;
+
+  const [bootstrapOperations] = await listCycles(admin, operationsId);
+  if (bootstrapOperations === undefined) throw new Error('the operations team has no cycle');
+  await completeCycle(admin, bootstrapOperations.id);
 });
 
 async function errorOf(run: () => Promise<unknown>): Promise<string> {
@@ -166,5 +212,65 @@ describe('resolveStateId', () => {
   it('refuses a state that belongs to another team', async () => {
     const onDesign = await resolveStateId(admin, designId, 'In Progress');
     expect(await errorOf(() => resolveStateId(admin, engineeringId, onDesign))).toBe('not_found');
+  });
+});
+
+describe('the cycle fixture holds more than one sprint on the asking team', () => {
+  it('gives engineering three sprints, only the first of which is running', async () => {
+    const sprints = await listCycles(admin, engineeringId);
+
+    expect(sprints.map((sprint) => sprint.id)).toEqual([
+      engineeringSprintOne,
+      engineeringSprintTwo,
+      engineeringSprintThree,
+    ]);
+    expect(sprints.map((sprint) => sprint.name)).toEqual(['Sprint 1', 'Sprint 2', 'Sprint 3']);
+  });
+});
+
+describe('resolveCycle', () => {
+  it('picks the third sprint by its name, its number and its id', async () => {
+    expect((await resolveCycle(admin, engineeringId, 'Sprint 3')).id).toBe(engineeringSprintThree);
+    expect((await resolveCycle(admin, engineeringId, '3')).id).toBe(engineeringSprintThree);
+    expect((await resolveCycle(admin, engineeringId, engineeringSprintThree)).id).toBe(
+      engineeringSprintThree,
+    );
+  });
+
+  it('picks the middle sprint rather than whatever comes first in the list', async () => {
+    expect((await resolveCycle(admin, engineeringId, 'Sprint 2')).id).toBe(engineeringSprintTwo);
+    expect((await resolveCycle(admin, engineeringId, '2')).id).toBe(engineeringSprintTwo);
+  });
+
+  it('ignores case and surrounding space', async () => {
+    expect((await resolveCycle(admin, engineeringId, '  sprint 3  ')).id).toBe(
+      engineeringSprintThree,
+    );
+    expect((await resolveCycle(admin, engineeringId, 'SPRINT 2')).id).toBe(engineeringSprintTwo);
+  });
+
+  it('reads "active" as the sprint running on the team it was asked about', async () => {
+    expect((await resolveCycle(admin, engineeringId, 'active')).id).toBe(engineeringSprintOne);
+    expect((await resolveCycle(admin, designId, 'active')).id).toBe(designSprintOne);
+    expect((await resolveCycle(admin, engineeringId, '  ACTIVE  ')).id).toBe(engineeringSprintOne);
+  });
+
+  it('refuses a sprint that belongs to another team', async () => {
+    expect(await errorOf(() => resolveCycle(admin, designId, engineeringSprintTwo))).toBe(
+      'not_found',
+    );
+    expect(await errorOf(() => resolveCycle(admin, engineeringId, designSprintOne))).toBe(
+      'not_found',
+    );
+    expect(await errorOf(() => resolveCycle(admin, designId, 'Sprint 2'))).toBe('not_found');
+  });
+
+  it('refuses a reference that matches no sprint', async () => {
+    expect(await errorOf(() => resolveCycle(admin, engineeringId, 'Sprint 9'))).toBe('not_found');
+    expect(await errorOf(() => resolveCycle(admin, engineeringId, '9'))).toBe('not_found');
+  });
+
+  it('refuses "active" on a team whose sprint has been closed', async () => {
+    expect(await errorOf(() => resolveCycle(admin, operationsId, 'active'))).toBe('not_found');
   });
 });

--- a/packages/realtime-server/tests/hub.test.ts
+++ b/packages/realtime-server/tests/hub.test.ts
@@ -45,13 +45,14 @@ afterAll(async () => {
   mock.module('../src/logger.ts', () => loggerModule);
 });
 
-async function newHub(): Promise<Hub> {
+async function newHub(overrides: Parameters<typeof createRealtimeHub>[0] = {}): Promise<Hub> {
   return await createRealtimeHub({
     redisUrl: REDIS_URL,
     ticketSecret: SECRET,
     batchWindowMs: 1,
     heartbeatIntervalMs: 60_000,
     heartbeatTimeoutMs: 60_000,
+    ...overrides,
   });
 }
 
@@ -415,6 +416,65 @@ describe('membership and session revocation', () => {
 
       expect(wired.socket.closures).toHaveLength(0);
       expect(hub.stats().connections).toBe(1);
+    } finally {
+      await hub.close();
+    }
+  });
+});
+
+describe('the periodic session sweep closes what no control message ever announced', () => {
+  it('closes a connection whose session quietly expired and spares the rest', async () => {
+    const hub = await newHub({ sessionSweepIntervalMs: 25 });
+    try {
+      const stale = await connect(hub, home.readerUserId, home.organizationId);
+      const fresh = await connect(hub, home.adminUserId, home.organizationId);
+      expect(hub.stats().connections).toBe(2);
+
+      await db
+        .update(schema.session)
+        .set({ expiresAt: new Date(Date.now() - 1_000) })
+        .where(eq(schema.session.id, stale.sessionId));
+
+      await waitFor(() => stale.socket.closures.length > 0, 'the expired session to be swept');
+
+      expect(stale.socket.closures[0]).toEqual({
+        code: SESSION_REVOKED_CLOSE_CODE,
+        reason: 'session_revoked',
+      });
+      expect(fresh.socket.closures).toHaveLength(0);
+      expect(hub.stats().connections).toBe(1);
+    } finally {
+      await hub.close();
+    }
+  });
+
+  it('closes a connection whose session row was deleted outright', async () => {
+    const hub = await newHub({ sessionSweepIntervalMs: 25 });
+    try {
+      const signedOut = await connect(hub, home.readerUserId, home.organizationId);
+
+      await db.delete(schema.session).where(eq(schema.session.id, signedOut.sessionId));
+
+      await waitFor(() => signedOut.socket.closures.length > 0, 'the deleted session to be swept');
+
+      expect(signedOut.socket.closures[0]?.code).toBe(SESSION_REVOKED_CLOSE_CODE);
+      expect(hub.stats().connections).toBe(0);
+    } finally {
+      await hub.close();
+    }
+  });
+
+  it('leaves a connection whose session is still live alone across many sweeps', async () => {
+    const hub = await newHub({ sessionSweepIntervalMs: 10 });
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`team:${home.teamCore}`]);
+
+      await new Promise((resolve) => setTimeout(resolve, 120));
+
+      expect(wired.socket.closures).toHaveLength(0);
+      expect(hub.stats().connections).toBe(1);
+      expect(hub.stats().subscriptions).toBe(1);
     } finally {
       await hub.close();
     }

--- a/packages/services/tests/slack/dispatch.test.ts
+++ b/packages/services/tests/slack/dispatch.test.ts
@@ -24,18 +24,28 @@ import { type TestTransaction, withRollback } from '../../src/test-database.ts';
 interface Fixture {
   readonly organizationId: string;
   readonly integrationId: string;
+  readonly userId: string;
   readonly teamA: string;
   readonly teamB: string;
 }
 
-async function seed(tx: TestTransaction): Promise<Fixture> {
+interface WorkspaceOptions {
+  readonly name: string;
+  readonly slackTeamId?: string;
+  readonly botToken?: string;
+  readonly connectGithubFirst?: boolean;
+}
+
+async function seedWorkspace(tx: TestTransaction, options: WorkspaceOptions): Promise<Fixture> {
   const suffix = randomUUIDv7();
+  const slug = options.name.toLowerCase().replace(/[^a-z0-9]/g, '');
   const organizationId = `org_${suffix}`;
   await tx
     .insert(organization)
-    .values({ id: organizationId, name: 'Acme', slug: `acme-${suffix.toLowerCase()}` });
+    .values({ id: organizationId, name: options.name, slug: `${slug}-${suffix.toLowerCase()}` });
+  const userId = `usr_${suffix}`;
   await tx.insert(user).values({
-    id: `usr_${suffix}`,
+    id: userId,
     name: 'Ada',
     email: `ada.${suffix}@orbit.local`,
     handle: `ada-${suffix.toLowerCase()}`,
@@ -48,17 +58,34 @@ async function seed(tx: TestTransaction): Promise<Fixture> {
     { id: teamB, organizationId, name: 'Design', key: 'DES' },
   ]);
 
-  const integrationId = `int_${suffix}`;
-  await tx.insert(integration).values({
-    id: integrationId,
-    organizationId,
-    provider: 'slack',
-    externalId: 'T123',
-    connectedById: `usr_${suffix}`,
-    credentials: { botToken: 'xoxb-test' },
-  });
+  if (options.connectGithubFirst === true) {
+    await tx.insert(integration).values({
+      id: `int_gh_${suffix}`,
+      organizationId,
+      provider: 'github',
+      externalId: `gh-${suffix}`,
+      connectedById: userId,
+      credentials: { accessToken: 'gho-not-a-slack-token' },
+    });
+  }
 
-  return { organizationId, integrationId, teamA, teamB };
+  const integrationId = `int_${suffix}`;
+  if (options.botToken !== undefined) {
+    await tx.insert(integration).values({
+      id: integrationId,
+      organizationId,
+      provider: 'slack',
+      externalId: options.slackTeamId ?? 'T123',
+      connectedById: userId,
+      credentials: { botToken: options.botToken },
+    });
+  }
+
+  return { organizationId, integrationId, userId, teamA, teamB };
+}
+
+async function seed(tx: TestTransaction): Promise<Fixture> {
+  return await seedWorkspace(tx, { name: 'Acme', botToken: 'xoxb-test' });
 }
 
 describe('resolveSlackContext', () => {
@@ -67,6 +94,136 @@ describe('resolveSlackContext', () => {
       const fixture = await seed(tx);
       const context = await resolveSlackContext(tx, fixture.organizationId);
       expect(context?.token).toBe('xoxb-test');
+    });
+  });
+});
+
+describe('resolveSlackContext stays inside the workspace it was asked about', () => {
+  it('hands each workspace its own integration row and its own bot token', async () => {
+    await withRollback(async (tx) => {
+      const acme = await seedWorkspace(tx, {
+        name: 'Acme',
+        slackTeamId: 'T-acme',
+        botToken: 'xoxb-acme',
+      });
+      const globex = await seedWorkspace(tx, {
+        name: 'Globex',
+        slackTeamId: 'T-globex',
+        botToken: 'xoxb-globex',
+      });
+
+      expect(await resolveSlackContext(tx, acme.organizationId)).toEqual({
+        integrationId: acme.integrationId,
+        token: 'xoxb-acme',
+      });
+      expect(await resolveSlackContext(tx, globex.organizationId)).toEqual({
+        integrationId: globex.integrationId,
+        token: 'xoxb-globex',
+      });
+    });
+  });
+
+  it('finds no slack context in a workspace that only connected another provider', async () => {
+    await withRollback(async (tx) => {
+      await seedWorkspace(tx, { name: 'Acme', slackTeamId: 'T-acme', botToken: 'xoxb-acme' });
+      const githubOnly = await seedWorkspace(tx, {
+        name: 'Initech',
+        connectGithubFirst: true,
+      });
+
+      expect(await resolveSlackContext(tx, githubOnly.organizationId)).toBeNull();
+    });
+  });
+
+  it('reads past an older integration from another provider in the same workspace', async () => {
+    await withRollback(async (tx) => {
+      const acme = await seedWorkspace(tx, {
+        name: 'Acme',
+        slackTeamId: 'T-acme',
+        botToken: 'xoxb-acme',
+        connectGithubFirst: true,
+      });
+
+      expect(await resolveSlackContext(tx, acme.organizationId)).toEqual({
+        integrationId: acme.integrationId,
+        token: 'xoxb-acme',
+      });
+    });
+  });
+});
+
+describe('resolveSlackTargets keeps a channel inside the workspace it belongs to', () => {
+  it('never offers another workspace channel to an issue on this one', async () => {
+    await withRollback(async (tx) => {
+      const acme = await seedWorkspace(tx, {
+        name: 'Acme',
+        slackTeamId: 'T-acme',
+        botToken: 'xoxb-acme',
+      });
+      const globex = await seedWorkspace(tx, {
+        name: 'Globex',
+        slackTeamId: 'T-globex',
+        botToken: 'xoxb-globex',
+      });
+      await connectSlackChannel(tx, {
+        organizationId: globex.organizationId,
+        integrationId: globex.integrationId,
+        channelId: 'C-globex-all',
+        channelName: 'globex-everything',
+        teamId: null,
+      });
+      await connectSlackChannel(tx, {
+        organizationId: globex.organizationId,
+        integrationId: globex.integrationId,
+        channelId: 'C-globex-eng',
+        channelName: 'globex-engineering',
+        teamId: globex.teamA,
+      });
+      await connectSlackChannel(tx, {
+        organizationId: acme.organizationId,
+        integrationId: acme.integrationId,
+        channelId: 'C-acme-eng',
+        channelName: 'acme-engineering',
+        teamId: acme.teamA,
+      });
+
+      expect(
+        (await resolveSlackTargets(tx, acme.organizationId, [acme.teamA])).map(
+          (target) => target.channelId,
+        ),
+      ).toEqual(['C-acme-eng']);
+      expect(await resolveSlackTargets(tx, acme.organizationId, [])).toEqual([]);
+      expect(
+        (await resolveSlackTargets(tx, globex.organizationId, [globex.teamA]))
+          .map((target) => target.channelId)
+          .sort(),
+      ).toEqual(['C-globex-all', 'C-globex-eng']);
+    });
+  });
+
+  it('never offers another workspace channel bound to a team id it does not know', async () => {
+    await withRollback(async (tx) => {
+      const acme = await seedWorkspace(tx, {
+        name: 'Acme',
+        slackTeamId: 'T-acme',
+        botToken: 'xoxb-acme',
+      });
+      const globex = await seedWorkspace(tx, {
+        name: 'Globex',
+        slackTeamId: 'T-globex',
+        botToken: 'xoxb-globex',
+      });
+      await connectSlackChannel(tx, {
+        organizationId: globex.organizationId,
+        integrationId: globex.integrationId,
+        channelId: 'C-globex-design',
+        channelName: 'globex-design',
+        teamId: globex.teamB,
+      });
+
+      expect(
+        await resolveSlackTargets(tx, acme.organizationId, [acme.teamA, globex.teamB]),
+      ).toEqual([]);
     });
   });
 });
@@ -244,7 +401,7 @@ describe('resolveSlackTargets keeps a channel inside the team it is bound to', (
         organizationId: fixture.organizationId,
         provider: 'slack',
         externalId: 'T456',
-        connectedById: `usr_${fixture.organizationId.slice(4)}`,
+        connectedById: fixture.userId,
         credentials: { botToken: 'xoxb-second' },
       });
       await connectSlackChannel(tx, {
@@ -295,6 +452,11 @@ describe('resolveSlackTargets keeps a channel inside the team it is bound to', (
 
 interface PostLog {
   readonly channels: string[];
+  readonly authorizations: string[];
+}
+
+function newLog(): PostLog {
+  return { channels: [], authorizations: [] };
 }
 
 function fetchStub(log: PostLog, failing: readonly string[] = []): typeof globalThis.fetch {
@@ -302,6 +464,8 @@ function fetchStub(log: PostLog, failing: readonly string[] = []): typeof global
     const body = JSON.parse(String(init?.body ?? '{}')) as { channel?: string };
     const channel = body.channel ?? '';
     log.channels.push(channel);
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    log.authorizations.push(headers['authorization'] ?? '');
     if (failing.includes(channel)) {
       return Promise.resolve(
         new Response(JSON.stringify({ ok: false, error: 'channel_not_found' }), { status: 200 }),
@@ -312,6 +476,90 @@ function fetchStub(log: PostLog, failing: readonly string[] = []): typeof global
     );
   }) as unknown as typeof globalThis.fetch;
 }
+
+describe('dispatchSlackMessage never crosses a workspace boundary', () => {
+  it('posts only into the asking workspace channels, with only its own bot token', async () => {
+    await withRollback(async (tx) => {
+      const acme = await seedWorkspace(tx, {
+        name: 'Acme',
+        slackTeamId: 'T-acme',
+        botToken: 'xoxb-acme',
+      });
+      const globex = await seedWorkspace(tx, {
+        name: 'Globex',
+        slackTeamId: 'T-globex',
+        botToken: 'xoxb-globex',
+      });
+      await connectSlackChannel(tx, {
+        organizationId: globex.organizationId,
+        integrationId: globex.integrationId,
+        channelId: 'C-globex-all',
+        channelName: 'globex-everything',
+        teamId: null,
+      });
+      await connectSlackChannel(tx, {
+        organizationId: acme.organizationId,
+        integrationId: acme.integrationId,
+        channelId: 'C-acme-eng',
+        channelName: 'acme-engineering',
+        teamId: acme.teamA,
+      });
+      const log = newLog();
+
+      const delivered = await dispatchSlackMessage(tx, {
+        organizationId: acme.organizationId,
+        teamIds: [acme.teamA],
+        text: 'ENG-1 moved',
+        fetch: fetchStub(log),
+      });
+
+      expect(delivered).toBe(1);
+      expect(log.channels).toEqual(['C-acme-eng']);
+      expect(log.authorizations).toEqual(['Bearer xoxb-acme']);
+    });
+  });
+
+  it('signs the other workspace dispatch with the other workspace token', async () => {
+    await withRollback(async (tx) => {
+      const acme = await seedWorkspace(tx, {
+        name: 'Acme',
+        slackTeamId: 'T-acme',
+        botToken: 'xoxb-acme',
+      });
+      const globex = await seedWorkspace(tx, {
+        name: 'Globex',
+        slackTeamId: 'T-globex',
+        botToken: 'xoxb-globex',
+      });
+      await connectSlackChannel(tx, {
+        organizationId: globex.organizationId,
+        integrationId: globex.integrationId,
+        channelId: 'C-globex-eng',
+        channelName: 'globex-engineering',
+        teamId: globex.teamA,
+      });
+      await connectSlackChannel(tx, {
+        organizationId: acme.organizationId,
+        integrationId: acme.integrationId,
+        channelId: 'C-acme-eng',
+        channelName: 'acme-engineering',
+        teamId: acme.teamA,
+      });
+      const log = newLog();
+
+      const delivered = await dispatchSlackMessage(tx, {
+        organizationId: globex.organizationId,
+        teamIds: [globex.teamA],
+        text: 'ENG-1 moved',
+        fetch: fetchStub(log),
+      });
+
+      expect(delivered).toBe(1);
+      expect(log.channels).toEqual(['C-globex-eng']);
+      expect(log.authorizations).toEqual(['Bearer xoxb-globex']);
+    });
+  });
+});
 
 describe('dispatchSlackMessage', () => {
   it('posts to every resolved channel and counts what it delivered', async () => {
@@ -330,7 +578,7 @@ describe('dispatchSlackMessage', () => {
           teamId,
         });
       }
-      const log: PostLog = { channels: [] };
+      const log = newLog();
 
       const delivered = await dispatchSlackMessage(tx, {
         organizationId: fixture.organizationId,
@@ -356,7 +604,7 @@ describe('dispatchSlackMessage', () => {
           teamId: null,
         });
       }
-      const log: PostLog = { channels: [] };
+      const log = newLog();
 
       const delivered = await dispatchSlackMessage(tx, {
         organizationId: fixture.organizationId,
@@ -384,7 +632,7 @@ describe('dispatchSlackMessage', () => {
         .update(integration)
         .set({ credentials: {} })
         .where(eq(integration.id, fixture.integrationId));
-      const log: PostLog = { channels: [] };
+      const log = newLog();
 
       const delivered = await dispatchSlackMessage(tx, {
         organizationId: fixture.organizationId,
@@ -408,7 +656,7 @@ describe('dispatchSlackMessage', () => {
         channelName: 'design',
         teamId: fixture.teamB,
       });
-      const log: PostLog = { channels: [] };
+      const log = newLog();
 
       const delivered = await dispatchSlackMessage(tx, {
         organizationId: fixture.organizationId,


### PR DESCRIPTION
Twelve guards that already exist in production code had nothing holding
them up. Each one could be deleted and the whole suite stayed green, so
the regression would have shipped without a red build anywhere.

Every test here was watched failing first: the guard it covers was
deliberately broken, the named tests went red, and the break was
reverted before the next one started. No production code changes.

## Slack, in `packages/services`

The suite seeded one workspace with one Slack integration, which can
prove team scoping and can never prove workspace scoping.

| Mutation | Killed by |
| --- | --- |
| `resolveSlackTargets` drops `eq(slackChannelSync.organizationId, organizationId)` | 3 tests |
| `resolveSlackContext` drops `eq(integration.organizationId, organizationId)` | 3 tests |
| `resolveSlackContext` drops `eq(integration.provider, 'slack')` | 2 tests |

A second workspace with its own Slack team and its own token now exists
in the fixture, so an issue on workspace A's Engineering team can be
shown never to resolve into workspace B's channel, and the dispatch
records the `authorization` header it actually sent. A workspace whose
only integration is GitHub resolves to no Slack context at all.

## `resolveCycle`, in `packages/mcp-server`

The one resolver `tests/resolve.test.ts` skipped. Replacing the whole
match with `cycles[0]` passed the suite, and so did deleting the
`active` shortcut. An agent told to file into Sprint 3 would have filed
into Sprint 1.

Engineering now has three sprints and only the first is running, design
and operations have one each, and operations has its sprint closed so
the empty active case lands somewhere. `cycles[0]` kills 5 tests,
dropping the `active` branch kills 1.

## The session sweep, in `packages/realtime-server`

`sweepSessions` is the fail-closed sweep that closes a socket whose
session went away with no control message to announce it, and it had no
test at all. Returning early from it passed 68 tests, and so did
dropping `gt(session.expiresAt, now)` from `liveSessionIds`. A signed
out tab would have kept streaming until the process restarted.

A hub with a short sweep interval now finds an expired session and a
deleted one, closes each with `session_revoked`, and leaves a live
session subscribed across a dozen sweeps. The early return kills 2
tests, the expiry filter kills 1.

## Labels, in `packages/core`

`getLabel`, `updateLabel` and `deleteLabel` each scope their where
clause to the caller's workspace, and every label test ran inside one
workspace, so all three clauses could be deleted with 553 tests green.
Any admin could have renamed or deleted a label in a workspace they
have never belonged to.

A same named label now sits in each of two workspaces and each reaches
for the other. The three clauses kill 1, 2 and 1 test respectively.

## `useToggleReaction` and the Slack webhook, in `apps/web`

`useToggleReaction` was the only exported hook in `use-comments` with
no test, so it could have posted anywhere and 1045 tests stayed green.
It now proves the endpoint it asks, the emoji it sends, the optimistic
add and the optimistic remove, and the rollback behind the error toast.

The webhook picks the bot token by Slack team id, and every fixture
workspace had exactly one integration, so the argument could be dropped
with nothing failing. One workspace now has two Slack teams, and the
recording client keeps the token it was constructed with.

## Verification

`bun run verify` exits 0 against `main` merged in: lint, comment
policy, byte policy, typecheck, and 2291 tests.
