### PR TITLE
fix(web): pin the dev port, which the squash of #95 dropped

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "bun --env-file=../../.env next dev",
+    "dev": "bun --env-file=../../.env next dev --port 3000",
     "build": "bun --env-file=../../.env next build",
     "start": "bun server.js",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
#95 landed without the replacement flag it was supposed to carry.

Its diagnosis was right: `--port ${PORT:-3000}` is POSIX parameter expansion, cmd.exe does not perform it, and Windows received the literal string. The fix was meant to be a literal `--port 3000`, which I pushed to the contributor's branch, but the squash took the branch as it stood before that push.

So `main` currently has no port flag at all, and that is not equivalent to what was there before:

- **Before:** the *shell* expanded `${PORT:-3000}`. The shell has no `PORT`, so the default won and Next got 3000.
- **Now:** `bun --env-file=../../.env` loads this repository's own `PORT=3001` into the process and Next reads `PORT` natively.

Verified rather than assumed:

```
$ bun --env-file=../../.env porttest.ts
PORT as the process sees it: 3001
```

So `bun run dev` currently serves the web app on 3001 while `CLAUDE.md`, `apps/web/e2e/base-url.ts` and the realtime origin all assume 3000.

The flag is now a literal, so it is the same number on every platform and the web app does not inherit a `PORT` set for something else. This is the change #95 intended.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pins the web development server to port 3000, preventing the repository-level `PORT=3001` value from changing Next.js behavior and restoring consistency with existing local URLs and service assumptions.

- Adds the literal `--port 3000` argument to the web `dev` script.
- Avoids platform-dependent shell parameter expansion.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and restores the web development server’s expected port consistently across platforms.

The literal port matches the repository’s documented web port and the URLs assumed by local tests, authentication defaults, and dependent development behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/package.json | The development command now explicitly uses the repository’s documented web port; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): pin the dev port, which the sq..."](https://github.com/noveum/orbit/commit/ff0380640f971e67658697a02a91ee67c0f64000) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51079447)</sub>

<!-- /greptile_comment -->