### PR TITLE
fix(ci): greeting workflow passed input names the action does not declare

### DIFF
--- a/.github/workflows/greeting.yml
+++ b/.github/workflows/greeting.yml
@@ -25,7 +25,7 @@ jobs:
             since that is what we run locally.
 
             If you fancy fixing it yourself, [CONTRIBUTING.md](https://github.com/Noveum/orbit/blob/main/CONTRIBUTING.md)
-            has the setup, and it is five commands.
+            walks through the setup. You need Bun and Docker, and nothing else.
           pr_message: |
             Thanks for your first pull request to Orbit.
 

--- a/.github/workflows/greeting.yml
+++ b/.github/workflows/greeting.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Thanks for opening your first issue on Orbit.
 
             A maintainer will triage this. If it is a bug, the fastest way to move it
@@ -26,7 +26,7 @@ jobs:
 
             If you fancy fixing it yourself, [CONTRIBUTING.md](https://github.com/Noveum/orbit/blob/main/CONTRIBUTING.md)
             has the setup, and it is five commands.
-          pr-message: |
+          pr_message: |
             Thanks for your first pull request to Orbit.
 
             Two things that will save you a review round: `bun run verify` runs the


### PR DESCRIPTION
## What this changes

Renames the inputs passed to `actions/first-interaction` from hyphens to underscores.

## Why

The greeting workflow has failed on **every issue and every pull request** since it landed in #123:

```
Error: Input required and not supplied: issue_message
```

`actions/first-interaction` declares `issue_message`, `pr_message` and `repo_token` with underscores. The workflow passed `issue-message`, `pr-message` and `repo-token`, so none of them reached the action and it threw before posting anything.

## Why it was missed

The convention is not consistent across first-party actions, which is the trap. The sibling `actions/labeler` added in the same batch really does take `repo-token` with a hyphen, and that one passes. I assumed the two matched instead of reading each `action.yml`.

Checked this time against the declared inputs on the exact pinned commit:

```
inputs:
  issue_message:
  pr_message:
  repo_token:
```

`repo_token` was masking part of the problem: it defaults to `${{ github.token }}`, so the wrong key still worked. Corrected here too.

## Expect this PR to show a failing "Say hello"

**That failure is expected and is not evidence the fix is broken.**

`greeting.yml` triggers on `pull_request_target`, and GitHub always runs that workflow from the **base** branch, never from the pull request's own head. So this PR runs `main`'s copy, which is still the broken one. The fix cannot be exercised until it is on `main`.

I originally wrote in this description that opening the PR would itself test the fix. That was wrong, and I am correcting it rather than leaving it to mislead a reviewer who sees the red X.

## How to confirm it after merge

Once merged, the next issue or pull request opened by a first-time contributor runs the corrected workflow. Either it posts the greeting, or it skips quietly for a repeat contributor. What it must not do is fail.

`.github/workflows/greeting.yml` is the only file touched. No source changed, so lint, types and tests are unaffected.

## Do not revert this to match the upstream README

`actions/first-interaction`'s own README at this pinned SHA still documents the inputs in kebab-case, contradicting the `action.yml` sitting beside it. That upstream documentation bug is almost certainly what produced the original mistake.

Confirmed at the call site in the action's source, not just its manifest:

```
core.getInput('issue_message', { required: true })
core.getInput('pr_message',    { required: true })
core.getInput('repo_token',    { required: true })
```

All three are required, and kebab-case keys set `INPUT_ISSUE-MESSAGE`, which `getInput` never reads. Anyone "correcting" these back to match the README will silently re-break the workflow.

I checked the other actions added in the same batch for the same mistake, and there is none: `actions/labeler` and `actions/stale` both declare kebab-case at their pinned SHAs and are passed kebab-case. `first-interaction` v3 is the outlier.

## Also in this PR

The greeting told a first-time contributor the setup "is five commands". The block in `CONTRIBUTING.md` is seven. Rather than swap one number for another that drifts on the next setup change, the message now says what they actually need: Bun and Docker.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The workflow now passes the underscored input names declared by the pinned `actions/first-interaction` action and refreshes the first-issue greeting text.
- Renames `repo-token`, `issue-message`, and `pr-message` to their declared underscored forms.
- Keeps the existing event triggers, token, permissions, and greeting behavior.

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/greeting.yml | Correctly aligns all three action input keys with the pinned action’s declared interface and updates greeting copy without introducing a blocking failure. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(ci): drop the command count from th..."](https://github.com/noveum/orbit/commit/d5a5932a57036ec85083297674115e0a723c4421) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51103734)</sub>

<!-- /greptile_comment -->