### PR TITLE
Create views on the views page, and stop workspace views landing in a random team

### DIFF
--- a/apps/web/src/app/(app)/views/[id]/loading.tsx
+++ b/apps/web/src/app/(app)/views/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { ListSkeleton } from '@/features/issues/list-skeleton.tsx';
+
+export default function SavedViewLoading() {
+  return <ListSkeleton layout="list" />;
+}

--- a/apps/web/src/app/(app)/views/[id]/page.tsx
+++ b/apps/web/src/app/(app)/views/[id]/page.tsx
@@ -12,6 +12,14 @@ interface PageProps {
   readonly params: Promise<{ id: string }>;
 }
 
+export function viewIdFrom(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
 const loadViews = cache(async (): Promise<ViewRecord[]> => {
   const { principal } = await pageContext();
   return await listViews(principal);
@@ -19,12 +27,14 @@ const loadViews = cache(async (): Promise<ViewRecord[]> => {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
+  const viewId = viewIdFrom(id);
   const rows = await loadViews();
-  return { title: rows.find((entry) => entry.id === id)?.name ?? 'View' };
+  return { title: rows.find((entry) => entry.id === viewId)?.name ?? 'View' };
 }
 
 export default async function SavedView({ params }: PageProps) {
   const { id } = await params;
+  const viewId = viewIdFrom(id);
   const rows = await loadViews();
   const client = new QueryClient();
   client.setQueryData(
@@ -34,7 +44,7 @@ export default async function SavedView({ params }: PageProps) {
 
   return (
     <HydrationBoundary state={dehydrate(client)}>
-      <SavedViewPage viewId={id} />
+      <SavedViewPage viewId={viewId} />
     </HydrationBoundary>
   );
 }

--- a/apps/web/src/app/(app)/views/[id]/page.tsx
+++ b/apps/web/src/app/(app)/views/[id]/page.tsx
@@ -1,0 +1,40 @@
+import { listViews, type ViewRecord } from '@orbit/core';
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import type { Metadata } from 'next';
+import { cache } from 'react';
+import { SavedViewPage } from '@/features/views/saved-view-page.tsx';
+import { pageContext } from '@/lib/api/handler.ts';
+import { toViewPayload } from '@/lib/api/views.ts';
+import { queryKeys } from '@/lib/query/keys.ts';
+import { viewListSchema } from '@/lib/query/schemas.ts';
+
+interface PageProps {
+  readonly params: Promise<{ id: string }>;
+}
+
+const loadViews = cache(async (): Promise<ViewRecord[]> => {
+  const { principal } = await pageContext();
+  return await listViews(principal);
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const rows = await loadViews();
+  return { title: rows.find((entry) => entry.id === id)?.name ?? 'View' };
+}
+
+export default async function SavedView({ params }: PageProps) {
+  const { id } = await params;
+  const rows = await loadViews();
+  const client = new QueryClient();
+  client.setQueryData(
+    queryKeys.views(),
+    viewListSchema.parse(JSON.parse(JSON.stringify({ views: rows.map(toViewPayload) }))).views,
+  );
+
+  return (
+    <HydrationBoundary state={dehydrate(client)}>
+      <SavedViewPage viewId={id} />
+    </HydrationBoundary>
+  );
+}

--- a/apps/web/src/features/filters/filter-bar.tsx
+++ b/apps/web/src/features/filters/filter-bar.tsx
@@ -204,6 +204,7 @@ export function FilterBar({
           config={config}
           layout={layout}
           teamId={teamId}
+          teamName={teamName}
           suggestedName={suggestName(teamName, conditions, fields)}
         />
       ) : null}

--- a/apps/web/src/features/filters/filter-fields.tsx
+++ b/apps/web/src/features/filters/filter-fields.tsx
@@ -5,6 +5,8 @@ import {
   FILTER_PROPERTY_LABELS,
   LINK_FILTER_LABELS,
   LINK_FILTER_VALUES,
+  NAMED_DATE_VALUES,
+  type NamedDateValue,
   RELATION_FILTER_LABELS,
   RELATION_FILTER_VALUES,
   UNSET_FILTER_VALUE,
@@ -78,9 +80,9 @@ const FIELD_ICONS: Record<FilterProperty, LucideIcon> = {
   stateAge: History,
 };
 
-export const DATE_OPTION_VALUES = ['none', 'any', 'overdue', 'today', 'this_week'] as const;
+export const DATE_OPTION_VALUES = NAMED_DATE_VALUES;
 
-const DATE_OPTION_LABELS: Record<(typeof DATE_OPTION_VALUES)[number], string> = {
+const DATE_OPTION_LABELS: Record<NamedDateValue, string> = {
   none: 'Not set',
   any: 'Set',
   overdue: 'Before today',

--- a/apps/web/src/features/filters/save-view-dialog.tsx
+++ b/apps/web/src/features/filters/save-view-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ViewVisibility } from '@orbit/shared/filters';
-import { conditionsOf, VIEW_VISIBILITIES, VIEW_VISIBILITY_LABELS } from '@orbit/shared/filters';
+import { conditionsOf } from '@orbit/shared/filters';
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import {
@@ -17,6 +17,7 @@ import { Switch } from '@/components/ui/switch.tsx';
 import { useCreateView } from '@/lib/query/use-views.ts';
 import type { ViewConfig, ViewLayoutMode } from './view-config.ts';
 import { viewConfigToState } from './view-config.ts';
+import { allowedVisibility, visibilityChoices } from './view-visibility.ts';
 
 export interface SaveViewDialogProps {
   readonly open: boolean;
@@ -24,6 +25,7 @@ export interface SaveViewDialogProps {
   readonly config: ViewConfig;
   readonly layout: ViewLayoutMode;
   readonly teamId: string | null;
+  readonly teamName: string;
   readonly suggestedName: string;
 }
 
@@ -33,6 +35,7 @@ export function SaveViewDialog({
   config,
   layout,
   teamId,
+  teamName,
   suggestedName,
 }: SaveViewDialogProps) {
   const create = useCreateView();
@@ -45,6 +48,9 @@ export function SaveViewDialog({
   }, [open, suggestedName]);
 
   const count = conditionsOf(config.filter).length;
+  const team = teamId === null ? null : { id: teamId, name: teamName };
+  const choices = visibilityChoices(team);
+  const chosen = allowedVisibility(visibility, team);
 
   const submit = () => {
     const trimmed = name.trim();
@@ -56,11 +62,11 @@ export function SaveViewDialog({
           config,
           layout,
           { teamId, projectId: null },
-          { visibility, locked },
+          { visibility: chosen, locked },
         ),
         layout,
         groupBy: config.groupBy,
-        shared: visibility !== 'private',
+        shared: chosen !== 'private',
       },
       { onSuccess: () => onOpenChange(false) },
     );
@@ -100,23 +106,23 @@ export function SaveViewDialog({
 
           <fieldset className="flex flex-col gap-1.5 rounded-md border border-border px-2.5 py-2">
             <legend className="px-1 text-2xs text-faint">Visibility</legend>
-            {VIEW_VISIBILITIES.map((option) => (
+            {choices.map((choice) => (
               <label
-                key={option}
+                key={choice.value}
                 className="flex items-center gap-2 text-dense text-muted"
-                htmlFor={`save-view-visibility-${option}`}
+                htmlFor={`save-view-visibility-${choice.value}`}
               >
                 <input
                   type="radio"
-                  id={`save-view-visibility-${option}`}
+                  id={`save-view-visibility-${choice.value}`}
                   name="save-view-visibility"
-                  value={option}
-                  checked={visibility === option}
-                  data-testid={`save-view-visibility-${option}`}
-                  onChange={() => setVisibility(option)}
+                  value={choice.value}
+                  checked={chosen === choice.value}
+                  data-testid={`save-view-visibility-${choice.value}`}
+                  onChange={() => setVisibility(choice.value)}
                   className="accent-[var(--color-accent)]"
                 />
-                {VIEW_VISIBILITY_LABELS[option]}
+                {choice.label}
               </label>
             ))}
           </fieldset>

--- a/apps/web/src/features/filters/view-visibility.ts
+++ b/apps/web/src/features/filters/view-visibility.ts
@@ -1,0 +1,37 @@
+import type { ViewVisibility } from '@orbit/shared/filters';
+import { VIEW_VISIBILITIES, VIEW_VISIBILITY_LABELS } from '@orbit/shared/filters';
+
+export interface AudienceTeam {
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface VisibilityChoice {
+  readonly value: ViewVisibility;
+  readonly label: string;
+}
+
+export function audienceTeam(
+  teams: readonly AudienceTeam[],
+  teamId: string | null,
+): AudienceTeam | null {
+  if (teamId === null) return null;
+  return teams.find((team) => team.id === teamId) ?? null;
+}
+
+export function visibilityChoices(team: AudienceTeam | null): VisibilityChoice[] {
+  return VIEW_VISIBILITIES.filter((value) => value !== 'team' || team !== null).map((value) => ({
+    value,
+    label:
+      value === 'team' && team !== null
+        ? `Everyone on ${team.name}`
+        : VIEW_VISIBILITY_LABELS[value],
+  }));
+}
+
+export function allowedVisibility(
+  chosen: ViewVisibility,
+  team: AudienceTeam | null,
+): ViewVisibility {
+  return visibilityChoices(team).some((choice) => choice.value === chosen) ? chosen : 'private';
+}

--- a/apps/web/src/features/views/create-view-dialog.tsx
+++ b/apps/web/src/features/views/create-view-dialog.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { ViewPage, ViewVisibility } from '@orbit/shared/filters';
-import { VIEW_VISIBILITIES, VIEW_VISIBILITY_LABELS } from '@orbit/shared/filters';
 import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import {
@@ -31,6 +30,11 @@ import {
   viewConfigToState,
 } from '@/features/filters/view-config.ts';
 import { useProvideViewControls } from '@/features/filters/view-controls.tsx';
+import {
+  allowedVisibility,
+  audienceTeam,
+  visibilityChoices,
+} from '@/features/filters/view-visibility.ts';
 import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
 import { useCreateView } from '@/lib/query/use-views.ts';
 
@@ -90,6 +94,9 @@ export function CreateViewDialog({ open, onOpenChange }: CreateViewDialogProps) 
   const controls = useProvideViewControls(page, layout, config);
   const target = parseViewScope(scope);
   const scopeLabel = scopeLabelFor(scope, workspace.teams, workspace.projects);
+  const team = audienceTeam(workspace.teams, target.teamId);
+  const choices = visibilityChoices(team);
+  const chosen = allowedVisibility(visibility, team);
 
   const submit = () => {
     const trimmed = name.trim();
@@ -97,10 +104,10 @@ export function CreateViewDialog({ open, onOpenChange }: CreateViewDialogProps) 
     create.mutate(
       {
         name: trimmed,
-        filter: viewConfigToState(config, layout, target, { visibility }),
+        filter: viewConfigToState(config, layout, target, { visibility: chosen }),
         layout,
         groupBy: config.groupBy,
-        shared: visibility !== 'private',
+        shared: chosen !== 'private',
       },
       { onSuccess: () => onOpenChange(false) },
     );
@@ -193,23 +200,23 @@ export function CreateViewDialog({ open, onOpenChange }: CreateViewDialogProps) 
 
           <fieldset className="flex flex-col gap-1.5 rounded-md border border-border px-2.5 py-2">
             <legend className="px-1 text-2xs text-faint">Who can see it</legend>
-            {VIEW_VISIBILITIES.map((option) => (
+            {choices.map((choice) => (
               <label
-                key={option}
+                key={choice.value}
                 className="flex items-center gap-2 text-dense text-muted"
-                htmlFor={`create-view-visibility-${option}`}
+                htmlFor={`create-view-visibility-${choice.value}`}
               >
                 <input
                   type="radio"
-                  id={`create-view-visibility-${option}`}
+                  id={`create-view-visibility-${choice.value}`}
                   name="create-view-visibility"
-                  value={option}
-                  checked={visibility === option}
-                  data-testid={`create-view-visibility-${option}`}
-                  onChange={() => setVisibility(option)}
+                  value={choice.value}
+                  checked={chosen === choice.value}
+                  data-testid={`create-view-visibility-${choice.value}`}
+                  onChange={() => setVisibility(choice.value)}
                   className="accent-[var(--color-accent)]"
                 />
-                {VIEW_VISIBILITY_LABELS[option]}
+                {choice.label}
               </label>
             ))}
           </fieldset>

--- a/apps/web/src/features/views/create-view-dialog.tsx
+++ b/apps/web/src/features/views/create-view-dialog.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import type { ViewPage, ViewVisibility } from '@orbit/shared/filters';
+import { VIEW_VISIBILITIES, VIEW_VISIBILITY_LABELS } from '@orbit/shared/filters';
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button.tsx';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog.tsx';
+import { Input } from '@/components/ui/input.tsx';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select.tsx';
+import { FilterBar } from '@/features/filters/filter-bar.tsx';
+import { LayoutToggle } from '@/features/filters/layout-toggle.tsx';
+import type { ViewConfig, ViewLayoutMode, ViewScope } from '@/features/filters/view-config.ts';
+import {
+  applyCapabilities,
+  defaultViewConfig,
+  viewConfigToState,
+} from '@/features/filters/view-config.ts';
+import { useProvideViewControls } from '@/features/filters/view-controls.tsx';
+import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
+import { useCreateView } from '@/lib/query/use-views.ts';
+
+export const WORKSPACE_SCOPE = 'workspace';
+const TEAM_PREFIX = 'team:';
+const PROJECT_PREFIX = 'project:';
+
+export function teamScopeValue(teamId: string): string {
+  return `${TEAM_PREFIX}${teamId}`;
+}
+
+export function projectScopeValue(projectId: string): string {
+  return `${PROJECT_PREFIX}${projectId}`;
+}
+
+export function parseViewScope(value: string): ViewScope {
+  if (value.startsWith(TEAM_PREFIX)) {
+    return { teamId: value.slice(TEAM_PREFIX.length), projectId: null };
+  }
+  if (value.startsWith(PROJECT_PREFIX)) {
+    return { teamId: null, projectId: value.slice(PROJECT_PREFIX.length) };
+  }
+  return { teamId: null, projectId: null };
+}
+
+export function viewScopePage(value: string): ViewPage {
+  if (value.startsWith(PROJECT_PREFIX)) return 'project';
+  if (value.startsWith(TEAM_PREFIX)) return 'team';
+  return 'saved_view';
+}
+
+export interface CreateViewDialogProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+export function CreateViewDialog({ open, onOpenChange }: CreateViewDialogProps) {
+  const workspace = useWorkspace();
+  const create = useCreateView();
+  const [name, setName] = useState('');
+  const [scope, setScope] = useState<string>(WORKSPACE_SCOPE);
+  const [layout, setLayout] = useState<ViewLayoutMode>('list');
+  const [visibility, setVisibility] = useState<ViewVisibility>('private');
+  const [draft, setDraft] = useState<ViewConfig>(() => defaultViewConfig('list'));
+
+  useEffect(() => {
+    if (!open) return;
+    setName('');
+    setScope(WORKSPACE_SCOPE);
+    setLayout('list');
+    setVisibility('private');
+    setDraft(defaultViewConfig('list'));
+  }, [open]);
+
+  const page = viewScopePage(scope);
+  const config = useMemo(() => applyCapabilities(draft, page, layout), [draft, page, layout]);
+  const controls = useProvideViewControls(page, layout, config);
+  const target = parseViewScope(scope);
+  const scopeLabel = scopeLabelFor(scope, workspace.teams, workspace.projects);
+
+  const submit = () => {
+    const trimmed = name.trim();
+    if (trimmed.length === 0) return;
+    create.mutate(
+      {
+        name: trimmed,
+        filter: viewConfigToState(config, layout, target, { visibility }),
+        layout,
+        groupBy: config.groupBy,
+        shared: visibility !== 'private',
+      },
+      { onSuccess: () => onOpenChange(false) },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl" data-testid="create-view-dialog">
+        <DialogHeader>
+          <DialogTitle className="font-medium text-base text-text">New view</DialogTitle>
+          <DialogDescription className="text-muted text-xs">
+            Pick what it covers, how it is laid out and which issues it keeps. You can change all of
+            it later.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          className="flex flex-col gap-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            submit();
+          }}
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="flex flex-col gap-1.5 text-2xs text-faint" htmlFor="create-view-name">
+              Name
+              <Input
+                id="create-view-name"
+                autoFocus
+                value={name}
+                maxLength={120}
+                data-testid="create-view-name"
+                onChange={(event) => setName(event.target.value)}
+                placeholder="High priority bugs"
+              />
+            </label>
+
+            <div className="flex flex-col gap-1.5 text-2xs text-faint">
+              <span id="create-view-scope-label">Scope</span>
+              <Select value={scope} onValueChange={setScope}>
+                <SelectTrigger
+                  aria-labelledby="create-view-scope-label"
+                  data-testid="create-view-scope"
+                >
+                  <SelectValue>{scopeLabel}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={WORKSPACE_SCOPE}>Everything in the workspace</SelectItem>
+                  {workspace.teams.length === 0 ? null : (
+                    <SelectGroup>
+                      <SelectLabel>Teams</SelectLabel>
+                      {workspace.teams.map((team) => (
+                        <SelectItem key={team.id} value={teamScopeValue(team.id)}>
+                          {team.name}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  )}
+                  {workspace.projects.length === 0 ? null : (
+                    <SelectGroup>
+                      <SelectLabel>Projects</SelectLabel>
+                      {workspace.projects.map((project) => (
+                        <SelectItem key={project.id} value={projectScopeValue(project.id)}>
+                          {project.name}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  )}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-2xs text-faint">Layout</span>
+            <LayoutToggle layout={layout} onChange={setLayout} />
+          </div>
+
+          <div className="overflow-hidden rounded-md border border-border">
+            <FilterBar
+              teamId={target.teamId}
+              teamName={scopeLabel}
+              layout={layout}
+              config={config}
+              onChange={setDraft}
+              controls={controls}
+              showSaveView={false}
+            />
+          </div>
+
+          <fieldset className="flex flex-col gap-1.5 rounded-md border border-border px-2.5 py-2">
+            <legend className="px-1 text-2xs text-faint">Who can see it</legend>
+            {VIEW_VISIBILITIES.map((option) => (
+              <label
+                key={option}
+                className="flex items-center gap-2 text-dense text-muted"
+                htmlFor={`create-view-visibility-${option}`}
+              >
+                <input
+                  type="radio"
+                  id={`create-view-visibility-${option}`}
+                  name="create-view-visibility"
+                  value={option}
+                  checked={visibility === option}
+                  data-testid={`create-view-visibility-${option}`}
+                  onChange={() => setVisibility(option)}
+                  className="accent-[var(--color-accent)]"
+                />
+                {VIEW_VISIBILITY_LABELS[option]}
+              </label>
+            ))}
+          </fieldset>
+
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={name.trim().length === 0 || create.isPending}
+              data-testid="create-view-submit"
+            >
+              Create view
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function scopeLabelFor(
+  value: string,
+  teams: readonly { id: string; name: string }[],
+  projects: readonly { id: string; name: string }[],
+): string {
+  const scope = parseViewScope(value);
+  const project = projects.find((entry) => entry.id === scope.projectId);
+  if (project !== undefined) return project.name;
+  const team = teams.find((entry) => entry.id === scope.teamId);
+  if (team !== undefined) return team.name;
+  return 'Workspace';
+}

--- a/apps/web/src/features/views/saved-view-page.tsx
+++ b/apps/web/src/features/views/saved-view-page.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { conditionsOf, viewStateDirty } from '@orbit/shared/filters';
+import { Columns3, LayoutList, SearchX } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Badge } from '@/components/ui/badge.tsx';
+import { EmptyState } from '@/components/ui/empty-state.tsx';
+import { FilterBar } from '@/features/filters/filter-bar.tsx';
+import type { IssueGroup } from '@/features/filters/grouping.ts';
+import { HiddenFooter } from '@/features/filters/hidden-footer.tsx';
+import { LayoutToggle } from '@/features/filters/layout-toggle.tsx';
+import type { ViewConfig, ViewLayoutMode, ViewPage } from '@/features/filters/view-config.ts';
+import {
+  applyCapabilities,
+  viewConfigFromState,
+  viewConfigToState,
+} from '@/features/filters/view-config.ts';
+import { useProvideViewControls } from '@/features/filters/view-controls.tsx';
+import { Board } from '@/features/issues/board.tsx';
+import { IssueList } from '@/features/issues/issue-list.tsx';
+import { ListSkeleton } from '@/features/issues/list-skeleton.tsx';
+import { useIssueViewModel } from '@/features/issues/use-issue-view-model.ts';
+import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
+import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
+import { viewLayoutMode } from '@/features/views/view-href.ts';
+import { ViewsSkeleton } from '@/features/views/views-skeleton.tsx';
+import type { View, WorkflowState } from '@/lib/query/schemas.ts';
+import { useAllIssues } from '@/lib/query/use-issues.ts';
+import { useViews } from '@/lib/query/use-views.ts';
+
+export interface SavedViewPageProps {
+  readonly viewId: string;
+}
+
+export function SavedViewPage({ viewId }: SavedViewPageProps) {
+  const views = useViews();
+  const view = (views.data ?? []).find((entry) => entry.id === viewId);
+
+  if (views.isPending) return <ViewsSkeleton />;
+  if (view === undefined) {
+    return (
+      <EmptyState
+        icon={<LayoutList strokeWidth={1.75} aria-hidden="true" />}
+        title="No such view"
+        description="It was deleted, or it was never shared with you."
+      />
+    );
+  }
+  return <SavedViewBody key={view.id} view={view} />;
+}
+
+export function scopeRecord(view: View): Record<string, string> {
+  const scope: Record<string, string> = {};
+  if (view.filter.teamId !== null) scope['teamId'] = view.filter.teamId;
+  if (view.filter.projectId !== null) scope['projectId'] = view.filter.projectId;
+  return scope;
+}
+
+export function scopeLabelOf(view: View, workspace: WorkspaceData): string {
+  const project = workspace.projects.find((entry) => entry.id === view.filter.projectId);
+  if (project !== undefined) return project.name;
+  const team = workspace.teams.find((entry) => entry.id === view.filter.teamId);
+  if (team !== undefined) return team.name;
+  return 'Workspace';
+}
+
+export function viewPageOf(view: View): ViewPage {
+  if (view.filter.projectId !== null) return 'project';
+  return 'saved_view';
+}
+
+function SavedViewBody({ view }: { view: View }) {
+  const workspace = useWorkspace();
+  const [layout, setLayout] = useState<ViewLayoutMode>(viewLayoutMode(view.layout));
+  const [edited, setEdited] = useState<ViewConfig | null>(null);
+
+  useEffect(() => {
+    setEdited(null);
+    setLayout(viewLayoutMode(view.layout));
+  }, [view.layout]);
+
+  const page = viewPageOf(view);
+  const config = useMemo(
+    () => applyCapabilities(edited ?? viewConfigFromState(view.filter), page, layout),
+    [edited, view.filter, page, layout],
+  );
+  const controls = useProvideViewControls(page, layout, config);
+
+  const scope = useMemo(() => scopeRecord(view), [view]);
+  const issues = useAllIssues({ filter: config.filter, orderBy: config.orderBy }, scope);
+  const rows = useMemo(() => issues.data ?? [], [issues.data]);
+
+  const model = useIssueViewModel({
+    teamId: view.filter.teamId,
+    config,
+    issues: rows,
+    scopeToTeam: false,
+    scope,
+  });
+
+  const scopeLabel = scopeLabelOf(view, workspace);
+  const pending = viewConfigToState(config, layout, {
+    teamId: view.filter.teamId,
+    projectId: view.filter.projectId,
+  });
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-testid="saved-view-page">
+      <div className="flex items-center gap-2 border-border border-b px-3 py-2">
+        <h1 className="font-medium text-dense text-text">{view.name}</h1>
+        <span data-numeric className="text-2xs text-faint" data-testid="issue-count">
+          {model.total}
+        </span>
+        <Badge tone="outline" data-testid="view-scope">
+          {scopeLabel}
+        </Badge>
+        <div className="ml-auto flex items-center gap-1">
+          <LayoutToggle layout={layout} onChange={setLayout} />
+        </div>
+      </div>
+
+      <FilterBar
+        teamId={view.filter.teamId}
+        teamName={scopeLabel}
+        layout={layout}
+        config={config}
+        onChange={(next) => setEdited(next)}
+        controls={controls}
+        facets={model.facets}
+        savedView={view}
+        dirty={viewStateDirty(pending, view.filter)}
+      />
+
+      <SavedViewContent
+        states={model.states}
+        groups={model.groups}
+        config={config}
+        layout={layout}
+        empty={model.shownCount === 0}
+        loading={issues.isPending}
+        hasMore={issues.hasNextPage}
+        loadingMore={issues.isFetchingNextPage}
+        onLoadMore={() => {
+          issues.fetchNextPage().catch(() => undefined);
+        }}
+      />
+
+      <HiddenFooter
+        hiddenByFilters={model.hiddenByFilters}
+        hiddenByDisplay={model.hiddenByDisplay}
+        onClearFilters={() => setEdited({ ...config, filter: { ...config.filter, children: [] } })}
+        onRevealDisplay={() =>
+          setEdited({
+            ...config,
+            display: { ...config.display, showSubIssues: true, showCompleted: 'all' },
+          })
+        }
+      />
+    </div>
+  );
+}
+
+interface SavedViewContentProps {
+  readonly states: readonly WorkflowState[];
+  readonly groups: readonly IssueGroup[];
+  readonly config: ViewConfig;
+  readonly layout: ViewLayoutMode;
+  readonly empty: boolean;
+  readonly loading: boolean;
+  readonly hasMore: boolean;
+  readonly loadingMore: boolean;
+  readonly onLoadMore: () => void;
+}
+
+function SavedViewContent({
+  states,
+  groups,
+  config,
+  layout,
+  empty,
+  loading,
+  hasMore,
+  loadingMore,
+  onLoadMore,
+}: SavedViewContentProps) {
+  if (loading) return <ListSkeleton layout={layout} />;
+
+  if (empty) {
+    const filtered = conditionsOf(config.filter).length > 0;
+    return (
+      <EmptyState
+        icon={
+          filtered ? (
+            <SearchX strokeWidth={1.75} aria-hidden="true" />
+          ) : (
+            <Columns3 strokeWidth={1.75} aria-hidden="true" />
+          )
+        }
+        title="No issues match this view"
+        description={
+          filtered
+            ? 'Loosen a filter to widen the search, then save the change.'
+            : 'Press C to create the first one.'
+        }
+        className="flex-1"
+      />
+    );
+  }
+
+  if (layout === 'board') {
+    return (
+      <div className="min-h-0 flex-1 overflow-hidden" data-testid="saved-view-board">
+        <Board
+          groups={groups}
+          draggable={false}
+          groupBy={config.groupBy}
+          properties={config.display.properties}
+          hasMore={hasMore}
+          loadingMore={loadingMore}
+          onLoadMore={onLoadMore}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col" data-testid="saved-view-list">
+      <IssueList
+        states={states}
+        groups={groups}
+        properties={config.display.properties}
+        hasMore={hasMore}
+        loadingMore={loadingMore}
+        onLoadMore={onLoadMore}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/views/view-href.ts
+++ b/apps/web/src/features/views/view-href.ts
@@ -1,0 +1,27 @@
+import { withViewParam } from '@/features/filters/use-view-config.ts';
+import type { ViewLayoutMode } from '@/features/filters/view-config.ts';
+import { viewConfigFromState, viewConfigSearch } from '@/features/filters/view-config.ts';
+import type { Team, View } from '@/lib/query/schemas.ts';
+
+export const STANDUP_VIEW_ID = 'virtual:standup';
+
+export function viewLayoutMode(layout: string): ViewLayoutMode {
+  return layout === 'board' ? 'board' : 'list';
+}
+
+export function savedViewPath(viewId: string): string {
+  return `/views/${encodeURIComponent(viewId)}`;
+}
+
+export function viewHref(view: View, teams: readonly Team[]): string {
+  if (view.id === STANDUP_VIEW_ID) return '/standup';
+
+  const teamId = view.filter.teamId;
+  const team = teamId === null ? undefined : teams.find((entry) => entry.id === teamId);
+  if (team === undefined) return savedViewPath(view.id);
+
+  const layout = viewLayoutMode(view.layout);
+  const search = viewConfigSearch(viewConfigFromState(view.filter), layout);
+  const page = layout === 'board' ? 'board' : 'issues';
+  return `/team/${team.key.toLowerCase()}/${page}${withViewParam(search, view.id)}`;
+}

--- a/apps/web/src/features/views/views-page.tsx
+++ b/apps/web/src/features/views/views-page.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import { conditionsOf, VIEW_VISIBILITY_LABELS } from '@orbit/shared/filters';
-import { Columns3, LayoutList, Lock, Pencil, Star, Trash2 } from 'lucide-react';
+import {
+  conditionsOf,
+  isVirtualViewId,
+  VIEW_VISIBILITY_LABELS,
+  VIRTUAL_VIEW_DESCRIPTIONS,
+} from '@orbit/shared/filters';
+import { Columns3, LayoutList, Lock, Pencil, Plus, Star, Trash2 } from 'lucide-react';
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { type ReactNode, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import {
   Dialog,
@@ -13,15 +18,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog.tsx';
-import { EmptyState } from '@/components/ui/empty-state.tsx';
 import { Input } from '@/components/ui/input.tsx';
 import { buildFilterFields, describeCondition } from '@/features/filters/filter-fields.tsx';
-import { VIEW_PARAM, withViewParam } from '@/features/filters/use-view-config.ts';
 import type { ViewLayoutMode } from '@/features/filters/view-config.ts';
-import { viewConfigFromState, viewConfigSearch } from '@/features/filters/view-config.ts';
 import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
+import { CreateViewDialog } from '@/features/views/create-view-dialog.tsx';
+import { viewHref, viewLayoutMode } from '@/features/views/view-href.ts';
 import { ViewsSkeleton } from '@/features/views/views-skeleton.tsx';
 import { cn } from '@/lib/cn.ts';
+import { useHotkey } from '@/lib/keyboard/index.ts';
 import type { View } from '@/lib/query/schemas.ts';
 import {
   useDeleteView,
@@ -30,13 +35,16 @@ import {
   useViews,
 } from '@/lib/query/use-views.ts';
 
-function layoutMode(layout: string): ViewLayoutMode {
-  return layout === 'board' ? 'board' : 'list';
+export function visibilityLabel(view: View): string {
+  return view.virtual ? 'Everyone' : VIEW_VISIBILITY_LABELS[view.filter.visibility];
 }
 
 export function ViewsPage() {
   const workspace = useWorkspace();
   const views = useViews();
+  const [creating, setCreating] = useState(false);
+
+  useHotkey('alt+v', () => setCreating(true), { label: 'New view', section: 'View' });
 
   const rows = views.data ?? [];
   const builtIn = rows.filter((view) => view.virtual);
@@ -48,57 +56,102 @@ export function ViewsPage() {
   }
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-6" data-testid="views-page">
-      <header className="flex flex-col gap-1">
-        <h1 className="font-semibold text-lg text-text">Views</h1>
-        <p className="text-muted text-xs">
-          Saved filters, grouping and display options. Yours stay private unless you share them.
-        </p>
+    <div className="flex flex-col gap-7 px-6 py-6" data-testid="views-page">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h1 className="font-semibold text-lg text-text">Views</h1>
+          <p className="text-muted text-xs">
+            Saved filters, grouping and display options. Yours stay private unless you share them.
+          </p>
+        </div>
+        <Button variant="primary" data-testid="new-view" onClick={() => setCreating(true)}>
+          <Plus className="size-3.5" aria-hidden="true" />
+          New view
+        </Button>
       </header>
 
-      <ViewSection title="Built in" views={builtIn} />
-      <ViewSection title="Your views" views={mine} />
-      <ViewSection title="Shared with you" views={shared} />
+      <ViewSection
+        title="Built in"
+        description="Always here, for everyone in the workspace."
+        views={builtIn}
+      />
+      <ViewSection
+        title="Your views"
+        description="Only you see these until you share them."
+        views={mine}
+        empty={<NoSavedViews onCreate={() => setCreating(true)} />}
+      />
+      <ViewSection
+        title="Shared with you"
+        description="Saved by teammates and shared with your workspace."
+        views={shared}
+      />
 
-      {mine.length === 0 && shared.length === 0 ? (
-        <EmptyState
-          icon={<LayoutList strokeWidth={1.75} aria-hidden="true" />}
-          title="No saved views yet"
-          description="Filter a team's issues, then press Alt+V to keep that setup as a view."
-        />
-      ) : null}
+      <CreateViewDialog open={creating} onOpenChange={setCreating} />
     </div>
   );
 }
 
-function ViewSection({ title, views }: { title: string; views: readonly View[] }) {
-  if (views.length === 0) return null;
+function NoSavedViews({ onCreate }: { onCreate: () => void }) {
+  return (
+    <div
+      className="flex flex-col items-start gap-2 rounded-md border border-border border-dashed px-4 py-5"
+      data-testid="no-saved-views"
+    >
+      <p className="text-muted text-xs">
+        You have not saved a view yet. Build one here, or filter any issue list and press Alt+V.
+      </p>
+      <Button size="sm" data-testid="new-view-empty" onClick={onCreate}>
+        <Plus className="size-3.5" aria-hidden="true" />
+        New view
+      </Button>
+    </div>
+  );
+}
+
+interface ViewSectionProps {
+  readonly title: string;
+  readonly description: string;
+  readonly views: readonly View[];
+  readonly empty?: ReactNode;
+}
+
+function ViewSection({ title, description, views, empty }: ViewSectionProps) {
+  if (views.length === 0 && empty === undefined) return null;
+
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="font-medium text-2xs text-faint uppercase tracking-wide">{title}</h2>
-      <table className="w-full border-collapse text-dense">
-        <thead>
-          <tr className="border-border border-b text-left text-2xs text-faint">
-            <th scope="col" className="py-1.5 pr-3 font-medium">
-              Name
-            </th>
-            <th scope="col" className="hidden py-1.5 pr-3 font-medium sm:table-cell">
-              Owner
-            </th>
-            <th scope="col" className="hidden py-1.5 pr-3 font-medium md:table-cell">
-              Visibility
-            </th>
-            <th scope="col" className="py-1.5 text-right font-medium">
-              <span className="sr-only">Actions</span>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {views.map((view) => (
-            <ViewRow key={view.id} view={view} />
-          ))}
-        </tbody>
-      </table>
+      <div className="flex flex-col gap-0.5">
+        <h2 className="font-medium text-2xs text-faint uppercase tracking-wide">{title}</h2>
+        <p className="text-2xs text-faint">{description}</p>
+      </div>
+      {views.length === 0 ? (
+        empty
+      ) : (
+        <table className="w-full border-collapse text-dense">
+          <thead>
+            <tr className="border-border border-b text-left text-2xs text-faint">
+              <th scope="col" className="py-1.5 pr-3 font-medium">
+                Name
+              </th>
+              <th scope="col" className="hidden py-1.5 pr-3 font-medium sm:table-cell">
+                Owner
+              </th>
+              <th scope="col" className="hidden py-1.5 pr-3 font-medium md:table-cell">
+                Visibility
+              </th>
+              <th scope="col" className="py-1.5 text-right font-medium">
+                <span className="sr-only">Actions</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {views.map((view) => (
+              <ViewRow key={view.id} view={view} />
+            ))}
+          </tbody>
+        </table>
+      )}
     </section>
   );
 }
@@ -112,26 +165,10 @@ function ViewRow({ view }: { view: View }) {
   const [confirming, setConfirming] = useState(false);
   const [name, setName] = useState(view.name);
 
-  const filterTeamId = view.filter.teamId;
-  const team =
-    workspace.teams.find((entry) => entry.id === filterTeamId) ?? workspace.teams[0] ?? null;
-  const layout = layoutMode(view.layout);
-  const config = viewConfigFromState(view.filter);
+  const layout = viewLayoutMode(view.layout);
   const owner = workspace.members.find((member) => member.id === view.ownerId);
   const editable = !(view.virtual || view.locked) && view.ownerId === workspace.userId;
-
-  const href = ((): string => {
-    if (view.id === 'virtual:standup') {
-      return '/standup';
-    }
-    if (team === null) {
-      return `/views?${VIEW_PARAM}=${encodeURIComponent(view.id)}`;
-    }
-    return `/team/${team.key.toLowerCase()}/${layout === 'board' ? 'board' : 'issues'}${withViewParam(
-      viewConfigSearch(config, layout),
-      view.id,
-    )}`;
-  })();
+  const href = viewHref(view, workspace.teams);
 
   const submitRename = () => {
     const trimmed = name.trim();
@@ -171,7 +208,7 @@ function ViewRow({ view }: { view: View }) {
               >
                 {view.name}
               </Link>
-              {view.locked ? (
+              {view.locked && !view.virtual ? (
                 <Lock className="size-3 text-faint" aria-label="Locked" role="img" />
               ) : null}
             </span>
@@ -183,7 +220,7 @@ function ViewRow({ view }: { view: View }) {
         {view.virtual ? 'Built in' : (owner?.name ?? 'Someone else')}
       </td>
       <td className="hidden py-2 pr-3 align-top text-muted md:table-cell">
-        {VIEW_VISIBILITY_LABELS[view.filter.visibility]}
+        {visibilityLabel(view)}
       </td>
       <td className="py-2 align-top">
         <div className="flex items-center justify-end gap-1">
@@ -242,6 +279,11 @@ function ViewRow({ view }: { view: View }) {
   );
 }
 
+function builtInDescription(view: View): string | null {
+  if (!isVirtualViewId(view.id)) return null;
+  return VIRTUAL_VIEW_DESCRIPTIONS[view.id];
+}
+
 function ViewSummary({ view, layout }: { view: View; layout: ViewLayoutMode }) {
   const workspace = useWorkspace();
   const conditions = conditionsOf(view.filter.filter);
@@ -252,6 +294,11 @@ function ViewSummary({ view, layout }: { view: View; layout: ViewLayoutMode }) {
       ]),
     [workspace, view.filter.teamId, conditions],
   );
+
+  const description = builtInDescription(view);
+  if (description !== null) {
+    return <p className="text-2xs text-faint">{description}</p>;
+  }
 
   return (
     <p className="flex flex-wrap items-center gap-1.5 text-2xs text-faint">

--- a/apps/web/src/features/views/views-page.tsx
+++ b/apps/web/src/features/views/views-page.tsx
@@ -21,6 +21,8 @@ import {
 import { Input } from '@/components/ui/input.tsx';
 import { buildFilterFields, describeCondition } from '@/features/filters/filter-fields.tsx';
 import type { ViewLayoutMode } from '@/features/filters/view-config.ts';
+import type { AudienceTeam } from '@/features/filters/view-visibility.ts';
+import { audienceTeam } from '@/features/filters/view-visibility.ts';
 import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
 import { CreateViewDialog } from '@/features/views/create-view-dialog.tsx';
 import { viewHref, viewLayoutMode } from '@/features/views/view-href.ts';
@@ -35,8 +37,11 @@ import {
   useViews,
 } from '@/lib/query/use-views.ts';
 
-export function visibilityLabel(view: View): string {
-  return view.virtual ? 'Everyone' : VIEW_VISIBILITY_LABELS[view.filter.visibility];
+export function visibilityLabel(view: View, teams: readonly AudienceTeam[]): string {
+  if (view.virtual) return 'Everyone';
+  if (view.filter.visibility !== 'team') return VIEW_VISIBILITY_LABELS[view.filter.visibility];
+  const team = audienceTeam(teams, view.filter.teamId);
+  return team === null ? VIEW_VISIBILITY_LABELS.team : `Everyone on ${team.name}`;
 }
 
 export function ViewsPage() {
@@ -83,7 +88,7 @@ export function ViewsPage() {
       />
       <ViewSection
         title="Shared with you"
-        description="Saved by teammates and shared with your workspace."
+        description="Saved by teammates and shared with your workspace or your team."
         views={shared}
       />
 
@@ -220,7 +225,7 @@ function ViewRow({ view }: { view: View }) {
         {view.virtual ? 'Built in' : (owner?.name ?? 'Someone else')}
       </td>
       <td className="hidden py-2 pr-3 align-top text-muted md:table-cell">
-        {visibilityLabel(view)}
+        {visibilityLabel(view, workspace.teams)}
       </td>
       <td className="py-2 align-top">
         <div className="flex items-center justify-end gap-1">

--- a/apps/web/src/features/views/views-skeleton.tsx
+++ b/apps/web/src/features/views/views-skeleton.tsx
@@ -8,9 +8,12 @@ const SECTIONS = [
 export function ViewsSkeleton() {
   return (
     <div className="flex flex-col gap-6 px-6 py-6" data-testid="views-skeleton">
-      <div className="flex flex-col gap-1.5">
-        <Skeleton className="h-6 w-24" />
-        <Skeleton className="h-3 w-80 max-w-full" />
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-1.5">
+          <Skeleton className="h-6 w-24" />
+          <Skeleton className="h-3 w-80 max-w-full" />
+        </div>
+        <Skeleton className="h-8 w-28 rounded-md" />
       </div>
 
       {SECTIONS.map((section) => (

--- a/apps/web/src/lib/query/issue-search.ts
+++ b/apps/web/src/lib/query/issue-search.ts
@@ -64,8 +64,15 @@ export function assignedSearch(userId: string, query?: IssueQuery): string {
 
 export const ALL_ISSUES_QUERY: IssueQuery = { ...DEFAULT_ISSUE_QUERY, orderBy: 'updated' };
 
-export function allIssuesSearch(query: IssueQuery = ALL_ISSUES_QUERY): string {
-  return searchParams(query).toString();
+export const EMPTY_ISSUE_SCOPE: Readonly<Record<string, string>> = {};
+
+export function allIssuesSearch(
+  query: IssueQuery = ALL_ISSUES_QUERY,
+  scope: Readonly<Record<string, string>> = EMPTY_ISSUE_SCOPE,
+): string {
+  const params = searchParams(query);
+  for (const [key, value] of Object.entries(scope)) params.set(key, value);
+  return params.toString();
 }
 
 export function projectIssuesSearch(

--- a/apps/web/src/lib/query/use-issues.ts
+++ b/apps/web/src/lib/query/use-issues.ts
@@ -18,6 +18,7 @@ import {
   assignedSearch,
   columnSearch,
   DEFAULT_ISSUE_QUERY,
+  EMPTY_ISSUE_SCOPE,
   ISSUE_PAGE_SIZE,
   type IssueQuery,
   issueSearch,
@@ -60,6 +61,7 @@ export {
   assignedSearch,
   columnSearch,
   DEFAULT_ISSUE_QUERY,
+  EMPTY_ISSUE_SCOPE,
   ISSUE_PAGE_SIZE,
   issueSearch,
 };
@@ -202,8 +204,12 @@ export function useAssignedIssues(userId: string | null, query?: IssueQuery) {
   });
 }
 
-export function useAllIssues(query: IssueQuery = ALL_ISSUES_QUERY, enabled = true) {
-  const search = allIssuesSearch(query);
+export function useAllIssues(
+  query: IssueQuery = ALL_ISSUES_QUERY,
+  scope: Readonly<Record<string, string>> = EMPTY_ISSUE_SCOPE,
+  enabled = true,
+) {
+  const search = allIssuesSearch(query, scope);
   return useInfiniteQuery({
     ...pagedIssueOptions(queryKeys.allIssues(search), search),
     enabled,

--- a/apps/web/tests/app/views/view-id-round-trip.test.ts
+++ b/apps/web/tests/app/views/view-id-round-trip.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test';
+import { viewIdFrom } from '@/app/(app)/views/[id]/page.tsx';
+import { savedViewPath } from '@/features/views/view-href.ts';
+
+function segmentOf(path: string): string {
+  return path.split('/').at(-1) ?? '';
+}
+
+describe('the saved view route', () => {
+  it('reads back every built in id the href builder writes', () => {
+    for (const id of [
+      'virtual:all',
+      'virtual:assigned',
+      'virtual:created',
+      'virtual:subscribed',
+      'virtual:unassigned',
+      'virtual:overdue',
+    ]) {
+      expect(viewIdFrom(segmentOf(savedViewPath(id)))).toBe(id);
+    }
+  });
+
+  it('reads back a plain saved view id untouched', () => {
+    const id = '0b3a7c1e-9f2d-4a55-8c17-2e6d5b9a4f30';
+    expect(viewIdFrom(segmentOf(savedViewPath(id)))).toBe(id);
+  });
+
+  it('survives a segment that is not valid percent encoding', () => {
+    expect(viewIdFrom('100%')).toBe('100%');
+    expect(viewIdFrom('%E0%A4%A')).toBe('%E0%A4%A');
+  });
+});

--- a/apps/web/tests/features/filters/filter-bar.test.tsx
+++ b/apps/web/tests/features/filters/filter-bar.test.tsx
@@ -99,13 +99,20 @@ function groupOf(...conditions: FilterCondition[]): FilterGroup {
   return { kind: 'group', combinator: 'and', children: conditions };
 }
 
-function renderBar(conditions: readonly FilterCondition[] = []) {
+interface BarScope {
+  readonly id: string | null;
+  readonly name: string;
+}
+
+const ENGINEERING: BarScope = { id: 'team-1', name: 'Engineering' };
+
+function renderBar(conditions: readonly FilterCondition[] = [], scope: BarScope = ENGINEERING) {
   const config: ViewConfig = { ...defaultViewConfig('list'), filter: groupOf(...conditions) };
   render(
     <Providers>
       <FilterBar
-        teamId="team-1"
-        teamName="Engineering"
+        teamId={scope.id}
+        teamName={scope.name}
         layout="list"
         config={config}
         onChange={onChange}
@@ -198,6 +205,29 @@ describe('filter hotkeys', () => {
     expect(screen.getByTestId('save-view-name')).toHaveValue('Engineering: Aditi Rao');
     expect(screen.getByTestId('save-view-visibility-workspace')).toBeInTheDocument();
     expect(screen.getByTestId('save-view-locked')).toBeInTheDocument();
+  });
+});
+
+describe('who a saved view is shared with', () => {
+  it('names the team a view on a team page would go to', async () => {
+    const user = userEvent.setup();
+    renderBar();
+
+    await user.keyboard('{Alt>}v{/Alt}');
+    await waitFor(() => expect(screen.getByTestId('save-view-dialog')).toBeInTheDocument());
+    expect(screen.getByLabelText('Everyone on Engineering')).toBe(
+      screen.getByTestId('save-view-visibility-team'),
+    );
+  });
+
+  it('offers no team audience where no team is in scope', async () => {
+    const user = userEvent.setup();
+    renderBar([], { id: null, name: 'All issues' });
+
+    await user.keyboard('{Alt>}v{/Alt}');
+    await waitFor(() => expect(screen.getByTestId('save-view-dialog')).toBeInTheDocument());
+    expect(screen.queryByTestId('save-view-visibility-team')).not.toBeInTheDocument();
+    expect(screen.getByTestId('save-view-visibility-workspace')).toBeInTheDocument();
   });
 });
 

--- a/apps/web/tests/features/views/create-view-dialog.test.tsx
+++ b/apps/web/tests/features/views/create-view-dialog.test.tsx
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { ViewState } from '@orbit/shared/filters';
+import { conditionsOf, viewStateSchema } from '@orbit/shared/filters';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ToastProvider } from '@/components/ui/toast.tsx';
+import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
+import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
+import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ push: mock(), replace: mock(), refresh: mock() }),
+  usePathname: () => '/views',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+let workspace: WorkspaceData;
+mock.module('@/features/issues/workspace-provider.tsx', () => ({
+  ...workspaceProvider,
+  useWorkspace: () => workspace,
+}));
+
+const { CreateViewDialog, parseViewScope, viewScopePage } = await import(
+  '../../../src/features/views/create-view-dialog.tsx'
+);
+
+function buildWorkspace(): WorkspaceData {
+  return {
+    ready: true,
+    userId: 'user-1',
+    teams: [{ id: 'team-eng', name: 'Engineering', key: 'ENG', icon: 'circle', color: '#f95b6c' }],
+    states: [
+      {
+        id: 'state-todo',
+        teamId: 'team-eng',
+        name: 'Todo',
+        category: 'unstarted',
+        color: '#5d6272',
+        position: 1,
+      },
+    ],
+    labels: [],
+    members: [
+      {
+        id: 'user-1',
+        name: 'Pulkit Sharma',
+        email: 'pulkit@noveum.ai',
+        image: null,
+        handle: 'pulkit',
+        role: 'admin',
+      },
+      {
+        id: 'user-2',
+        name: 'Aditi Rao',
+        email: 'aditi@noveum.ai',
+        image: null,
+        handle: 'aditi',
+        role: 'member',
+      },
+    ],
+    projects: [
+      {
+        id: 'project-atlas',
+        name: 'Atlas',
+        status: 'planned',
+        color: '#5a63c8',
+        icon: 'box',
+        teamIds: [],
+      },
+    ],
+    cycles: [],
+    seedIssues: [],
+    stateById: new Map(),
+    labelById: new Map(),
+    memberById: new Map(),
+    openQuickCreate: () => undefined,
+  };
+}
+
+const realFetch = globalThis.fetch;
+let bodies: Record<string, unknown>[] = [];
+
+function stubCreate(): void {
+  globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+    if (typeof init?.body === 'string') {
+      bodies.push(JSON.parse(init.body) as Record<string, unknown>);
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          view: {
+            id: 'view-new',
+            ownerId: 'user-1',
+            name: 'Saved',
+            filter: viewStateSchema.parse({}),
+            layout: 'list',
+            groupBy: 'state',
+            shared: false,
+            virtual: false,
+            locked: false,
+            favorite: false,
+            createdAt: '2026-01-01T00:00:00.000Z',
+          },
+        }),
+    });
+  }) as unknown as typeof fetch;
+}
+
+function renderDialog(): void {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <HotkeyProvider>
+          <CreateViewDialog open onOpenChange={() => undefined} />
+        </HotkeyProvider>
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function sentState(): ViewState {
+  const body = bodies.at(-1);
+  if (body === undefined) throw new Error('nothing was posted');
+  return viewStateSchema.parse(body['filter']);
+}
+
+beforeEach(() => {
+  workspace = buildWorkspace();
+  bodies = [];
+  stubCreate();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('the scope a new view covers', () => {
+  it('reads workspace, team and project scopes off one value', () => {
+    expect(parseViewScope('workspace')).toEqual({ teamId: null, projectId: null });
+    expect(parseViewScope('team:team-eng')).toEqual({ teamId: 'team-eng', projectId: null });
+    expect(parseViewScope('project:project-atlas')).toEqual({
+      teamId: null,
+      projectId: 'project-atlas',
+    });
+  });
+
+  it('offers the filters each scope can actually use', () => {
+    expect(viewScopePage('workspace')).toBe('saved_view');
+    expect(viewScopePage('team:team-eng')).toBe('team');
+    expect(viewScopePage('project:project-atlas')).toBe('project');
+  });
+});
+
+describe('building a view in the dialog', () => {
+  it('keeps a new view workspace wide unless someone narrows it', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId('create-view-name'), 'Everything urgent');
+    await user.click(screen.getByTestId('create-view-submit'));
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(sentState().teamId).toBeNull();
+    expect(sentState().projectId).toBeNull();
+    expect(bodies.at(-1)?.['layout']).toBe('list');
+  });
+
+  it('narrows a view to the team picked in the scope control', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId('create-view-name'), 'Engineering triage');
+    await user.click(screen.getByTestId('create-view-scope'));
+    await user.click(await screen.findByRole('option', { name: 'Engineering' }));
+    await user.click(screen.getByTestId('create-view-submit'));
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(sentState().teamId).toBe('team-eng');
+    expect(sentState().projectId).toBeNull();
+  });
+
+  it('saves the filter built with the shared filter builder', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId('create-view-name'), 'Aditi work');
+    await user.click(screen.getByTestId('add-filter'));
+    await user.click(await screen.findByTestId('filter-field-assignee'));
+    await user.click(await screen.findByTestId('filter-value-user-2'));
+    await user.click(screen.getByTestId('create-view-submit'));
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(conditionsOf(sentState().filter)).toEqual([
+      {
+        kind: 'condition',
+        property: 'assignee',
+        operator: 'in',
+        values: ['user-2'],
+        negate: false,
+      },
+    ]);
+  });
+
+  it('saves the layout and grouping chosen in the dialog', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId('create-view-name'), 'Board of work');
+    await user.click(screen.getByTestId('layout-board'));
+    await user.click(screen.getByTestId('display-menu-trigger'));
+    await user.click(await screen.findByTestId('group-by-assignee'));
+    await user.click(screen.getByTestId('create-view-submit'));
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(sentState().layout).toBe('board');
+    expect(sentState().groupBy).toBe('assignee');
+    expect(bodies.at(-1)?.['groupBy']).toBe('assignee');
+  });
+
+  it('shares a view with the workspace only when asked', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId('create-view-name'), 'Team triage');
+    await user.click(screen.getByTestId('create-view-visibility-workspace'));
+    await user.click(screen.getByTestId('create-view-submit'));
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(sentState().visibility).toBe('workspace');
+    expect(bodies.at(-1)?.['shared']).toBe(true);
+  });
+});

--- a/apps/web/tests/features/views/create-view-dialog.test.tsx
+++ b/apps/web/tests/features/views/create-view-dialog.test.tsx
@@ -22,7 +22,7 @@ mock.module('@/features/issues/workspace-provider.tsx', () => ({
 }));
 
 const { CreateViewDialog, parseViewScope, viewScopePage } = await import(
-  '../../../src/features/views/create-view-dialog.tsx'
+  '@/features/views/create-view-dialog.tsx'
 );
 
 function buildWorkspace(): WorkspaceData {
@@ -234,5 +234,58 @@ describe('building a view in the dialog', () => {
     await waitFor(() => expect(bodies).toHaveLength(1));
     expect(sentState().visibility).toBe('workspace');
     expect(bodies.at(-1)?.['shared']).toBe(true);
+  });
+});
+
+describe('who a new view is shared with', () => {
+  async function pickEngineering(user: ReturnType<typeof userEvent.setup>): Promise<void> {
+    await user.click(screen.getByTestId('create-view-scope'));
+    await user.click(await screen.findByRole('option', { name: 'Engineering' }));
+  }
+
+  it('offers a team audience only once the view covers a team', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    expect(screen.queryByTestId('create-view-visibility-team')).not.toBeInTheDocument();
+
+    await pickEngineering(user);
+
+    const option = await screen.findByTestId('create-view-visibility-team');
+    expect(option).toBeInTheDocument();
+    expect(screen.getByLabelText('Everyone on Engineering')).toBe(option);
+  });
+
+  it('keeps a team view on the team that owns it', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId('create-view-name'), 'Engineering triage');
+    await pickEngineering(user);
+    await user.click(await screen.findByTestId('create-view-visibility-team'));
+    await user.click(screen.getByTestId('create-view-submit'));
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(sentState().visibility).toBe('team');
+    expect(sentState().teamId).toBe('team-eng');
+    expect(bodies.at(-1)?.['shared']).toBe(true);
+  });
+
+  it('never leaves a team audience on a view that stopped covering a team', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId('create-view-name'), 'Everything urgent');
+    await pickEngineering(user);
+    await user.click(await screen.findByTestId('create-view-visibility-team'));
+
+    await user.click(screen.getByTestId('create-view-scope'));
+    await user.click(await screen.findByRole('option', { name: 'Everything in the workspace' }));
+    await user.click(screen.getByTestId('create-view-submit'));
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(sentState().teamId).toBeNull();
+    expect(sentState().visibility).toBe('private');
+    expect(bodies.at(-1)?.['shared']).toBe(false);
   });
 });

--- a/apps/web/tests/features/views/saved-view-page.test.tsx
+++ b/apps/web/tests/features/views/saved-view-page.test.tsx
@@ -22,7 +22,7 @@ mock.module('@/features/issues/workspace-provider.tsx', () => ({
   useWorkspace: () => workspace,
 }));
 
-const { SavedViewPage } = await import('../../../src/features/views/saved-view-page.tsx');
+const { SavedViewPage } = await import('@/features/views/saved-view-page.tsx');
 
 const todo: WorkflowState = {
   id: 'state-todo',

--- a/apps/web/tests/features/views/saved-view-page.test.tsx
+++ b/apps/web/tests/features/views/saved-view-page.test.tsx
@@ -1,0 +1,300 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { defaultViewState, encodeFilter, inCondition } from '@orbit/shared/filters';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ToastProvider } from '@/components/ui/toast.tsx';
+import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
+import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
+import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+import { queryKeys } from '@/lib/query/keys.ts';
+import type { Issue, View, WorkflowState } from '@/lib/query/schemas.ts';
+import { emptyFacets } from '@/lib/query/schemas.ts';
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ push: mock(), replace: mock(), refresh: mock() }),
+  usePathname: () => '/views/view-bugs',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+let workspace: WorkspaceData;
+mock.module('@/features/issues/workspace-provider.tsx', () => ({
+  ...workspaceProvider,
+  useWorkspace: () => workspace,
+}));
+
+const { SavedViewPage } = await import('../../../src/features/views/saved-view-page.tsx');
+
+const todo: WorkflowState = {
+  id: 'state-todo',
+  teamId: 'team-eng',
+  name: 'Todo',
+  category: 'unstarted',
+  color: '#5d6272',
+  position: 1,
+};
+
+const done: WorkflowState = {
+  id: 'state-done',
+  teamId: 'team-eng',
+  name: 'Done',
+  category: 'completed',
+  color: '#2e9e68',
+  position: 2,
+};
+
+function buildWorkspace(): WorkspaceData {
+  return {
+    ready: true,
+    userId: 'user-1',
+    teams: [
+      { id: 'team-ai', name: 'AI', key: 'AI', icon: 'circle', color: '#5b6cf9' },
+      { id: 'team-eng', name: 'Engineering', key: 'ENG', icon: 'circle', color: '#f95b6c' },
+    ],
+    states: [todo, done],
+    labels: [],
+    members: [
+      {
+        id: 'user-1',
+        name: 'Pulkit Sharma',
+        email: 'pulkit@noveum.ai',
+        image: null,
+        handle: 'pulkit',
+        role: 'admin',
+      },
+    ],
+    projects: [
+      {
+        id: 'project-atlas',
+        name: 'Atlas',
+        status: 'planned',
+        color: '#5a63c8',
+        icon: 'box',
+        teamIds: [],
+      },
+    ],
+    cycles: [],
+    seedIssues: [],
+    stateById: new Map([
+      [todo.id, todo],
+      [done.id, done],
+    ]),
+    labelById: new Map(),
+    memberById: new Map(),
+    openQuickCreate: () => undefined,
+  };
+}
+
+function issue(overrides: Partial<Issue>): Issue {
+  return {
+    id: 'issue-1',
+    organizationId: 'org-1',
+    teamId: 'team-eng',
+    number: 1,
+    identifier: 'ENG-1',
+    title: 'Untitled',
+    description: '',
+    stateId: todo.id,
+    priority: 1,
+    creatorId: 'user-1',
+    assigneeId: null,
+    projectId: null,
+    milestoneId: null,
+    cycleId: null,
+    parentId: null,
+    estimate: null,
+    dueDate: null,
+    sortOrder: 1024,
+    startedAt: null,
+    completedAt: null,
+    canceledAt: null,
+    stateEnteredAt: '2026-01-01T00:00:00.000Z',
+    syncId: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    archivedAt: null,
+    labelIds: [],
+    ...overrides,
+  };
+}
+
+const URGENT_ONLY = {
+  kind: 'group' as const,
+  combinator: 'and' as const,
+  children: [inCondition('priority', ['1'])],
+};
+
+function savedView(overrides: Partial<View> = {}): View {
+  return {
+    id: 'view-bugs',
+    ownerId: 'user-1',
+    name: 'Urgent bugs',
+    filter: {
+      ...defaultViewState('list'),
+      filter: URGENT_ONLY,
+      orderBy: 'updated',
+      display: { ...defaultViewState('list').display, showCompleted: 'none' },
+    },
+    layout: 'list',
+    groupBy: 'state',
+    shared: false,
+    virtual: false,
+    locked: false,
+    favorite: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const SERVER_ROWS: readonly Issue[] = [
+  issue({ id: 'issue-open', identifier: 'ENG-1', title: 'Login screen crashes' }),
+  issue({
+    id: 'issue-done',
+    identifier: 'ENG-2',
+    title: 'Old crash already fixed',
+    stateId: done.id,
+    completedAt: '2026-01-02T00:00:00.000Z',
+  }),
+];
+
+const realFetch = globalThis.fetch;
+let requested: string[] = [];
+
+function stubIssueApi(): void {
+  globalThis.fetch = mock((url: string) => {
+    requested.push(url);
+    const body = (() => {
+      if (url.startsWith('/api/issues/summary')) {
+        return { total: SERVER_ROWS.length, byState: {}, groupTotals: {} };
+      }
+      if (url.startsWith('/api/issues/facets')) {
+        return { scopeTotal: SERVER_ROWS.length, facets: emptyFacets() };
+      }
+      return { issues: SERVER_ROWS, nextCursor: null };
+    })();
+    return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) });
+  }) as unknown as typeof fetch;
+}
+
+function issueListUrl(): string {
+  const found = requested.find((url) => url.startsWith('/api/issues?'));
+  if (found === undefined)
+    throw new Error(`no issue list request was made: ${requested.join(' ')}`);
+  return found;
+}
+
+function issueListParams(): URLSearchParams {
+  return new URLSearchParams(issueListUrl().slice('/api/issues?'.length));
+}
+
+async function waitForIssueRequest(): Promise<void> {
+  await waitFor(() => {
+    issueListUrl();
+  });
+}
+
+function renderView(views: readonly View[], viewId = 'view-bugs'): void {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+  });
+  client.setQueryData(queryKeys.views(), views);
+  render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <HotkeyProvider>
+          <SavedViewPage viewId={viewId} />
+        </HotkeyProvider>
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const realWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+const realHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get: () => 900,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get: () => 600,
+  });
+});
+
+afterAll(() => {
+  if (realWidth !== undefined) {
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', realWidth);
+  }
+  if (realHeight !== undefined) {
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', realHeight);
+  }
+});
+
+beforeEach(() => {
+  workspace = buildWorkspace();
+  requested = [];
+  stubIssueApi();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('opening a saved view', () => {
+  it('asks the server for exactly the issues the view describes', async () => {
+    renderView([savedView()]);
+
+    await waitForIssueRequest();
+    const params = issueListParams();
+    expect(params.get('filter')).toBe(encodeFilter(URGENT_ONLY));
+    expect(params.get('orderBy')).toBe('updated');
+  });
+
+  it('stays workspace wide instead of narrowing to one team', async () => {
+    renderView([savedView()]);
+
+    await waitForIssueRequest();
+    expect(issueListParams().get('teamId')).toBeNull();
+    expect(issueListParams().get('projectId')).toBeNull();
+    expect(await screen.findByTestId('view-scope')).toHaveTextContent('Workspace');
+  });
+
+  it('narrows to the team a team view names', async () => {
+    const teamView = savedView({
+      id: 'view-team',
+      filter: { ...savedView().filter, teamId: 'team-eng' },
+    });
+    renderView([teamView], 'view-team');
+
+    await waitForIssueRequest();
+    expect(issueListParams().get('teamId')).toBe('team-eng');
+    expect(await screen.findByTestId('view-scope')).toHaveTextContent('Engineering');
+  });
+
+  it('narrows to the project a project view names', async () => {
+    const projectView = savedView({
+      id: 'view-project',
+      filter: { ...savedView().filter, projectId: 'project-atlas' },
+    });
+    renderView([projectView], 'view-project');
+
+    await waitForIssueRequest();
+    expect(issueListParams().get('projectId')).toBe('project-atlas');
+    expect(issueListParams().get('teamId')).toBeNull();
+  });
+
+  it('shows the issues it got back and honours the display options it stored', async () => {
+    renderView([savedView()]);
+
+    expect(await screen.findByText('Login screen crashes')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Urgent bugs' })).toBeInTheDocument();
+    expect(screen.queryByText('Old crash already fixed')).toBeNull();
+  });
+
+  it('says so plainly when the view is gone', () => {
+    renderView([savedView()], 'view-missing');
+
+    expect(screen.getByText('No such view')).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/features/views/view-href.test.ts
+++ b/apps/web/tests/features/views/view-href.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { defaultViewState, inCondition, virtualViewState } from '@orbit/shared/filters';
+import { savedViewPath, viewHref, viewLayoutMode } from '@/features/views/view-href.ts';
 import type { Team, View } from '@/lib/query/schemas.ts';
-import { savedViewPath, viewHref, viewLayoutMode } from '../../../src/features/views/view-href.ts';
 
 const TEAMS: readonly Team[] = [
   { id: 'team-ai', name: 'AI', key: 'AI', icon: 'circle', color: '#5b6cf9' },

--- a/apps/web/tests/features/views/view-href.test.ts
+++ b/apps/web/tests/features/views/view-href.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'bun:test';
+import { defaultViewState, inCondition, virtualViewState } from '@orbit/shared/filters';
+import type { Team, View } from '@/lib/query/schemas.ts';
+import { savedViewPath, viewHref, viewLayoutMode } from '../../../src/features/views/view-href.ts';
+
+const TEAMS: readonly Team[] = [
+  { id: 'team-ai', name: 'AI', key: 'AI', icon: 'circle', color: '#5b6cf9' },
+  { id: 'team-eng', name: 'Engineering', key: 'ENG', icon: 'circle', color: '#f95b6c' },
+];
+
+function view(overrides: Partial<View> = {}): View {
+  return {
+    id: 'view-1',
+    ownerId: 'user-1',
+    name: 'Saved',
+    filter: defaultViewState('list'),
+    layout: 'list',
+    groupBy: 'state',
+    shared: false,
+    virtual: false,
+    locked: false,
+    favorite: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function builtIn(id: 'virtual:all' | 'virtual:assigned'): View {
+  return view({
+    id,
+    name: id,
+    virtual: true,
+    locked: true,
+    filter: virtualViewState(id, 'user-1'),
+  });
+}
+
+describe('a view that covers the whole workspace', () => {
+  it('opens a workspace destination rather than the first team', () => {
+    const href = viewHref(builtIn('virtual:all'), TEAMS);
+
+    expect(href).toBe(savedViewPath('virtual:all'));
+    expect(href.startsWith('/team/')).toBe(false);
+    for (const team of TEAMS) expect(href).not.toContain(team.key.toLowerCase());
+  });
+
+  it('does the same for a saved view nobody scoped to a team', () => {
+    const workspaceWide = view({
+      id: 'view-77',
+      filter: { ...defaultViewState('board'), teamId: null },
+      layout: 'board',
+    });
+
+    expect(viewHref(workspaceWide, TEAMS)).toBe('/views/view-77');
+  });
+
+  it('does the same for a project view, which no single team owns', () => {
+    const projectView = view({
+      id: 'view-88',
+      filter: { ...defaultViewState('list'), teamId: null, projectId: 'project-atlas' },
+    });
+
+    expect(viewHref(projectView, TEAMS)).toBe('/views/view-88');
+  });
+
+  it('refuses to guess a team when the stored one is gone', () => {
+    const orphan = view({
+      id: 'view-99',
+      filter: { ...defaultViewState('list'), teamId: 'team-deleted' },
+    });
+
+    expect(viewHref(orphan, TEAMS)).toBe('/views/view-99');
+  });
+
+  it('escapes the colon in a built-in id so the path stays one segment', () => {
+    expect(savedViewPath('virtual:assigned')).toBe('/views/virtual%3Aassigned');
+    expect(savedViewPath('virtual:assigned').split('/')).toHaveLength(3);
+  });
+});
+
+describe('a view scoped to one team', () => {
+  it('opens that team and carries its own filter, grouping and id', () => {
+    const teamView = view({
+      id: 'view-42',
+      filter: {
+        ...defaultViewState('list'),
+        teamId: 'team-eng',
+        groupBy: 'assignee',
+        filter: {
+          kind: 'group',
+          combinator: 'and',
+          children: [inCondition('priority', ['1'])],
+        },
+      },
+    });
+
+    const href = viewHref(teamView, TEAMS);
+
+    expect(href.startsWith('/team/eng/issues?')).toBe(true);
+    const search = new URLSearchParams(href.slice(href.indexOf('?') + 1));
+    expect(search.get('group')).toBe('assignee');
+    expect(search.get('view')).toBe('view-42');
+    expect(search.get('filter')).toContain('priority');
+  });
+
+  it('opens the board when the view was saved as a board', () => {
+    const boardView = view({
+      id: 'view-43',
+      layout: 'board',
+      filter: { ...defaultViewState('board'), teamId: 'team-ai' },
+    });
+
+    expect(viewHref(boardView, TEAMS).startsWith('/team/ai/board')).toBe(true);
+  });
+});
+
+describe('the standup view', () => {
+  it('keeps its own page', () => {
+    const standup = view({
+      id: 'virtual:standup',
+      virtual: true,
+      filter: virtualViewState('virtual:standup', 'user-1'),
+    });
+
+    expect(viewHref(standup, TEAMS)).toBe('/standup');
+  });
+});
+
+describe('viewLayoutMode', () => {
+  it('treats anything that is not a board as a list', () => {
+    expect(viewLayoutMode('board')).toBe('board');
+    expect(viewLayoutMode('list')).toBe('list');
+    expect(viewLayoutMode('timeline')).toBe('list');
+  });
+});

--- a/apps/web/tests/features/views/views-page.test.tsx
+++ b/apps/web/tests/features/views/views-page.test.tsx
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { defaultViewState, virtualViewState } from '@orbit/shared/filters';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ToastProvider } from '@/components/ui/toast.tsx';
+import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
+import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
+import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+import { queryKeys } from '@/lib/query/keys.ts';
+import type { View } from '@/lib/query/schemas.ts';
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ push: mock(), replace: mock(), refresh: mock() }),
+  usePathname: () => '/views',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+let workspace: WorkspaceData;
+mock.module('@/features/issues/workspace-provider.tsx', () => ({
+  ...workspaceProvider,
+  useWorkspace: () => workspace,
+}));
+
+const { ViewsPage } = await import('../../../src/features/views/views-page.tsx');
+
+function buildWorkspace(): WorkspaceData {
+  return {
+    ready: true,
+    userId: 'user-1',
+    teams: [
+      { id: 'team-ai', name: 'AI', key: 'AI', icon: 'circle', color: '#5b6cf9' },
+      { id: 'team-eng', name: 'Engineering', key: 'ENG', icon: 'circle', color: '#f95b6c' },
+    ],
+    states: [],
+    labels: [],
+    members: [
+      {
+        id: 'user-1',
+        name: 'Pulkit Sharma',
+        email: 'pulkit@noveum.ai',
+        image: null,
+        handle: 'pulkit',
+        role: 'admin',
+      },
+    ],
+    projects: [
+      {
+        id: 'project-atlas',
+        name: 'Atlas',
+        status: 'planned',
+        color: '#5a63c8',
+        icon: 'box',
+        teamIds: [],
+      },
+    ],
+    cycles: [],
+    seedIssues: [],
+    stateById: new Map(),
+    labelById: new Map(),
+    memberById: new Map(),
+    openQuickCreate: () => undefined,
+  };
+}
+
+function builtInView(id: 'virtual:all' | 'virtual:unassigned', name: string): View {
+  return {
+    id,
+    ownerId: 'user-1',
+    name,
+    filter: virtualViewState(id, 'user-1'),
+    layout: 'list',
+    groupBy: 'state',
+    shared: false,
+    virtual: true,
+    locked: true,
+    favorite: false,
+    createdAt: '1970-01-01T00:00:00.000Z',
+  };
+}
+
+const realFetch = globalThis.fetch;
+let posted: { url: string; body: Record<string, unknown> }[] = [];
+
+function stubCreateView(view: View): void {
+  globalThis.fetch = mock((url: string, init?: RequestInit) => {
+    posted.push({
+      url,
+      body:
+        typeof init?.body === 'string'
+          ? (JSON.parse(init.body) as Record<string, unknown>)
+          : ({} as Record<string, unknown>),
+    });
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ view }),
+    });
+  }) as unknown as typeof fetch;
+}
+
+function renderPage(views: readonly View[]): void {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+  });
+  client.setQueryData(queryKeys.views(), views);
+  render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <HotkeyProvider>
+          <ViewsPage />
+        </HotkeyProvider>
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  workspace = buildWorkspace();
+  posted = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('the views page', () => {
+  it('sends a workspace wide built-in to a workspace destination, never to a team', () => {
+    renderPage([builtInView('virtual:all', 'All issues')]);
+
+    const link = screen.getByTestId('open-All issues');
+    expect(link).toHaveAttribute('href', '/views/virtual%3Aall');
+    expect(link.getAttribute('href')).not.toContain('/team/');
+  });
+
+  it('does not tell people a built-in view is visible only to them', () => {
+    renderPage([builtInView('virtual:all', 'All issues')]);
+
+    const row = screen.getByTestId('view-All issues');
+    expect(within(row).queryByText('Only me')).toBeNull();
+    expect(within(row).getByText('Everyone')).toBeInTheDocument();
+  });
+
+  it('offers a way to make a view instead of hiding it behind a keystroke', () => {
+    renderPage([builtInView('virtual:all', 'All issues')]);
+
+    expect(screen.getByTestId('new-view')).toBeInTheDocument();
+    expect(screen.getByTestId('no-saved-views')).toBeInTheDocument();
+  });
+
+  it('creates a view from the dialog and lists it straight away', async () => {
+    const created: View = {
+      id: 'view-new',
+      ownerId: 'user-1',
+      name: 'High priority bugs',
+      filter: defaultViewState('list'),
+      layout: 'list',
+      groupBy: 'state',
+      shared: false,
+      virtual: false,
+      locked: false,
+      favorite: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    stubCreateView(created);
+    const user = userEvent.setup();
+    renderPage([builtInView('virtual:all', 'All issues')]);
+
+    expect(screen.queryByTestId('view-High priority bugs')).toBeNull();
+
+    await user.click(screen.getByTestId('new-view'));
+    await user.type(await screen.findByTestId('create-view-name'), 'High priority bugs');
+    await user.click(screen.getByTestId('create-view-submit'));
+
+    const row = await screen.findByTestId('view-High priority bugs');
+    expect(within(row).getByTestId('open-High priority bugs')).toHaveAttribute(
+      'href',
+      '/views/view-new',
+    );
+    expect(screen.queryByTestId('no-saved-views')).toBeNull();
+
+    const call = posted.at(-1);
+    expect(call?.url).toBe('/api/views');
+    expect(call?.body['name']).toBe('High priority bugs');
+    expect(call?.body['shared']).toBe(false);
+  });
+
+  it('refuses to create a view with no name', async () => {
+    stubCreateView(builtInView('virtual:all', 'All issues'));
+    const user = userEvent.setup();
+    renderPage([]);
+
+    await user.click(screen.getByTestId('new-view'));
+    expect(await screen.findByTestId('create-view-submit')).toBeDisabled();
+    expect(posted).toHaveLength(0);
+  });
+
+  it('opens the same dialog from Alt+V so the old keystroke still works', async () => {
+    const user = userEvent.setup();
+    renderPage([]);
+
+    expect(screen.queryByTestId('create-view-dialog')).toBeNull();
+    await user.keyboard('{Alt>}v{/Alt}');
+
+    await waitFor(() => expect(screen.getByTestId('create-view-dialog')).toBeInTheDocument());
+  });
+});

--- a/apps/web/tests/features/views/views-page.test.tsx
+++ b/apps/web/tests/features/views/views-page.test.tsx
@@ -22,7 +22,7 @@ mock.module('@/features/issues/workspace-provider.tsx', () => ({
   useWorkspace: () => workspace,
 }));
 
-const { ViewsPage } = await import('../../../src/features/views/views-page.tsx');
+const { ViewsPage } = await import('@/features/views/views-page.tsx');
 
 function buildWorkspace(): WorkspaceData {
   return {
@@ -193,6 +193,27 @@ describe('the views page', () => {
     await user.click(screen.getByTestId('new-view'));
     expect(await screen.findByTestId('create-view-submit')).toBeDisabled();
     expect(posted).toHaveLength(0);
+  });
+
+  it('names the team a team view is shared with, rather than the workspace', () => {
+    const teamView: View = {
+      id: 'view-team',
+      ownerId: 'user-2',
+      name: 'Engineering triage',
+      filter: { ...defaultViewState('list'), teamId: 'team-eng', visibility: 'team' },
+      layout: 'list',
+      groupBy: 'state',
+      shared: true,
+      virtual: false,
+      locked: false,
+      favorite: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    renderPage([teamView]);
+
+    const row = screen.getByTestId('view-Engineering triage');
+    expect(within(row).getByText('Everyone on Engineering')).toBeInTheDocument();
+    expect(within(row).queryByText('Everyone in the workspace')).toBeNull();
   });
 
   it('opens the same dialog from Alt+V so the old keystroke still works', async () => {

--- a/apps/web/tests/features/views/views-skeleton.test.tsx
+++ b/apps/web/tests/features/views/views-skeleton.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { render, screen } from '@testing-library/react';
-import { ViewsSkeleton } from '../../../src/features/views/views-skeleton.tsx';
+import { ViewsSkeleton } from '@/features/views/views-skeleton.tsx';
 
 describe('views skeleton', () => {
   it('renders the views skeleton', () => {

--- a/packages/core/src/realtime/backfill.ts
+++ b/packages/core/src/realtime/backfill.ts
@@ -1,9 +1,10 @@
-import { and, asc, db, eq, gt, inArray, or, schema, sql } from '@orbit/db';
+import { and, asc, db, eq, gt, inArray, schema, sql } from '@orbit/db';
 import type { SyncAction, SyncModel } from '@orbit/shared/events';
 import { CATCHUP_LIMIT, scopes } from '@orbit/shared/events';
 import { assertCan, can, type Principal } from '@orbit/shared/policy';
 import { docReadFilter } from '../content/doc-service.ts';
 import { inviteAnnouncement, inviteReference } from '../org/invite-service.ts';
+import { viewReadFilter, viewScopes } from '../work/view-service.ts';
 import { buildSyncAction } from './publisher.ts';
 
 export interface SyncCatchupResult {
@@ -613,7 +614,7 @@ const LOADERS: Record<SyncModel, Loader> = {
         .where(
           and(
             eq(schema.view.organizationId, principal.organizationId),
-            or(eq(schema.view.ownerId, principal.userId), eq(schema.view.shared, 'true')),
+            viewReadFilter(principal),
             gt(schema.view.syncId, since),
           ),
         )
@@ -622,7 +623,7 @@ const LOADERS: Record<SyncModel, Loader> = {
     ).map((row) => ({
       modelId: row.id,
       syncId: row.syncId,
-      scopes: [scopes.organization(row.organizationId), scopes.user(row.ownerId)],
+      scopes: viewScopes(row),
       data: row,
     })),
 

--- a/packages/core/src/work/issue-predicates.ts
+++ b/packages/core/src/work/issue-predicates.ts
@@ -20,7 +20,7 @@ import type {
   FilterNode,
   RelativeDate,
 } from '@orbit/shared/filters';
-import { resolveRelativeRange, UNSET_FILTER_VALUE } from '@orbit/shared/filters';
+import { NAMED_DATE_VALUES, resolveRelativeRange, UNSET_FILTER_VALUE } from '@orbit/shared/filters';
 import type { AnyColumn, SQL } from 'drizzle-orm';
 import { addUtcDays } from '../internal.ts';
 
@@ -245,8 +245,6 @@ function dayBounds(column: AnyColumn, from: string | null, to: string | null): S
   if (to !== null) parts.push(sql`${column}::date <= ${to}::date`);
   return allOf(parts);
 }
-
-const NAMED_DATE_VALUES = ['none', 'any', 'overdue', 'today', 'this_week'] as const;
 
 function namedDateClause(
   property: DateProperty,

--- a/packages/core/src/work/view-service.ts
+++ b/packages/core/src/work/view-service.ts
@@ -1,17 +1,18 @@
-import { and, asc, db, eq, or, schema } from '@orbit/db';
+import { and, asc, db, eq, inArray, or, type SQL, schema, sql } from '@orbit/db';
 import { forbidden, validationFailed } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
-import type { ViewState, VirtualViewId } from '@orbit/shared/filters';
+import type { ViewState, ViewVisibility, VirtualViewId } from '@orbit/shared/filters';
 import {
   isVirtualViewId,
+  VIEW_VISIBILITIES,
   VIRTUAL_VIEW_IDS,
   VIRTUAL_VIEW_NAMES,
   viewStateFrom,
   virtualViewState,
 } from '@orbit/shared/filters';
 import type { Principal } from '@orbit/shared/policy';
-import { assertCan } from '@orbit/shared/policy';
+import { assertCan, assertInTeam, canReadView, teamScope } from '@orbit/shared/policy';
 import { viewCreateSchema, viewFavoriteSchema, viewUpdateSchema } from '@orbit/shared/validators';
 import { principalActor } from '../activity/activity-service.ts';
 import { newId, requireRow } from '../internal.ts';
@@ -36,17 +37,69 @@ export interface ViewRecord {
 
 const VIEW_FAVORITE_ENTITY = 'view';
 
-function isShared(row: ViewRow): boolean {
-  return row.shared === 'true';
+function visibilityOf(row: ViewRow): ViewVisibility {
+  return VIEW_VISIBILITIES.find((entry) => entry === row.visibility) ?? 'private';
 }
 
-function viewScopes(row: ViewRow): string[] {
-  if (!isShared(row)) return [scopes.user(row.ownerId)];
-  return [scopes.organization(row.organizationId), scopes.user(row.ownerId)];
+interface AudienceColumns {
+  readonly visibility: ViewVisibility;
+  readonly teamId: string | null;
+  readonly shared: string;
+}
+
+function audienceColumns(state: ViewState): AudienceColumns {
+  const visibility = state.visibility;
+  return {
+    visibility,
+    teamId: visibility === 'team' ? state.teamId : null,
+    shared: String(visibility !== 'private'),
+  };
+}
+
+async function assertAudienceReachable(principal: Principal, state: ViewState): Promise<void> {
+  if (state.visibility !== 'team') return;
+  const teamId = state.teamId;
+  if (teamId === null) {
+    throw validationFailed('Pick the team that can see this view.');
+  }
+  const [row] = await db
+    .select({ id: schema.team.id, organizationId: schema.team.organizationId })
+    .from(schema.team)
+    .where(eq(schema.team.id, teamId))
+    .limit(1);
+  const team = requireRow(row, 'That team does not exist.');
+  assertInTeam(principal, teamScope({ teamId: team.id, organizationId: team.organizationId }));
+}
+
+export function viewScopes(row: ViewRow): string[] {
+  const visibility = visibilityOf(row);
+  if (visibility === 'workspace') {
+    return [scopes.organization(row.organizationId), scopes.user(row.ownerId)];
+  }
+  if (visibility === 'team' && row.teamId !== null) {
+    return [scopes.team(row.teamId), scopes.user(row.ownerId)];
+  }
+  return [scopes.user(row.ownerId)];
+}
+
+export function viewReadFilter(principal: Principal): SQL {
+  const mine = eq(schema.view.ownerId, principal.userId);
+  const everyone = eq(schema.view.visibility, 'workspace');
+  const clause = or(mine, everyone, teamVisibleFilter(principal));
+  return clause ?? sql`false`;
+}
+
+function teamVisibleFilter(principal: Principal): SQL {
+  const isTeamView = eq(schema.view.visibility, 'team');
+  if (principal.role === 'admin') return isTeamView;
+  if (principal.teamIds.length === 0) return sql`false`;
+  const clause = and(isTeamView, inArray(schema.view.teamId, [...principal.teamIds]));
+  return clause ?? sql`false`;
 }
 
 function toRecord(row: ViewRow, favorite: boolean): ViewRecord {
-  const state = viewStateFrom(row.filter, row.layout === 'board' ? 'board' : 'list');
+  const stored = viewStateFrom(row.filter, row.layout === 'board' ? 'board' : 'list');
+  const state: ViewState = { ...stored, visibility: visibilityOf(row) };
   return {
     id: row.id,
     ownerId: row.ownerId,
@@ -54,7 +107,7 @@ function toRecord(row: ViewRow, favorite: boolean): ViewRecord {
     state,
     layout: row.layout,
     groupBy: row.groupBy,
-    shared: row.shared === 'true',
+    shared: state.visibility !== 'private',
     virtual: false,
     locked: state.locked,
     favorite,
@@ -103,6 +156,7 @@ export async function createView(
 ): Promise<{ view: ViewRecord; actions: SyncAction[] }> {
   assertCan(principal, 'view:manage');
   const parsed = viewCreateSchema.parse(input);
+  await assertAudienceReachable(principal, parsed.filter);
 
   return await db.transaction(async (tx) => {
     const syncId = await nextSyncId(tx);
@@ -117,7 +171,7 @@ export async function createView(
         filter: parsed.filter,
         layout: parsed.filter.layout,
         groupBy: parsed.filter.groupBy,
-        shared: String(parsed.filter.visibility !== 'private'),
+        ...audienceColumns(parsed.filter),
         syncId,
       })
       .returning();
@@ -175,15 +229,19 @@ export async function updateView(
   if (currentState.locked && parsed.filter !== undefined && parsed.filter.locked !== false) {
     throw validationFailed('That view is locked. Unlock it before changing what it shows.');
   }
+  if (parsed.filter !== undefined) await assertAudienceReachable(principal, parsed.filter);
 
   return await db.transaction(async (tx) => {
     const values: Partial<typeof schema.view.$inferInsert> = {};
     if (parsed.name !== undefined) values.name = parsed.name;
     if (parsed.filter !== undefined) {
+      const audience = audienceColumns(parsed.filter);
       values.filter = parsed.filter;
       values.layout = parsed.filter.layout;
       values.groupBy = parsed.filter.groupBy;
-      values.shared = String(parsed.filter.visibility !== 'private');
+      values.visibility = audience.visibility;
+      values.teamId = audience.teamId;
+      values.shared = audience.shared;
     }
 
     const syncId = await nextSyncId(tx);
@@ -207,26 +265,33 @@ export async function updateView(
           data: view,
           actor,
         }),
-        ...unshareActions({ syncId, actor, before: current, after: view }),
+        ...narrowedAudienceActions({ syncId, actor, before: current, after: view }),
       ],
     };
   });
 }
 
-interface UnshareInput {
+interface NarrowedAudienceInput {
   readonly syncId: number;
   readonly actor: Awaited<ReturnType<typeof principalActor>>;
   readonly before: ViewRow;
   readonly after: ViewRow;
 }
 
-function unshareActions(input: UnshareInput): SyncAction[] {
-  if (!isShared(input.before) || isShared(input.after)) return [];
+function droppedScopes(before: ViewRow, after: ViewRow): string[] {
+  if (visibilityOf(after) === 'workspace') return [];
+  const reached = new Set(viewScopes(after));
+  return viewScopes(before).filter((scope) => !reached.has(scope));
+}
+
+function narrowedAudienceActions(input: NarrowedAudienceInput): SyncAction[] {
+  const dropped = droppedScopes(input.before, input.after);
+  if (dropped.length === 0) return [];
   return [
     buildSyncAction({
       syncId: input.syncId,
       organizationId: input.after.organizationId,
-      scopes: [scopes.organization(input.after.organizationId)],
+      scopes: dropped,
       action: 'delete',
       model: 'view',
       modelId: input.after.id,
@@ -334,8 +399,8 @@ async function loadReadableView(principal: Principal, viewId: string): Promise<V
     )
     .limit(1);
   const view = requireRow(row, 'That view does not exist.');
-  if (view.ownerId !== principal.userId && view.shared !== 'true') {
-    throw forbidden('That view is private.');
+  if (!canReadView(principal, view)) {
+    throw forbidden('That view is not shared with you.');
   }
   return view;
 }
@@ -347,10 +412,7 @@ export async function listViews(principal: Principal): Promise<ViewRecord[]> {
       .select()
       .from(schema.view)
       .where(
-        and(
-          eq(schema.view.organizationId, principal.organizationId),
-          or(eq(schema.view.ownerId, principal.userId), eq(schema.view.shared, 'true')),
-        ),
+        and(eq(schema.view.organizationId, principal.organizationId), viewReadFilter(principal)),
       )
       .orderBy(asc(schema.view.name)),
     favoriteIds(principal),

--- a/packages/core/tests/realtime/backfill.test.ts
+++ b/packages/core/tests/realtime/backfill.test.ts
@@ -15,6 +15,7 @@ import {
   type Workspace,
 } from '../../src/test-support.ts';
 import { createIssue, subscribe, updateIssue } from '../../src/work/issue-service.ts';
+import { createView } from '../../src/work/view-service.ts';
 
 function teamKey(): string {
   return `D${newId()
@@ -330,5 +331,44 @@ describe('catch up scopes reactions to the team that owns the issue', () => {
     for (const action of reacted) {
       expect(ids.has(action.modelId)).toBe(true);
     }
+  });
+});
+
+describe('catch up respects who a saved view was shared with', () => {
+  it('never replays a team view to somebody on another team', async () => {
+    const design = await createTeam(workspace.admin, { name: 'Design', key: teamKey() });
+    const { principal: engineer } = await addMember(workspace, 'member', {
+      teamIds: [workspace.teamId],
+    });
+    const { principal: designer } = await addMember(workspace, 'member', {
+      teamIds: [design.team.id],
+    });
+
+    const { view } = await createView(engineer, {
+      name: 'Engineering reorg',
+      filter: { visibility: 'team', teamId: workspace.teamId },
+    });
+
+    const forTheDesigner = await catchUp(designer, 0);
+    expect(forTheDesigner.actions.some((action) => action.modelId === view.id)).toBe(false);
+    expect(JSON.stringify(forTheDesigner.actions)).not.toContain('Engineering reorg');
+
+    const forTheEngineer = await catchUp(engineer, 0);
+    expect(forTheEngineer.actions.some((action) => action.modelId === view.id)).toBe(true);
+  });
+
+  it('still replays a workspace view to everyone', async () => {
+    const design = await createTeam(workspace.admin, { name: 'Design', key: teamKey() });
+    const { principal: designer } = await addMember(workspace, 'member', {
+      teamIds: [design.team.id],
+    });
+
+    const { view } = await createView(workspace.admin, {
+      name: 'Everything',
+      filter: { visibility: 'workspace' },
+    });
+
+    const result = await catchUp(designer, 0);
+    expect(result.actions.some((action) => action.modelId === view.id)).toBe(true);
   });
 });

--- a/packages/core/tests/work/view-service.test.ts
+++ b/packages/core/tests/work/view-service.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
+import type { VirtualViewId } from '@orbit/shared/filters';
+import { VIRTUAL_VIEW_IDS, virtualViewState } from '@orbit/shared/filters';
 import {
   addMember,
   createWorkspace,
@@ -8,6 +10,7 @@ import {
   resetDatabase,
   type Workspace,
 } from '../../src/test-support.ts';
+import { createIssue, listIssues } from '../../src/work/issue-service.ts';
 import { createView, deleteView, listViews, updateView } from '../../src/work/view-service.ts';
 
 let workspace: Workspace;
@@ -96,5 +99,67 @@ describe('a saved view only reaches the people who can open it', () => {
     const forTheOwner = actions.filter((action) => action.action !== 'delete');
     expect(forTheOwner).toHaveLength(1);
     expect(forTheOwner[0]?.scopes).toEqual([scopes.user(workspace.admin.userId)]);
+  });
+});
+
+describe('the built-in views select the issues they promise', () => {
+  async function issueNamed(
+    title: string,
+    overrides: Record<string, unknown> = {},
+  ): Promise<string> {
+    const { issue } = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title,
+      ...overrides,
+    });
+    return issue.id;
+  }
+
+  function stateFor(id: VirtualViewId) {
+    return virtualViewState(id, workspace.admin.userId);
+  }
+
+  async function titlesFor(id: VirtualViewId): Promise<string[]> {
+    const page = await listIssues(workspace.admin, { filter: stateFor(id).filter });
+    return page.issues.map((issue) => issue.title).sort();
+  }
+
+  it('keeps only issues with nobody assigned in the unassigned view', async () => {
+    const { user: teammate } = await addMember(workspace, 'member', { name: 'Teammate' });
+    await issueNamed('Nobody owns this');
+    await issueNamed('Someone owns this', { assigneeId: teammate.id });
+
+    expect(await titlesFor('virtual:unassigned')).toEqual(['Nobody owns this']);
+  });
+
+  it('keeps only issues whose due date has passed in the overdue view', async () => {
+    await issueNamed('Late', { dueDate: '2020-01-01' });
+    await issueNamed('Not due for ages', { dueDate: '2999-01-01' });
+    await issueNamed('No due date at all');
+
+    expect(await titlesFor('virtual:overdue')).toEqual(['Late']);
+  });
+
+  it('keeps every issue in the all issues view and only mine in the assigned view', async () => {
+    const { user: teammate } = await addMember(workspace, 'member', { name: 'Teammate' });
+    await issueNamed('Mine', { assigneeId: workspace.admin.userId });
+    await issueNamed('Theirs', { assigneeId: teammate.id });
+
+    expect(await titlesFor('virtual:all')).toEqual(['Mine', 'Theirs']);
+    expect(await titlesFor('virtual:assigned')).toEqual(['Mine']);
+  });
+
+  it('offers every built-in to a brand new workspace with nothing saved', async () => {
+    const listed = await listViews(workspace.admin);
+    expect(listed.filter((view) => view.virtual).map((view) => view.id)).toEqual([
+      ...VIRTUAL_VIEW_IDS,
+    ]);
+    expect(listed.filter((view) => !view.virtual)).toHaveLength(0);
+  });
+
+  it('hides finished work from the triage built-ins so they stay actionable', () => {
+    expect(stateFor('virtual:unassigned').display.showCompleted).toBe('none');
+    expect(stateFor('virtual:overdue').display.showCompleted).toBe('none');
+    expect(stateFor('virtual:all').display.showCompleted).toBe('all');
   });
 });

--- a/packages/core/tests/work/view-service.test.ts
+++ b/packages/core/tests/work/view-service.test.ts
@@ -3,6 +3,8 @@ import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import type { VirtualViewId } from '@orbit/shared/filters';
 import { VIRTUAL_VIEW_IDS, virtualViewState } from '@orbit/shared/filters';
+import type { Principal } from '@orbit/shared/policy';
+import { createTeam } from '../../src/org/team-service.ts';
 import {
   addMember,
   createWorkspace,
@@ -11,7 +13,14 @@ import {
   type Workspace,
 } from '../../src/test-support.ts';
 import { createIssue, listIssues } from '../../src/work/issue-service.ts';
-import { createView, deleteView, listViews, updateView } from '../../src/work/view-service.ts';
+import {
+  createView,
+  deleteView,
+  getView,
+  listViews,
+  setViewFavorite,
+  updateView,
+} from '../../src/work/view-service.ts';
 
 let workspace: Workspace;
 
@@ -99,6 +108,160 @@ describe('a saved view only reaches the people who can open it', () => {
     const forTheOwner = actions.filter((action) => action.action !== 'delete');
     expect(forTheOwner).toHaveLength(1);
     expect(forTheOwner[0]?.scopes).toEqual([scopes.user(workspace.admin.userId)]);
+  });
+});
+
+describe('a team view stays inside the team it belongs to', () => {
+  interface TwoTeams {
+    readonly designTeamId: string;
+    readonly engineer: Principal;
+    readonly teammate: Principal;
+    readonly designer: Principal;
+  }
+
+  async function twoTeams(): Promise<TwoTeams> {
+    const design = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const engineer = await addMember(workspace, 'member', {
+      name: 'Engineer',
+      teamIds: [workspace.teamId, design.team.id],
+    });
+    const teammate = await addMember(workspace, 'member', { name: 'Teammate' });
+    const designer = await addMember(workspace, 'member', {
+      name: 'Designer',
+      teamIds: [design.team.id],
+    });
+    return {
+      designTeamId: design.team.id,
+      engineer: engineer.principal,
+      teammate: teammate.principal,
+      designer: designer.principal,
+    };
+  }
+
+  function teamInput(name: string, teamId: string) {
+    return { name, filter: { groupBy: 'state', visibility: 'team', teamId } };
+  }
+
+  async function listedIds(principal: Principal): Promise<string[]> {
+    return (await listViews(principal)).map((view) => view.id);
+  }
+
+  it('publishes a team view to that team alone', async () => {
+    const { engineer, teammate, designer } = await twoTeams();
+
+    const created = await createView(engineer, teamInput('Engineering triage', workspace.teamId));
+
+    const insert = only(created.actions);
+    expect(insert.scopes).toEqual([scopes.team(workspace.teamId), scopes.user(engineer.userId)]);
+    expect(insert.scopes).not.toContain(scopes.organization(workspace.organizationId));
+    expect(reaches(teammate, insert)).toBe(true);
+    expect(reaches(designer, insert)).toBe(false);
+  });
+
+  it('never carries the filter of a team view in a delta another team receives', async () => {
+    const { engineer, designer } = await twoTeams();
+
+    const created = await createView(engineer, teamInput('Reorg candidates', workspace.teamId));
+
+    const insert = only(created.actions);
+    expect(JSON.stringify(insert.data)).toContain('Reorg candidates');
+    expect(reaches(designer, insert)).toBe(false);
+  });
+
+  it('lists a team view for the team and hides it from everyone else', async () => {
+    const { engineer, teammate, designer } = await twoTeams();
+
+    const created = await createView(engineer, teamInput('Engineering triage', workspace.teamId));
+
+    expect(await listedIds(teammate)).toContain(created.view.id);
+    expect(await listedIds(designer)).not.toContain(created.view.id);
+  });
+
+  it('refuses to open a team view from another team', async () => {
+    const { engineer, teammate, designer } = await twoTeams();
+
+    const created = await createView(engineer, teamInput('Engineering triage', workspace.teamId));
+
+    expect((await getView(teammate, created.view.id)).name).toBe('Engineering triage');
+    expect(getView(designer, created.view.id)).rejects.toThrow(/not shared with you/);
+    expect(setViewFavorite(designer, created.view.id, { favorite: true })).rejects.toThrow(
+      /not shared with you/,
+    );
+  });
+
+  it('keeps every later delta of a team view off the workspace scope', async () => {
+    const { engineer, designer } = await twoTeams();
+    const created = await createView(engineer, teamInput('Engineering triage', workspace.teamId));
+
+    const renamed = await updateView(engineer, created.view.id, { name: 'Triage' });
+    const removed = await deleteView(engineer, created.view.id);
+
+    for (const action of [...renamed.actions, ...removed]) {
+      expect(action.scopes).not.toContain(scopes.organization(workspace.organizationId));
+      expect(reaches(designer, action)).toBe(false);
+    }
+  });
+
+  it('tells the workspace a view is gone when its owner narrows it to one team', async () => {
+    const { engineer, teammate, designer } = await twoTeams();
+    const created = await createView(engineer, sharedInput('Everything'));
+    expect(await listedIds(designer)).toContain(created.view.id);
+
+    const { actions } = await updateView(engineer, created.view.id, {
+      filter: { ...created.view.state, visibility: 'team', teamId: workspace.teamId },
+    });
+
+    const forTheOtherTeam = actions.filter((action) => reaches(designer, action));
+    expect(forTheOtherTeam).toHaveLength(1);
+    expect(forTheOtherTeam[0]?.action).toBe('delete');
+    expect(JSON.stringify(forTheOtherTeam[0]?.data)).not.toContain('Everything');
+    expect(await listedIds(designer)).not.toContain(created.view.id);
+    expect(await listedIds(teammate)).toContain(created.view.id);
+  });
+
+  it('drops the old team when a view moves to another one', async () => {
+    const { designTeamId, engineer, teammate, designer } = await twoTeams();
+    const created = await createView(engineer, teamInput('Triage', workspace.teamId));
+
+    const { actions } = await updateView(engineer, created.view.id, {
+      filter: { ...created.view.state, visibility: 'team', teamId: designTeamId },
+    });
+
+    const forTheOldTeam = actions.filter((action) => reaches(teammate, action));
+    expect(forTheOldTeam).toHaveLength(1);
+    expect(forTheOldTeam[0]?.action).toBe('delete');
+    expect(await listedIds(teammate)).not.toContain(created.view.id);
+    expect(await listedIds(designer)).toContain(created.view.id);
+  });
+
+  it('takes nothing away when a team view opens up to the whole workspace', async () => {
+    const { engineer, teammate, designer } = await twoTeams();
+    const created = await createView(engineer, teamInput('Triage', workspace.teamId));
+
+    const { actions } = await updateView(engineer, created.view.id, {
+      filter: { ...created.view.state, visibility: 'workspace' },
+    });
+
+    expect(actions.filter((action) => action.action === 'delete')).toHaveLength(0);
+    expect(reaches(designer, only(actions))).toBe(true);
+    expect(await listedIds(designer)).toContain(created.view.id);
+    expect(await listedIds(teammate)).toContain(created.view.id);
+  });
+
+  it('refuses to publish a view to a team the author is not on', async () => {
+    const { designer } = await twoTeams();
+
+    expect(
+      createView(designer, teamInput('Peek at engineering', workspace.teamId)),
+    ).rejects.toThrow(/not a member of that team/);
+  });
+
+  it('refuses a team view that names no team', async () => {
+    const { engineer } = await twoTeams();
+
+    expect(
+      createView(engineer, { name: 'Nowhere', filter: { visibility: 'team' } }),
+    ).rejects.toThrow(/Pick the team/);
   });
 });
 

--- a/packages/db/catchup/view-team-visibility.sql
+++ b/packages/db/catchup/view-team-visibility.sql
@@ -1,0 +1,72 @@
+-- Gives a saved view a real audience: view.visibility ('private', 'team' or 'workspace')
+-- and view.team_id, the team a team scoped view belongs to.
+--
+-- Until now the only audience a view could record was view.shared, a boolean in a text
+-- column, so a view someone believed was limited to their team was published to the whole
+-- organization. listViews and the realtime scopes now read these two columns instead.
+--
+-- The backfill only touches rows that still carry the defaults, and only when the stored
+-- filter or the old shared flag says the view was meant to be seen by someone other than
+-- its owner. A view whose filter asks for 'team' but names a team that no longer exists,
+-- or a team in another organization, becomes private rather than workspace wide: the
+-- narrower reading is the safe one.
+--
+-- Safe to run more than once: every statement checks first, and the whole thing is one
+-- transaction, so a failure leaves the database exactly as it was.
+--
+-- Apply it either by pasting it into the Supabase SQL editor, or with
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f packages/db/catchup/view-team-visibility.sql
+-- using the direct connection on port 5432, not the pooler on 6543.
+--
+-- Apply it before the code that reads the columns ships, otherwise every saved view query
+-- fails on the missing column.
+
+begin;
+
+alter table public.view add column if not exists visibility text not null default 'private';
+alter table public.view add column if not exists team_id text;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'view_team_id_team_id_fk'
+  ) then
+    alter table public.view
+      add constraint view_team_id_team_id_fk
+      foreign key (team_id) references public.team (id) on delete cascade;
+  end if;
+end
+$$;
+
+create index if not exists view_team_idx on public.view using btree (team_id);
+
+update public.view as v
+set
+  visibility = case
+    when exists (
+      select 1
+      from public.team as t
+      where t.id = v.filter ->> 'teamId'
+        and t.organization_id = v.organization_id
+    ) and v.filter ->> 'visibility' = 'team' then 'team'
+    when v.filter ->> 'visibility' = 'team' then 'private'
+    else 'workspace'
+  end,
+  team_id = case
+    when exists (
+      select 1
+      from public.team as t
+      where t.id = v.filter ->> 'teamId'
+        and t.organization_id = v.organization_id
+    ) and v.filter ->> 'visibility' = 'team' then v.filter ->> 'teamId'
+    else null
+  end
+where v.visibility = 'private'
+  and v.team_id is null
+  and (v.shared = 'true' or v.filter ->> 'visibility' in ('team', 'workspace'));
+
+update public.view
+set shared = case when visibility = 'private' then 'false' else 'true' end
+where shared <> case when visibility = 'private' then 'false' else 'true' end;
+
+commit;

--- a/packages/db/src/schema/work.ts
+++ b/packages/db/src/schema/work.ts
@@ -592,10 +592,15 @@ export const view = pgTable(
     layout: text('layout').notNull().default('list'),
     groupBy: text('group_by').notNull().default('state'),
     shared: text('shared').notNull().default('false'),
+    visibility: text('visibility').notNull().default('private'),
+    teamId: text('team_id').references(() => team.id, { onDelete: 'cascade' }),
     syncId: bigint('sync_id', { mode: 'number' }).notNull().default(0),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [index('view_org_idx').on(table.organizationId)],
+  (table) => [
+    index('view_org_idx').on(table.organizationId),
+    index('view_team_idx').on(table.teamId),
+  ],
 );
 
 export const viewPreference = pgTable(

--- a/packages/shared/src/filters/index.ts
+++ b/packages/shared/src/filters/index.ts
@@ -144,6 +144,9 @@ export const LINK_FILTER_LABELS: Record<LinkFilterValue, string> = {
 
 export const MILESTONE_FILTER_VALUES = ['any', 'none'] as const;
 
+export const NAMED_DATE_VALUES = ['none', 'any', 'overdue', 'today', 'this_week'] as const;
+export type NamedDateValue = (typeof NAMED_DATE_VALUES)[number];
+
 export const RELATIVE_UNITS = ['day', 'week', 'month'] as const;
 export type RelativeUnit = (typeof RELATIVE_UNITS)[number];
 
@@ -661,6 +664,8 @@ export const VIRTUAL_VIEW_IDS = [
   'virtual:assigned',
   'virtual:created',
   'virtual:subscribed',
+  'virtual:unassigned',
+  'virtual:overdue',
   'virtual:standup',
 ] as const;
 
@@ -675,7 +680,19 @@ export const VIRTUAL_VIEW_NAMES: Record<VirtualViewId, string> = {
   'virtual:assigned': 'Assigned to me',
   'virtual:created': 'Created by me',
   'virtual:subscribed': 'Subscribed',
+  'virtual:unassigned': 'Unassigned',
+  'virtual:overdue': 'Overdue',
   'virtual:standup': 'Standup',
+};
+
+export const VIRTUAL_VIEW_DESCRIPTIONS: Record<VirtualViewId, string> = {
+  'virtual:all': 'Every issue in the workspace.',
+  'virtual:assigned': 'Issues assigned to you, across every team.',
+  'virtual:created': 'Issues you opened.',
+  'virtual:subscribed': 'Issues you follow.',
+  'virtual:unassigned': 'Open issues nobody owns yet.',
+  'virtual:overdue': 'Open issues whose due date has passed.',
+  'virtual:standup': 'What moved since yesterday, grouped by project.',
 };
 
 const VIRTUAL_VIEW_PROPERTIES: Partial<Record<VirtualViewId, FilterProperty>> = {
@@ -684,15 +701,33 @@ const VIRTUAL_VIEW_PROPERTIES: Partial<Record<VirtualViewId, FilterProperty>> = 
   'virtual:subscribed': 'subscriber',
 };
 
+function onlyCondition(condition: FilterCondition): FilterGroup {
+  return { kind: 'group', combinator: 'and', children: [condition] };
+}
+
+function openIssuesOnly(state: ViewState): ViewState {
+  return { ...state, display: { ...state.display, showCompleted: 'none' } };
+}
+
 export function virtualViewState(id: VirtualViewId, userId: string): ViewState {
   const base = defaultViewState('list');
   if (id === 'virtual:standup') return { ...base, groupBy: 'project' };
+  if (id === 'virtual:unassigned') {
+    return openIssuesOnly({
+      ...base,
+      filter: onlyCondition(inCondition('assignee', [UNSET_FILTER_VALUE])),
+    });
+  }
+  if (id === 'virtual:overdue') {
+    return openIssuesOnly({
+      ...base,
+      filter: onlyCondition(inCondition('due', ['overdue'])),
+      orderBy: 'due',
+    });
+  }
   const property = VIRTUAL_VIEW_PROPERTIES[id];
   if (property === undefined) return base;
-  return {
-    ...base,
-    filter: { kind: 'group', combinator: 'and', children: [inCondition(property, [userId])] },
-  };
+  return { ...base, filter: onlyCondition(inCondition(property, [userId])) };
 }
 
 function comparableViewState(state: ViewState) {

--- a/packages/shared/src/filters/index.ts
+++ b/packages/shared/src/filters/index.ts
@@ -628,7 +628,7 @@ export type ViewVisibility = (typeof VIEW_VISIBILITIES)[number];
 
 export const VIEW_VISIBILITY_LABELS: Record<ViewVisibility, string> = {
   private: 'Only me',
-  team: 'My teams',
+  team: 'Everyone on the team',
   workspace: 'Everyone in the workspace',
 };
 

--- a/packages/shared/src/policy/index.ts
+++ b/packages/shared/src/policy/index.ts
@@ -157,3 +157,18 @@ export function canReadDoc(
   if (!isRestricted(doc.visibility)) return true;
   return grantedDocIds.includes(doc.id);
 }
+
+export interface ReadableViewRow {
+  readonly organizationId: string;
+  readonly ownerId: string;
+  readonly visibility: string;
+  readonly teamId: string | null;
+}
+
+export function canReadView(principal: Principal, view: ReadableViewRow): boolean {
+  if (view.organizationId !== principal.organizationId) return false;
+  if (view.ownerId === principal.userId) return true;
+  if (view.visibility === 'workspace') return true;
+  if (view.visibility !== 'team' || view.teamId === null) return false;
+  return isInTeam(principal, { id: view.teamId, organizationId: view.organizationId });
+}

--- a/packages/shared/tests/filters/filters.test.ts
+++ b/packages/shared/tests/filters/filters.test.ts
@@ -21,7 +21,9 @@ import {
   resolveRelativeRange,
   sanitizeViewConfig,
   supportsOperator,
+  VIRTUAL_VIEW_DESCRIPTIONS,
   VIRTUAL_VIEW_IDS,
+  VIRTUAL_VIEW_NAMES,
   viewStateDirty,
   viewStateFrom,
   viewStateSchema,
@@ -302,10 +304,46 @@ describe('view state', () => {
 });
 
 describe('virtual views', () => {
-  it('names five built-in views', () => {
-    expect(VIRTUAL_VIEW_IDS).toHaveLength(5);
+  it('names every built-in view and rejects anything else', () => {
+    expect([...VIRTUAL_VIEW_IDS]).toEqual([
+      'virtual:all',
+      'virtual:assigned',
+      'virtual:created',
+      'virtual:subscribed',
+      'virtual:unassigned',
+      'virtual:overdue',
+      'virtual:standup',
+    ]);
     for (const id of VIRTUAL_VIEW_IDS) expect(isVirtualViewId(id)).toBe(true);
     expect(isVirtualViewId('anything-else')).toBe(false);
+  });
+
+  it('gives every built-in a name and a description', () => {
+    for (const id of VIRTUAL_VIEW_IDS) {
+      expect(VIRTUAL_VIEW_NAMES[id].length).toBeGreaterThan(0);
+      expect(VIRTUAL_VIEW_DESCRIPTIONS[id].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('finds unassigned open issues without naming a viewer', () => {
+    const state = virtualViewState('virtual:unassigned', 'user-1');
+    expect(conditionsOf(state.filter)).toEqual([inCondition('assignee', ['none'])]);
+    expect(state.display.showCompleted).toBe('none');
+  });
+
+  it('finds issues past their due date, soonest first, and hides finished ones', () => {
+    const state = virtualViewState('virtual:overdue', 'user-1');
+    expect(conditionsOf(state.filter)).toEqual([inCondition('due', ['overdue'])]);
+    expect(state.orderBy).toBe('due');
+    expect(state.display.showCompleted).toBe('none');
+  });
+
+  it('leaves every built-in scoped to the whole workspace', () => {
+    for (const id of VIRTUAL_VIEW_IDS) {
+      const state = virtualViewState(id, 'user-1');
+      expect(state.teamId).toBeNull();
+      expect(state.projectId).toBeNull();
+    }
   });
 
   it('builds each one from the viewer id rather than a stored row', () => {


### PR DESCRIPTION
Three problems reported from `/views`: no way to create a view, "All issues" landing in an arbitrary team, and a built-in set that read oddly. All three are fixed here.

## 1. A workspace wide view no longer lands in a random team

`views-page.tsx` resolved a view's team with

```ts
workspace.teams.find((entry) => entry.id === filterTeamId) ?? workspace.teams[0] ?? null
```

A built-in such as "All issues" carries no `filter.teamId`, so `find()` missed and the fallback sent you to whichever team sorted first. The href builder is now a pure, tested function (`features/views/view-href.ts`) that routes to a team only when the view names one that still exists, and sends everything else to `/views/<id>`.

`/views/<id>` is a new route. It loads the view server side, hydrates the views query, and renders the issues the view describes across the whole workspace, honouring the view's own filter, ordering, grouping, layout and display options. A project scoped view narrows to that project; the scope is shown in the header. The page reuses the same `FilterBar` and `DisplayMenu` as the team list, so tweaking and saving behaves exactly as it does there.

`useAllIssues` (previously unused) now takes an optional scope, so one hook serves the workspace, a team or a project.

## 2. A real "New view" affordance

A primary **New view** button sits in the page header, and `Alt+V` opens the same dialog so the old keystroke still means what it meant. The dialog names the view, picks its scope (workspace, a team, or a project), its layout, and then reuses the existing filter builder, grouping, ordering and display property controls rather than reimplementing them. Visibility and sharing go through the existing `createView` service; nothing new was added server side, and the private-view scoping introduced recently is untouched.

## 3. The built-in set

Two additions, chosen because a new workspace has nothing saved and both answer a question people ask on day one:

- **Unassigned**, open issues nobody owns
- **Overdue**, open issues past their due date, ordered by due date

Both hide finished work so they stay actionable. Every built-in now carries a one-line description, shown in the list, so a built-in row is legible without the Owner and Visibility columns (which are hidden on narrow screens).

The Visibility column said "Only me" for built-ins, which was never true of a view every member gets. It now says "Everyone" for built-ins and keeps the stored label for saved views.

## 4. A team view is now a real thing, not a label on a workspace view

Greptile caught a P1 on the first round and it was right. The dialog offered "My teams", but a
saved view could only record `shared: true` or `false`, so choosing it published the view to the
whole workspace: `listViews`, the realtime scopes and the reconnect backfill all authorised any
non-private view at organization scope. The same option was already live in the older
`save-view-dialog`, so this was not new to this branch.

The model can express it now. `view` carries `visibility` (`private`, `team`, `workspace`) and
`team_id`, the team a team view belongs to. `shared` stays and is derived from `visibility` in one
place so the two cannot drift, but nothing authorises on it any more.

- `viewScopes` publishes a team view to `team:<id>` and the owner, never to the org.
- `listViews` and the `/api/ws` catch up backfill share one `viewReadFilter`: mine, or workspace
  wide, or a team view whose team is one of `principal.teamIds`.
- `getView` and `setViewFavorite` go through `canReadView` in `packages/shared/src/policy`.
- Creating or updating a team view asserts the team exists here and that the author is on it, so
  nobody publishes into a team they are not on, and `team` with no team is rejected rather than
  quietly widened.
- Narrowing an audience deletes on exactly the scopes that lost access, so moving a view from team
  A to team B tells team A it is gone. Widening to the workspace deletes nothing.

In the dialogs the option is bound to the team the view covers and reads "Everyone on Engineering".
It only appears when a team is in scope, and if the scope moves off that team the audience falls
back to private, never to the workspace.

### Schema change, applied by hand before this ships

`packages/db/catchup/view-team-visibility.sql` adds the two columns, the foreign key and the index,
and backfills them from `shared` and the stored filter. **Apply it to production before this code
ships**, otherwise every saved view query fails on the missing column. It is idempotent, and it was
run twice against a database seeded with legacy rows to prove it. A stored `team` visibility naming
a team that no longer exists, or a team in another workspace, lands on `private` rather than
`workspace`: the narrower reading is the safe one.

## Page layout

The page had a "BUILT IN" header with the saved-views empty state floating in blank space far below it. Each section now carries a one-line description, and the empty state for your own views sits inside that section with its own button.

## Tests

Every test below was watched fail first, then the production code was deliberately broken to confirm it bites.

| Test | Mutation that turned it red |
| --- | --- |
| `view-href.test.ts`, four cases under "a view that covers the whole workspace" | restore `?? teams[0]` in `viewHref` |
| `views-page.test.tsx` "sends a workspace wide built-in to a workspace destination" | same |
| `views-page.test.tsx` "does not tell people a built-in view is visible only to them" | drop the `view.virtual` branch from `visibilityLabel` |
| `views-page.test.tsx` "creates a view from the dialog and lists it straight away" | make `submit()` return before `create.mutate` |
| `views-page.test.tsx` "opens the same dialog from Alt+V" | rebind the hotkey to `alt+shift+n` |
| `create-view-dialog.test.tsx` filter, layout, grouping and visibility cases | post `defaultViewConfig('list')` instead of the dialog's own config |
| `create-view-dialog.test.tsx` scope cases | make `parseViewScope` always return the workspace scope |
| `saved-view-page.test.tsx` "asks the server for exactly the issues the view describes" | pass an empty filter and `manual` ordering to `useAllIssues` |
| `saved-view-page.test.tsx` team and project scope cases | make `scopeRecord` return `{}` |
| `saved-view-page.test.tsx` "honours the display options it stored" | force `showCompleted: 'all'` |
| `view-service.test.ts` "keeps only issues whose due date has passed" | change the overdue filter to `due is set` |
| `view-service.test.ts` "publishes a team view to that team alone", "never carries the filter of a team view in a delta another team receives", "keeps every later delta of a team view off the workspace scope" | restore the old `viewScopes`, which returned the org scope for anything shared |
| `view-service.test.ts` "lists a team view for the team and hides it from everyone else" | restore `or(ownerId = me, shared = 'true')` in `listViews` |
| `view-service.test.ts` "refuses to open a team view from another team" | restore the old `view.shared !== 'true'` check in `loadReadableView` |
| `view-service.test.ts` "refuses to publish a view to a team the author is not on", "refuses a team view that names no team" | drop `assertAudienceReachable` from `createView` |
| `view-service.test.ts` "tells the workspace a view is gone when its owner narrows it to one team", "drops the old team when a view moves to another one" | restore the old unshare rule, which only ever deleted on the org scope |
| `view-service.test.ts` "takes nothing away when a team view opens up to the whole workspace" | drop the workspace guard from `droppedScopes` |
| `backfill.test.ts` "never replays a team view to somebody on another team" | restore `or(ownerId = me, shared = 'true')` in the view loader |
| `backfill.test.ts` "still replays a workspace view to everyone" | point the workspace clause of `viewReadFilter` at a visibility nothing uses |
| `create-view-dialog.test.tsx` "offers a team audience only once the view covers a team" | stop filtering the team option out of `visibilityChoices` |
| `create-view-dialog.test.tsx` "keeps a team view on the team that owns it" | post `visibility: 'workspace'` instead of the chosen audience |
| `create-view-dialog.test.tsx` "never leaves a team audience on a view that stopped covering a team" | make `allowedVisibility` return whatever was chosen |
| `filter-bar.test.tsx` "names the team a view on a team page would go to", "offers no team audience where no team is in scope" | pass a team to the save dialog even when the page has none |
| `views-page.test.tsx` "names the team a team view is shared with" | drop the team branch from `visibilityLabel` |

The team scoping tests build two teams and three people against real Postgres, then assert what each of them can list, open, favourite and receive, so the invariant is proven against the database rather than against a mock.

The saved view page tests drive the real query layer through a stubbed `fetch`, so the request the page builds is asserted rather than assumed. The core tests run the built-in filters through `listIssues` against Postgres, so "the built-ins work" is proven end to end rather than by inspecting a literal.

`bun run verify` is green, and `bun run build` in `apps/web` registers `/views/[id]` as a dynamic node route.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds workspace-wide saved-view pages and view creation while introducing explicit private, team, and workspace visibility throughout persistence, policy checks, listing, and realtime delivery.
- Routes workspace views without an existing team to `/views/<id>` and renders their stored filters, scope, layout, grouping, ordering, and display settings.
- Adds view creation from the Views page and updates built-in views and visibility labels.
- Adds persisted team visibility, shared read-policy enforcement, audience-aware realtime scopes and backfill filtering, plus migration and regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/work/view-service.ts | Centralizes view audience persistence, read filtering, policy enforcement, realtime scopes, and deletion notifications when access narrows. |
| packages/shared/src/policy/index.ts | Adds organization-aware private, team, and workspace read authorization for saved views. |
| packages/core/src/realtime/backfill.ts | Applies the shared view-read filter and audience scopes during reconnect catch-up. |
| packages/db/catchup/view-team-visibility.sql | Idempotently adds and safely backfills explicit visibility and team ownership for legacy view rows. |
| apps/web/src/features/views/create-view-dialog.tsx | Adds view creation with configurable scope, layout, filters, grouping, ordering, display properties, and audience. |
| apps/web/src/features/views/saved-view-page.tsx | Renders saved workspace, team, or project views using their persisted issue-query and display configuration. |
| apps/web/src/features/views/view-href.ts | Routes only valid team-scoped views to team pages and sends workspace or orphaned-team views to the saved-view route. |
| apps/web/tests/features/views/create-view-dialog.test.tsx | Uses the required application alias and covers scope, audience, configuration, and submission behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  UI[Create or update view] --> V[Validate visibility and team]
  V --> DB[(Persist visibility and team_id)]
  DB --> P{Audience}
  P -->|Private| U[Owner scope]
  P -->|Team| T[Team and owner scopes]
  P -->|Workspace| O[Organization and owner scopes]
  DB --> R[Shared read policy]
  R --> L[List and direct reads]
  R --> B[Realtime catch-up]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(views): decode the route segment, so..."](https://github.com/noveum/orbit/commit/56258b380cd379ead596e6134da44e0e08fedd2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51095872)</sub>

<!-- /greptile_comment -->