### PR TITLE
docs: make the cost argument without naming a competitor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Orbit
 
-Free, realtime, keyboard-first work tracker. Linear-grade UX, Plane-grade breadth, plus docs, files, notifications, Slack, and an MCP server. No pricing, no billing, no paid tiers anywhere.
+Free, realtime, keyboard-first work tracker. The UX polish of the best paid trackers with the breadth of the open source ones, plus docs, files, notifications, Slack, and an MCP server. No pricing, no billing, no paid tiers anywhere.
 
 ## Hard rules
 
@@ -114,7 +114,7 @@ domain verified in Resend, otherwise every send fails.
   creation and on user creation, so it covers every provider. Empty means no restriction. A
   workspace can narrow it further with its own `allowedEmailDomains`.
 - **Permissions.** All authorization goes through `packages/shared/src/policy`. Server routes enforce it. The UI reads the same policy to hide affordances, never as the only gate.
-- **Motion.** No layout animation on the critical path, ever: nothing that triggers reflow may animate. Entrance, exit and gesture motion is transform and opacity only. Hover and focus state changes may additionally transition colour, which is what the measured Linear behaviour does, but only through the shared tokens in `apps/web/src/lib/interaction.ts` so the set stays auditable, never hand-rolled at a call site. Micro-interactions such as row and item highlights may go as fast as 80ms; nothing exceeds 200ms; everything respects `prefers-reduced-motion`.
+- **Motion.** No layout animation on the critical path, ever: nothing that triggers reflow may animate. Entrance, exit and gesture motion is transform and opacity only. Hover and focus state changes may additionally transition colour, which is what the trackers we measured against do, but only through the shared tokens in `apps/web/src/lib/interaction.ts` so the set stays auditable, never hand-rolled at a call site. Micro-interactions such as row and item highlights may go as fast as 80ms; nothing exceeds 200ms; everything respects `prefers-reduced-motion`.
 - **Theming.** Light and dark both first class, driven by CSS custom properties and `next-themes`. Never hardcode a hex value in a component.
 - **Accessibility.** Keyboard operable everywhere, visible focus rings, real semantics from Radix primitives.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 **A free, realtime, keyboard-first work tracker.**
 
 Issues, boards, sprints, projects and docs that update the moment anyone changes
-anything. Linear-grade feel, no per-seat bill at the end of the month.
+anything. The polish you expect from paid tooling, with no per-seat bill at the
+end of the month.
 
 **No pricing. No billing. No paid tiers. Not now, not later.**
 
@@ -34,8 +35,9 @@ anything. Linear-grade feel, no per-seat bill at the end of the month.
 
 ## Why Orbit exists
 
-Linear costs 18 dollars per person per month. For a team of twenty that is a
-little over four thousand pounds a year to keep a list of tasks in order.
+The tools teams use to track work cost around 18 dollars per person per month.
+For a team of twenty that is over four thousand pounds a year to keep a list of
+tasks in order.
 
 The alternatives were not a real answer. The free ones are slow and feel like
 filling in a form. The self-hosted ones are heavy to run. The cheap ones are

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,8 +1,8 @@
 # Concepts
 
 The vocabulary Orbit uses, and what each thing is actually for. If you have used
-Linear or Jira most of this will be familiar, and the places where Orbit differs
-are called out.
+any other issue tracker most of this will be familiar, and the places where
+Orbit differs are called out.
 
 ## Workspace
 


### PR DESCRIPTION
## What this changes

Removes the competitor name from the pitch, keeping the cost argument that motivates the project.

| Where | Before | After |
| --- | --- | --- |
| `README.md` hero | "Linear-grade feel" | "The polish you expect from paid tooling" |
| `README.md` why | "Linear costs 18 dollars per person per month" | "The tools teams use to track work cost around 18 dollars per person per month" |
| `docs/concepts.md` | "If you have used Linear or Jira" | "If you have used any other issue tracker" |
| `CLAUDE.md` | "Linear-grade UX, Plane-grade breadth" | "The UX polish of the best paid trackers with the breadth of the open source ones" |
| `CLAUDE.md` motion | "the measured Linear behaviour" | "the trackers we measured against" |

## Why

The argument does not need a target. The category costs what it costs, a team of twenty pays over four thousand pounds a year for a list of tasks, and Orbit is free either way. Naming one company dates the pitch, invites an argument about that company rather than about the price, and is a needless trademark surface on a project that already asks forks to pick their own name.

The number stays. So does the point.

## Not changed, deliberately

`CONTRIBUTING.md` and the landing page already made the argument without naming anyone, quoting only the per-seat price. Both left alone.

## Note on the `linear-alternative` repo topic

The repository still carries `linear-alternative` and `jira-alternative` as GitHub topics. Those are discovery metadata rather than pitch copy, and they are how people actually find a project like this one, so removing them costs real reach. Flagging rather than deciding unilaterally, since it pulls in the opposite direction from this PR.

## How you know it works

`bun run verify` is green: 2615 tests passing, zero failures. Copy only, no source touched.

`grep -rn Linear` across `README.md`, `CONTRIBUTING.md`, `docs/`, `CLAUDE.md`, `AGENTS.md` and `apps/web/src` now returns nothing outside the Linear **importer**, which is a real code path for importing from that tool and has to keep the name to mean anything.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes competitor-specific positioning while preserving Orbit's cost and product-quality arguments.

- Rephrases the README hero and pricing rationale using category-level language.
- Generalizes competitor references in the contributor guidance and concepts documentation.

<h3>Confidence Score: 5/5</h3>

The documentation-only changes appear safe to merge.

The revised copy remains consistent with surrounding documentation and complies with the repository's documentation rules.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | Generalizes product-positioning and motion-guidance language without changing the underlying requirements. |
| README.md | Replaces competitor-specific marketing copy while preserving the free-product and per-seat-cost arguments. |
| docs/concepts.md | Broadens the introductory comparison from named products to issue trackers generally. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: describe the cost without naming a..."](https://github.com/noveum/orbit/commit/1ab5f892e0863dd3fedb7c218e7bd27383850b0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51110091)</sub>

<!-- /greptile_comment -->