### PR TITLE
Let a workspace own its labels and its board columns

### DIFF
--- a/apps/web/e2e/account-and-workspaces.spec.ts
+++ b/apps/web/e2e/account-and-workspaces.spec.ts
@@ -124,7 +124,7 @@ test('account settings, passkeys, and workspace switching', async ({ browser }) 
     animations: 'disabled',
   });
 
-  for (const section of ['general', 'members', 'teams', 'notifications']) {
+  for (const section of ['general', 'members', 'teams', 'labels', 'workflow', 'notifications']) {
     await page.goto(`${BASE}/settings/${section}`);
     await expect(page.getByRole('link', { name: 'Profile' })).toBeVisible();
     await expect(page.getByRole('heading', { level: 2 })).toBeVisible();

--- a/apps/web/src/app/(app)/settings/labels/loading.tsx
+++ b/apps/web/src/app/(app)/settings/labels/loading.tsx
@@ -1,0 +1,5 @@
+import { LabelsSettingsSkeleton } from '@/features/settings/settings-skeletons.tsx';
+
+export default function LabelsSettingsLoading() {
+  return <LabelsSettingsSkeleton />;
+}

--- a/apps/web/src/app/(app)/settings/labels/page.tsx
+++ b/apps/web/src/app/(app)/settings/labels/page.tsx
@@ -1,0 +1,22 @@
+import { can } from '@orbit/shared/policy';
+import { listLabelViews, listTeamBadges } from '@/features/settings/data.ts';
+import { LabelsPanel } from '@/features/settings/labels-panel.tsx';
+import { pageContext } from '@/lib/api/handler.ts';
+
+export default async function LabelsSettingsPage() {
+  const { principal } = await pageContext();
+  const [labels, teams] = await Promise.all([listLabelViews(principal), listTeamBadges(principal)]);
+
+  return (
+    <section className="flex flex-col gap-5">
+      <div className="flex flex-col gap-1">
+        <h2 className="font-medium text-lg text-text">Labels</h2>
+        <p className="text-muted text-xs">
+          Labels tag issues across the workspace. Keep one on a single team when only that team
+          should see it and use it.
+        </p>
+      </div>
+      <LabelsPanel labels={labels} teams={teams} canManage={can(principal, 'label:manage')} />
+    </section>
+  );
+}

--- a/apps/web/src/app/(app)/settings/workflow/loading.tsx
+++ b/apps/web/src/app/(app)/settings/workflow/loading.tsx
@@ -1,0 +1,5 @@
+import { WorkflowSettingsSkeleton } from '@/features/settings/settings-skeletons.tsx';
+
+export default function WorkflowSettingsLoading() {
+  return <WorkflowSettingsSkeleton />;
+}

--- a/apps/web/src/app/(app)/settings/workflow/page.tsx
+++ b/apps/web/src/app/(app)/settings/workflow/page.tsx
@@ -1,0 +1,26 @@
+import { can } from '@orbit/shared/policy';
+import { listTeamBadges, listWorkflowStateViews } from '@/features/settings/data.ts';
+import { WorkflowPanel } from '@/features/settings/workflow-panel.tsx';
+import { pageContext } from '@/lib/api/handler.ts';
+
+export default async function WorkflowSettingsPage() {
+  const { principal } = await pageContext();
+  const teams = await listTeamBadges(principal);
+  const states = await listWorkflowStateViews(
+    principal,
+    teams.map((team) => team.id),
+  );
+
+  return (
+    <section className="flex flex-col gap-5">
+      <div className="flex flex-col gap-1">
+        <h2 className="font-medium text-lg text-text">Workflow</h2>
+        <p className="text-muted text-xs">
+          Each team owns its board columns, in order. The category behind a status is what the rest
+          of Orbit reads to know whether an issue has started, finished, or been dropped.
+        </p>
+      </div>
+      <WorkflowPanel teams={teams} states={states} canManage={can(principal, 'workflow:manage')} />
+    </section>
+  );
+}

--- a/apps/web/src/app/api/labels/[id]/route.ts
+++ b/apps/web/src/app/api/labels/[id]/route.ts
@@ -1,0 +1,33 @@
+import { deleteLabel, getLabel, updateLabel } from '@orbit/core';
+import { apiContext, handleRoute, publish, readJson, routeId } from '@/lib/api/handler.ts';
+
+interface RouteParams {
+  readonly params: Promise<{ id: string }>;
+}
+
+export async function GET(_request: Request, { params }: RouteParams): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const id = routeId((await params).id, 'label');
+    return { label: await getLabel(principal, id) };
+  });
+}
+
+export async function PATCH(request: Request, { params }: RouteParams): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const id = routeId((await params).id, 'label');
+    const result = await updateLabel(principal, id, await readJson(request));
+    await publish(result.actions);
+    return { label: result.label };
+  });
+}
+
+export async function DELETE(_request: Request, { params }: RouteParams): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const id = routeId((await params).id, 'label');
+    await publish(await deleteLabel(principal, id));
+    return { deleted: true };
+  });
+}

--- a/apps/web/src/app/api/labels/route.ts
+++ b/apps/web/src/app/api/labels/route.ts
@@ -1,0 +1,21 @@
+import { createLabel, listLabels } from '@orbit/core';
+import { labelListQuerySchema } from '@orbit/shared/validators';
+import { apiContext, handleRoute, publish, readJson, searchParamsOf } from '@/lib/api/handler.ts';
+
+export async function GET(request: Request): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const query = labelListQuerySchema.parse(searchParamsOf(request));
+    const options = query.teamId === undefined ? {} : { teamId: query.teamId };
+    return { labels: await listLabels(principal, options) };
+  });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const result = await createLabel(principal, await readJson(request));
+    await publish(result.actions);
+    return { label: result.label };
+  });
+}

--- a/apps/web/src/app/api/workflow-states/[id]/route.ts
+++ b/apps/web/src/app/api/workflow-states/[id]/route.ts
@@ -1,0 +1,35 @@
+import { deleteWorkflowState, updateWorkflowState } from '@orbit/core';
+import { workflowStateDeleteQuerySchema } from '@orbit/shared/validators';
+import {
+  apiContext,
+  handleRoute,
+  publish,
+  readJson,
+  routeId,
+  searchParamsOf,
+} from '@/lib/api/handler.ts';
+
+interface RouteParams {
+  readonly params: Promise<{ id: string }>;
+}
+
+export async function PATCH(request: Request, { params }: RouteParams): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const id = routeId((await params).id, 'status');
+    const result = await updateWorkflowState(principal, id, await readJson(request));
+    await publish(result.actions);
+    return { state: result.state };
+  });
+}
+
+export async function DELETE(request: Request, { params }: RouteParams): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const id = routeId((await params).id, 'status');
+    const query = workflowStateDeleteQuerySchema.parse(searchParamsOf(request));
+    const options = query.moveToStateId === undefined ? {} : { moveToStateId: query.moveToStateId };
+    await publish(await deleteWorkflowState(principal, id, options));
+    return { deleted: true };
+  });
+}

--- a/apps/web/src/app/api/workflow-states/reorder/route.ts
+++ b/apps/web/src/app/api/workflow-states/reorder/route.ts
@@ -1,0 +1,11 @@
+import { reorderWorkflowStates } from '@orbit/core';
+import { apiContext, handleRoute, publish, readJson } from '@/lib/api/handler.ts';
+
+export async function POST(request: Request): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const result = await reorderWorkflowStates(principal, await readJson(request));
+    await publish(result.actions);
+    return { states: result.states };
+  });
+}

--- a/apps/web/src/app/api/workflow-states/route.ts
+++ b/apps/web/src/app/api/workflow-states/route.ts
@@ -1,0 +1,20 @@
+import { createWorkflowState, listWorkflowStates } from '@orbit/core';
+import { workflowStateListQuerySchema } from '@orbit/shared/validators';
+import { apiContext, handleRoute, publish, readJson, searchParamsOf } from '@/lib/api/handler.ts';
+
+export async function GET(request: Request): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const query = workflowStateListQuerySchema.parse(searchParamsOf(request));
+    return { states: await listWorkflowStates(principal, query.teamId) };
+  });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const result = await createWorkflowState(principal, await readJson(request));
+    await publish(result.actions);
+    return { state: result.state };
+  });
+}

--- a/apps/web/src/features/settings/color-swatches.tsx
+++ b/apps/web/src/features/settings/color-swatches.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { SWATCH_COLORS } from '@orbit/shared/constants';
+import { Check } from 'lucide-react';
+import { cn } from '@/lib/cn.ts';
+import { swatchLift } from '@/lib/interaction.ts';
+
+export interface ColorSwatchesProps {
+  readonly value: string;
+  readonly onChange: (color: string) => void;
+  readonly legend: string;
+  readonly disabled?: boolean;
+}
+
+export function ColorSwatches({ value, onChange, legend, disabled = false }: ColorSwatchesProps) {
+  const chosen = value.toLowerCase();
+  return (
+    <fieldset disabled={disabled} className="flex min-w-0 flex-col gap-1.5">
+      <legend className="mb-1 text-2xs text-faint uppercase tracking-wide">{legend}</legend>
+      <div className="flex flex-wrap gap-1.5">
+        {SWATCH_COLORS.map((color) => {
+          const active = color.toLowerCase() === chosen;
+          return (
+            <button
+              key={color}
+              type="button"
+              aria-label={color}
+              aria-pressed={active}
+              onClick={() => onChange(color)}
+              style={{ backgroundColor: color }}
+              className={cn(
+                'flex size-6 items-center justify-center rounded-full',
+                swatchLift,
+                'focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2',
+                'disabled:cursor-not-allowed disabled:opacity-50',
+                active ? 'scale-110' : '',
+              )}
+            >
+              {active ? <Check className="size-3.5 text-surface" aria-hidden="true" /> : null}
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/apps/web/src/features/settings/data.ts
+++ b/apps/web/src/features/settings/data.ts
@@ -3,7 +3,7 @@ import {
   listMembers,
   listPendingInvites,
   listTeams,
-  listWorkflowStates,
+  listWorkflowStatesForTeams,
 } from '@orbit/core';
 import { and, db, eq, inArray, schema } from '@orbit/db';
 import type { OrgRole, StateCategory } from '@orbit/shared/constants';
@@ -168,8 +168,8 @@ export async function listWorkflowStateViews(
   principal: Principal,
   teamIds: readonly string[],
 ): Promise<WorkflowStateView[]> {
-  const perTeam = await Promise.all(teamIds.map((teamId) => listWorkflowStates(principal, teamId)));
-  return perTeam.flat().map((state) => ({
+  const states = await listWorkflowStatesForTeams(principal, teamIds);
+  return states.map((state) => ({
     id: state.id,
     teamId: state.teamId,
     name: state.name,

--- a/apps/web/src/features/settings/data.ts
+++ b/apps/web/src/features/settings/data.ts
@@ -1,7 +1,13 @@
-import { listMembers, listPendingInvites, listTeams } from '@orbit/core';
+import {
+  listLabels,
+  listMembers,
+  listPendingInvites,
+  listTeams,
+  listWorkflowStates,
+} from '@orbit/core';
 import { and, db, eq, inArray, schema } from '@orbit/db';
-import type { OrgRole } from '@orbit/shared/constants';
-import { ORG_ROLES } from '@orbit/shared/constants';
+import type { OrgRole, StateCategory } from '@orbit/shared/constants';
+import { ORG_ROLES, STATE_CATEGORIES } from '@orbit/shared/constants';
 import type { Principal } from '@orbit/shared/policy';
 
 export interface TeamBadge {
@@ -125,5 +131,50 @@ export async function listTeamDetails(principal: Principal): Promise<TeamDetail[
     description: team.description,
     archivedAt: team.archivedAt?.toISOString() ?? null,
     memberIds: byTeam.get(team.id) ?? [],
+  }));
+}
+
+export interface LabelView {
+  readonly id: string;
+  readonly name: string;
+  readonly color: string;
+  readonly teamId: string | null;
+}
+
+export async function listLabelViews(principal: Principal): Promise<LabelView[]> {
+  const labels = await listLabels(principal);
+  return labels.map((label) => ({
+    id: label.id,
+    name: label.name,
+    color: label.color,
+    teamId: label.teamId,
+  }));
+}
+
+export interface WorkflowStateView {
+  readonly id: string;
+  readonly teamId: string;
+  readonly name: string;
+  readonly category: StateCategory;
+  readonly color: string;
+  readonly position: number;
+}
+
+function toStateCategory(value: string): StateCategory {
+  return STATE_CATEGORIES.find((category) => category === value) ?? 'unstarted';
+}
+
+export async function listWorkflowStateViews(
+  principal: Principal,
+  teamIds: readonly string[],
+): Promise<WorkflowStateView[]> {
+  const perTeam = await Promise.all(teamIds.map((teamId) => listWorkflowStates(principal, teamId)));
+  return perTeam.flat().map((state) => ({
+    id: state.id,
+    teamId: state.teamId,
+    name: state.name,
+    category: toStateCategory(state.category),
+    color: state.color,
+    position: state.position,
   }));
 }

--- a/apps/web/src/features/settings/labels-panel.tsx
+++ b/apps/web/src/features/settings/labels-panel.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { DEFAULT_LABEL_COLOR } from '@orbit/shared/constants';
+import { useRouter } from 'next/navigation';
+import { type FormEvent, useState } from 'react';
+import { Badge } from '@/components/ui/badge.tsx';
+import { Button } from '@/components/ui/button.tsx';
+import { Input } from '@/components/ui/input.tsx';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select.tsx';
+import { apiRequest, messageOf } from '@/lib/api/client.ts';
+import { cn } from '@/lib/cn.ts';
+import { rowHover } from '@/lib/interaction.ts';
+import { ColorSwatches } from './color-swatches.tsx';
+import type { LabelView, TeamBadge } from './data.ts';
+
+const WORKSPACE_SCOPE = 'workspace';
+
+export interface LabelsPanelProps {
+  readonly labels: readonly LabelView[];
+  readonly teams: readonly TeamBadge[];
+  readonly canManage: boolean;
+}
+
+interface LabelRowProps {
+  readonly label: LabelView;
+  readonly teams: readonly TeamBadge[];
+  readonly canManage: boolean;
+  readonly busy: boolean;
+  readonly onSave: (patch: { name: string; color: string; teamId: string | null }) => Promise<void>;
+  readonly onDelete: () => Promise<void>;
+}
+
+function scopeName(teams: readonly TeamBadge[], teamId: string | null): string {
+  if (teamId === null) return 'Workspace';
+  return teams.find((team) => team.id === teamId)?.key ?? 'Team';
+}
+
+function LabelRow({ label, teams, canManage, busy, onSave, onDelete }: LabelRowProps) {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(label.name);
+  const [color, setColor] = useState(label.color);
+  const [scope, setScope] = useState(label.teamId ?? WORKSPACE_SCOPE);
+
+  function startEditing(): void {
+    setName(label.name);
+    setColor(label.color);
+    setScope(label.teamId ?? WORKSPACE_SCOPE);
+    setEditing(true);
+  }
+
+  async function save(): Promise<void> {
+    await onSave({ name, color, teamId: scope === WORKSPACE_SCOPE ? null : scope });
+    setEditing(false);
+  }
+
+  if (!editing) {
+    return (
+      <li
+        className={cn('flex items-center gap-3 rounded-md px-2 py-1.5', rowHover)}
+        data-testid="label-row"
+      >
+        <span
+          className="size-3 shrink-0 rounded-full"
+          style={{ backgroundColor: label.color }}
+          aria-hidden="true"
+        />
+        <span className="min-w-0 flex-1 truncate text-dense text-text">{label.name}</span>
+        <Badge tone={label.teamId === null ? 'neutral' : 'accent'}>
+          {scopeName(teams, label.teamId)}
+        </Badge>
+        <Button size="sm" variant="ghost" disabled={!canManage || busy} onClick={startEditing}>
+          Edit
+        </Button>
+        <Button size="sm" variant="ghost" disabled={!canManage || busy} onClick={() => onDelete()}>
+          Delete
+        </Button>
+      </li>
+    );
+  }
+
+  return (
+    <li className="flex flex-col gap-3 rounded-md border border-border p-3">
+      <div className="flex flex-wrap items-end gap-3">
+        <label htmlFor={`label-name-${label.id}`} className="flex min-w-48 flex-1 flex-col gap-1.5">
+          <span className="font-medium text-dense text-text">Name</span>
+          <Input
+            id={`label-name-${label.id}`}
+            value={name}
+            maxLength={48}
+            onChange={(event) => setName(event.target.value)}
+          />
+        </label>
+        <div className="flex w-44 flex-col gap-1.5">
+          <span className="font-medium text-dense text-text" id={`label-scope-${label.id}`}>
+            Available to
+          </span>
+          <Select value={scope} onValueChange={setScope}>
+            <SelectTrigger aria-labelledby={`label-scope-${label.id}`}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={WORKSPACE_SCOPE}>Everyone in the workspace</SelectItem>
+              {teams.map((team) => (
+                <SelectItem key={team.id} value={team.id}>
+                  {team.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <ColorSwatches legend="Colour" value={color} onChange={setColor} />
+      <div className="flex items-center gap-1">
+        <Button size="sm" variant="primary" disabled={busy} onClick={() => save()}>
+          Save
+        </Button>
+        <Button size="sm" variant="ghost" onClick={() => setEditing(false)}>
+          Cancel
+        </Button>
+      </div>
+    </li>
+  );
+}
+
+export function LabelsPanel({ labels, teams, canManage }: LabelsPanelProps) {
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [color, setColor] = useState(DEFAULT_LABEL_COLOR);
+  const [scope, setScope] = useState<string>(WORKSPACE_SCOPE);
+  const [pending, setPending] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function run(id: string | null, action: () => Promise<unknown>): Promise<void> {
+    setBusyId(id);
+    setError(null);
+    try {
+      await action();
+      router.refresh();
+    } catch (caught) {
+      setError(messageOf(caught));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function onCreate(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setPending(true);
+    setError(null);
+    try {
+      await apiRequest('/api/labels', {
+        method: 'POST',
+        body: { name, color, teamId: scope === WORKSPACE_SCOPE ? null : scope },
+      });
+      setName('');
+      router.refresh();
+    } catch (caught) {
+      setError(messageOf(caught));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <form
+        onSubmit={onCreate}
+        className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4"
+      >
+        <div className="flex flex-wrap items-end gap-3">
+          <label htmlFor="new-label-name" className="flex min-w-48 flex-1 flex-col gap-1.5">
+            <span className="font-medium text-dense text-text">Label name</span>
+            <Input
+              id="new-label-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              required
+              maxLength={48}
+              placeholder="Regression"
+              disabled={!canManage || pending}
+              name="labelName"
+            />
+          </label>
+          <div className="flex w-56 flex-col gap-1.5">
+            <span className="font-medium text-dense text-text" id="new-label-scope">
+              Available to
+            </span>
+            <Select value={scope} onValueChange={setScope} disabled={!canManage || pending}>
+              <SelectTrigger aria-labelledby="new-label-scope">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={WORKSPACE_SCOPE}>Everyone in the workspace</SelectItem>
+                {teams.map((team) => (
+                  <SelectItem key={team.id} value={team.id}>
+                    {team.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button type="submit" variant="primary" disabled={!canManage || pending}>
+            {pending ? 'Creating' : 'Create label'}
+          </Button>
+        </div>
+        <ColorSwatches
+          legend="Colour"
+          value={color}
+          onChange={setColor}
+          disabled={!canManage || pending}
+        />
+      </form>
+
+      {error === null ? null : (
+        <p role="alert" className="text-danger text-xs">
+          {error}
+        </p>
+      )}
+
+      {labels.length === 0 ? (
+        <p className="text-muted text-xs">No labels yet. The first one goes above.</p>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {labels.map((label) => (
+            <LabelRow
+              key={label.id}
+              label={label}
+              teams={teams}
+              canManage={canManage}
+              busy={busyId === label.id}
+              onSave={(patch) =>
+                run(label.id, () =>
+                  apiRequest(`/api/labels/${label.id}`, { method: 'PATCH', body: patch }),
+                )
+              }
+              onDelete={() =>
+                run(label.id, () => apiRequest(`/api/labels/${label.id}`, { method: 'DELETE' }))
+              }
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/settings/settings-nav.tsx
+++ b/apps/web/src/features/settings/settings-nav.tsx
@@ -33,6 +33,8 @@ export const SETTINGS_GROUPS: readonly SettingsGroup[] = [
       { href: '/settings/general', label: 'General' },
       { href: '/settings/members', label: 'Members' },
       { href: '/settings/teams', label: 'Teams' },
+      { href: '/settings/labels', label: 'Labels' },
+      { href: '/settings/workflow', label: 'Workflow' },
       { href: '/settings/notifications', label: 'Notifications' },
       { href: '/settings/integrations', label: 'Integrations' },
     ],

--- a/apps/web/src/features/settings/settings-skeletons.tsx
+++ b/apps/web/src/features/settings/settings-skeletons.tsx
@@ -112,6 +112,72 @@ export function TeamsSettingsSkeleton() {
   );
 }
 
+const TAXONOMY_ROWS = ['a', 'b', 'c', 'd', 'e', 'f'];
+const SWATCHES = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'];
+
+function TaxonomyComposerSkeleton() {
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex min-w-48 flex-1 flex-col gap-1.5">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-9 w-full rounded-md" />
+        </div>
+        <div className="flex w-48 flex-col gap-1.5">
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-9 w-full rounded-md" />
+        </div>
+        <Skeleton className="h-9 w-28 rounded-md" />
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {SWATCHES.map((swatch) => (
+          <Skeleton key={swatch} className="size-6 rounded-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TaxonomyRowsSkeleton() {
+  return (
+    <ul className="flex flex-col gap-1">
+      {TAXONOMY_ROWS.map((row) => (
+        <li key={row} className="flex items-center gap-3 px-2 py-1.5">
+          <Skeleton className="size-3 rounded-full" />
+          <Skeleton className="h-3 w-40" />
+          <Skeleton className="ml-auto h-4 w-16 rounded-sm" />
+          <Skeleton className="h-7 w-14 rounded-md" />
+          <Skeleton className="h-7 w-14 rounded-md" />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function LabelsSettingsSkeleton() {
+  return (
+    <section className="flex flex-col gap-5" data-testid="settings-labels-skeleton">
+      <SettingsHeading />
+      <TaxonomyComposerSkeleton />
+      <TaxonomyRowsSkeleton />
+    </section>
+  );
+}
+
+export function WorkflowSettingsSkeleton() {
+  return (
+    <section className="flex flex-col gap-5" data-testid="settings-workflow-skeleton">
+      <SettingsHeading />
+      <div className="flex w-64 max-w-full flex-col gap-1.5">
+        <Skeleton className="h-3 w-12" />
+        <Skeleton className="h-9 w-full rounded-md" />
+      </div>
+      <TaxonomyComposerSkeleton />
+      <TaxonomyRowsSkeleton />
+    </section>
+  );
+}
+
 const MEMBER_ROWS = ['a', 'b', 'c', 'd', 'e'];
 const MEMBER_COLUMNS = ['member', 'email', 'role', 'teams', 'joined', 'actions'];
 

--- a/apps/web/src/features/settings/workflow-panel.tsx
+++ b/apps/web/src/features/settings/workflow-panel.tsx
@@ -1,0 +1,433 @@
+'use client';
+
+import {
+  DEFAULT_STATE_COLOR,
+  STATE_CATEGORIES,
+  STATE_CATEGORY_LABELS,
+  type StateCategory,
+} from '@orbit/shared/constants';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { type FormEvent, useMemo, useState } from 'react';
+import { Badge } from '@/components/ui/badge.tsx';
+import { Button } from '@/components/ui/button.tsx';
+import { Input } from '@/components/ui/input.tsx';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select.tsx';
+import { ApiRequestError, apiRequest, messageOf } from '@/lib/api/client.ts';
+import { cn } from '@/lib/cn.ts';
+import { rowHover } from '@/lib/interaction.ts';
+import { ColorSwatches } from './color-swatches.tsx';
+import type { TeamBadge, WorkflowStateView } from './data.ts';
+
+export interface WorkflowPanelProps {
+  readonly teams: readonly TeamBadge[];
+  readonly states: readonly WorkflowStateView[];
+  readonly canManage: boolean;
+}
+
+interface StateRowProps {
+  readonly state: WorkflowStateView;
+  readonly canManage: boolean;
+  readonly busy: boolean;
+  readonly first: boolean;
+  readonly last: boolean;
+  readonly onMove: (direction: -1 | 1) => void;
+  readonly onSave: (patch: {
+    name: string;
+    category: StateCategory;
+    color: string;
+  }) => Promise<void>;
+  readonly onDelete: () => void;
+}
+
+function StateRow({
+  state,
+  canManage,
+  busy,
+  first,
+  last,
+  onMove,
+  onSave,
+  onDelete,
+}: StateRowProps) {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(state.name);
+  const [category, setCategory] = useState<StateCategory>(state.category);
+  const [color, setColor] = useState(state.color);
+
+  function startEditing(): void {
+    setName(state.name);
+    setCategory(state.category);
+    setColor(state.color);
+    setEditing(true);
+  }
+
+  if (editing) {
+    return (
+      <li className="flex flex-col gap-3 rounded-md border border-border p-3">
+        <div className="flex flex-wrap items-end gap-3">
+          <label
+            htmlFor={`state-name-${state.id}`}
+            className="flex min-w-48 flex-1 flex-col gap-1.5"
+          >
+            <span className="font-medium text-dense text-text">Name</span>
+            <Input
+              id={`state-name-${state.id}`}
+              value={name}
+              maxLength={48}
+              onChange={(event) => setName(event.target.value)}
+            />
+          </label>
+          <div className="flex w-48 flex-col gap-1.5">
+            <span className="font-medium text-dense text-text" id={`state-category-${state.id}`}>
+              Category
+            </span>
+            <Select value={category} onValueChange={(next) => setCategory(next as StateCategory)}>
+              <SelectTrigger aria-labelledby={`state-category-${state.id}`}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STATE_CATEGORIES.map((entry) => (
+                  <SelectItem key={entry} value={entry}>
+                    {STATE_CATEGORY_LABELS[entry]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <p className="text-faint text-2xs">
+          Moving a status to another category re-dates every issue sitting in it, because started,
+          completed and canceled are read from the category.
+        </p>
+        <ColorSwatches legend="Colour" value={color} onChange={setColor} />
+        <div className="flex items-center gap-1">
+          <Button
+            size="sm"
+            variant="primary"
+            disabled={busy}
+            onClick={() => onSave({ name, category, color }).then(() => setEditing(false))}
+          >
+            Save
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => setEditing(false)}>
+            Cancel
+          </Button>
+        </div>
+      </li>
+    );
+  }
+
+  return (
+    <li
+      className={cn('flex items-center gap-3 rounded-md px-2 py-1.5', rowHover)}
+      data-testid="workflow-state-row"
+    >
+      <span
+        className="size-3 shrink-0 rounded-full"
+        style={{ backgroundColor: state.color }}
+        aria-hidden="true"
+      />
+      <span className="min-w-0 flex-1 truncate text-dense text-text">{state.name}</span>
+      <Badge tone="neutral">{STATE_CATEGORY_LABELS[state.category]}</Badge>
+      <Button
+        size="sm"
+        variant="ghost"
+        aria-label={`Move ${state.name} earlier`}
+        disabled={!canManage || busy || first}
+        onClick={() => onMove(-1)}
+      >
+        <ChevronUp className="size-3.5" aria-hidden="true" />
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        aria-label={`Move ${state.name} later`}
+        disabled={!canManage || busy || last}
+        onClick={() => onMove(1)}
+      >
+        <ChevronDown className="size-3.5" aria-hidden="true" />
+      </Button>
+      <Button size="sm" variant="ghost" disabled={!canManage || busy} onClick={startEditing}>
+        Edit
+      </Button>
+      <Button size="sm" variant="ghost" disabled={!canManage || busy} onClick={onDelete}>
+        Delete
+      </Button>
+    </li>
+  );
+}
+
+interface BlockedDelete {
+  readonly stateId: string;
+  readonly message: string;
+}
+
+function reordered(
+  ids: readonly string[],
+  stateId: string,
+  direction: -1 | 1,
+): readonly string[] | null {
+  const at = ids.indexOf(stateId);
+  const to = at + direction;
+  if (at === -1 || to < 0 || to >= ids.length) return null;
+  const next = [...ids];
+  const moving = next[at];
+  const displaced = next[to];
+  if (moving === undefined || displaced === undefined) return null;
+  next[at] = displaced;
+  next[to] = moving;
+  return next;
+}
+
+export function WorkflowPanel({ teams, states, canManage }: WorkflowPanelProps) {
+  const router = useRouter();
+  const [teamId, setTeamId] = useState(teams[0]?.id ?? '');
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState<StateCategory>('unstarted');
+  const [color, setColor] = useState(DEFAULT_STATE_COLOR);
+  const [pending, setPending] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [blocked, setBlocked] = useState<BlockedDelete | null>(null);
+  const [moveTo, setMoveTo] = useState('');
+
+  const ordered = useMemo(
+    () =>
+      states
+        .filter((state) => state.teamId === teamId)
+        .slice()
+        .sort((left, right) => left.position - right.position),
+    [states, teamId],
+  );
+
+  async function run(id: string | null, action: () => Promise<unknown>): Promise<void> {
+    setBusyId(id);
+    setError(null);
+    try {
+      await action();
+      router.refresh();
+    } catch (caught) {
+      setError(messageOf(caught));
+      throw caught;
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  function guarded(id: string | null, action: () => Promise<unknown>): Promise<void> {
+    return run(id, action).catch(() => undefined);
+  }
+
+  async function onCreate(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setPending(true);
+    setError(null);
+    try {
+      await apiRequest('/api/workflow-states', {
+        method: 'POST',
+        body: { teamId, name, category, color },
+      });
+      setName('');
+      router.refresh();
+    } catch (caught) {
+      setError(messageOf(caught));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  function onMove(stateId: string, direction: -1 | 1): Promise<void> {
+    const next = reordered(
+      ordered.map((state) => state.id),
+      stateId,
+      direction,
+    );
+    if (next === null) return Promise.resolve();
+    return guarded(stateId, () =>
+      apiRequest('/api/workflow-states/reorder', {
+        method: 'POST',
+        body: { teamId, stateIds: next },
+      }),
+    );
+  }
+
+  async function onDelete(stateId: string): Promise<void> {
+    setBusyId(stateId);
+    setError(null);
+    setBlocked(null);
+    try {
+      await apiRequest(`/api/workflow-states/${stateId}`, { method: 'DELETE' });
+      router.refresh();
+    } catch (caught) {
+      const others = ordered.filter((state) => state.id !== stateId);
+      if (caught instanceof ApiRequestError && caught.is('conflict') && others.length > 0) {
+        setBlocked({ stateId, message: caught.message });
+        setMoveTo(others[0]?.id ?? '');
+      } else {
+        setError(messageOf(caught));
+      }
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  const blockedState = ordered.find((state) => state.id === blocked?.stateId) ?? null;
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex w-64 max-w-full flex-col gap-1.5">
+        <span className="font-medium text-dense text-text" id="workflow-team">
+          Team
+        </span>
+        <Select value={teamId} onValueChange={setTeamId}>
+          <SelectTrigger aria-labelledby="workflow-team">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {teams.map((team) => (
+              <SelectItem key={team.id} value={team.id}>
+                {team.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <form
+        onSubmit={onCreate}
+        className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4"
+      >
+        <div className="flex flex-wrap items-end gap-3">
+          <label htmlFor="new-state-name" className="flex min-w-48 flex-1 flex-col gap-1.5">
+            <span className="font-medium text-dense text-text">Status name</span>
+            <Input
+              id="new-state-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              required
+              maxLength={48}
+              placeholder="Blocked"
+              disabled={!canManage || pending}
+              name="stateName"
+            />
+          </label>
+          <div className="flex w-48 flex-col gap-1.5">
+            <span className="font-medium text-dense text-text" id="new-state-category">
+              Category
+            </span>
+            <Select
+              value={category}
+              onValueChange={(next) => setCategory(next as StateCategory)}
+              disabled={!canManage || pending}
+            >
+              <SelectTrigger aria-labelledby="new-state-category">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STATE_CATEGORIES.map((entry) => (
+                  <SelectItem key={entry} value={entry}>
+                    {STATE_CATEGORY_LABELS[entry]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button type="submit" variant="primary" disabled={!canManage || pending || teamId === ''}>
+            {pending ? 'Adding' : 'Add status'}
+          </Button>
+        </div>
+        <ColorSwatches
+          legend="Colour"
+          value={color}
+          onChange={setColor}
+          disabled={!canManage || pending}
+        />
+      </form>
+
+      {error === null ? null : (
+        <p role="alert" className="text-danger text-xs">
+          {error}
+        </p>
+      )}
+
+      {blocked === null || blockedState === null ? null : (
+        <div
+          role="alert"
+          className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4"
+        >
+          <p className="text-dense text-text">{blocked.message}</p>
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="flex w-56 flex-col gap-1.5">
+              <span className="font-medium text-dense text-text" id="move-issues-to">
+                Move its issues to
+              </span>
+              <Select value={moveTo} onValueChange={setMoveTo}>
+                <SelectTrigger aria-labelledby="move-issues-to">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ordered
+                    .filter((state) => state.id !== blocked.stateId)
+                    .map((state) => (
+                      <SelectItem key={state.id} value={state.id}>
+                        {state.name}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              variant="primary"
+              disabled={!canManage || moveTo === ''}
+              onClick={() => {
+                setBlocked(null);
+                return guarded(blocked.stateId, () =>
+                  apiRequest(
+                    `/api/workflow-states/${blocked.stateId}?moveToStateId=${encodeURIComponent(moveTo)}`,
+                    { method: 'DELETE' },
+                  ),
+                );
+              }}
+            >
+              Move and delete
+            </Button>
+            <Button variant="ghost" onClick={() => setBlocked(null)}>
+              Keep it
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {ordered.length === 0 ? (
+        <p className="text-muted text-xs">That team has no statuses yet.</p>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {ordered.map((state, index) => (
+            <StateRow
+              key={state.id}
+              state={state}
+              canManage={canManage}
+              busy={busyId === state.id}
+              first={index === 0}
+              last={index === ordered.length - 1}
+              onMove={(direction) => onMove(state.id, direction)}
+              onSave={(patch) =>
+                run(state.id, () =>
+                  apiRequest(`/api/workflow-states/${state.id}`, { method: 'PATCH', body: patch }),
+                )
+              }
+              onDelete={() => onDelete(state.id)}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/api/bootstrap.ts
+++ b/apps/web/src/lib/api/bootstrap.ts
@@ -3,6 +3,7 @@ import {
   listMembers,
   listProjectsForTeams,
   listTeams,
+  listWorkflowStatesForTeams,
   projectTeamLinks,
 } from '@orbit/core';
 import { and, asc, db, eq, inArray, schema, sql } from '@orbit/db';
@@ -15,25 +16,16 @@ export interface BootstrapQuery {
   readonly team?: string | undefined;
 }
 
-async function listWorkflowStatesForTeams(principal: Principal, teamIds: readonly string[]) {
-  if (teamIds.length === 0) return [];
-  return await db
-    .select({
-      id: schema.workflowState.id,
-      teamId: schema.workflowState.teamId,
-      name: schema.workflowState.name,
-      category: schema.workflowState.category,
-      color: schema.workflowState.color,
-      position: schema.workflowState.position,
-    })
-    .from(schema.workflowState)
-    .where(
-      and(
-        eq(schema.workflowState.organizationId, principal.organizationId),
-        inArray(schema.workflowState.teamId, [...teamIds]),
-      ),
-    )
-    .orderBy(asc(schema.workflowState.position));
+async function boardColumnsForTeams(principal: Principal, teamIds: readonly string[]) {
+  const states = await listWorkflowStatesForTeams(principal, teamIds);
+  return states.map((state) => ({
+    id: state.id,
+    teamId: state.teamId,
+    name: state.name,
+    category: state.category,
+    color: state.color,
+    position: state.position,
+  }));
 }
 
 async function listRecentCyclesForTeams(principal: Principal, teamIds: readonly string[]) {
@@ -97,7 +89,7 @@ export async function bootstrapPayload(principal: Principal, query: BootstrapQue
   const teamIds = teams.map((team) => team.id);
 
   const [states, cycles, labels, members, projects, links] = await Promise.all([
-    listWorkflowStatesForTeams(principal, teamIds),
+    boardColumnsForTeams(principal, teamIds),
     listRecentCyclesForTeams(principal, teamIds),
     listLabels(principal),
     listMembers(principal),

--- a/apps/web/src/lib/api/handler.ts
+++ b/apps/web/src/lib/api/handler.ts
@@ -121,7 +121,9 @@ export async function cachedJson(
 }
 
 export async function readJson(request: Request): Promise<unknown> {
-  const raw = await request.text().catch(() => '');
+  const raw = await request.text().catch(() => {
+    throw validationFailed('That request body could not be read.');
+  });
   if (raw.trim() === '') return {};
   try {
     return JSON.parse(raw) as unknown;

--- a/apps/web/src/lib/api/handler.ts
+++ b/apps/web/src/lib/api/handler.ts
@@ -1,5 +1,11 @@
 import { publishDeltas } from '@orbit/core';
-import { internal, isDomainError, notFound, unauthorized } from '@orbit/shared/errors';
+import {
+  internal,
+  isDomainError,
+  notFound,
+  unauthorized,
+  validationFailed,
+} from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
 import { ORIGIN_CLIENT_ID_HEADER, originClientIdSchema } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
@@ -115,10 +121,12 @@ export async function cachedJson(
 }
 
 export async function readJson(request: Request): Promise<unknown> {
+  const raw = await request.text().catch(() => '');
+  if (raw.trim() === '') return {};
   try {
-    return await request.json();
+    return JSON.parse(raw) as unknown;
   } catch {
-    return {};
+    throw validationFailed('That request body is not valid JSON.');
   }
 }
 

--- a/apps/web/src/lib/interaction.ts
+++ b/apps/web/src/lib/interaction.ts
@@ -9,3 +9,6 @@ export const cardHover =
 
 export const tabHover =
   'transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)] hover:text-text';
+
+export const swatchLift =
+  'transition-transform duration-[var(--duration-instant)] ease-[var(--ease-standard)] not-disabled:hover:scale-110 motion-reduce:transition-none motion-reduce:hover:scale-100';

--- a/apps/web/tests/app/api/issues/delete-issue.test.ts
+++ b/apps/web/tests/app/api/issues/delete-issue.test.ts
@@ -12,6 +12,9 @@ import { z } from 'zod';
 
 const published: SyncAction[][] = [];
 const core = await import('@orbit/core');
+const realSession = await import('@/lib/auth/session.ts');
+const realPrincipal = await import('@/lib/auth/principal.ts');
+
 mock.module('@orbit/core', () => ({
   ...core,
   publishDeltas: (actions: readonly SyncAction[]) => {
@@ -55,6 +58,8 @@ const { DELETE } = await import('@/app/api/issues/[id]/route.ts');
 
 afterAll(() => {
   mock.module('@orbit/core', () => core);
+  mock.module('@/lib/auth/session.ts', () => realSession);
+  mock.module('@/lib/auth/principal.ts', () => realPrincipal);
 });
 
 const deletedSchema = z.object({

--- a/apps/web/tests/app/api/issues/delete-issue.test.ts
+++ b/apps/web/tests/app/api/issues/delete-issue.test.ts
@@ -12,9 +12,6 @@ import { z } from 'zod';
 
 const published: SyncAction[][] = [];
 const core = await import('@orbit/core');
-const realSession = await import('@/lib/auth/session.ts');
-const realPrincipal = await import('@/lib/auth/principal.ts');
-
 mock.module('@orbit/core', () => ({
   ...core,
   publishDeltas: (actions: readonly SyncAction[]) => {
@@ -58,8 +55,6 @@ const { DELETE } = await import('@/app/api/issues/[id]/route.ts');
 
 afterAll(() => {
   mock.module('@orbit/core', () => core);
-  mock.module('@/lib/auth/session.ts', () => realSession);
-  mock.module('@/lib/auth/principal.ts', () => realPrincipal);
 });
 
 const deletedSchema = z.object({

--- a/apps/web/tests/app/api/labels/route.test.ts
+++ b/apps/web/tests/app/api/labels/route.test.ts
@@ -12,7 +12,6 @@ import { scopes } from '@orbit/shared/events';
 import { z } from 'zod';
 
 const coreModule = await import('@orbit/core');
-const sessionModule = await import('@/lib/auth/session.ts');
 const published: SyncAction[] = [];
 
 mock.module('@orbit/core', () => ({
@@ -54,7 +53,6 @@ const {
 
 afterAll(() => {
   mock.module('@orbit/core', () => coreModule);
-  mock.module('@/lib/auth/session.ts', () => sessionModule);
 });
 
 const labelSchema = z.object({

--- a/apps/web/tests/app/api/labels/route.test.ts
+++ b/apps/web/tests/app/api/labels/route.test.ts
@@ -10,6 +10,7 @@ import { db, eq, schema } from '@orbit/db';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import { z } from 'zod';
+import { mockSession } from '../../../../tests-support.ts';
 
 const coreModule = await import('@orbit/core');
 const published: SyncAction[] = [];
@@ -31,17 +32,9 @@ let caller: Caller = { userId: '', organizationId: '' };
 
 mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
 
-mock.module('@/lib/auth/session.ts', () => ({
-  getSession: () =>
-    Promise.resolve({
-      user: { id: caller.userId, name: 'Somebody', email: 'somebody@orbit.test' },
-      session: { activeOrganizationId: caller.organizationId },
-    }),
-  requireSession: () =>
-    Promise.resolve({
-      user: { id: caller.userId, name: 'Somebody', email: 'somebody@orbit.test' },
-      session: { activeOrganizationId: caller.organizationId },
-    }),
+mockSession(() => ({
+  user: { id: caller.userId, name: 'Somebody', email: 'somebody@orbit.test' },
+  session: { activeOrganizationId: caller.organizationId },
 }));
 
 const { GET, POST } = await import('../../../../src/app/api/labels/route.ts');

--- a/apps/web/tests/app/api/labels/route.test.ts
+++ b/apps/web/tests/app/api/labels/route.test.ts
@@ -231,6 +231,44 @@ describe('GET, PATCH and DELETE /api/labels/[id]', () => {
     );
   });
 
+  it('strips the narrowed label off the issues of every other team, over the wire', async () => {
+    const created = await coreModule.createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+    const outside = await coreModule.createIssue(nova.admin, {
+      teamId: nova.teamId,
+      title: 'Platform work',
+      labelIds: [created.label.id],
+    });
+    published.length = 0;
+
+    const response = await PATCH(
+      request(`/api/labels/${created.label.id}`, 'PATCH', { teamId: designTeamId }),
+      params(created.label.id),
+    );
+
+    expect(response.status).toBe(200);
+    const links = await db
+      .select()
+      .from(schema.issueLabel)
+      .where(eq(schema.issueLabel.issueId, outside.issue.id));
+    expect(links).toHaveLength(0);
+    const issueAction = published.find((action) => action.model === 'issue');
+    expect(issueAction?.modelId).toBe(outside.issue.id);
+    expect(issueAction?.scopes).toContain(scopes.team(nova.teamId));
+  });
+
+  it('publishes nothing when the patch asks for the values already stored', async () => {
+    const created = await coreModule.createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+    published.length = 0;
+
+    const response = await PATCH(
+      request(`/api/labels/${created.label.id}`, 'PATCH', { name: 'Flaky', color: '#EF4444' }),
+      params(created.label.id),
+    );
+
+    expect(response.status).toBe(200);
+    expect(published).toHaveLength(0);
+  });
+
   it('turns away an id no label could carry before the service is asked', async () => {
     const response = await DELETE(request('/api/labels/x', 'DELETE'), params('l'.repeat(65)));
 

--- a/apps/web/tests/app/api/labels/route.test.ts
+++ b/apps/web/tests/app/api/labels/route.test.ts
@@ -269,6 +269,40 @@ describe('GET, PATCH and DELETE /api/labels/[id]', () => {
     expect(published).toHaveLength(0);
   });
 
+  it('refuses a body that is not json rather than calling it an empty patch', async () => {
+    const created = await coreModule.createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+    published.length = 0;
+
+    const response = await PATCH(
+      new Request(`http://localhost:3000/api/labels/${created.label.id}`, {
+        method: 'PATCH',
+        body: '{"name": "Broken"',
+      }),
+      params(created.label.id),
+    );
+
+    expect(response.status).toBe(422);
+    expect(published).toHaveLength(0);
+    const [survivor] = await db
+      .select()
+      .from(schema.label)
+      .where(eq(schema.label.id, created.label.id));
+    expect(survivor?.name).toBe('Flaky');
+  });
+
+  it('still takes a patch that sends no body at all as a patch that changes nothing', async () => {
+    const created = await coreModule.createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+    published.length = 0;
+
+    const response = await PATCH(
+      new Request(`http://localhost:3000/api/labels/${created.label.id}`, { method: 'PATCH' }),
+      params(created.label.id),
+    );
+
+    expect(response.status).toBe(200);
+    expect(published).toHaveLength(0);
+  });
+
   it('turns away an id no label could carry before the service is asked', async () => {
     const response = await DELETE(request('/api/labels/x', 'DELETE'), params('l'.repeat(65)));
 

--- a/apps/web/tests/app/api/labels/route.test.ts
+++ b/apps/web/tests/app/api/labels/route.test.ts
@@ -12,6 +12,7 @@ import { scopes } from '@orbit/shared/events';
 import { z } from 'zod';
 
 const coreModule = await import('@orbit/core');
+const sessionModule = await import('@/lib/auth/session.ts');
 const published: SyncAction[] = [];
 
 mock.module('@orbit/core', () => ({
@@ -53,6 +54,7 @@ const {
 
 afterAll(() => {
   mock.module('@orbit/core', () => coreModule);
+  mock.module('@/lib/auth/session.ts', () => sessionModule);
 });
 
 const labelSchema = z.object({

--- a/apps/web/tests/app/api/labels/route.test.ts
+++ b/apps/web/tests/app/api/labels/route.test.ts
@@ -1,0 +1,240 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { createTeam } from '@orbit/core';
+import {
+  addMember,
+  createWorkspace,
+  resetDatabase,
+  type Workspace,
+} from '@orbit/core/test-support';
+import { db, eq, schema } from '@orbit/db';
+import type { SyncAction } from '@orbit/shared/events';
+import { scopes } from '@orbit/shared/events';
+import { z } from 'zod';
+
+const coreModule = await import('@orbit/core');
+const published: SyncAction[] = [];
+
+mock.module('@orbit/core', () => ({
+  ...coreModule,
+  publishDeltas: (actions: SyncAction[]) => {
+    published.push(...actions);
+    return Promise.resolve();
+  },
+}));
+
+interface Caller {
+  readonly userId: string;
+  readonly organizationId: string;
+}
+
+let caller: Caller = { userId: '', organizationId: '' };
+
+mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
+
+mock.module('@/lib/auth/session.ts', () => ({
+  getSession: () =>
+    Promise.resolve({
+      user: { id: caller.userId, name: 'Somebody', email: 'somebody@orbit.test' },
+      session: { activeOrganizationId: caller.organizationId },
+    }),
+  requireSession: () =>
+    Promise.resolve({
+      user: { id: caller.userId, name: 'Somebody', email: 'somebody@orbit.test' },
+      session: { activeOrganizationId: caller.organizationId },
+    }),
+}));
+
+const { GET, POST } = await import('../../../../src/app/api/labels/route.ts');
+const {
+  GET: READ_ONE,
+  PATCH,
+  DELETE,
+} = await import('../../../../src/app/api/labels/[id]/route.ts');
+
+afterAll(() => {
+  mock.module('@orbit/core', () => coreModule);
+});
+
+const labelSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  color: z.string(),
+  teamId: z.string().nullable(),
+});
+
+let nova: Workspace;
+let orion: Workspace;
+let designTeamId: string;
+let orionLabelId: string;
+let designLabelId: string;
+let contributorId: string;
+let outsiderId: string;
+
+function acting(workspace: Workspace, userId: string): void {
+  caller = { userId, organizationId: workspace.organizationId };
+}
+
+function request(path: string, method: string, body?: unknown): Request {
+  return new Request(`http://localhost:3000${path}`, {
+    method,
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+function params(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(async () => {
+  await resetDatabase();
+  published.length = 0;
+  nova = await createWorkspace('Nova');
+  orion = await createWorkspace('Orion');
+  const design = await createTeam(nova.admin, { name: 'Design', key: 'DSGN' });
+  designTeamId = design.team.id;
+  designLabelId = (
+    await coreModule.createLabel(nova.admin, {
+      name: 'Pixel polish',
+      color: '#EC4899',
+      teamId: designTeamId,
+    })
+  ).label.id;
+  orionLabelId = (await coreModule.createLabel(orion.admin, { name: 'Theirs', color: '#22C55E' }))
+    .label.id;
+  contributorId = (await addMember(nova, 'contributor', { teamIds: [nova.teamId] })).principal
+    .userId;
+  outsiderId = (await addMember(nova, 'member', { teamIds: [nova.teamId] })).principal.userId;
+  acting(nova, nova.admin.userId);
+});
+
+describe('POST /api/labels', () => {
+  it('creates a workspace label and fans it out to the whole workspace', async () => {
+    const response = await POST(
+      request('/api/labels', 'POST', { name: 'Flaky', color: '#EF4444' }),
+    );
+    const payload = z.object({ label: labelSchema }).parse(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(payload.label.teamId).toBeNull();
+    expect(published.at(-1)?.scopes).toEqual([scopes.organization(nova.organizationId)]);
+  });
+
+  it('refuses a contributor, who has no label:manage, and writes nothing', async () => {
+    acting(nova, contributorId);
+
+    const response = await POST(request('/api/labels', 'POST', { name: 'Nope', color: '#EF4444' }));
+
+    expect(response.status).toBe(403);
+    expect(await db.select().from(schema.label).where(eq(schema.label.name, 'Nope'))).toHaveLength(
+      0,
+    );
+    expect(published).toHaveLength(0);
+  });
+
+  it('refuses a team that belongs to another workspace', async () => {
+    const response = await POST(
+      request('/api/labels', 'POST', {
+        name: 'Stolen',
+        color: '#EF4444',
+        teamId: orion.teamId,
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(
+      await db.select().from(schema.label).where(eq(schema.label.name, 'Stolen')),
+    ).toHaveLength(0);
+  });
+
+  it('reports a body the validator rejects as a 422', async () => {
+    const response = await POST(request('/api/labels', 'POST', { name: '', color: 'purple' }));
+
+    expect(response.status).toBe(422);
+    expect(published).toHaveLength(0);
+  });
+});
+
+describe('GET /api/labels', () => {
+  it('never lists a label that belongs to another workspace', async () => {
+    const response = await GET(request('/api/labels', 'GET'));
+    const payload = z.object({ labels: z.array(labelSchema) }).parse(await response.json());
+
+    expect(payload.labels.map((label) => label.id)).not.toContain(orionLabelId);
+    expect(payload.labels.map((label) => label.id)).toContain(designLabelId);
+  });
+
+  it('hides a team label from a member who is not on that team', async () => {
+    acting(nova, outsiderId);
+
+    const response = await GET(request('/api/labels', 'GET'));
+    const payload = z.object({ labels: z.array(labelSchema) }).parse(await response.json());
+
+    expect(payload.labels.map((label) => label.id)).not.toContain(designLabelId);
+  });
+});
+
+describe('GET, PATCH and DELETE /api/labels/[id]', () => {
+  it('answers 404 for a label in another workspace and leaves it untouched', async () => {
+    const read = await READ_ONE(
+      request(`/api/labels/${orionLabelId}`, 'GET'),
+      params(orionLabelId),
+    );
+    const patched = await PATCH(
+      request(`/api/labels/${orionLabelId}`, 'PATCH', { name: 'Stolen' }),
+      params(orionLabelId),
+    );
+    const deleted = await DELETE(
+      request(`/api/labels/${orionLabelId}`, 'DELETE'),
+      params(orionLabelId),
+    );
+
+    expect([read.status, patched.status, deleted.status]).toEqual([404, 404, 404]);
+    const [survivor] = await db
+      .select()
+      .from(schema.label)
+      .where(eq(schema.label.id, orionLabelId));
+    expect(survivor?.name).toBe('Theirs');
+  });
+
+  it('answers 404 for a team label the caller cannot reach', async () => {
+    acting(nova, outsiderId);
+
+    const response = await PATCH(
+      request(`/api/labels/${designLabelId}`, 'PATCH', { name: 'Mine now' }),
+      params(designLabelId),
+    );
+
+    expect(response.status).toBe(404);
+    const [survivor] = await db
+      .select()
+      .from(schema.label)
+      .where(eq(schema.label.id, designLabelId));
+    expect(survivor?.name).toBe('Pixel polish');
+  });
+
+  it('narrows a workspace label to a team and reaches both audiences', async () => {
+    const created = await coreModule.createLabel(nova.admin, {
+      name: 'Flaky',
+      color: '#EF4444',
+    });
+    published.length = 0;
+
+    const response = await PATCH(
+      request(`/api/labels/${created.label.id}`, 'PATCH', { teamId: designTeamId }),
+      params(created.label.id),
+    );
+    const payload = z.object({ label: labelSchema }).parse(await response.json());
+
+    expect(payload.label.teamId).toBe(designTeamId);
+    expect(published.at(-1)?.scopes.slice().sort()).toEqual(
+      [scopes.organization(nova.organizationId), scopes.team(designTeamId)].sort(),
+    );
+  });
+
+  it('turns away an id no label could carry before the service is asked', async () => {
+    const response = await DELETE(request('/api/labels/x', 'DELETE'), params('l'.repeat(65)));
+
+    expect(response.status).toBe(404);
+    expect(published).toHaveLength(0);
+  });
+});

--- a/apps/web/tests/app/api/workflow-states/route.test.ts
+++ b/apps/web/tests/app/api/workflow-states/route.test.ts
@@ -1,0 +1,374 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { createTeam } from '@orbit/core';
+import {
+  addMember,
+  createWorkspace,
+  resetDatabase,
+  stateNamed,
+  type Workspace,
+} from '@orbit/core/test-support';
+import { asc, db, eq, schema } from '@orbit/db';
+import type { SyncAction } from '@orbit/shared/events';
+import { scopes } from '@orbit/shared/events';
+import { z } from 'zod';
+
+const coreModule = await import('@orbit/core');
+const published: SyncAction[] = [];
+
+mock.module('@orbit/core', () => ({
+  ...coreModule,
+  publishDeltas: (actions: SyncAction[]) => {
+    published.push(...actions);
+    return Promise.resolve();
+  },
+}));
+
+interface Caller {
+  readonly userId: string;
+  readonly organizationId: string;
+}
+
+let caller: Caller = { userId: '', organizationId: '' };
+
+const session = () =>
+  Promise.resolve({
+    user: { id: caller.userId, name: 'Somebody', email: 'somebody@orbit.test' },
+    session: { activeOrganizationId: caller.organizationId },
+  });
+
+mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
+
+mock.module('@/lib/auth/session.ts', () => ({
+  getSession: session,
+  requireSession: session,
+}));
+
+const { GET, POST } = await import('../../../../src/app/api/workflow-states/route.ts');
+const { PATCH, DELETE } = await import('../../../../src/app/api/workflow-states/[id]/route.ts');
+const { POST: REORDER } = await import('../../../../src/app/api/workflow-states/reorder/route.ts');
+
+afterAll(() => {
+  mock.module('@orbit/core', () => coreModule);
+});
+
+const stateSchema = z.object({
+  id: z.string(),
+  teamId: z.string(),
+  name: z.string(),
+  category: z.string(),
+  position: z.number(),
+});
+
+let nova: Workspace;
+let vega: Workspace;
+let designTeamId: string;
+let contributorId: string;
+let outsiderId: string;
+
+function acting(workspace: Workspace, userId: string): void {
+  caller = { userId, organizationId: workspace.organizationId };
+}
+
+function request(path: string, method: string, body?: unknown): Request {
+  return new Request(`http://localhost:3000${path}`, {
+    method,
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+function params(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) };
+}
+
+async function statesOf(teamId: string) {
+  return await db
+    .select()
+    .from(schema.workflowState)
+    .where(eq(schema.workflowState.teamId, teamId))
+    .orderBy(asc(schema.workflowState.position));
+}
+
+beforeEach(async () => {
+  await resetDatabase();
+  published.length = 0;
+  nova = await createWorkspace('Nova');
+  vega = await createWorkspace('Vega');
+  designTeamId = (await createTeam(nova.admin, { name: 'Design', key: 'DSGN' })).team.id;
+  contributorId = (await addMember(nova, 'contributor', { teamIds: [nova.teamId] })).principal
+    .userId;
+  outsiderId = (await addMember(nova, 'member', { teamIds: [nova.teamId] })).principal.userId;
+  acting(nova, nova.admin.userId);
+});
+
+describe('POST /api/workflow-states', () => {
+  it('appends the status at the end and fans it out to the team only', async () => {
+    const response = await POST(
+      request('/api/workflow-states', 'POST', {
+        teamId: nova.teamId,
+        name: 'Blocked',
+        category: 'started',
+        color: '#EF4444',
+      }),
+    );
+    const payload = z.object({ state: stateSchema }).parse(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(payload.state.position).toBe(7);
+    expect(published.at(-1)?.scopes).toEqual([scopes.team(nova.teamId)]);
+  });
+
+  it('ignores a position the caller sends, because the server owns the order', async () => {
+    const response = await POST(
+      request('/api/workflow-states', 'POST', {
+        teamId: nova.teamId,
+        name: 'Blocked',
+        category: 'started',
+        color: '#EF4444',
+        position: 0,
+      }),
+    );
+    const payload = z.object({ state: stateSchema }).parse(await response.json());
+
+    expect(payload.state.position).toBe(7);
+    expect((await statesOf(nova.teamId)).map((state) => state.position)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7,
+    ]);
+  });
+
+  it('refuses a contributor and writes nothing', async () => {
+    acting(nova, contributorId);
+
+    const response = await POST(
+      request('/api/workflow-states', 'POST', {
+        teamId: nova.teamId,
+        name: 'Nope',
+        category: 'started',
+        color: '#EF4444',
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await statesOf(nova.teamId)).toHaveLength(7);
+    expect(published).toHaveLength(0);
+  });
+
+  it('refuses a team in another workspace', async () => {
+    const response = await POST(
+      request('/api/workflow-states', 'POST', {
+        teamId: vega.teamId,
+        name: 'Smuggled',
+        category: 'started',
+        color: '#EF4444',
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await statesOf(vega.teamId)).toHaveLength(7);
+  });
+});
+
+describe('GET /api/workflow-states', () => {
+  it('refuses a team in another workspace and a team the caller has not joined', async () => {
+    const foreign = await GET(request(`/api/workflow-states?teamId=${vega.teamId}`, 'GET'));
+    acting(nova, outsiderId);
+    const unjoined = await GET(request(`/api/workflow-states?teamId=${designTeamId}`, 'GET'));
+
+    expect(foreign.status).toBe(404);
+    expect(unjoined.status).toBe(403);
+  });
+
+  it('needs a team, so a bare call is a 422 rather than every team at once', async () => {
+    const response = await GET(request('/api/workflow-states', 'GET'));
+
+    expect(response.status).toBe(422);
+  });
+});
+
+describe('PATCH /api/workflow-states/[id]', () => {
+  it('refuses a status in another workspace and leaves the name alone', async () => {
+    const theirs = (await statesOf(vega.teamId))[0];
+    if (theirs === undefined) throw new Error('the other workspace had no states');
+
+    const response = await PATCH(
+      request(`/api/workflow-states/${theirs.id}`, 'PATCH', { name: 'Stolen' }),
+      params(theirs.id),
+    );
+
+    expect(response.status).toBe(404);
+    expect((await statesOf(vega.teamId))[0]?.name).toBe(theirs.name);
+  });
+
+  it('refuses a member who is not on that team', async () => {
+    acting(nova, outsiderId);
+    const theirs = (await statesOf(designTeamId))[0];
+    if (theirs === undefined) throw new Error('the design team had no states');
+
+    const response = await PATCH(
+      request(`/api/workflow-states/${theirs.id}`, 'PATCH', { name: 'Mine now' }),
+      params(theirs.id),
+    );
+
+    expect(response.status).toBe(403);
+    expect((await statesOf(designTeamId))[0]?.name).toBe(theirs.name);
+  });
+
+  it('refuses a category the enum does not know', async () => {
+    const todo = stateNamed(nova, 'Todo');
+
+    const response = await PATCH(
+      request(`/api/workflow-states/${todo.id}`, 'PATCH', { category: 'nearly_done' }),
+      params(todo.id),
+    );
+
+    expect(response.status).toBe(422);
+  });
+});
+
+describe('DELETE /api/workflow-states/[id]', () => {
+  it('refuses a status that still holds issues until a replacement is named', async () => {
+    const todo = stateNamed(nova, 'Todo');
+    const created = await coreModule.createIssue(nova.admin, {
+      teamId: nova.teamId,
+      title: 'Parked',
+      stateId: todo.id,
+    });
+
+    const refused = await DELETE(
+      request(`/api/workflow-states/${todo.id}`, 'DELETE'),
+      params(todo.id),
+    );
+
+    expect(refused.status).toBe(409);
+    const [issue] = await db
+      .select()
+      .from(schema.issue)
+      .where(eq(schema.issue.id, created.issue.id));
+    expect(issue?.stateId).toBe(todo.id);
+  });
+
+  it('moves the issues and deletes the status when a replacement is named', async () => {
+    const todo = stateNamed(nova, 'Todo');
+    const done = stateNamed(nova, 'Done');
+    const created = await coreModule.createIssue(nova.admin, {
+      teamId: nova.teamId,
+      title: 'Parked',
+      stateId: todo.id,
+    });
+    published.length = 0;
+
+    const response = await DELETE(
+      request(`/api/workflow-states/${todo.id}?moveToStateId=${done.id}`, 'DELETE'),
+      params(todo.id),
+    );
+
+    expect(response.status).toBe(200);
+    const [issue] = await db
+      .select()
+      .from(schema.issue)
+      .where(eq(schema.issue.id, created.issue.id));
+    expect(issue?.stateId).toBe(done.id);
+    expect(issue?.completedAt).not.toBeNull();
+    expect((await statesOf(nova.teamId)).map((state) => state.id)).not.toContain(todo.id);
+    expect(published.some((action) => action.model === 'issue')).toBe(true);
+  });
+
+  it('refuses a replacement on another team', async () => {
+    const todo = stateNamed(nova, 'Todo');
+    await coreModule.createIssue(nova.admin, {
+      teamId: nova.teamId,
+      title: 'Parked',
+      stateId: todo.id,
+    });
+    const theirs = (await statesOf(designTeamId))[0];
+    if (theirs === undefined) throw new Error('the design team had no states');
+
+    const response = await DELETE(
+      request(`/api/workflow-states/${todo.id}?moveToStateId=${theirs.id}`, 'DELETE'),
+      params(todo.id),
+    );
+
+    expect(response.status).toBe(422);
+    expect((await statesOf(nova.teamId)).map((state) => state.id)).toContain(todo.id);
+  });
+
+  it('refuses a contributor', async () => {
+    acting(nova, contributorId);
+    const triage = stateNamed(nova, 'Triage');
+
+    const response = await DELETE(
+      request(`/api/workflow-states/${triage.id}`, 'DELETE'),
+      params(triage.id),
+    );
+
+    expect(response.status).toBe(403);
+    expect((await statesOf(nova.teamId)).map((state) => state.id)).toContain(triage.id);
+  });
+});
+
+describe('POST /api/workflow-states/reorder', () => {
+  it('refuses a partial order so two columns cannot land on one position', async () => {
+    const before = await statesOf(nova.teamId);
+
+    const response = await REORDER(
+      request('/api/workflow-states/reorder', 'POST', {
+        teamId: nova.teamId,
+        stateIds: before.slice(0, 3).map((state) => state.id),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect((await statesOf(nova.teamId)).map((state) => state.id)).toEqual(
+      before.map((state) => state.id),
+    );
+  });
+
+  it('renumbers the board when the whole order arrives', async () => {
+    const before = await statesOf(nova.teamId);
+    const flipped = before.map((state) => state.id).reverse();
+
+    const response = await REORDER(
+      request('/api/workflow-states/reorder', 'POST', {
+        teamId: nova.teamId,
+        stateIds: flipped,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const after = await statesOf(nova.teamId);
+    expect(after.map((state) => state.id)).toEqual(flipped);
+    expect(after.map((state) => state.position)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+
+  it('refuses a contributor even with a perfectly formed order', async () => {
+    const before = await statesOf(nova.teamId);
+    acting(nova, contributorId);
+
+    const response = await REORDER(
+      request('/api/workflow-states/reorder', 'POST', {
+        teamId: nova.teamId,
+        stateIds: before.map((state) => state.id).reverse(),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect((await statesOf(nova.teamId)).map((state) => state.id)).toEqual(
+      before.map((state) => state.id),
+    );
+  });
+
+  it('refuses a team in another workspace', async () => {
+    const theirs = await statesOf(vega.teamId);
+
+    const response = await REORDER(
+      request('/api/workflow-states/reorder', 'POST', {
+        teamId: vega.teamId,
+        stateIds: theirs.map((state) => state.id).reverse(),
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect((await statesOf(vega.teamId)).map((state) => state.id)).toEqual(
+      theirs.map((state) => state.id),
+    );
+  });
+});

--- a/apps/web/tests/app/api/workflow-states/route.test.ts
+++ b/apps/web/tests/app/api/workflow-states/route.test.ts
@@ -11,6 +11,7 @@ import { asc, db, eq, schema } from '@orbit/db';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import { z } from 'zod';
+import { mockSession } from '../../../../tests-support.ts';
 
 const coreModule = await import('@orbit/core');
 const published: SyncAction[] = [];
@@ -38,10 +39,7 @@ const session = () =>
 
 mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
 
-mock.module('@/lib/auth/session.ts', () => ({
-  getSession: session,
-  requireSession: session,
-}));
+mockSession(session);
 
 const { GET, POST } = await import('../../../../src/app/api/workflow-states/route.ts');
 const { PATCH, DELETE } = await import('../../../../src/app/api/workflow-states/[id]/route.ts');

--- a/apps/web/tests/app/api/workflow-states/route.test.ts
+++ b/apps/web/tests/app/api/workflow-states/route.test.ts
@@ -212,6 +212,23 @@ describe('PATCH /api/workflow-states/[id]', () => {
     expect((await statesOf(designTeamId))[0]?.name).toBe(theirs.name);
   });
 
+  it('publishes nothing when the patch asks for the values already stored', async () => {
+    const todo = stateNamed(nova, 'Todo');
+    published.length = 0;
+
+    const response = await PATCH(
+      request(`/api/workflow-states/${todo.id}`, 'PATCH', {
+        name: todo.name,
+        category: 'unstarted',
+        color: todo.color,
+      }),
+      params(todo.id),
+    );
+
+    expect(response.status).toBe(200);
+    expect(published).toHaveLength(0);
+  });
+
   it('refuses a category the enum does not know', async () => {
     const todo = stateNamed(nova, 'Todo');
 

--- a/apps/web/tests/app/api/workflow-states/route.test.ts
+++ b/apps/web/tests/app/api/workflow-states/route.test.ts
@@ -13,6 +13,7 @@ import { scopes } from '@orbit/shared/events';
 import { z } from 'zod';
 
 const coreModule = await import('@orbit/core');
+const sessionModule = await import('@/lib/auth/session.ts');
 const published: SyncAction[] = [];
 
 mock.module('@orbit/core', () => ({
@@ -49,6 +50,7 @@ const { POST: REORDER } = await import('../../../../src/app/api/workflow-states/
 
 afterAll(() => {
   mock.module('@orbit/core', () => coreModule);
+  mock.module('@/lib/auth/session.ts', () => sessionModule);
 });
 
 const stateSchema = z.object({

--- a/apps/web/tests/app/api/workflow-states/route.test.ts
+++ b/apps/web/tests/app/api/workflow-states/route.test.ts
@@ -13,7 +13,6 @@ import { scopes } from '@orbit/shared/events';
 import { z } from 'zod';
 
 const coreModule = await import('@orbit/core');
-const sessionModule = await import('@/lib/auth/session.ts');
 const published: SyncAction[] = [];
 
 mock.module('@orbit/core', () => ({
@@ -50,7 +49,6 @@ const { POST: REORDER } = await import('../../../../src/app/api/workflow-states/
 
 afterAll(() => {
   mock.module('@orbit/core', () => coreModule);
-  mock.module('@/lib/auth/session.ts', () => sessionModule);
 });
 
 const stateSchema = z.object({

--- a/apps/web/tests/features/settings/labels-panel.test.tsx
+++ b/apps/web/tests/features/settings/labels-panel.test.tsx
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { LabelView, TeamBadge } from '../../../src/features/settings/data.ts';
+import { LabelsPanel } from '../../../src/features/settings/labels-panel.tsx';
+
+const refresh = mock();
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+const TEAMS: TeamBadge[] = [
+  { id: 'team-1', key: 'ENG', name: 'Engineering' },
+  { id: 'team-2', key: 'DSGN', name: 'Design' },
+];
+
+const LABELS: LabelView[] = [
+  { id: 'label-1', name: 'Flaky', color: '#EF4444', teamId: null },
+  { id: 'label-2', name: 'Pixel polish', color: '#EC4899', teamId: 'team-2' },
+];
+
+const realFetch = globalThis.fetch;
+
+interface Sent {
+  readonly url: string;
+  readonly method: string;
+  readonly body: Record<string, unknown>;
+}
+
+let sent: Sent[] = [];
+
+function respondWith(status: number, payload: unknown): void {
+  globalThis.fetch = mock((url: string, init: { method: string; body?: string }) => {
+    sent.push({
+      url,
+      method: init.method,
+      body: init.body === undefined ? {} : (JSON.parse(init.body) as Record<string, unknown>),
+    });
+    return Promise.resolve({
+      ok: status < 400,
+      status,
+      json: () => Promise.resolve(payload),
+    });
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  refresh.mockClear();
+  sent = [];
+  respondWith(200, {});
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('LabelsPanel', () => {
+  it('creates a workspace label with the name and the colour the form holds', async () => {
+    const user = userEvent.setup();
+    render(<LabelsPanel labels={[]} teams={TEAMS} canManage />);
+
+    await user.type(screen.getByLabelText('Label name'), 'Regression');
+    await user.click(screen.getByRole('button', { name: '#22C55E' }));
+    await user.click(screen.getByRole('button', { name: 'Create label' }));
+
+    await waitFor(() => {
+      expect(sent).toHaveLength(1);
+    });
+    expect(sent[0]?.url).toBe('/api/labels');
+    expect(sent[0]?.method).toBe('POST');
+    expect(sent[0]?.body).toEqual({ name: 'Regression', color: '#22C55E', teamId: null });
+    await waitFor(() => {
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('patches the label the row is for, and nothing else', async () => {
+    const user = userEvent.setup();
+    render(<LabelsPanel labels={LABELS} teams={TEAMS} canManage />);
+
+    const rows = screen.getAllByTestId('label-row');
+    const second = rows[1];
+    if (second === undefined) throw new Error('the second label row is missing');
+    await user.click(within(second).getByRole('button', { name: 'Edit' }));
+
+    const name = screen.getByLabelText('Name');
+    await user.clear(name);
+    await user.type(name, 'Polish');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(sent).toHaveLength(1);
+    });
+    expect(sent[0]?.url).toBe('/api/labels/label-2');
+    expect(sent[0]?.method).toBe('PATCH');
+    expect(sent[0]?.body).toEqual({ name: 'Polish', color: '#EC4899', teamId: 'team-2' });
+  });
+
+  it('deletes the label the row is for', async () => {
+    const user = userEvent.setup();
+    render(<LabelsPanel labels={LABELS} teams={TEAMS} canManage />);
+
+    const rows = screen.getAllByTestId('label-row');
+    const first = rows[0];
+    if (first === undefined) throw new Error('the first label row is missing');
+    await user.click(within(first).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(sent).toHaveLength(1);
+    });
+    expect(sent[0]?.url).toBe('/api/labels/label-1');
+    expect(sent[0]?.method).toBe('DELETE');
+  });
+
+  it('shows what the server refused rather than pretending it worked', async () => {
+    respondWith(409, {
+      error: { code: 'conflict', message: 'A label with that name already lives here.' },
+    });
+    const user = userEvent.setup();
+    render(<LabelsPanel labels={[]} teams={TEAMS} canManage />);
+
+    await user.type(screen.getByLabelText('Label name'), 'Flaky');
+    await user.click(screen.getByRole('button', { name: 'Create label' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'A label with that name already lives here.',
+    );
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('names the team a label is pinned to, and calls the workspace one workspace', () => {
+    render(<LabelsPanel labels={LABELS} teams={TEAMS} canManage />);
+
+    expect(screen.getByText('Workspace')).toBeInTheDocument();
+    expect(screen.getByText('DSGN')).toBeInTheDocument();
+  });
+
+  it('disables every write when the viewer cannot manage labels', () => {
+    render(<LabelsPanel labels={LABELS} teams={TEAMS} canManage={false} />);
+
+    expect(screen.getByLabelText('Label name')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Create label' })).toBeDisabled();
+    for (const button of screen.getAllByRole('button', { name: 'Delete' })) {
+      expect(button).toBeDisabled();
+    }
+  });
+});

--- a/apps/web/tests/features/settings/workflow-panel.test.tsx
+++ b/apps/web/tests/features/settings/workflow-panel.test.tsx
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { TeamBadge, WorkflowStateView } from '../../../src/features/settings/data.ts';
+import { WorkflowPanel } from '../../../src/features/settings/workflow-panel.tsx';
+
+const refresh = mock();
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+const TEAMS: TeamBadge[] = [{ id: 'team-1', key: 'ENG', name: 'Engineering' }];
+
+const STATES: WorkflowStateView[] = [
+  { id: 'state-1', teamId: 'team-1', name: 'Todo', category: 'unstarted', color: '#6B7280' },
+  { id: 'state-2', teamId: 'team-1', name: 'In Progress', category: 'started', color: '#F2C94C' },
+  { id: 'state-3', teamId: 'team-1', name: 'Done', category: 'completed', color: '#22C55E' },
+].map((state, position) => ({ ...state, position }) as WorkflowStateView);
+
+const OTHER_TEAM_STATE: WorkflowStateView = {
+  id: 'state-9',
+  teamId: 'team-2',
+  name: 'Somebody else',
+  category: 'unstarted',
+  color: '#6B7280',
+  position: 0,
+};
+
+const realFetch = globalThis.fetch;
+
+interface Sent {
+  readonly url: string;
+  readonly method: string;
+  readonly body: Record<string, unknown>;
+}
+
+let sent: Sent[] = [];
+let responses: { status: number; payload: unknown }[] = [];
+
+function installFetch(): void {
+  globalThis.fetch = mock((url: string, init: { method: string; body?: string }) => {
+    sent.push({
+      url,
+      method: init.method,
+      body: init.body === undefined ? {} : (JSON.parse(init.body) as Record<string, unknown>),
+    });
+    const next = responses.shift() ?? { status: 200, payload: {} };
+    return Promise.resolve({
+      ok: next.status < 400,
+      status: next.status,
+      json: () => Promise.resolve(next.payload),
+    });
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  refresh.mockClear();
+  sent = [];
+  responses = [];
+  installFetch();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function rowFor(name: string): HTMLElement {
+  const row = screen
+    .getAllByTestId('workflow-state-row')
+    .find((candidate) => within(candidate).queryByText(name) !== null);
+  if (row === undefined) throw new Error(`no row for ${name}`);
+  return row;
+}
+
+describe('WorkflowPanel', () => {
+  it('creates a status on the chosen team without sending a position', async () => {
+    const user = userEvent.setup();
+    render(<WorkflowPanel teams={TEAMS} states={STATES} canManage />);
+
+    await user.type(screen.getByLabelText('Status name'), 'Blocked');
+    await user.click(screen.getByRole('button', { name: 'Add status' }));
+
+    await waitFor(() => {
+      expect(sent).toHaveLength(1);
+    });
+    expect(sent[0]?.url).toBe('/api/workflow-states');
+    expect(sent[0]?.method).toBe('POST');
+    expect(sent[0]?.body).toEqual({
+      teamId: 'team-1',
+      name: 'Blocked',
+      category: 'unstarted',
+      color: '#6B7280',
+    });
+    expect(Object.keys(sent[0]?.body ?? {})).not.toContain('position');
+  });
+
+  it('sends the whole board order on a move, not just the status that moved', async () => {
+    const user = userEvent.setup();
+    render(<WorkflowPanel teams={TEAMS} states={STATES} canManage />);
+
+    await user.click(screen.getByRole('button', { name: 'Move In Progress earlier' }));
+
+    await waitFor(() => {
+      expect(sent).toHaveLength(1);
+    });
+    expect(sent[0]?.url).toBe('/api/workflow-states/reorder');
+    expect(sent[0]?.body).toEqual({
+      teamId: 'team-1',
+      stateIds: ['state-2', 'state-1', 'state-3'],
+    });
+  });
+
+  it('never offers a move past either end of the board', () => {
+    render(<WorkflowPanel teams={TEAMS} states={STATES} canManage />);
+
+    expect(screen.getByRole('button', { name: 'Move Todo earlier' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Move Done later' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Move Todo later' })).toBeEnabled();
+  });
+
+  it('shows the board of the selected team only', () => {
+    render(<WorkflowPanel teams={TEAMS} states={[...STATES, OTHER_TEAM_STATE]} canManage />);
+
+    expect(screen.getAllByTestId('workflow-state-row')).toHaveLength(3);
+    expect(screen.queryByText('Somebody else')).not.toBeInTheDocument();
+  });
+
+  it('asks the server first, then offers the move only once it has refused', async () => {
+    responses = [
+      {
+        status: 409,
+        payload: {
+          error: {
+            code: 'conflict',
+            message: 'Name a status to move those issues to before deleting this one.',
+          },
+        },
+      },
+      { status: 200, payload: {} },
+    ];
+    const user = userEvent.setup();
+    render(<WorkflowPanel teams={TEAMS} states={STATES} canManage />);
+
+    expect(screen.queryByLabelText('Move its issues to')).not.toBeInTheDocument();
+
+    await user.click(within(rowFor('Todo')).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(sent).toHaveLength(1);
+    });
+    expect(sent[0]?.url).toBe('/api/workflow-states/state-1');
+    expect(sent[0]?.method).toBe('DELETE');
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Name a status to move those issues to before deleting this one.',
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Move and delete' }));
+
+    await waitFor(() => {
+      expect(sent).toHaveLength(2);
+    });
+    expect(sent[1]?.url).toBe('/api/workflow-states/state-1?moveToStateId=state-2');
+    expect(sent[1]?.method).toBe('DELETE');
+  });
+
+  it('reports a refusal that is not about issues rather than offering a move', async () => {
+    responses = [
+      {
+        status: 409,
+        payload: {
+          error: { code: 'forbidden', message: 'Your role cannot workflow manage.' },
+        },
+      },
+    ];
+    const user = userEvent.setup();
+    render(<WorkflowPanel teams={TEAMS} states={STATES} canManage />);
+
+    await user.click(within(rowFor('Todo')).getByRole('button', { name: 'Delete' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Your role cannot workflow manage.');
+    expect(screen.queryByLabelText('Move its issues to')).not.toBeInTheDocument();
+  });
+
+  it('patches a status through the row it belongs to', async () => {
+    const user = userEvent.setup();
+    render(<WorkflowPanel teams={TEAMS} states={STATES} canManage />);
+
+    await user.click(within(rowFor('In Progress')).getByRole('button', { name: 'Edit' }));
+    const name = screen.getByLabelText('Name');
+    await user.clear(name);
+    await user.type(name, 'Doing');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(sent).toHaveLength(1);
+    });
+    expect(sent[0]?.url).toBe('/api/workflow-states/state-2');
+    expect(sent[0]?.method).toBe('PATCH');
+    expect(sent[0]?.body).toEqual({
+      name: 'Doing',
+      category: 'started',
+      color: '#F2C94C',
+    });
+  });
+
+  it('disables every write when the viewer cannot manage the workflow', () => {
+    render(<WorkflowPanel teams={TEAMS} states={STATES} canManage={false} />);
+
+    expect(screen.getByLabelText('Status name')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Add status' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Move Todo later' })).toBeDisabled();
+    for (const button of screen.getAllByRole('button', { name: 'Delete' })) {
+      expect(button).toBeDisabled();
+    }
+  });
+});

--- a/apps/web/tests/lib/api/handler.test.ts
+++ b/apps/web/tests/lib/api/handler.test.ts
@@ -18,7 +18,9 @@ mock.module('@orbit/core', () => ({ ...core, publishDeltas }));
 const requestHeaders = new Headers();
 mock.module('next/headers', () => ({ headers: () => Promise.resolve(requestHeaders) }));
 
-const { cachedJson, errorResponse, publish } = await import('../../../src/lib/api/handler.ts');
+const { cachedJson, errorResponse, publish, readJson } = await import(
+  '../../../src/lib/api/handler.ts'
+);
 
 function action(overrides: Partial<SyncAction> = {}): SyncAction {
   return {
@@ -152,5 +154,45 @@ describe('publish stamps the writing tab so its own echo can be suppressed', () 
 
     await expect(publish([action()])).resolves.toBeUndefined();
     expect(published).toHaveLength(1);
+  });
+});
+
+describe('reading a request body', () => {
+  function requestThatFailsToRead(): Request {
+    const request = new Request('http://localhost/api/labels/lbl_1', { method: 'PATCH' });
+    Object.defineProperty(request, 'text', {
+      value: () => Promise.reject(new Error('connection reset while reading the body')),
+    });
+    return request;
+  }
+
+  it('reads a body the client actually sent', async () => {
+    const request = new Request('http://localhost/api/labels/lbl_1', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: 'Urgent' }),
+    });
+
+    expect(await readJson(request)).toEqual({ name: 'Urgent' });
+  });
+
+  it('still treats a deliberately empty body as no fields, which archive and subscribe send', async () => {
+    const request = new Request('http://localhost/api/issues/iss_1/subscribe', { method: 'POST' });
+
+    expect(await readJson(request)).toEqual({});
+  });
+
+  it('refuses a body it could not read rather than reporting an unchanged record', async () => {
+    await expect(readJson(requestThatFailsToRead())).rejects.toThrow(
+      'That request body could not be read.',
+    );
+  });
+
+  it('rejects a body that is not JSON', async () => {
+    const request = new Request('http://localhost/api/labels/lbl_1', {
+      method: 'PATCH',
+      body: 'not json at all',
+    });
+
+    await expect(readJson(request)).rejects.toThrow('not valid JSON');
   });
 });

--- a/apps/web/tests/lib/interaction.test.ts
+++ b/apps/web/tests/lib/interaction.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, it } from 'bun:test';
 import * as interaction from '@/lib/interaction.ts';
 
-const ALLOWED_TRANSITIONS = ['transition-opacity', 'transition-colors'];
+const ALLOWED_TRANSITIONS = ['transition-opacity', 'transition-colors', 'transition-transform'];
+
+const REFLOWING_TRANSITIONS = [
+  'transition-all',
+  'transition-[width]',
+  'transition-[height]',
+  'transition-[margin]',
+  'transition-[padding]',
+  'transition-[top]',
+  'transition-[left]',
+];
 
 function tokens(): [string, string][] {
   return Object.entries(interaction).flatMap(([name, value]) =>
@@ -25,13 +35,23 @@ describe('the shared interaction tokens', () => {
     }
   });
 
-  it('transitions opacity and colour only, never a property that reflows', () => {
+  it('transitions opacity, colour and transform only, never a property that reflows', () => {
     for (const [name, value] of transitioning()) {
       const declared = value
         .split(' ')
         .filter((part) => part.startsWith('transition-') && part !== 'transition-none');
       const stray = declared.filter((part) => !ALLOWED_TRANSITIONS.includes(part));
       expect([name, stray]).toEqual([name, []]);
+    }
+  });
+
+  it('names no reflowing property, whatever the allow list grows to hold', () => {
+    for (const banned of REFLOWING_TRANSITIONS) {
+      expect([banned, ALLOWED_TRANSITIONS.includes(banned)]).toEqual([banned, false]);
+    }
+    for (const [name, value] of tokens()) {
+      const reflowing = REFLOWING_TRANSITIONS.filter((banned) => value.includes(banned));
+      expect([name, reflowing]).toEqual([name, []]);
     }
   });
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -103,7 +103,10 @@ thing filters and saved views are built from.
 
 A label can instead be pinned to one team. A team label is only visible to that
 team, only pushed over realtime to that team, and only attachable to that team's
-issues. Manage both under **Settings**, **Labels**.
+issues. Pinning a workspace label to a team also takes it off the issues of every
+other team, so the rule holds for issues that already carried it rather than only
+for the next edit. Widening a team label back to the workspace touches no issue.
+Manage both under **Settings**, **Labels**.
 
 ## Workflow states
 
@@ -115,7 +118,8 @@ The category is the part the rest of Orbit reads. It is what decides whether an
 issue counts as open on a sprint burndown, when `startedAt` and `completedAt`
 are stamped, and which bucket the standup board puts it in. Renaming a status or
 moving it in the order leaves the category alone; changing the category re-dates
-every issue sitting in that status, on the server, in the same transaction.
+every issue sitting in that status, on the server, in the same transaction. Those
+issues did not move, so how long they have sat where they are is left alone.
 
 Deleting a status that still holds issues is refused until you name the status
 those issues move to, and a team always keeps at least one status. Manage them

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -106,7 +106,15 @@ team, only pushed over realtime to that team, and only attachable to that team's
 issues. Pinning a workspace label to a team also takes it off the issues of every
 other team, so the rule holds for issues that already carried it rather than only
 for the next edit. Widening a team label back to the workspace touches no issue.
+Carrying an issue to another team works the same way round: the labels the new
+team cannot use come off it as it lands, and the workspace-wide ones stay.
 Manage both under **Settings**, **Labels**.
+
+Two labels may share a name when they live in different places, a workspace
+`Regression` alongside a team `Regression`. The API and the settings screen take
+ids, so that is unambiguous, but a name given to an MCP tool is not: when more
+than one label answers to it, the tool refuses and lists the ids rather than
+picking one.
 
 ## Workflow states
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -97,9 +97,29 @@ by points, and analytics shows both.
 
 ## Labels
 
-Workspace-wide tags with a colour. Labels cross teams, which is what makes them
+Tags with a colour. A label is workspace wide by default, which is what makes it
 useful for things like `Bug`, `Performance` or `Docs`, and they are the main
 thing filters and saved views are built from.
+
+A label can instead be pinned to one team. A team label is only visible to that
+team, only pushed over realtime to that team, and only attachable to that team's
+issues. Manage both under **Settings**, **Labels**.
+
+## Workflow states
+
+The columns of a team board. Each one belongs to a single team, carries a
+position that fixes its place in the order, and carries a **category**, one of
+`triage`, `backlog`, `unstarted`, `started`, `review`, `completed` or `canceled`.
+
+The category is the part the rest of Orbit reads. It is what decides whether an
+issue counts as open on a sprint burndown, when `startedAt` and `completedAt`
+are stamped, and which bucket the standup board puts it in. Renaming a status or
+moving it in the order leaves the category alone; changing the category re-dates
+every issue sitting in that status, on the server, in the same transaction.
+
+Deleting a status that still holds issues is refused until you name the status
+those issues move to, and a team always keeps at least one status. Manage them
+under **Settings**, **Workflow**.
 
 ## Sprints and cycles
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -205,7 +205,7 @@ and post it to Slack without anyone opening Orbit.
 | `create_team`, `update_team` | write | |
 | `add_team_member`, `remove_team_member` | write | |
 | `remove_member` | write | Remove from the workspace |
-| `create_label`, `update_label`, `delete_label` | write | Pass `team` to pin a label to one team, `null` to widen it back |
+| `create_label`, `update_label`, `delete_label` | write | Pass `team` to pin a label to one team, `null` to widen it back. Name a label by id when two share a name |
 | `create_state`, `update_state` | write | A status carries a category the product reads, so changing it re-dates the issues in it |
 | `delete_state` | write | Refused while issues sit in it unless `moveTo` names the status they go to |
 | `reorder_states` | write | The whole board order, first column first |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -132,9 +132,9 @@ them.
 | `search_issues` | read | Search and filter |
 | `list_my_issues` | read | Assigned to the caller |
 | `copy_branch_name` | read | The git branch name for an issue |
-| `create_issue` | write | Create one, returns `ENG-42` |
+| `create_issue` | write | Create one, returns `ENG-42`. Name a label by id when two share a name |
 | `update_issue` | write | Title, description, state, priority, assignee, labels, estimate |
-| `move_issue` | write | Move between states or teams |
+| `move_issue` | write | Move between states or teams. A team move drops the labels the new team cannot use |
 | `add_comment` | write | Comment |
 | `set_relation` | write | Blocks, blocked by, relates to, duplicates |
 | `archive_issue`, `unarchive_issue`, `delete_issue` | write | |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -197,14 +197,17 @@ and post it to Slack without anyone opening Orbit.
 | `list_views` | read | Saved views |
 | `create_view`, `update_view`, `delete_view` | write | |
 
-### Teams and labels
+### Teams, labels and workflow states
 
 | Tool | Scope | Does |
 | --- | --- | --- |
 | `create_team`, `update_team` | write | |
 | `add_team_member`, `remove_team_member` | write | |
 | `remove_member` | write | Remove from the workspace |
-| `create_label`, `update_label`, `delete_label` | write | |
+| `create_label`, `update_label`, `delete_label` | write | Pass `team` to pin a label to one team, `null` to widen it back |
+| `create_state`, `update_state` | write | A status carries a category the product reads, so changing it re-dates the issues in it |
+| `delete_state` | write | Refused while issues sit in it unless `moveTo` names the status they go to |
+| `reorder_states` | write | The whole board order, first column first |
 
 ## Things worth asking for
 

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -17,6 +17,19 @@ export function requireRow<T>(row: T | undefined, message: string): T {
   return row;
 }
 
+const UNIQUE_VIOLATION = '23505';
+const CAUSE_DEPTH = 5;
+
+export function isUniqueViolation(error: unknown): boolean {
+  let cursor: unknown = error;
+  for (let depth = 0; depth < CAUSE_DEPTH; depth += 1) {
+    if (typeof cursor !== 'object' || cursor === null) return false;
+    if ('code' in cursor && (cursor as { code: unknown }).code === UNIQUE_VIOLATION) return true;
+    cursor = (cursor as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
 export function toDateString(value: Date | null | undefined): string | null | undefined {
   if (value === undefined) return undefined;
   if (value === null) return null;

--- a/packages/core/src/realtime/backfill.ts
+++ b/packages/core/src/realtime/backfill.ts
@@ -4,6 +4,7 @@ import { CATCHUP_LIMIT, scopes } from '@orbit/shared/events';
 import { assertCan, can, type Principal } from '@orbit/shared/policy';
 import { docReadFilter } from '../content/doc-service.ts';
 import { inviteAnnouncement, inviteReference } from '../org/invite-service.ts';
+import { labelIdsByIssue } from '../work/label-service.ts';
 import { viewReadFilter, viewScopes } from '../work/view-service.ts';
 import { buildSyncAction } from './publisher.ts';
 
@@ -56,22 +57,6 @@ async function issueTeamsById(issueIds: readonly string[]): Promise<Map<string, 
     .from(schema.issue)
     .where(inArray(schema.issue.id, ids));
   return new Map(rows.map((row) => [row.id, row.teamId]));
-}
-
-async function labelsForIssues(issueIds: readonly string[]): Promise<Map<string, string[]>> {
-  const grouped = new Map<string, string[]>();
-  const ids = [...new Set(issueIds)];
-  if (ids.length === 0) return grouped;
-  const rows = await db
-    .select({ issueId: schema.issueLabel.issueId, labelId: schema.issueLabel.labelId })
-    .from(schema.issueLabel)
-    .where(inArray(schema.issueLabel.issueId, ids));
-  for (const row of rows) {
-    const existing = grouped.get(row.issueId);
-    if (existing === undefined) grouped.set(row.issueId, [row.labelId]);
-    else existing.push(row.labelId);
-  }
-  return grouped;
 }
 
 async function commentTeamsById(commentIds: readonly string[]): Promise<Map<string, string>> {
@@ -362,7 +347,10 @@ const LOADERS: Record<SyncModel, Loader> = {
       )
       .orderBy(asc(schema.issue.syncId))
       .limit(limit);
-    const labels = await labelsForIssues(rows.map((row) => row.id));
+    const labels = await labelIdsByIssue(
+      db,
+      rows.map((row) => row.id),
+    );
     return rows.map((row) => ({
       modelId: row.id,
       syncId: row.syncId,

--- a/packages/core/src/work/issue-fields.ts
+++ b/packages/core/src/work/issue-fields.ts
@@ -1,0 +1,37 @@
+import type { schema } from '@orbit/db';
+import { scopes } from '@orbit/shared/events';
+
+export type IssueRow = typeof schema.issue.$inferSelect;
+export type IssueValues = Partial<typeof schema.issue.$inferInsert>;
+
+export function issueScopes(
+  row: Pick<IssueRow, 'organizationId' | 'teamId' | 'id' | 'projectId'>,
+): string[] {
+  const list = [scopes.team(row.teamId), scopes.issue(row.id)];
+  if (row.projectId !== null) list.push(scopes.project(row.projectId));
+  return list;
+}
+
+export function stateTimestamps(category: string, now: Date): IssueValues {
+  if (category === 'completed') {
+    return { completedAt: now, canceledAt: null, stateEnteredAt: now };
+  }
+  if (category === 'canceled') {
+    return { canceledAt: now, completedAt: null, stateEnteredAt: now };
+  }
+  if (category === 'started' || category === 'review') {
+    return { startedAt: now, completedAt: null, canceledAt: null, stateEnteredAt: now };
+  }
+  return { startedAt: null, completedAt: null, canceledAt: null, stateEnteredAt: now };
+}
+
+export function applyStateTimestamps(current: IssueRow, category: string, now: Date): IssueValues {
+  const next = stateTimestamps(category, now);
+  if ((category === 'started' || category === 'review') && current.startedAt !== null) {
+    return { ...next, startedAt: current.startedAt };
+  }
+  if (category === 'completed') {
+    return { ...next, startedAt: current.startedAt ?? now };
+  }
+  return next;
+}

--- a/packages/core/src/work/issue-service.ts
+++ b/packages/core/src/work/issue-service.ts
@@ -46,7 +46,7 @@ import {
   stateTimestamps,
 } from './issue-fields.ts';
 import { buildFilterFilters, today } from './issue-predicates.ts';
-import { assertLabelsUsable } from './label-service.ts';
+import { assertLabelsUsable, dropLabelsForeignToTeam, labelIdsByIssue } from './label-service.ts';
 import { initialStateFor } from './workflow-state-service.ts';
 
 export {
@@ -348,25 +348,6 @@ async function loadIssue(
   const issue = requireRow(row, 'That issue does not exist.');
   if (!isInTeam(principal, teamScope(issue))) throw notFound('That issue does not exist.');
   return issue;
-}
-
-async function labelsByIssue(
-  executor: Executor,
-  issueIds: readonly string[],
-): Promise<Map<string, string[]>> {
-  const grouped = new Map<string, string[]>();
-  const ids = [...new Set(issueIds)];
-  if (ids.length === 0) return grouped;
-  const rows = await executor
-    .select({ issueId: schema.issueLabel.issueId, labelId: schema.issueLabel.labelId })
-    .from(schema.issueLabel)
-    .where(inArray(schema.issueLabel.issueId, ids));
-  for (const row of rows) {
-    const existing = grouped.get(row.issueId);
-    if (existing === undefined) grouped.set(row.issueId, [row.labelId]);
-    else existing.push(row.labelId);
-  }
-  return grouped;
 }
 
 async function replaceLabelsFor(
@@ -959,7 +940,7 @@ async function applyIssueUpdates(
     updated,
     state,
   });
-  const labels = await labelsByIssue(
+  const labels = await labelIdsByIssue(
     tx,
     pending.map((entry) => entry.current.id),
   );
@@ -1125,6 +1106,22 @@ async function recordRegroupings(tx: Executor, input: RegroupActivityInput): Pro
   }
 }
 
+async function carryToTeam(
+  executor: Executor,
+  current: IssueRow,
+  team: TeamRow,
+  values: IssueValues,
+): Promise<void> {
+  const number = await allocateIssueNumber(executor, team);
+  values.teamId = team.id;
+  values.number = number;
+  values.identifier = issueIdentifier(team.key, number);
+  values.cycleId = null;
+  if (await projectFitsTeam(executor, team.id, current.projectId)) return;
+  values.projectId = null;
+  values.milestoneId = null;
+}
+
 export async function moveIssue(
   principal: Principal,
   issueId: string,
@@ -1157,18 +1154,9 @@ export async function moveIssue(
     }
 
     const now = new Date();
+    const changingTeam = teamId !== current.teamId;
     const values: IssueValues = { sortOrder: sortOrderBetween(before, after) };
-    if (teamId !== current.teamId) {
-      const number = await allocateIssueNumber(tx, team);
-      values.teamId = teamId;
-      values.number = number;
-      values.identifier = issueIdentifier(team.key, number);
-      values.cycleId = null;
-      if (!(await projectFitsTeam(tx, teamId, current.projectId))) {
-        values.projectId = null;
-        values.milestoneId = null;
-      }
-    }
+    if (changingTeam) await carryToTeam(tx, current, team, values);
     if (state.id !== current.stateId) {
       values.stateId = state.id;
       Object.assign(values, applyStateTimestamps(current, state.category, now));
@@ -1188,6 +1176,8 @@ export async function moveIssue(
       .where(eq(schema.issue.id, issueId))
       .returning();
     const issue = requireRow(moved, 'That issue does not exist.');
+
+    if (changingTeam) await dropLabelsForeignToTeam(tx, principal.organizationId, issue.id, teamId);
 
     if (state.id !== current.stateId) {
       await appendActivities(tx, [
@@ -1213,7 +1203,7 @@ export async function moveIssue(
       issue,
     });
 
-    const movedLabels = await labelsByIssue(tx, [issue.id, ...rebalanced.map((row) => row.id)]);
+    const movedLabels = await labelIdsByIssue(tx, [issue.id, ...rebalanced.map((row) => row.id)]);
     const notifications = await moveNotifications(tx, principal, actor, { current, issue, state });
 
     return {
@@ -1314,7 +1304,7 @@ async function setArchived(
           syncId,
           actor,
           archivedAt === null ? 'unarchive' : 'archive',
-          (await labelsByIssue(tx, [issue.id])).get(issue.id) ?? [],
+          (await labelIdsByIssue(tx, [issue.id])).get(issue.id) ?? [],
         ),
       ],
     };
@@ -1350,7 +1340,7 @@ export async function deleteIssue(principal: Principal, issueId: string): Promis
       .returning();
     await tx.delete(schema.issue).where(eq(schema.issue.id, issueId));
 
-    const labels = await labelsByIssue(
+    const labels = await labelIdsByIssue(
       tx,
       orphaned.map((child) => child.id),
     );

--- a/packages/core/src/work/issue-service.ts
+++ b/packages/core/src/work/issue-service.ts
@@ -38,12 +38,25 @@ import {
 import { requireTeam, type TeamRow } from '../org/team-service.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
+import {
+  applyStateTimestamps,
+  type IssueRow,
+  type IssueValues,
+  issueScopes,
+  stateTimestamps,
+} from './issue-fields.ts';
 import { buildFilterFilters, today } from './issue-predicates.ts';
+import { assertLabelsUsable } from './label-service.ts';
 import { initialStateFor } from './workflow-state-service.ts';
 
-export type IssueRow = typeof schema.issue.$inferSelect;
+export {
+  type IssueRow,
+  type IssueValues,
+  issueScopes,
+  stateTimestamps,
+} from './issue-fields.ts';
+
 export type IssueRelationRow = typeof schema.issueRelation.$inferSelect;
-export type IssueValues = Partial<typeof schema.issue.$inferInsert>;
 
 type GroupedMoveField = 'cycleId' | 'assigneeId' | 'priority' | 'projectId';
 
@@ -81,14 +94,6 @@ async function assertParentAllowed(
     const parent = requireRow(rows[0], 'That parent issue does not exist.');
     cursor = parent.parentId;
   }
-}
-
-export function issueScopes(
-  row: Pick<IssueRow, 'organizationId' | 'teamId' | 'id' | 'projectId'>,
-): string[] {
-  const list = [scopes.team(row.teamId), scopes.issue(row.id)];
-  if (row.projectId !== null) list.push(scopes.project(row.projectId));
-  return list;
 }
 
 function issueAction(
@@ -137,30 +142,6 @@ async function stateOf(executor: Executor, stateId: string) {
     .where(eq(schema.workflowState.id, stateId))
     .limit(1);
   return requireRow(row, 'That status does not exist.');
-}
-
-export function stateTimestamps(category: string, now: Date): IssueValues {
-  if (category === 'completed') {
-    return { completedAt: now, canceledAt: null, stateEnteredAt: now };
-  }
-  if (category === 'canceled') {
-    return { canceledAt: now, completedAt: null, stateEnteredAt: now };
-  }
-  if (category === 'started' || category === 'review') {
-    return { startedAt: now, completedAt: null, canceledAt: null, stateEnteredAt: now };
-  }
-  return { startedAt: null, completedAt: null, canceledAt: null, stateEnteredAt: now };
-}
-
-function applyStateTimestamps(current: IssueRow, category: string, now: Date): IssueValues {
-  const next = stateTimestamps(category, now);
-  if ((category === 'started' || category === 'review') && current.startedAt !== null) {
-    return { ...next, startedAt: current.startedAt };
-  }
-  if (category === 'completed') {
-    return { ...next, startedAt: current.startedAt ?? now };
-  }
-  return next;
 }
 
 const NAME_LOADERS: Record<string, (executor: Executor, id: string) => Promise<string | null>> = {
@@ -757,6 +738,7 @@ export async function createIssue(principal: Principal, input: unknown): Promise
       projectId: parsed.projectId,
       milestoneId: parsed.milestoneId,
     });
+    await assertLabelsUsable(tx, principal.organizationId, team.id, parsed.labelIds);
 
     const number = await allocateIssueNumber(tx, team);
     const now = new Date();
@@ -859,6 +841,36 @@ function updateGroups(pending: readonly PendingUpdate[]): Map<string, PendingUpd
   return groups;
 }
 
+interface UpdateContext {
+  readonly tx: Executor;
+  readonly principal: Principal;
+  readonly parsed: ReturnType<typeof issueUpdateSchema.parse>;
+  readonly state: Awaited<ReturnType<typeof stateOf>> | null;
+  readonly now: Date;
+}
+
+async function pendingUpdateFor(context: UpdateContext, current: IssueRow): Promise<PendingUpdate> {
+  const { tx, principal, parsed, state, now } = context;
+  assertInTeam(principal, teamScope(current));
+
+  const { values, changes } = collectIssueChanges(current, parsed);
+  if (values.parentId !== undefined && values.parentId !== null) {
+    await assertParentAllowed(tx, principal.organizationId, current.id, values.parentId);
+  }
+  if (values.stateId !== undefined) {
+    if (state === null || state.teamId !== current.teamId) {
+      throw validationFailed('That status belongs to another team.');
+    }
+    Object.assign(values, applyStateTimestamps(current, state.category, now));
+  }
+  await assertMemberOfWorkspace(tx, principal.organizationId, values.assigneeId);
+  await assertAssignableToTeam(tx, principal.organizationId, current.teamId, values);
+  if (parsed.labelIds !== undefined) {
+    await assertLabelsUsable(tx, principal.organizationId, current.teamId, parsed.labelIds);
+  }
+  return { current, values, changes };
+}
+
 async function applyIssueUpdates(
   tx: Executor,
   principal: Principal,
@@ -868,25 +880,12 @@ async function applyIssueUpdates(
   const loaded = await loadIssues(tx, principal.organizationId, issueIds);
   const now = new Date();
   const state = parsed.stateId === undefined ? null : await stateOf(tx, parsed.stateId);
+  const context: UpdateContext = { tx, principal, parsed, state, now };
 
   const pending: PendingUpdate[] = [];
   for (const issueId of issueIds) {
     const current = requireRow(loaded.get(issueId), 'That issue does not exist.');
-    assertInTeam(principal, teamScope(current));
-
-    const { values, changes } = collectIssueChanges(current, parsed);
-    if (values.parentId !== undefined && values.parentId !== null) {
-      await assertParentAllowed(tx, principal.organizationId, current.id, values.parentId);
-    }
-    if (values.stateId !== undefined) {
-      if (state === null || state.teamId !== current.teamId) {
-        throw validationFailed('That status belongs to another team.');
-      }
-      Object.assign(values, applyStateTimestamps(current, state.category, now));
-    }
-    await assertMemberOfWorkspace(tx, principal.organizationId, values.assigneeId);
-    await assertAssignableToTeam(tx, principal.organizationId, current.teamId, values);
-    pending.push({ current, values, changes });
+    pending.push(await pendingUpdateFor(context, current));
   }
 
   const labelsChanged = parsed.labelIds !== undefined;

--- a/packages/core/src/work/label-service.ts
+++ b/packages/core/src/work/label-service.ts
@@ -130,21 +130,55 @@ async function issuesOutsideTeam(
   return rows.map((row) => row.id);
 }
 
-async function remainingLabelsByIssue(
+export async function labelIdsByIssue(
   executor: Executor,
   issueIds: readonly string[],
 ): Promise<Map<string, string[]>> {
   const grouped = new Map<string, string[]>();
+  const ids = [...new Set(issueIds)];
+  if (ids.length === 0) return grouped;
   const rows = await executor
     .select({ issueId: schema.issueLabel.issueId, labelId: schema.issueLabel.labelId })
     .from(schema.issueLabel)
-    .where(inArray(schema.issueLabel.issueId, [...issueIds]));
+    .where(inArray(schema.issueLabel.issueId, ids));
   for (const row of rows) {
     const bucket = grouped.get(row.issueId) ?? [];
     bucket.push(row.labelId);
     grouped.set(row.issueId, bucket);
   }
   return grouped;
+}
+
+export async function dropLabelsForeignToTeam(
+  executor: Executor,
+  organizationId: string,
+  issueId: string,
+  teamId: string,
+): Promise<void> {
+  const attached = await executor
+    .select({ labelId: schema.issueLabel.labelId })
+    .from(schema.issueLabel)
+    .where(eq(schema.issueLabel.issueId, issueId));
+  if (attached.length === 0) return;
+
+  const wanted = [...new Set(attached.map((row) => row.labelId))];
+  const usable = await executor
+    .select({ id: schema.label.id })
+    .from(schema.label)
+    .where(
+      and(
+        eq(schema.label.organizationId, organizationId),
+        inArray(schema.label.id, wanted),
+        or(isNull(schema.label.teamId), eq(schema.label.teamId, teamId)),
+      ),
+    );
+  const keep = new Set(usable.map((row) => row.id));
+  const drop = wanted.filter((labelId) => !keep.has(labelId));
+  if (drop.length === 0) return;
+
+  await executor
+    .delete(schema.issueLabel)
+    .where(and(eq(schema.issueLabel.issueId, issueId), inArray(schema.issueLabel.labelId, drop)));
 }
 
 async function detachFromOtherTeams(
@@ -164,7 +198,7 @@ async function detachFromOtherTeams(
       and(eq(schema.issueLabel.labelId, label.id), inArray(schema.issueLabel.issueId, issueIds)),
     );
 
-  const remaining = await remainingLabelsByIssue(executor, issueIds);
+  const remaining = await labelIdsByIssue(executor, issueIds);
   const rows = await executor
     .update(schema.issue)
     .set({ syncId, updatedAt: new Date() })

--- a/packages/core/src/work/label-service.ts
+++ b/packages/core/src/work/label-service.ts
@@ -1,11 +1,13 @@
-import { and, asc, db, eq, schema } from '@orbit/db';
+import { and, asc, db, eq, inArray, isNull, or, type SQL, schema } from '@orbit/db';
+import { conflict, validationFailed } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan } from '@orbit/shared/policy';
 import { labelCreateSchema, labelUpdateSchema } from '@orbit/shared/validators';
 import { principalActor } from '../activity/activity-service.ts';
-import { type Executor, newId, requireRow } from '../internal.ts';
+import { type Executor, isUniqueViolation, newId, requireRow } from '../internal.ts';
+import { requireTeam } from '../org/team-service.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
 
@@ -20,10 +22,50 @@ export const STARTER_LABELS: readonly { name: string; color: string }[] = [
   { name: 'Chore', color: '#6B7280' },
 ];
 
-function labelScopes(row: LabelRow): string[] {
-  const list = [scopes.organization(row.organizationId)];
-  if (row.teamId !== null) list.push(scopes.team(row.teamId));
-  return list;
+const NAME_TAKEN = 'A label with that name already lives here.';
+const MISSING_LABEL = 'That label does not exist.';
+
+async function refusingDuplicates<T>(run: () => Promise<T>): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (isUniqueViolation(error)) throw conflict(NAME_TAKEN);
+    throw error;
+  }
+}
+
+function labelScopes(row: Pick<LabelRow, 'organizationId' | 'teamId'>): string[] {
+  if (row.teamId === null) return [scopes.organization(row.organizationId)];
+  return [scopes.team(row.teamId)];
+}
+
+function bothAudiences(before: LabelRow, after: LabelRow): string[] {
+  return [...new Set([...labelScopes(before), ...labelScopes(after)])];
+}
+
+function readableLabels(principal: Principal): SQL {
+  const owned = eq(schema.label.organizationId, principal.organizationId);
+  if (principal.role === 'admin') return owned;
+  const workspaceWide = isNull(schema.label.teamId);
+  const reachable =
+    principal.teamIds.length === 0
+      ? workspaceWide
+      : or(workspaceWide, inArray(schema.label.teamId, [...principal.teamIds]));
+  const clause = and(owned, reachable);
+  return clause ?? owned;
+}
+
+async function readableLabel(
+  executor: Executor,
+  principal: Principal,
+  labelId: string,
+): Promise<LabelRow> {
+  const [row] = await executor
+    .select()
+    .from(schema.label)
+    .where(and(eq(schema.label.id, labelId), readableLabels(principal)))
+    .limit(1);
+  return requireRow(row, MISSING_LABEL);
 }
 
 export async function createStarterLabels(
@@ -45,6 +87,29 @@ export async function createStarterLabels(
     .returning();
 }
 
+export async function assertLabelsUsable(
+  executor: Executor,
+  organizationId: string,
+  teamId: string,
+  labelIds: readonly string[],
+): Promise<void> {
+  const wanted = [...new Set(labelIds)];
+  if (wanted.length === 0) return;
+  const rows = await executor
+    .select({ id: schema.label.id })
+    .from(schema.label)
+    .where(
+      and(
+        eq(schema.label.organizationId, organizationId),
+        inArray(schema.label.id, wanted),
+        or(isNull(schema.label.teamId), eq(schema.label.teamId, teamId)),
+      ),
+    );
+  if (rows.length !== wanted.length) {
+    throw validationFailed('Some of those labels are not available on that team.');
+  }
+}
+
 export async function listLabels(
   principal: Principal,
   options: { teamId?: string } = {},
@@ -53,7 +118,7 @@ export async function listLabels(
   const rows = await db
     .select()
     .from(schema.label)
-    .where(eq(schema.label.organizationId, principal.organizationId))
+    .where(readableLabels(principal))
     .orderBy(asc(schema.label.name));
   if (options.teamId === undefined) return rows;
   return rows.filter((row) => row.teamId === null || row.teamId === options.teamId);
@@ -61,14 +126,7 @@ export async function listLabels(
 
 export async function getLabel(principal: Principal, labelId: string): Promise<LabelRow> {
   assertCan(principal, 'issue:read');
-  const [row] = await db
-    .select()
-    .from(schema.label)
-    .where(
-      and(eq(schema.label.id, labelId), eq(schema.label.organizationId, principal.organizationId)),
-    )
-    .limit(1);
-  return requireRow(row, 'That label does not exist.');
+  return await readableLabel(db, principal, labelId);
 }
 
 export async function createLabel(
@@ -78,37 +136,40 @@ export async function createLabel(
   assertCan(principal, 'label:manage');
   const parsed = labelCreateSchema.parse(input);
 
-  return await db.transaction(async (tx) => {
-    const syncId = await nextSyncId(tx);
-    const actor = await principalActor(tx, principal);
-    const [created] = await tx
-      .insert(schema.label)
-      .values({
-        id: newId(),
-        organizationId: principal.organizationId,
-        teamId: parsed.teamId,
-        name: parsed.name,
-        color: parsed.color,
-        syncId,
-      })
-      .returning();
-    const row = requireRow(created, 'The label could not be created.');
-    return {
-      label: row,
-      actions: [
-        buildSyncAction({
-          syncId,
+  return await refusingDuplicates(async () =>
+    db.transaction(async (tx) => {
+      if (parsed.teamId !== null) await requireTeam(principal, parsed.teamId, tx);
+      const syncId = await nextSyncId(tx);
+      const actor = await principalActor(tx, principal);
+      const [created] = await tx
+        .insert(schema.label)
+        .values({
+          id: newId(),
           organizationId: principal.organizationId,
-          scopes: labelScopes(row),
-          action: 'insert',
-          model: 'label',
-          modelId: row.id,
-          data: row,
-          actor,
-        }),
-      ],
-    };
-  });
+          teamId: parsed.teamId,
+          name: parsed.name,
+          color: parsed.color,
+          syncId,
+        })
+        .returning();
+      const row = requireRow(created, 'The label could not be created.');
+      return {
+        label: row,
+        actions: [
+          buildSyncAction({
+            syncId,
+            organizationId: principal.organizationId,
+            scopes: labelScopes(row),
+            action: 'insert',
+            model: 'label',
+            modelId: row.id,
+            data: row,
+            actor,
+          }),
+        ],
+      };
+    }),
+  );
 }
 
 export async function updateLabel(
@@ -119,62 +180,63 @@ export async function updateLabel(
   assertCan(principal, 'label:manage');
   const parsed = labelUpdateSchema.parse(input);
 
-  return await db.transaction(async (tx) => {
-    const values: Partial<typeof schema.label.$inferInsert> = {};
-    if (parsed.name !== undefined) values.name = parsed.name;
-    if (parsed.color !== undefined) values.color = parsed.color;
-    if (parsed.teamId !== undefined) values.teamId = parsed.teamId;
+  return await refusingDuplicates(async () =>
+    db.transaction(async (tx) => {
+      const current = await readableLabel(tx, principal, labelId);
+      if (parsed.teamId !== undefined && parsed.teamId !== null) {
+        await requireTeam(principal, parsed.teamId, tx);
+      }
 
-    const syncId = await nextSyncId(tx);
-    const actor = await principalActor(tx, principal);
-    const [updated] = await tx
-      .update(schema.label)
-      .set({ ...values, syncId })
-      .where(
-        and(
-          eq(schema.label.id, labelId),
-          eq(schema.label.organizationId, principal.organizationId),
-        ),
-      )
-      .returning();
-    const row = requireRow(updated, 'That label does not exist.');
-    return {
-      label: row,
-      actions: [
-        buildSyncAction({
-          syncId,
-          organizationId: principal.organizationId,
-          scopes: labelScopes(row),
-          action: 'update',
-          model: 'label',
-          modelId: row.id,
-          data: row,
-          actor,
-        }),
-      ],
-    };
-  });
+      const values: Partial<typeof schema.label.$inferInsert> = {};
+      if (parsed.name !== undefined) values.name = parsed.name;
+      if (parsed.color !== undefined) values.color = parsed.color;
+      if (parsed.teamId !== undefined) values.teamId = parsed.teamId;
+
+      const syncId = await nextSyncId(tx);
+      const actor = await principalActor(tx, principal);
+      const [updated] = await tx
+        .update(schema.label)
+        .set({ ...values, syncId })
+        .where(
+          and(
+            eq(schema.label.id, current.id),
+            eq(schema.label.organizationId, principal.organizationId),
+          ),
+        )
+        .returning();
+      const row = requireRow(updated, MISSING_LABEL);
+      return {
+        label: row,
+        actions: [
+          buildSyncAction({
+            syncId,
+            organizationId: principal.organizationId,
+            scopes: bothAudiences(current, row),
+            action: 'update',
+            model: 'label',
+            modelId: row.id,
+            data: row,
+            actor,
+          }),
+        ],
+      };
+    }),
+  );
 }
 
 export async function deleteLabel(principal: Principal, labelId: string): Promise<SyncAction[]> {
   assertCan(principal, 'label:manage');
 
   return await db.transaction(async (tx) => {
-    const [existing] = await tx
-      .select()
-      .from(schema.label)
-      .where(
-        and(
-          eq(schema.label.id, labelId),
-          eq(schema.label.organizationId, principal.organizationId),
-        ),
-      )
-      .limit(1);
-    const row = requireRow(existing, 'That label does not exist.');
+    const row = await readableLabel(tx, principal, labelId);
 
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
-    await tx.delete(schema.label).where(eq(schema.label.id, labelId));
+    await tx
+      .delete(schema.label)
+      .where(
+        and(eq(schema.label.id, row.id), eq(schema.label.organizationId, principal.organizationId)),
+      );
     return [
       buildSyncAction({
         syncId,
@@ -182,8 +244,8 @@ export async function deleteLabel(principal: Principal, labelId: string): Promis
         scopes: labelScopes(row),
         action: 'delete',
         model: 'label',
-        modelId: labelId,
-        data: { id: labelId },
+        modelId: row.id,
+        data: { id: row.id, teamId: row.teamId },
         actor,
       }),
     ];

--- a/packages/core/src/work/label-service.ts
+++ b/packages/core/src/work/label-service.ts
@@ -1,6 +1,6 @@
-import { and, asc, db, eq, inArray, isNull, or, type SQL, schema } from '@orbit/db';
+import { and, asc, db, eq, inArray, isNull, ne, or, type SQL, schema } from '@orbit/db';
 import { conflict, validationFailed } from '@orbit/shared/errors';
-import type { SyncAction } from '@orbit/shared/events';
+import type { Actor, SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan } from '@orbit/shared/policy';
@@ -10,6 +10,7 @@ import { type Executor, isUniqueViolation, newId, requireRow } from '../internal
 import { requireTeam } from '../org/team-service.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
+import { issueScopes } from './issue-fields.ts';
 
 export type LabelRow = typeof schema.label.$inferSelect;
 
@@ -110,6 +111,80 @@ export async function assertLabelsUsable(
   }
 }
 
+async function issuesOutsideTeam(
+  executor: Executor,
+  label: LabelRow,
+  teamId: string,
+): Promise<string[]> {
+  const rows = await executor
+    .select({ id: schema.issue.id })
+    .from(schema.issueLabel)
+    .innerJoin(schema.issue, eq(schema.issue.id, schema.issueLabel.issueId))
+    .where(
+      and(
+        eq(schema.issueLabel.labelId, label.id),
+        eq(schema.issue.organizationId, label.organizationId),
+        ne(schema.issue.teamId, teamId),
+      ),
+    );
+  return rows.map((row) => row.id);
+}
+
+async function remainingLabelsByIssue(
+  executor: Executor,
+  issueIds: readonly string[],
+): Promise<Map<string, string[]>> {
+  const grouped = new Map<string, string[]>();
+  const rows = await executor
+    .select({ issueId: schema.issueLabel.issueId, labelId: schema.issueLabel.labelId })
+    .from(schema.issueLabel)
+    .where(inArray(schema.issueLabel.issueId, [...issueIds]));
+  for (const row of rows) {
+    const bucket = grouped.get(row.issueId) ?? [];
+    bucket.push(row.labelId);
+    grouped.set(row.issueId, bucket);
+  }
+  return grouped;
+}
+
+async function detachFromOtherTeams(
+  executor: Executor,
+  label: LabelRow,
+  syncId: number,
+  actor: Actor,
+): Promise<SyncAction[]> {
+  const teamId = label.teamId;
+  if (teamId === null) return [];
+  const issueIds = await issuesOutsideTeam(executor, label, teamId);
+  if (issueIds.length === 0) return [];
+
+  await executor
+    .delete(schema.issueLabel)
+    .where(
+      and(eq(schema.issueLabel.labelId, label.id), inArray(schema.issueLabel.issueId, issueIds)),
+    );
+
+  const remaining = await remainingLabelsByIssue(executor, issueIds);
+  const rows = await executor
+    .update(schema.issue)
+    .set({ syncId, updatedAt: new Date() })
+    .where(inArray(schema.issue.id, issueIds))
+    .returning();
+
+  return rows.map((row) =>
+    buildSyncAction({
+      syncId,
+      organizationId: row.organizationId,
+      scopes: issueScopes(row),
+      action: 'update',
+      model: 'issue',
+      modelId: row.id,
+      data: { ...row, labelIds: remaining.get(row.id) ?? [] },
+      actor,
+    }),
+  );
+}
+
 export async function listLabels(
   principal: Principal,
   options: { teamId?: string } = {},
@@ -172,6 +247,19 @@ export async function createLabel(
   );
 }
 
+function labelChanges(
+  current: LabelRow,
+  parsed: ReturnType<typeof labelUpdateSchema.parse>,
+): Partial<typeof schema.label.$inferInsert> {
+  const values: Partial<typeof schema.label.$inferInsert> = {};
+  if (parsed.name !== undefined && parsed.name !== current.name) values.name = parsed.name;
+  if (parsed.color !== undefined && parsed.color !== current.color) values.color = parsed.color;
+  if (parsed.teamId !== undefined && parsed.teamId !== current.teamId) {
+    values.teamId = parsed.teamId;
+  }
+  return values;
+}
+
 export async function updateLabel(
   principal: Principal,
   labelId: string,
@@ -187,10 +275,8 @@ export async function updateLabel(
         await requireTeam(principal, parsed.teamId, tx);
       }
 
-      const values: Partial<typeof schema.label.$inferInsert> = {};
-      if (parsed.name !== undefined) values.name = parsed.name;
-      if (parsed.color !== undefined) values.color = parsed.color;
-      if (parsed.teamId !== undefined) values.teamId = parsed.teamId;
+      const values = labelChanges(current, parsed);
+      if (Object.keys(values).length === 0) return { label: current, actions: [] };
 
       const syncId = await nextSyncId(tx);
       const actor = await principalActor(tx, principal);
@@ -205,6 +291,8 @@ export async function updateLabel(
         )
         .returning();
       const row = requireRow(updated, MISSING_LABEL);
+      const detached =
+        values.teamId === undefined ? [] : await detachFromOtherTeams(tx, row, syncId, actor);
       return {
         label: row,
         actions: [
@@ -218,6 +306,7 @@ export async function updateLabel(
             data: row,
             actor,
           }),
+          ...detached,
         ],
       };
     }),

--- a/packages/core/src/work/workflow-state-service.ts
+++ b/packages/core/src/work/workflow-state-service.ts
@@ -16,6 +16,7 @@ import { requireTeam } from '../org/team-service.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
 import { applyStateTimestamps, type IssueRow, issueScopes } from './issue-fields.ts';
+import { labelIdsByIssue } from './label-service.ts';
 
 export type WorkflowStateRow = typeof schema.workflowState.$inferSelect;
 
@@ -203,6 +204,10 @@ interface RestateParams {
 
 async function restateIssues(executor: Executor, params: RestateParams): Promise<SyncAction[]> {
   const now = new Date();
+  const labels = await labelIdsByIssue(
+    executor,
+    params.issues.map((issue) => issue.id),
+  );
   const actions: SyncAction[] = [];
   for (const issue of params.issues) {
     const timestamps = applyStateTimestamps(issue, params.category, now);
@@ -226,7 +231,7 @@ async function restateIssues(executor: Executor, params: RestateParams): Promise
         action: 'update',
         model: 'issue',
         modelId: row.id,
-        data: row,
+        data: { ...row, labelIds: labels.get(row.id) ?? [] },
         actor: params.actor,
       }),
     );

--- a/packages/core/src/work/workflow-state-service.ts
+++ b/packages/core/src/work/workflow-state-service.ts
@@ -1,5 +1,5 @@
 import { and, asc, count, db, desc, eq, inArray, ne, schema } from '@orbit/db';
-import type { StateCategory } from '@orbit/shared/constants';
+import { isOpenCategory, type StateCategory } from '@orbit/shared/constants';
 import { conflict, validationFailed } from '@orbit/shared/errors';
 import type { Actor, SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
@@ -172,13 +172,13 @@ export async function initialStateFor(
   if (unstarted !== undefined) return unstarted;
   const backlog = await defaultStateFor(executor, teamId, 'backlog');
   if (backlog !== undefined) return backlog;
-  const [any] = await executor
+  const board = await executor
     .select()
     .from(schema.workflowState)
     .where(eq(schema.workflowState.teamId, teamId))
-    .orderBy(asc(schema.workflowState.position))
-    .limit(1);
-  return requireRow(any, 'That team has no workflow states.');
+    .orderBy(asc(schema.workflowState.position));
+  const open = board.find((state) => isOpenCategory(state.category));
+  return requireRow(open ?? board[0], 'That team has no workflow states.');
 }
 
 async function issuesInState(

--- a/packages/core/src/work/workflow-state-service.ts
+++ b/packages/core/src/work/workflow-state-service.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, db, desc, eq, ne, schema } from '@orbit/db';
+import { and, asc, count, db, desc, eq, inArray, ne, schema } from '@orbit/db';
 import type { StateCategory } from '@orbit/shared/constants';
 import { conflict, validationFailed } from '@orbit/shared/errors';
 import type { Actor, SyncAction } from '@orbit/shared/events';
@@ -126,6 +126,28 @@ export async function listWorkflowStates(
     .orderBy(asc(schema.workflowState.position));
 }
 
+export async function listWorkflowStatesForTeams(
+  principal: Principal,
+  teamIds: readonly string[],
+): Promise<WorkflowStateRow[]> {
+  assertCan(principal, 'issue:read');
+  const reachable =
+    principal.role === 'admin'
+      ? [...new Set(teamIds)]
+      : [...new Set(teamIds)].filter((teamId) => principal.teamIds.includes(teamId));
+  if (reachable.length === 0) return [];
+  return await db
+    .select()
+    .from(schema.workflowState)
+    .where(
+      and(
+        eq(schema.workflowState.organizationId, principal.organizationId),
+        inArray(schema.workflowState.teamId, reachable),
+      ),
+    )
+    .orderBy(asc(schema.workflowState.position));
+}
+
 export async function defaultStateFor(
   executor: Executor,
   teamId: string,
@@ -159,8 +181,15 @@ export async function initialStateFor(
   return requireRow(any, 'That team has no workflow states.');
 }
 
-async function issuesInState(executor: Executor, stateId: string): Promise<IssueRow[]> {
-  return await executor.select().from(schema.issue).where(eq(schema.issue.stateId, stateId));
+async function issuesInState(
+  executor: Executor,
+  organizationId: string,
+  stateId: string,
+): Promise<IssueRow[]> {
+  return await executor
+    .select()
+    .from(schema.issue)
+    .where(and(eq(schema.issue.organizationId, organizationId), eq(schema.issue.stateId, stateId)));
 }
 
 interface RestateParams {
@@ -169,17 +198,20 @@ interface RestateParams {
   readonly category: string;
   readonly syncId: number;
   readonly actor: Actor;
+  readonly moved: boolean;
 }
 
 async function restateIssues(executor: Executor, params: RestateParams): Promise<SyncAction[]> {
   const now = new Date();
   const actions: SyncAction[] = [];
   for (const issue of params.issues) {
+    const timestamps = applyStateTimestamps(issue, params.category, now);
     const [row] = await executor
       .update(schema.issue)
       .set({
         stateId: params.stateId,
-        ...applyStateTimestamps(issue, params.category, now),
+        ...timestamps,
+        ...(params.moved ? {} : { stateEnteredAt: issue.stateEnteredAt }),
         updatedAt: now,
         syncId: params.syncId,
       })
@@ -243,6 +275,19 @@ export async function createWorkflowState(
   );
 }
 
+function stateChanges(
+  current: WorkflowStateRow,
+  parsed: ReturnType<typeof workflowStateUpdateSchema.parse>,
+): Partial<typeof schema.workflowState.$inferInsert> {
+  const values: Partial<typeof schema.workflowState.$inferInsert> = {};
+  if (parsed.name !== undefined && parsed.name !== current.name) values.name = parsed.name;
+  if (parsed.category !== undefined && parsed.category !== current.category) {
+    values.category = parsed.category;
+  }
+  if (parsed.color !== undefined && parsed.color !== current.color) values.color = parsed.color;
+  return values;
+}
+
 export async function updateWorkflowState(
   principal: Principal,
   stateId: string,
@@ -254,31 +299,29 @@ export async function updateWorkflowState(
   return await refusingDuplicates(async () =>
     db.transaction(async (tx) => {
       const current = await ownedState(tx, principal, stateId);
+      const values = stateChanges(current, parsed);
+      if (Object.keys(values).length === 0) return { state: current, actions: [] };
+
       const syncId = await nextSyncId(tx);
       const actor = await principalActor(tx, principal);
-
-      const values: Partial<typeof schema.workflowState.$inferInsert> = { syncId };
-      if (parsed.name !== undefined) values.name = parsed.name;
-      if (parsed.category !== undefined) values.category = parsed.category;
-      if (parsed.color !== undefined) values.color = parsed.color;
-
       const [updated] = await tx
         .update(schema.workflowState)
-        .set(values)
+        .set({ ...values, syncId })
         .where(eq(schema.workflowState.id, current.id))
         .returning();
       const row = requireRow(updated, MISSING_STATE);
 
       const recategorised =
-        parsed.category !== undefined && parsed.category !== current.category
-          ? await restateIssues(tx, {
-              issues: await issuesInState(tx, current.id),
+        values.category === undefined
+          ? []
+          : await restateIssues(tx, {
+              issues: await issuesInState(tx, current.organizationId, current.id),
               stateId: current.id,
               category: row.category,
               syncId,
               actor,
-            })
-          : [];
+              moved: false,
+            });
 
       return { state: row, actions: [stateAction(row, syncId, actor, 'update'), ...recategorised] };
     }),
@@ -338,7 +381,7 @@ export async function deleteWorkflowState(
       });
     }
 
-    const occupants = await issuesInState(tx, current.id);
+    const occupants = await issuesInState(tx, current.organizationId, current.id);
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
 
@@ -389,6 +432,7 @@ async function moveOccupants(
     category: target.category,
     syncId: params.syncId,
     actor: params.actor,
+    moved: true,
   });
   await appendActivities(
     tx,

--- a/packages/core/src/work/workflow-state-service.ts
+++ b/packages/core/src/work/workflow-state-service.ts
@@ -1,16 +1,21 @@
-import { and, asc, count, db, eq, inArray, schema } from '@orbit/db';
+import { and, asc, count, db, desc, eq, ne, schema } from '@orbit/db';
 import type { StateCategory } from '@orbit/shared/constants';
-import { conflict, notFound } from '@orbit/shared/errors';
-import type { SyncAction } from '@orbit/shared/events';
+import { conflict, validationFailed } from '@orbit/shared/errors';
+import type { Actor, SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan, assertInTeam, teamScope } from '@orbit/shared/policy';
-import { workflowStateCreateSchema, workflowStateUpdateSchema } from '@orbit/shared/validators';
-import { principalActor } from '../activity/activity-service.ts';
-import { type Executor, newId, requireRow } from '../internal.ts';
+import {
+  workflowStateCreateSchema,
+  workflowStateReorderSchema,
+  workflowStateUpdateSchema,
+} from '@orbit/shared/validators';
+import { appendActivities, principalActor } from '../activity/activity-service.ts';
+import { type Executor, isUniqueViolation, newId, requireRow } from '../internal.ts';
 import { requireTeam } from '../org/team-service.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
+import { applyStateTimestamps, type IssueRow, issueScopes } from './issue-fields.ts';
 
 export type WorkflowStateRow = typeof schema.workflowState.$inferSelect;
 
@@ -28,8 +33,58 @@ export const DEFAULT_WORKFLOW_STATES: readonly {
   { name: 'Canceled', category: 'canceled', color: '#EF4444' },
 ];
 
-function stateScopes(row: WorkflowStateRow): string[] {
+const NAME_TAKEN = 'That team already has a status with that name.';
+const MISSING_STATE = 'That workflow state does not exist.';
+
+async function refusingDuplicates<T>(run: () => Promise<T>): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (isUniqueViolation(error)) throw conflict(NAME_TAKEN);
+    throw error;
+  }
+}
+
+function stateScopes(row: Pick<WorkflowStateRow, 'teamId'>): string[] {
   return [scopes.team(row.teamId)];
+}
+
+function stateAction(
+  row: WorkflowStateRow,
+  syncId: number,
+  actor: Actor,
+  action: 'insert' | 'update',
+): SyncAction {
+  return buildSyncAction({
+    syncId,
+    organizationId: row.organizationId,
+    scopes: stateScopes(row),
+    action,
+    model: 'workflow_state',
+    modelId: row.id,
+    data: row,
+    actor,
+  });
+}
+
+async function ownedState(
+  executor: Executor,
+  principal: Principal,
+  stateId: string,
+): Promise<WorkflowStateRow> {
+  const [row] = await executor
+    .select()
+    .from(schema.workflowState)
+    .where(
+      and(
+        eq(schema.workflowState.id, stateId),
+        eq(schema.workflowState.organizationId, principal.organizationId),
+      ),
+    )
+    .limit(1);
+  const current = requireRow(row, MISSING_STATE);
+  assertInTeam(principal, teamScope(current));
+  return current;
 }
 
 export async function createDefaultWorkflowStates(
@@ -104,6 +159,59 @@ export async function initialStateFor(
   return requireRow(any, 'That team has no workflow states.');
 }
 
+async function issuesInState(executor: Executor, stateId: string): Promise<IssueRow[]> {
+  return await executor.select().from(schema.issue).where(eq(schema.issue.stateId, stateId));
+}
+
+interface RestateParams {
+  readonly issues: readonly IssueRow[];
+  readonly stateId: string;
+  readonly category: string;
+  readonly syncId: number;
+  readonly actor: Actor;
+}
+
+async function restateIssues(executor: Executor, params: RestateParams): Promise<SyncAction[]> {
+  const now = new Date();
+  const actions: SyncAction[] = [];
+  for (const issue of params.issues) {
+    const [row] = await executor
+      .update(schema.issue)
+      .set({
+        stateId: params.stateId,
+        ...applyStateTimestamps(issue, params.category, now),
+        updatedAt: now,
+        syncId: params.syncId,
+      })
+      .where(eq(schema.issue.id, issue.id))
+      .returning();
+    if (row === undefined) continue;
+    actions.push(
+      buildSyncAction({
+        syncId: params.syncId,
+        organizationId: row.organizationId,
+        scopes: issueScopes(row),
+        action: 'update',
+        model: 'issue',
+        modelId: row.id,
+        data: row,
+        actor: params.actor,
+      }),
+    );
+  }
+  return actions;
+}
+
+async function nextPosition(executor: Executor, teamId: string): Promise<number> {
+  const [row] = await executor
+    .select({ position: schema.workflowState.position })
+    .from(schema.workflowState)
+    .where(eq(schema.workflowState.teamId, teamId))
+    .orderBy(desc(schema.workflowState.position))
+    .limit(1);
+  return row === undefined ? 0 : row.position + 1;
+}
+
 export async function createWorkflowState(
   principal: Principal,
   input: unknown,
@@ -111,44 +219,28 @@ export async function createWorkflowState(
   assertCan(principal, 'workflow:manage');
   const parsed = workflowStateCreateSchema.parse(input);
 
-  return await db.transaction(async (tx) => {
-    const team = await requireTeam(principal, parsed.teamId, tx);
-    const syncId = await nextSyncId(tx);
-    const actor = await principalActor(tx, principal);
-    const [maxPosition] = await tx
-      .select({ total: count() })
-      .from(schema.workflowState)
-      .where(eq(schema.workflowState.teamId, team.id));
-    const [state] = await tx
-      .insert(schema.workflowState)
-      .values({
-        id: newId(),
-        organizationId: principal.organizationId,
-        teamId: team.id,
-        name: parsed.name,
-        category: parsed.category,
-        color: parsed.color,
-        position: parsed.position ?? maxPosition?.total ?? 0,
-        syncId,
-      })
-      .returning();
-    const row = requireRow(state, 'The workflow state could not be created.');
-    return {
-      state: row,
-      actions: [
-        buildSyncAction({
-          syncId,
+  return await refusingDuplicates(async () =>
+    db.transaction(async (tx) => {
+      const team = await requireTeam(principal, parsed.teamId, tx);
+      const syncId = await nextSyncId(tx);
+      const actor = await principalActor(tx, principal);
+      const [state] = await tx
+        .insert(schema.workflowState)
+        .values({
+          id: newId(),
           organizationId: principal.organizationId,
-          scopes: stateScopes(row),
-          action: 'insert',
-          model: 'workflow_state',
-          modelId: row.id,
-          data: row,
-          actor,
-        }),
-      ],
-    };
-  });
+          teamId: team.id,
+          name: parsed.name,
+          category: parsed.category,
+          color: parsed.color,
+          position: await nextPosition(tx, team.id),
+          syncId,
+        })
+        .returning();
+      const row = requireRow(state, 'The workflow state could not be created.');
+      return { state: row, actions: [stateAction(row, syncId, actor, 'insert')] };
+    }),
+  );
 }
 
 export async function updateWorkflowState(
@@ -159,127 +251,193 @@ export async function updateWorkflowState(
   assertCan(principal, 'workflow:manage');
   const parsed = workflowStateUpdateSchema.parse(input);
 
-  return await db.transaction(async (tx) => {
-    const [existing] = await tx
-      .select()
-      .from(schema.workflowState)
-      .where(
-        and(
-          eq(schema.workflowState.id, stateId),
-          eq(schema.workflowState.organizationId, principal.organizationId),
-        ),
-      )
-      .limit(1);
-    const current = requireRow(existing, 'That workflow state does not exist.');
-    assertInTeam(principal, teamScope(current));
+  return await refusingDuplicates(async () =>
+    db.transaction(async (tx) => {
+      const current = await ownedState(tx, principal, stateId);
+      const syncId = await nextSyncId(tx);
+      const actor = await principalActor(tx, principal);
 
-    const syncId = await nextSyncId(tx);
-    const actor = await principalActor(tx, principal);
-    const values: Partial<typeof schema.workflowState.$inferInsert> = { syncId };
-    if (parsed.name !== undefined) values.name = parsed.name;
-    if (parsed.category !== undefined) values.category = parsed.category;
-    if (parsed.color !== undefined) values.color = parsed.color;
-    if (parsed.position !== undefined) values.position = parsed.position;
+      const values: Partial<typeof schema.workflowState.$inferInsert> = { syncId };
+      if (parsed.name !== undefined) values.name = parsed.name;
+      if (parsed.category !== undefined) values.category = parsed.category;
+      if (parsed.color !== undefined) values.color = parsed.color;
 
-    const [updated] = await tx
-      .update(schema.workflowState)
-      .set(values)
-      .where(eq(schema.workflowState.id, stateId))
-      .returning();
-    const row = requireRow(updated, 'That workflow state does not exist.');
-    return {
-      state: row,
-      actions: [
-        buildSyncAction({
-          syncId,
-          organizationId: principal.organizationId,
-          scopes: stateScopes(row),
-          action: 'update',
-          model: 'workflow_state',
-          modelId: row.id,
-          data: row,
-          actor,
-        }),
-      ],
-    };
-  });
+      const [updated] = await tx
+        .update(schema.workflowState)
+        .set(values)
+        .where(eq(schema.workflowState.id, current.id))
+        .returning();
+      const row = requireRow(updated, MISSING_STATE);
+
+      const recategorised =
+        parsed.category !== undefined && parsed.category !== current.category
+          ? await restateIssues(tx, {
+              issues: await issuesInState(tx, current.id),
+              stateId: current.id,
+              category: row.category,
+              syncId,
+              actor,
+            })
+          : [];
+
+      return { state: row, actions: [stateAction(row, syncId, actor, 'update'), ...recategorised] };
+    }),
+  );
+}
+
+async function targetForMove(
+  executor: Executor,
+  current: WorkflowStateRow,
+  moveToStateId: string | undefined,
+  occupants: number,
+): Promise<WorkflowStateRow> {
+  if (moveToStateId === undefined) {
+    throw conflict('Name a status to move those issues to before deleting this one.', {
+      details: { stateId: current.id, issues: occupants },
+    });
+  }
+  const [row] = await executor
+    .select()
+    .from(schema.workflowState)
+    .where(
+      and(
+        eq(schema.workflowState.id, moveToStateId),
+        eq(schema.workflowState.organizationId, current.organizationId),
+        eq(schema.workflowState.teamId, current.teamId),
+        ne(schema.workflowState.id, current.id),
+      ),
+    )
+    .limit(1);
+  if (row === undefined) {
+    throw validationFailed('That replacement status is not another status on this team.');
+  }
+  return row;
+}
+
+export interface DeleteWorkflowStateOptions {
+  readonly moveToStateId?: string | undefined;
 }
 
 export async function deleteWorkflowState(
   principal: Principal,
   stateId: string,
+  options: DeleteWorkflowStateOptions = {},
 ): Promise<SyncAction[]> {
   assertCan(principal, 'workflow:manage');
 
   return await db.transaction(async (tx) => {
-    const [existing] = await tx
-      .select()
-      .from(schema.workflowState)
-      .where(
-        and(
-          eq(schema.workflowState.id, stateId),
-          eq(schema.workflowState.organizationId, principal.organizationId),
-        ),
-      )
-      .limit(1);
-    const current = requireRow(existing, 'That workflow state does not exist.');
-    assertInTeam(principal, teamScope(current));
+    const current = await ownedState(tx, principal, stateId);
 
-    const [used] = await tx
-      .select({ total: count() })
-      .from(schema.issue)
-      .where(eq(schema.issue.stateId, stateId));
-    if ((used?.total ?? 0) > 0) {
-      throw conflict('Move the issues in that status somewhere else first.', {
-        details: { stateId, issues: used?.total ?? 0 },
+    const [total] = await tx
+      .select({ states: count() })
+      .from(schema.workflowState)
+      .where(eq(schema.workflowState.teamId, current.teamId));
+    if ((total?.states ?? 0) <= 1) {
+      throw conflict('A team keeps at least one status, so this one cannot go.', {
+        details: { stateId: current.id },
       });
     }
 
+    const occupants = await issuesInState(tx, current.id);
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
-    await tx.delete(schema.workflowState).where(eq(schema.workflowState.id, stateId));
+
+    const moved =
+      occupants.length === 0
+        ? []
+        : await moveOccupants(tx, { current, occupants, options, syncId, actor, principal });
+
+    await tx.delete(schema.workflowState).where(eq(schema.workflowState.id, current.id));
     return [
       buildSyncAction({
         syncId,
-        organizationId: principal.organizationId,
+        organizationId: current.organizationId,
         scopes: stateScopes(current),
         action: 'delete',
         model: 'workflow_state',
-        modelId: stateId,
-        data: { id: stateId, teamId: current.teamId },
+        modelId: current.id,
+        data: { id: current.id, teamId: current.teamId },
         actor,
       }),
+      ...moved,
     ];
   });
 }
 
+interface MoveOccupantsParams {
+  readonly current: WorkflowStateRow;
+  readonly occupants: readonly IssueRow[];
+  readonly options: DeleteWorkflowStateOptions;
+  readonly syncId: number;
+  readonly actor: Actor;
+  readonly principal: Principal;
+}
+
+async function moveOccupants(
+  tx: Executor,
+  params: MoveOccupantsParams,
+): Promise<readonly SyncAction[]> {
+  const target = await targetForMove(
+    tx,
+    params.current,
+    params.options.moveToStateId,
+    params.occupants.length,
+  );
+  const actions = await restateIssues(tx, {
+    issues: params.occupants,
+    stateId: target.id,
+    category: target.category,
+    syncId: params.syncId,
+    actor: params.actor,
+  });
+  await appendActivities(
+    tx,
+    params.occupants.map((issue) => ({
+      organizationId: params.principal.organizationId,
+      issueId: issue.id,
+      actor: params.actor,
+      field: 'stateId',
+      from: params.current.name,
+      to: target.name,
+      syncId: params.syncId,
+    })),
+  );
+  return actions;
+}
+
 export async function reorderWorkflowStates(
   principal: Principal,
-  teamId: string,
-  orderedStateIds: readonly string[],
+  input: unknown,
 ): Promise<{ states: WorkflowStateRow[]; actions: SyncAction[] }> {
   assertCan(principal, 'workflow:manage');
-  if (orderedStateIds.length === 0) throw notFound('Provide the states to reorder.');
+  const parsed = workflowStateReorderSchema.parse(input);
+  const wanted = [...new Set(parsed.stateIds)];
+  if (wanted.length !== parsed.stateIds.length) {
+    throw validationFailed('That order names the same status twice.');
+  }
 
   return await db.transaction(async (tx) => {
-    await requireTeam(principal, teamId, tx);
+    const team = await requireTeam(principal, parsed.teamId, tx);
     const existing = await tx
       .select()
       .from(schema.workflowState)
       .where(
         and(
-          eq(schema.workflowState.teamId, teamId),
-          inArray(schema.workflowState.id, [...orderedStateIds]),
+          eq(schema.workflowState.organizationId, principal.organizationId),
+          eq(schema.workflowState.teamId, team.id),
         ),
       );
-    if (existing.length !== orderedStateIds.length) {
-      throw conflict('Some of those states do not belong to this team.');
+    const known = new Set(existing.map((row) => row.id));
+    if (existing.length !== wanted.length || wanted.some((id) => !known.has(id))) {
+      throw conflict('Reordering needs every status on the team, exactly once.', {
+        details: { teamId: team.id, expected: existing.length, received: wanted.length },
+      });
     }
 
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
     const states: WorkflowStateRow[] = [];
-    for (const [position, id] of orderedStateIds.entries()) {
+    for (const [position, id] of wanted.entries()) {
       const [updated] = await tx
         .update(schema.workflowState)
         .set({ position, syncId })
@@ -290,18 +448,7 @@ export async function reorderWorkflowStates(
 
     return {
       states,
-      actions: states.map((row) =>
-        buildSyncAction({
-          syncId,
-          organizationId: principal.organizationId,
-          scopes: stateScopes(row),
-          action: 'update',
-          model: 'workflow_state',
-          modelId: row.id,
-          data: row,
-          actor,
-        }),
-      ),
+      actions: states.map((row) => stateAction(row, syncId, actor, 'update')),
     };
   });
 }

--- a/packages/core/tests/work/label-scope.test.ts
+++ b/packages/core/tests/work/label-scope.test.ts
@@ -7,9 +7,10 @@ import {
   addMember,
   createWorkspace,
   resetDatabase,
+  stateNamed,
   type Workspace,
 } from '../../src/test-support.ts';
-import { createIssue, updateIssue } from '../../src/work/issue-service.ts';
+import { createIssue, moveIssue, updateIssue } from '../../src/work/issue-service.ts';
 import {
   createLabel,
   deleteLabel,
@@ -317,6 +318,86 @@ describe('narrowing a label to a team takes it off the issues that team cannot s
 
     expect(await labelIdsOn(inside.issue.id)).toEqual([teamOnly.label.id]);
     expect(result.actions.filter((action) => action.model === 'issue')).toHaveLength(0);
+  });
+});
+
+describe('carrying an issue to another team drops the labels that team cannot use', () => {
+  async function labelIdsOn(issueId: string): Promise<string[]> {
+    const rows = await db
+      .select()
+      .from(schema.issueLabel)
+      .where(eq(schema.issueLabel.issueId, issueId));
+    return rows.map((row) => row.labelId);
+  }
+
+  it('strips the old team label, keeps the workspace one, and says so over the wire', async () => {
+    const designOnly = await createLabel(nova.admin, {
+      name: 'Pixel polish',
+      color: '#EC4899',
+      teamId: designTeamId,
+    });
+    const shared = await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+    const issue = await createIssue(nova.admin, {
+      teamId: designTeamId,
+      title: 'Design work',
+      labelIds: [designOnly.label.id, shared.label.id],
+    });
+
+    const moved = await moveIssue(nova.admin, issue.issue.id, {
+      teamId: nova.teamId,
+      stateId: stateNamed(nova, 'Todo').id,
+    });
+
+    expect(moved.issue.teamId).toBe(nova.teamId);
+    expect(await labelIdsOn(issue.issue.id)).toEqual([shared.label.id]);
+    const action = moved.actions.find(
+      (entry) => entry.model === 'issue' && entry.modelId === issue.issue.id,
+    );
+    expect(action?.data['labelIds']).toEqual([shared.label.id]);
+    expect(action?.scopes).toContain(scopes.team(nova.teamId));
+  });
+
+  it('takes it off the issue that moved and off no other', async () => {
+    const designOnly = await createLabel(nova.admin, {
+      name: 'Pixel polish',
+      color: '#EC4899',
+      teamId: designTeamId,
+    });
+    const leaving = await createIssue(nova.admin, {
+      teamId: designTeamId,
+      title: 'Design work',
+      labelIds: [designOnly.label.id],
+    });
+    const staying = await createIssue(nova.admin, {
+      teamId: designTeamId,
+      title: 'More design work',
+      labelIds: [designOnly.label.id],
+    });
+
+    await moveIssue(nova.admin, leaving.issue.id, {
+      teamId: nova.teamId,
+      stateId: stateNamed(nova, 'Todo').id,
+    });
+
+    expect(await labelIdsOn(leaving.issue.id)).toEqual([]);
+    expect(await labelIdsOn(staying.issue.id)).toEqual([designOnly.label.id]);
+  });
+
+  it('leaves the labels alone when the move keeps the issue on its own team', async () => {
+    const designOnly = await createLabel(nova.admin, {
+      name: 'Pixel polish',
+      color: '#EC4899',
+      teamId: designTeamId,
+    });
+    const issue = await createIssue(nova.admin, {
+      teamId: designTeamId,
+      title: 'Design work',
+      labelIds: [designOnly.label.id],
+    });
+
+    await moveIssue(nova.admin, issue.issue.id, {});
+
+    expect(await labelIdsOn(issue.issue.id)).toEqual([designOnly.label.id]);
   });
 });
 

--- a/packages/core/tests/work/label-scope.test.ts
+++ b/packages/core/tests/work/label-scope.test.ts
@@ -232,6 +232,123 @@ describe('an issue can only carry a label its team is allowed', () => {
   });
 });
 
+describe('narrowing a label to a team takes it off the issues that team cannot see', () => {
+  async function labelIdsOn(issueId: string): Promise<string[]> {
+    const rows = await db
+      .select()
+      .from(schema.issueLabel)
+      .where(eq(schema.issueLabel.issueId, issueId));
+    return rows.map((row) => row.labelId);
+  }
+
+  it('detaches it from an issue on another team and leaves the issue on its own team alone', async () => {
+    const shared = await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+    const outside = await createIssue(nova.admin, {
+      teamId: nova.teamId,
+      title: 'Platform work',
+      labelIds: [shared.label.id],
+    });
+    const inside = await createIssue(nova.admin, {
+      teamId: designTeamId,
+      title: 'Design work',
+      labelIds: [shared.label.id],
+    });
+
+    await updateLabel(nova.admin, shared.label.id, { teamId: designTeamId });
+
+    expect(await labelIdsOn(outside.issue.id)).toEqual([]);
+    expect(await labelIdsOn(inside.issue.id)).toEqual([shared.label.id]);
+  });
+
+  it('keeps the other labels of the issue it strips', async () => {
+    const shared = await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+    const kept = await createLabel(nova.admin, { name: 'Slow', color: '#22C55E' });
+    const outside = await createIssue(nova.admin, {
+      teamId: nova.teamId,
+      title: 'Platform work',
+      labelIds: [shared.label.id, kept.label.id],
+    });
+
+    await updateLabel(nova.admin, shared.label.id, { teamId: designTeamId });
+
+    expect(await labelIdsOn(outside.issue.id)).toEqual([kept.label.id]);
+  });
+
+  it('tells the issue audience, so a live board drops the chip without a refetch', async () => {
+    const shared = await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+    const kept = await createLabel(nova.admin, { name: 'Slow', color: '#22C55E' });
+    const outside = await createIssue(nova.admin, {
+      teamId: nova.teamId,
+      title: 'Platform work',
+      labelIds: [shared.label.id, kept.label.id],
+    });
+    const [before] = await db
+      .select()
+      .from(schema.issue)
+      .where(eq(schema.issue.id, outside.issue.id));
+
+    const result = await updateLabel(nova.admin, shared.label.id, { teamId: designTeamId });
+
+    const issueAction = result.actions.find((action) => action.model === 'issue');
+    expect(issueAction?.modelId).toBe(outside.issue.id);
+    expect(issueAction?.data['labelIds']).toEqual([kept.label.id]);
+    expect(issueAction?.scopes).toContain(scopes.team(nova.teamId));
+    expect(issueAction?.scopes).not.toContain(scopes.team(designTeamId));
+    const [after] = await db
+      .select()
+      .from(schema.issue)
+      .where(eq(schema.issue.id, outside.issue.id));
+    expect(after?.syncId).toBeGreaterThan(before?.syncId ?? 0);
+  });
+
+  it('touches nothing when the label widens back to the whole workspace', async () => {
+    const teamOnly = await createLabel(nova.admin, {
+      name: 'Pixel polish',
+      color: '#EC4899',
+      teamId: designTeamId,
+    });
+    const inside = await createIssue(nova.admin, {
+      teamId: designTeamId,
+      title: 'Design work',
+      labelIds: [teamOnly.label.id],
+    });
+
+    const result = await updateLabel(nova.admin, teamOnly.label.id, { teamId: null });
+
+    expect(await labelIdsOn(inside.issue.id)).toEqual([teamOnly.label.id]);
+    expect(result.actions.filter((action) => action.model === 'issue')).toHaveLength(0);
+  });
+});
+
+describe('a patch that changes nothing changes nothing', () => {
+  it('does not bump the sync id and does not fan out', async () => {
+    const shared = await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+
+    const empty = await updateLabel(nova.admin, shared.label.id, {});
+    const same = await updateLabel(nova.admin, shared.label.id, {
+      name: 'Flaky',
+      color: '#EF4444',
+      teamId: null,
+    });
+
+    expect(empty.actions).toHaveLength(0);
+    expect(same.actions).toHaveLength(0);
+    expect((await rowById(shared.label.id))?.syncId).toBe(shared.label.syncId);
+  });
+
+  it('still fans out when one field really moves', async () => {
+    const shared = await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+
+    const changed = await updateLabel(nova.admin, shared.label.id, {
+      name: 'Flaky',
+      color: '#22C55E',
+    });
+
+    expect(changed.actions).toHaveLength(1);
+    expect((await rowById(shared.label.id))?.color).toBe('#22C55E');
+  });
+});
+
 describe('two labels cannot share a name in the same place', () => {
   it('answers a duplicate workspace name with a conflict, not a server fault', async () => {
     await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });

--- a/packages/core/tests/work/label-scope.test.ts
+++ b/packages/core/tests/work/label-scope.test.ts
@@ -1,0 +1,268 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { db, eq, schema } from '@orbit/db';
+import { scopes } from '@orbit/shared/events';
+import type { Principal } from '@orbit/shared/policy';
+import { createTeam } from '../../src/org/team-service.ts';
+import {
+  addMember,
+  createWorkspace,
+  resetDatabase,
+  type Workspace,
+} from '../../src/test-support.ts';
+import { createIssue, updateIssue } from '../../src/work/issue-service.ts';
+import {
+  createLabel,
+  deleteLabel,
+  getLabel,
+  type LabelRow,
+  listLabels,
+  updateLabel,
+} from '../../src/work/label-service.ts';
+
+let nova: Workspace;
+let orion: Workspace;
+let designTeamId: string;
+let designMember: Principal;
+let platformMember: Principal;
+
+beforeEach(async () => {
+  await resetDatabase();
+  nova = await createWorkspace('Nova');
+  orion = await createWorkspace('Orion');
+  const design = await createTeam(nova.admin, { name: 'Design', key: 'DSGN' });
+  designTeamId = design.team.id;
+  designMember = (await addMember(nova, 'member', { teamIds: [designTeamId] })).principal;
+  platformMember = (await addMember(nova, 'member', { teamIds: [nova.teamId] })).principal;
+});
+
+async function errorOf(run: () => Promise<unknown>): Promise<string> {
+  try {
+    await run();
+  } catch (error: unknown) {
+    const thrown = error as { code?: unknown };
+    return typeof thrown.code === 'string' ? thrown.code : 'not-a-domain-error';
+  }
+  throw new Error('the call was expected to throw and did not');
+}
+
+async function rowById(labelId: string): Promise<LabelRow | undefined> {
+  const [row] = await db.select().from(schema.label).where(eq(schema.label.id, labelId)).limit(1);
+  return row;
+}
+
+describe('a team label is fanned out to that team only', () => {
+  it('gives a workspace label the org scope and a team label the team scope, never both', async () => {
+    const workspaceWide = await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+    const teamOnly = await createLabel(nova.admin, {
+      name: 'Pixel polish',
+      color: '#EC4899',
+      teamId: designTeamId,
+    });
+
+    expect(workspaceWide.actions[0]?.scopes).toEqual([scopes.organization(nova.organizationId)]);
+    expect(teamOnly.actions[0]?.scopes).toEqual([scopes.team(designTeamId)]);
+    expect(teamOnly.actions[0]?.scopes).not.toContain(scopes.organization(nova.organizationId));
+  });
+
+  it('reaches the audience that is losing it and the audience that is gaining it on a move', async () => {
+    const created = await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+
+    const narrowed = await updateLabel(nova.admin, created.label.id, { teamId: designTeamId });
+
+    expect(narrowed.actions[0]?.scopes.slice().sort()).toEqual(
+      [scopes.organization(nova.organizationId), scopes.team(designTeamId)].sort(),
+    );
+  });
+
+  it('deletes a team label to the team that could see it', async () => {
+    const teamOnly = await createLabel(nova.admin, {
+      name: 'Pixel polish',
+      color: '#EC4899',
+      teamId: designTeamId,
+    });
+
+    const actions = await deleteLabel(nova.admin, teamOnly.label.id);
+
+    expect(actions[0]?.scopes).toEqual([scopes.team(designTeamId)]);
+  });
+});
+
+describe('a team label is invisible to a member of another team', () => {
+  it('hides it from a list, a read, an edit and a delete, while the admin still sees it', async () => {
+    const teamOnly = await createLabel(nova.admin, {
+      name: 'Pixel polish',
+      color: '#EC4899',
+      teamId: designTeamId,
+    });
+
+    expect((await listLabels(designMember)).map((row) => row.id)).toContain(teamOnly.label.id);
+    expect((await listLabels(platformMember)).map((row) => row.id)).not.toContain(
+      teamOnly.label.id,
+    );
+    expect((await listLabels(nova.admin)).map((row) => row.id)).toContain(teamOnly.label.id);
+
+    expect(await errorOf(() => getLabel(platformMember, teamOnly.label.id))).toBe('not_found');
+    expect(
+      await errorOf(() => updateLabel(platformMember, teamOnly.label.id, { name: 'Taken' })),
+    ).toBe('not_found');
+    expect(await errorOf(() => deleteLabel(platformMember, teamOnly.label.id))).toBe('not_found');
+    expect((await rowById(teamOnly.label.id))?.name).toBe('Pixel polish');
+  });
+
+  it('still shows a workspace label to everybody', async () => {
+    const shared = await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+
+    expect((await listLabels(platformMember)).map((row) => row.id)).toContain(shared.label.id);
+    expect((await getLabel(platformMember, shared.label.id)).name).toBe('Flaky');
+  });
+});
+
+describe('a label cannot be pinned to a team the writer has no claim on', () => {
+  it('refuses a team in another workspace on create and writes nothing', async () => {
+    const before = await db.select().from(schema.label);
+
+    expect(
+      await errorOf(() =>
+        createLabel(nova.admin, { name: 'Stolen', color: '#EF4444', teamId: orion.teamId }),
+      ),
+    ).toBe('not_found');
+
+    expect(await db.select().from(schema.label)).toHaveLength(before.length);
+  });
+
+  it('refuses a team in another workspace on update and leaves the label workspace wide', async () => {
+    const created = await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+
+    expect(
+      await errorOf(() => updateLabel(nova.admin, created.label.id, { teamId: orion.teamId })),
+    ).toBe('not_found');
+
+    expect((await rowById(created.label.id))?.teamId).toBeNull();
+  });
+
+  it('refuses a team of this workspace that the writer has not joined', async () => {
+    expect(
+      await errorOf(() =>
+        createLabel(platformMember, {
+          name: 'Pixel polish',
+          color: '#EC4899',
+          teamId: designTeamId,
+        }),
+      ),
+    ).toBe('forbidden');
+  });
+});
+
+describe('an issue can only carry a label its team is allowed', () => {
+  it('refuses a label pinned to another team, and refuses one from another workspace', async () => {
+    const designOnly = await createLabel(nova.admin, {
+      name: 'Pixel polish',
+      color: '#EC4899',
+      teamId: designTeamId,
+    });
+    const foreign = await createLabel(orion.admin, { name: 'Theirs', color: '#22C55E' });
+
+    expect(
+      await errorOf(() =>
+        createIssue(nova.admin, {
+          teamId: nova.teamId,
+          title: 'Borrowed',
+          labelIds: [designOnly.label.id],
+        }),
+      ),
+    ).toBe('validation_failed');
+    expect(
+      await errorOf(() =>
+        createIssue(nova.admin, {
+          teamId: nova.teamId,
+          title: 'Borrowed',
+          labelIds: [foreign.label.id],
+        }),
+      ),
+    ).toBe('validation_failed');
+  });
+
+  it('refuses the same reach on an update and leaves the issue labels alone', async () => {
+    const designOnly = await createLabel(nova.admin, {
+      name: 'Pixel polish',
+      color: '#EC4899',
+      teamId: designTeamId,
+    });
+    const shared = await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+    const created = await createIssue(nova.admin, {
+      teamId: nova.teamId,
+      title: 'Mine',
+      labelIds: [shared.label.id],
+    });
+
+    expect(
+      await errorOf(() =>
+        updateIssue(nova.admin, created.issue.id, { labelIds: [designOnly.label.id] }),
+      ),
+    ).toBe('validation_failed');
+
+    const links = await db
+      .select()
+      .from(schema.issueLabel)
+      .where(eq(schema.issueLabel.issueId, created.issue.id));
+    expect(links.map((row) => row.labelId)).toEqual([shared.label.id]);
+  });
+
+  it('still accepts a workspace label and a label of the issue own team', async () => {
+    const shared = await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+    const designOnly = await createLabel(nova.admin, {
+      name: 'Pixel polish',
+      color: '#EC4899',
+      teamId: designTeamId,
+    });
+
+    const created = await createIssue(nova.admin, {
+      teamId: designTeamId,
+      title: 'Design work',
+      labelIds: [shared.label.id, designOnly.label.id],
+    });
+
+    const links = await db
+      .select()
+      .from(schema.issueLabel)
+      .where(eq(schema.issueLabel.issueId, created.issue.id));
+    expect(links.map((row) => row.labelId).sort()).toEqual(
+      [shared.label.id, designOnly.label.id].sort(),
+    );
+  });
+});
+
+describe('two labels cannot share a name in the same place', () => {
+  it('answers a duplicate workspace name with a conflict, not a server fault', async () => {
+    await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+
+    expect(await errorOf(() => createLabel(nova.admin, { name: 'Flaky', color: '#22C55E' }))).toBe(
+      'conflict',
+    );
+  });
+
+  it('answers a rename onto a taken name with a conflict', async () => {
+    await createLabel(nova.admin, { name: 'Flaky', color: '#EF4444' });
+    const second = await createLabel(nova.admin, { name: 'Slow', color: '#22C55E' });
+
+    expect(await errorOf(() => updateLabel(nova.admin, second.label.id, { name: 'Flaky' }))).toBe(
+      'conflict',
+    );
+    expect((await rowById(second.label.id))?.name).toBe('Slow');
+  });
+
+  it('lets two teams each hold a label of the same name', async () => {
+    const first = await createLabel(nova.admin, {
+      name: 'Polish',
+      color: '#EF4444',
+      teamId: designTeamId,
+    });
+    const second = await createLabel(nova.admin, {
+      name: 'Polish',
+      color: '#22C55E',
+      teamId: nova.teamId,
+    });
+
+    expect(first.label.id).not.toBe(second.label.id);
+  });
+});

--- a/packages/core/tests/work/workflow-state-lifecycle.test.ts
+++ b/packages/core/tests/work/workflow-state-lifecycle.test.ts
@@ -10,6 +10,7 @@ import {
   type Workspace,
 } from '../../src/test-support.ts';
 import { createIssue } from '../../src/work/issue-service.ts';
+import { createLabel } from '../../src/work/label-service.ts';
 import {
   createWorkflowState,
   deleteWorkflowState,
@@ -374,6 +375,61 @@ describe('deleting a status that still holds issues needs an answer', () => {
     expect(await errorOf(() => deleteWorkflowState(workspace.admin, last.id))).toBe('conflict');
 
     expect(await statesOf(workspace.teamId)).toHaveLength(1);
+  });
+});
+
+describe('an issue a status change touches goes out whole, labels and all', () => {
+  it('carries the labels through a category change, so a board cannot blank the chips', async () => {
+    const label = await createLabel(workspace.admin, { name: 'Flaky', color: '#EF4444' });
+    const todo = stateNamed(workspace, 'Todo');
+    const created = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Parked',
+      stateId: todo.id,
+      labelIds: [label.label.id],
+    });
+
+    const saved = await updateWorkflowState(workspace.admin, todo.id, { category: 'completed' });
+
+    const action = saved.actions.find(
+      (entry) => entry.model === 'issue' && entry.modelId === created.issue.id,
+    );
+    expect(action?.data['labelIds']).toEqual([label.label.id]);
+  });
+
+  it('carries them through a delete that moves the issues too', async () => {
+    const label = await createLabel(workspace.admin, { name: 'Flaky', color: '#EF4444' });
+    const todo = stateNamed(workspace, 'Todo');
+    const done = stateNamed(workspace, 'Done');
+    const created = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Parked',
+      stateId: todo.id,
+      labelIds: [label.label.id],
+    });
+
+    const actions = await deleteWorkflowState(workspace.admin, todo.id, { moveToStateId: done.id });
+
+    const action = actions.find(
+      (entry) => entry.model === 'issue' && entry.modelId === created.issue.id,
+    );
+    expect(action?.data['labelIds']).toEqual([label.label.id]);
+  });
+
+  it('sends an empty list rather than nothing for an issue that carries no label', async () => {
+    const todo = stateNamed(workspace, 'Todo');
+    const created = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Bare',
+      stateId: todo.id,
+    });
+
+    const saved = await updateWorkflowState(workspace.admin, todo.id, { category: 'completed' });
+
+    const action = saved.actions.find(
+      (entry) => entry.model === 'issue' && entry.modelId === created.issue.id,
+    );
+    expect(action?.data['labelIds']).toEqual([]);
   });
 });
 

--- a/packages/core/tests/work/workflow-state-lifecycle.test.ts
+++ b/packages/core/tests/work/workflow-state-lifecycle.test.ts
@@ -250,6 +250,36 @@ describe('a status carries a category the rest of the product reads', () => {
     expect((await issueById(created.issue.id)).syncId).toBe(created.issue.syncId);
   });
 
+  it('never births a new issue into a closed column when the open ones are gone', async () => {
+    const board = await statesOf(workspace.teamId);
+    for (const state of board) {
+      if (state.name === 'In Review') continue;
+      await updateWorkflowState(workspace.admin, state.id, { category: 'completed' });
+    }
+    await updateWorkflowState(workspace.admin, stateNamed(workspace, 'In Review').id, {
+      category: 'review',
+    });
+
+    const created = await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'New' });
+
+    const landed = await issueById(created.issue.id);
+    expect(landed.stateId).toBe(stateNamed(workspace, 'In Review').id);
+    expect(landed.completedAt).toBeNull();
+  });
+
+  it('still takes the first column when a team has closed every one of them', async () => {
+    const board = await statesOf(workspace.teamId);
+    const first = board[0];
+    if (first === undefined) throw new Error('the fixture had no states');
+    for (const state of board) {
+      await updateWorkflowState(workspace.admin, state.id, { category: 'canceled' });
+    }
+
+    const created = await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'New' });
+
+    expect((await issueById(created.issue.id)).stateId).toBe(first.id);
+  });
+
   it('refuses two statuses of the same name on one team', async () => {
     expect(
       await errorOf(() =>

--- a/packages/core/tests/work/workflow-state-lifecycle.test.ts
+++ b/packages/core/tests/work/workflow-state-lifecycle.test.ts
@@ -1,0 +1,346 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { asc, db, eq, schema } from '@orbit/db';
+import { scopes } from '@orbit/shared/events';
+import { createTeam } from '../../src/org/team-service.ts';
+import {
+  addMember,
+  createWorkspace,
+  resetDatabase,
+  stateNamed,
+  type Workspace,
+} from '../../src/test-support.ts';
+import { createIssue } from '../../src/work/issue-service.ts';
+import {
+  createWorkflowState,
+  deleteWorkflowState,
+  listWorkflowStates,
+  reorderWorkflowStates,
+  updateWorkflowState,
+  type WorkflowStateRow,
+} from '../../src/work/workflow-state-service.ts';
+
+let workspace: Workspace;
+
+beforeEach(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+});
+
+async function errorOf(run: () => Promise<unknown>): Promise<string> {
+  try {
+    await run();
+  } catch (error: unknown) {
+    const thrown = error as { code?: unknown };
+    return typeof thrown.code === 'string' ? thrown.code : 'not-a-domain-error';
+  }
+  throw new Error('the call was expected to throw and did not');
+}
+
+async function issueById(issueId: string) {
+  const [row] = await db.select().from(schema.issue).where(eq(schema.issue.id, issueId)).limit(1);
+  if (row === undefined) throw new Error('the issue vanished');
+  return row;
+}
+
+async function statesOf(teamId: string): Promise<WorkflowStateRow[]> {
+  return await db
+    .select()
+    .from(schema.workflowState)
+    .where(eq(schema.workflowState.teamId, teamId))
+    .orderBy(asc(schema.workflowState.position));
+}
+
+describe('the board order is the server position, contiguous and complete', () => {
+  it('appends a new status after the last one and ignores a position the caller sends', async () => {
+    const created = await createWorkflowState(workspace.admin, {
+      teamId: workspace.teamId,
+      name: 'Blocked',
+      category: 'started',
+      color: '#EF4444',
+      position: 0,
+    });
+
+    expect(created.state.position).toBe(7);
+    expect((await statesOf(workspace.teamId)).map((state) => state.position)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7,
+    ]);
+  });
+
+  it('refuses an order that leaves a status out, so no two columns collide', async () => {
+    const before = await statesOf(workspace.teamId);
+    const subset = before.slice(0, 3).map((state) => state.id);
+
+    expect(
+      await errorOf(() =>
+        reorderWorkflowStates(workspace.admin, { teamId: workspace.teamId, stateIds: subset }),
+      ),
+    ).toBe('conflict');
+
+    expect((await statesOf(workspace.teamId)).map((state) => state.id)).toEqual(
+      before.map((state) => state.id),
+    );
+  });
+
+  it('refuses an order that names one status twice', async () => {
+    const before = await statesOf(workspace.teamId);
+    const doubled = before.map((state) => state.id);
+    doubled[1] = doubled[0] ?? '';
+
+    expect(
+      await errorOf(() =>
+        reorderWorkflowStates(workspace.admin, { teamId: workspace.teamId, stateIds: doubled }),
+      ),
+    ).toBe('validation_failed');
+
+    expect((await statesOf(workspace.teamId)).map((state) => state.id)).toEqual(
+      before.map((state) => state.id),
+    );
+  });
+
+  it('refuses an order that smuggles in a status from another team', async () => {
+    const design = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const mine = await statesOf(workspace.teamId);
+    const theirs = await statesOf(design.team.id);
+    const mixed = [...mine.slice(1).map((state) => state.id), theirs[0]?.id ?? ''];
+
+    expect(
+      await errorOf(() =>
+        reorderWorkflowStates(workspace.admin, { teamId: workspace.teamId, stateIds: mixed }),
+      ),
+    ).toBe('conflict');
+
+    expect((await statesOf(design.team.id)).map((state) => state.position)).toEqual(
+      theirs.map((state) => state.position),
+    );
+  });
+
+  it('renumbers every status when the whole order is given, and keeps each category', async () => {
+    const before = await statesOf(workspace.teamId);
+    const flipped = before.map((state) => state.id).reverse();
+
+    const result = await reorderWorkflowStates(workspace.admin, {
+      teamId: workspace.teamId,
+      stateIds: flipped,
+    });
+
+    const after = await statesOf(workspace.teamId);
+    expect(after.map((state) => state.id)).toEqual(flipped);
+    expect(after.map((state) => state.position)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(new Map(after.map((state) => [state.id, state.category]))).toEqual(
+      new Map(before.map((state) => [state.id, state.category])),
+    );
+    expect(result.actions).toHaveLength(before.length);
+    expect(result.actions.every((action) => action.scopes.length === 1)).toBe(true);
+    expect(result.actions[0]?.scopes).toEqual([scopes.team(workspace.teamId)]);
+  });
+});
+
+describe('a status carries a category the rest of the product reads', () => {
+  it('re-dates the issues sitting in a status when its category moves to completed', async () => {
+    const todo = stateNamed(workspace, 'Todo');
+    const created = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Parked',
+      stateId: todo.id,
+    });
+    expect((await issueById(created.issue.id)).completedAt).toBeNull();
+
+    const saved = await updateWorkflowState(workspace.admin, todo.id, { category: 'completed' });
+
+    const after = await issueById(created.issue.id);
+    expect(saved.state.category).toBe('completed');
+    expect(after.completedAt).not.toBeNull();
+    expect(after.startedAt).not.toBeNull();
+    expect(saved.actions.some((action) => action.model === 'issue')).toBe(true);
+  });
+
+  it('clears the completion when the category moves back off completed', async () => {
+    const done = stateNamed(workspace, 'Done');
+    const created = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Shipped',
+      stateId: done.id,
+    });
+    expect((await issueById(created.issue.id)).completedAt).not.toBeNull();
+
+    await updateWorkflowState(workspace.admin, done.id, { category: 'unstarted' });
+
+    const after = await issueById(created.issue.id);
+    expect(after.completedAt).toBeNull();
+    expect(after.startedAt).toBeNull();
+  });
+
+  it('leaves the issues alone when only the name and the colour change', async () => {
+    const todo = stateNamed(workspace, 'Todo');
+    const created = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Parked',
+      stateId: todo.id,
+    });
+    const before = await issueById(created.issue.id);
+
+    const saved = await updateWorkflowState(workspace.admin, todo.id, {
+      name: 'Up next',
+      color: '#123456',
+    });
+
+    const after = await issueById(created.issue.id);
+    expect(saved.state.name).toBe('Up next');
+    expect(saved.state.category).toBe('unstarted');
+    expect(after.syncId).toBe(before.syncId);
+    expect(saved.actions.some((action) => action.model === 'issue')).toBe(false);
+  });
+
+  it('refuses two statuses of the same name on one team', async () => {
+    expect(
+      await errorOf(() =>
+        createWorkflowState(workspace.admin, {
+          teamId: workspace.teamId,
+          name: 'Todo',
+          category: 'unstarted',
+          color: '#EF4444',
+        }),
+      ),
+    ).toBe('conflict');
+  });
+
+  it('publishes a status change to the team only, never to the whole workspace', async () => {
+    const saved = await updateWorkflowState(workspace.admin, stateNamed(workspace, 'Todo').id, {
+      name: 'Up next',
+    });
+
+    expect(saved.actions[0]?.scopes).toEqual([scopes.team(workspace.teamId)]);
+    expect(saved.actions[0]?.scopes).not.toContain(scopes.organization(workspace.organizationId));
+  });
+});
+
+describe('deleting a status that still holds issues needs an answer', () => {
+  it('refuses when no replacement is named and leaves every issue where it was', async () => {
+    const todo = stateNamed(workspace, 'Todo');
+    const created = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Parked',
+      stateId: todo.id,
+    });
+
+    expect(await errorOf(() => deleteWorkflowState(workspace.admin, todo.id))).toBe('conflict');
+
+    expect((await issueById(created.issue.id)).stateId).toBe(todo.id);
+    expect((await statesOf(workspace.teamId)).map((state) => state.id)).toContain(todo.id);
+  });
+
+  it('moves the issues to the named status, re-dates them, and records the move', async () => {
+    const todo = stateNamed(workspace, 'Todo');
+    const done = stateNamed(workspace, 'Done');
+    const created = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Parked',
+      stateId: todo.id,
+    });
+
+    const actions = await deleteWorkflowState(workspace.admin, todo.id, {
+      moveToStateId: done.id,
+    });
+
+    const after = await issueById(created.issue.id);
+    expect(after.stateId).toBe(done.id);
+    expect(after.completedAt).not.toBeNull();
+    expect((await statesOf(workspace.teamId)).map((state) => state.id)).not.toContain(todo.id);
+    expect(actions.filter((action) => action.model === 'issue')).toHaveLength(1);
+
+    const activity = await db
+      .select()
+      .from(schema.issueActivity)
+      .where(eq(schema.issueActivity.issueId, created.issue.id));
+    expect(activity.some((row) => row.field === 'stateId' && row.toValue === 'Done')).toBe(true);
+  });
+
+  it('refuses a replacement that belongs to another team and keeps the status', async () => {
+    const design = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const todo = stateNamed(workspace, 'Todo');
+    const created = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Parked',
+      stateId: todo.id,
+    });
+    const theirs = await statesOf(design.team.id);
+
+    expect(
+      await errorOf(() =>
+        deleteWorkflowState(workspace.admin, todo.id, { moveToStateId: theirs[0]?.id ?? '' }),
+      ),
+    ).toBe('validation_failed');
+
+    expect((await issueById(created.issue.id)).stateId).toBe(todo.id);
+  });
+
+  it('refuses to empty a team of statuses altogether', async () => {
+    const states = await statesOf(workspace.teamId);
+    for (const state of states.slice(1)) {
+      await deleteWorkflowState(workspace.admin, state.id);
+    }
+    const last = states[0];
+    if (last === undefined) throw new Error('the fixture had no states');
+
+    expect(await errorOf(() => deleteWorkflowState(workspace.admin, last.id))).toBe('conflict');
+
+    expect(await statesOf(workspace.teamId)).toHaveLength(1);
+  });
+});
+
+describe('the server is the gate, whatever the caller sends', () => {
+  it('refuses a contributor on every write', async () => {
+    const { principal } = await addMember(workspace, 'contributor');
+    const todo = stateNamed(workspace, 'Todo');
+    const ids = (await statesOf(workspace.teamId)).map((state) => state.id);
+
+    expect(
+      await errorOf(() =>
+        createWorkflowState(principal, {
+          teamId: workspace.teamId,
+          name: 'Nope',
+          category: 'started',
+          color: '#EF4444',
+        }),
+      ),
+    ).toBe('forbidden');
+    expect(await errorOf(() => updateWorkflowState(principal, todo.id, { name: 'Nope' }))).toBe(
+      'forbidden',
+    );
+    expect(await errorOf(() => deleteWorkflowState(principal, todo.id))).toBe('forbidden');
+    expect(
+      await errorOf(() =>
+        reorderWorkflowStates(principal, { teamId: workspace.teamId, stateIds: ids.reverse() }),
+      ),
+    ).toBe('forbidden');
+  });
+
+  it('refuses a member of this workspace who is not on that team', async () => {
+    const design = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const outsider = await addMember(workspace, 'member', { teamIds: [workspace.teamId] });
+    const theirs = await statesOf(design.team.id);
+    const target = theirs[0];
+    if (target === undefined) throw new Error('the new team had no states');
+
+    expect(
+      await errorOf(() => updateWorkflowState(outsider.principal, target.id, { name: 'Nope' })),
+    ).toBe('forbidden');
+    expect(await errorOf(() => deleteWorkflowState(outsider.principal, target.id))).toBe(
+      'forbidden',
+    );
+    expect((await listWorkflowStates(workspace.admin, design.team.id))[0]?.name).toBe(target.name);
+  });
+
+  it('refuses a status in another workspace outright', async () => {
+    const vega = await createWorkspace('Vega');
+    const theirs = await statesOf(vega.teamId);
+    const target = theirs[0];
+    if (target === undefined) throw new Error('the other workspace had no states');
+
+    expect(
+      await errorOf(() => updateWorkflowState(workspace.admin, target.id, { name: 'Stolen' })),
+    ).toBe('not_found');
+    expect(await errorOf(() => deleteWorkflowState(workspace.admin, target.id))).toBe('not_found');
+    expect((await statesOf(vega.teamId))[0]?.name).toBe(target.name);
+  });
+});

--- a/packages/core/tests/work/workflow-state-lifecycle.test.ts
+++ b/packages/core/tests/work/workflow-state-lifecycle.test.ts
@@ -14,6 +14,7 @@ import {
   createWorkflowState,
   deleteWorkflowState,
   listWorkflowStates,
+  listWorkflowStatesForTeams,
   reorderWorkflowStates,
   updateWorkflowState,
   type WorkflowStateRow,
@@ -191,6 +192,64 @@ describe('a status carries a category the rest of the product reads', () => {
     expect(saved.actions.some((action) => action.model === 'issue')).toBe(false);
   });
 
+  it('keeps the age of an issue that never moved when only the category is renamed', async () => {
+    const todo = stateNamed(workspace, 'Todo');
+    const created = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Parked',
+      stateId: todo.id,
+    });
+    const before = await issueById(created.issue.id);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    await updateWorkflowState(workspace.admin, todo.id, { category: 'backlog' });
+
+    const after = await issueById(created.issue.id);
+    expect(after.stateId).toBe(todo.id);
+    expect(after.stateEnteredAt.getTime()).toBe(before.stateEnteredAt.getTime());
+  });
+
+  it('restarts the age of an issue that really was carried to another status', async () => {
+    const todo = stateNamed(workspace, 'Todo');
+    const done = stateNamed(workspace, 'Done');
+    const created = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Parked',
+      stateId: todo.id,
+    });
+    const before = await issueById(created.issue.id);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    await deleteWorkflowState(workspace.admin, todo.id, { moveToStateId: done.id });
+
+    const after = await issueById(created.issue.id);
+    expect(after.stateId).toBe(done.id);
+    expect(after.stateEnteredAt.getTime()).toBeGreaterThan(before.stateEnteredAt.getTime());
+  });
+
+  it('answers a patch that changes nothing with no action and no sync id bump', async () => {
+    const todo = stateNamed(workspace, 'Todo');
+    const created = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Parked',
+      stateId: todo.id,
+    });
+
+    const empty = await updateWorkflowState(workspace.admin, todo.id, {});
+    const same = await updateWorkflowState(workspace.admin, todo.id, {
+      name: todo.name,
+      category: 'unstarted',
+      color: todo.color,
+    });
+
+    expect(empty.actions).toHaveLength(0);
+    expect(same.actions).toHaveLength(0);
+    expect((await statesOf(workspace.teamId)).find((s) => s.id === todo.id)?.syncId).toBe(
+      todo.syncId,
+    );
+    expect((await issueById(created.issue.id)).syncId).toBe(created.issue.syncId);
+  });
+
   it('refuses two statuses of the same name on one team', async () => {
     expect(
       await errorOf(() =>
@@ -329,6 +388,36 @@ describe('the server is the gate, whatever the caller sends', () => {
       'forbidden',
     );
     expect((await listWorkflowStates(workspace.admin, design.team.id))[0]?.name).toBe(target.name);
+  });
+
+  it('never answers a batch read with a team the caller has not joined', async () => {
+    const design = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const vega = await createWorkspace('Vega');
+    const outsider = await addMember(workspace, 'member', { teamIds: [workspace.teamId] });
+
+    const asked = await listWorkflowStatesForTeams(outsider.principal, [
+      workspace.teamId,
+      design.team.id,
+      vega.teamId,
+    ]);
+
+    expect(new Set(asked.map((state) => state.teamId))).toEqual(new Set([workspace.teamId]));
+    expect(asked).toHaveLength(7);
+  });
+
+  it('gives an admin every team it asks for and still stops at the workspace edge', async () => {
+    const design = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const vega = await createWorkspace('Vega');
+
+    const asked = await listWorkflowStatesForTeams(workspace.admin, [
+      workspace.teamId,
+      design.team.id,
+      vega.teamId,
+    ]);
+
+    expect(new Set(asked.map((state) => state.teamId))).toEqual(
+      new Set([workspace.teamId, design.team.id]),
+    );
   });
 
   it('refuses a status in another workspace outright', async () => {

--- a/packages/core/tests/work/workflow-state-service.test.ts
+++ b/packages/core/tests/work/workflow-state-service.test.ts
@@ -73,7 +73,10 @@ describe('workflow states', () => {
     const ids = (await listWorkflowStates(workspace.admin, workspace.teamId))
       .map((state) => state.id)
       .reverse();
-    const reordered = await reorderWorkflowStates(workspace.admin, workspace.teamId, ids);
+    const reordered = await reorderWorkflowStates(workspace.admin, {
+      teamId: workspace.teamId,
+      stateIds: ids,
+    });
     expect(reordered.states).toHaveLength(8);
     const after = await listWorkflowStates(workspace.admin, workspace.teamId);
     expect(after.map((state) => state.id)).toEqual(ids);

--- a/packages/db/catchup/label-and-state-name-uniqueness-catchup.sql
+++ b/packages/db/catchup/label-and-state-name-uniqueness-catchup.sql
@@ -1,0 +1,32 @@
+-- Guarantees the three name uniqueness indexes that labels and workflow states now depend on:
+-- label_org_name_unique, label_team_name_unique and workflow_state_team_name_unique.
+--
+-- No table and no column changes. All three indexes have been in the Drizzle schema since the
+-- first migration, so a database created by db:push already has them and this file is a no-op.
+-- It exists because the new /api/labels and /api/workflow-states routes turn the unique
+-- violation into a 409 conflict, and a database missing an index would silently accept two
+-- labels of the same name in one workspace instead.
+--
+-- Safe to run more than once: every statement checks first, and the whole thing is one
+-- transaction, so a failure leaves the database exactly as it was. If a statement fails on
+-- duplicate rows, that is the real answer: the workspace already holds two rows the code now
+-- forbids, and they have to be merged by hand before this file can be applied.
+--
+-- Apply it either by pasting it into the Supabase SQL editor, or with
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f packages/db/catchup/label-and-state-name-uniqueness-catchup.sql
+-- using the direct connection on port 5432, not the pooler on 6543.
+
+begin;
+
+create unique index if not exists label_org_name_unique
+  on public.label using btree (organization_id, name)
+  where team_id is null;
+
+create unique index if not exists label_team_name_unique
+  on public.label using btree (organization_id, team_id, name)
+  where team_id is not null;
+
+create unique index if not exists workflow_state_team_name_unique
+  on public.workflow_state using btree (team_id, name);
+
+commit;

--- a/packages/mcp-server/src/resolve.ts
+++ b/packages/mcp-server/src/resolve.ts
@@ -1,6 +1,7 @@
 import {
   activeCycle,
   type CycleRow,
+  type LabelRow,
   listCycles,
   listLabels,
   listMembers,
@@ -61,6 +62,25 @@ export async function resolveStateId(
   return found.id;
 }
 
+function oneLabelId(labels: readonly LabelRow[], ref: string): string {
+  const needle = ref.trim();
+  const byId = labels.find((label) => label.id === needle);
+  if (byId !== undefined) return byId.id;
+  const named = labels.filter((label) => matches([label.name], needle));
+  const first = named[0];
+  if (first === undefined) throw notFound(`No label matches "${ref}".`);
+  if (named.length > 1) {
+    throw conflict(`More than one label is named "${ref}". Name the one you mean by its id.`, {
+      details: { labelIds: named.map((label) => label.id) },
+    });
+  }
+  return first.id;
+}
+
+export async function resolveLabelId(principal: Principal, ref: string): Promise<string> {
+  return oneLabelId(await listLabels(principal, {}), ref);
+}
+
 export async function resolveLabelIds(
   principal: Principal,
   refs: readonly string[],
@@ -68,11 +88,7 @@ export async function resolveLabelIds(
 ): Promise<string[]> {
   if (refs.length === 0) return [];
   const labels = await listLabels(principal, teamId === undefined ? {} : { teamId });
-  return refs.map((ref) => {
-    const found = pick(labels, ref, (label) => [label.id, label.name]);
-    if (found === undefined) throw notFound(`No label matches "${ref}".`);
-    return found.id;
-  });
+  return refs.map((ref) => oneLabelId(labels, ref));
 }
 
 export async function resolveProject(principal: Principal, ref: string): Promise<ProjectRow> {

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -7,6 +7,7 @@ import { registerIssueTools } from './issues.ts';
 import { registerOrgTools } from './org.ts';
 import { registerPlanningTools } from './planning.ts';
 import { registerScrumTools } from './scrum.ts';
+import { registerTaxonomyTools } from './taxonomy.ts';
 import { registerWorkspaceTools } from './workspace.ts';
 
 export function registerTools(server: McpServer, principal: Principal): void {
@@ -17,5 +18,6 @@ export function registerTools(server: McpServer, principal: Principal): void {
   registerAdminTools(server, principal);
   registerDocTools(server, principal);
   registerWorkspaceTools(server, principal);
+  registerTaxonomyTools(server, principal);
   registerOrgTools(server, principal);
 }

--- a/packages/mcp-server/src/tools/taxonomy.ts
+++ b/packages/mcp-server/src/tools/taxonomy.ts
@@ -4,7 +4,6 @@ import {
   createWorkflowState,
   deleteLabel,
   deleteWorkflowState,
-  listLabels,
   listWorkflowStates,
   reorderWorkflowStates,
   updateLabel,
@@ -15,10 +14,9 @@ import {
   DEFAULT_STATE_COLOR,
   STATE_CATEGORIES,
 } from '@orbit/shared/constants';
-import { conflict, notFound } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import { z } from 'zod';
-import { resolveStateId, resolveTeam } from '../resolve.ts';
+import { resolveLabelId, resolveStateId, resolveTeam } from '../resolve.ts';
 import { defineTool, publish } from './support.ts';
 
 const teamRef = z.string().min(1).describe('A team key like "ENG", a team name, or a team id.');
@@ -34,23 +32,6 @@ const labelTeam = z
   .describe(
     'Team key, name or id to restrict the label to. Null or omitted keeps it workspace wide.',
   );
-
-async function resolveLabel(principal: Principal, ref: string): Promise<string> {
-  const needle = ref.trim();
-  const labels = await listLabels(principal, {});
-  const byId = labels.find((label) => label.id === needle);
-  if (byId !== undefined) return byId.id;
-  const lowered = needle.toLowerCase();
-  const byName = labels.filter((label) => label.name.trim().toLowerCase() === lowered);
-  const found = byName[0];
-  if (found === undefined) throw notFound(`No label matches "${ref}".`);
-  if (byName.length > 1) {
-    throw conflict(`More than one label is named "${ref}". Name the one you mean by its id.`, {
-      details: { labelIds: byName.map((label) => label.id) },
-    });
-  }
-  return found.id;
-}
 
 async function labelTeamId(
   principal: Principal,
@@ -109,7 +90,7 @@ function registerLabelTools(server: McpServer, principal: Principal): void {
       },
     },
     async (args) => {
-      const id = await resolveLabel(principal, args.label);
+      const id = await resolveLabelId(principal, args.label);
       const saved = await updateLabel(principal, id, {
         ...(args.name === undefined ? {} : { name: args.name }),
         ...(args.color === undefined ? {} : { color: args.color }),
@@ -137,7 +118,7 @@ function registerLabelTools(server: McpServer, principal: Principal): void {
       inputSchema: { label: labelRef },
     },
     async (args) => {
-      const id = await resolveLabel(principal, args.label);
+      const id = await resolveLabelId(principal, args.label);
       const actions = await deleteLabel(principal, id);
       await publish(actions);
       return { deleted: id };

--- a/packages/mcp-server/src/tools/taxonomy.ts
+++ b/packages/mcp-server/src/tools/taxonomy.ts
@@ -10,15 +10,16 @@ import {
   updateLabel,
   updateWorkflowState,
 } from '@orbit/core';
-import { STATE_CATEGORIES } from '@orbit/shared/constants';
-import { notFound } from '@orbit/shared/errors';
+import {
+  DEFAULT_LABEL_COLOR,
+  DEFAULT_STATE_COLOR,
+  STATE_CATEGORIES,
+} from '@orbit/shared/constants';
+import { conflict, notFound } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import { z } from 'zod';
 import { resolveStateId, resolveTeam } from '../resolve.ts';
 import { defineTool, publish } from './support.ts';
-
-const DEFAULT_LABEL_COLOR = '#5a63c8';
-const DEFAULT_STATE_COLOR = '#6b7280';
 
 const teamRef = z.string().min(1).describe('A team key like "ENG", a team name, or a team id.');
 const stateRef = z.string().min(1).describe('A workflow state name or id on that team.');
@@ -35,12 +36,19 @@ const labelTeam = z
   );
 
 async function resolveLabel(principal: Principal, ref: string): Promise<string> {
-  const needle = ref.trim().toLowerCase();
+  const needle = ref.trim();
   const labels = await listLabels(principal, {});
-  const found = labels.find(
-    (label) => label.id === ref.trim() || label.name.trim().toLowerCase() === needle,
-  );
+  const byId = labels.find((label) => label.id === needle);
+  if (byId !== undefined) return byId.id;
+  const lowered = needle.toLowerCase();
+  const byName = labels.filter((label) => label.name.trim().toLowerCase() === lowered);
+  const found = byName[0];
   if (found === undefined) throw notFound(`No label matches "${ref}".`);
+  if (byName.length > 1) {
+    throw conflict(`More than one label is named "${ref}". Name the one you mean by its id.`, {
+      details: { labelIds: byName.map((label) => label.id) },
+    });
+  }
   return found.id;
 }
 

--- a/packages/mcp-server/src/tools/taxonomy.ts
+++ b/packages/mcp-server/src/tools/taxonomy.ts
@@ -1,0 +1,285 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  createLabel,
+  createWorkflowState,
+  deleteLabel,
+  deleteWorkflowState,
+  listLabels,
+  listWorkflowStates,
+  reorderWorkflowStates,
+  updateLabel,
+  updateWorkflowState,
+} from '@orbit/core';
+import { STATE_CATEGORIES } from '@orbit/shared/constants';
+import { notFound } from '@orbit/shared/errors';
+import type { Principal } from '@orbit/shared/policy';
+import { z } from 'zod';
+import { resolveStateId, resolveTeam } from '../resolve.ts';
+import { defineTool, publish } from './support.ts';
+
+const DEFAULT_LABEL_COLOR = '#5a63c8';
+const DEFAULT_STATE_COLOR = '#6b7280';
+
+const teamRef = z.string().min(1).describe('A team key like "ENG", a team name, or a team id.');
+const stateRef = z.string().min(1).describe('A workflow state name or id on that team.');
+const labelRef = z.string().min(1).describe('Label name or id.');
+const hexColor = z.string().regex(/^#[0-9a-fA-F]{6}$/);
+
+const labelTeam = z
+  .string()
+  .min(1)
+  .nullable()
+  .optional()
+  .describe(
+    'Team key, name or id to restrict the label to. Null or omitted keeps it workspace wide.',
+  );
+
+async function resolveLabel(principal: Principal, ref: string): Promise<string> {
+  const needle = ref.trim().toLowerCase();
+  const labels = await listLabels(principal, {});
+  const found = labels.find(
+    (label) => label.id === ref.trim() || label.name.trim().toLowerCase() === needle,
+  );
+  if (found === undefined) throw notFound(`No label matches "${ref}".`);
+  return found.id;
+}
+
+async function labelTeamId(
+  principal: Principal,
+  ref: string | null | undefined,
+): Promise<string | null> {
+  if (ref === null || ref === undefined) return null;
+  return (await resolveTeam(principal, ref)).id;
+}
+
+function registerLabelTools(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'create_label',
+      title: 'Create a label',
+      description:
+        'Create a label that can be applied to issues. Pass a team to keep the label on that team only, otherwise it is available across the workspace.',
+      readOnly: false,
+      inputSchema: {
+        name: z.string().trim().min(1).max(48).describe('Label name.'),
+        color: hexColor.optional().describe('Hex colour such as "#7c3aed".'),
+        team: labelTeam,
+      },
+    },
+    async (args) => {
+      const saved = await createLabel(principal, {
+        name: args.name,
+        color: args.color ?? DEFAULT_LABEL_COLOR,
+        teamId: await labelTeamId(principal, args.team),
+      });
+      await publish(saved.actions);
+      return {
+        label: {
+          id: saved.label.id,
+          name: saved.label.name,
+          color: saved.label.color,
+          teamId: saved.label.teamId,
+        },
+      };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'update_label',
+      title: 'Update a label',
+      description:
+        'Rename a label, change its colour, or move it between a team and the whole workspace.',
+      readOnly: false,
+      inputSchema: {
+        label: labelRef,
+        name: z.string().trim().min(1).max(48).optional(),
+        color: hexColor.optional(),
+        team: labelTeam,
+      },
+    },
+    async (args) => {
+      const id = await resolveLabel(principal, args.label);
+      const saved = await updateLabel(principal, id, {
+        ...(args.name === undefined ? {} : { name: args.name }),
+        ...(args.color === undefined ? {} : { color: args.color }),
+        ...(args.team === undefined ? {} : { teamId: await labelTeamId(principal, args.team) }),
+      });
+      await publish(saved.actions);
+      return {
+        label: {
+          id: saved.label.id,
+          name: saved.label.name,
+          color: saved.label.color,
+          teamId: saved.label.teamId,
+        },
+      };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'delete_label',
+      title: 'Delete a label',
+      description: 'Remove a label from the workspace and from every issue carrying it.',
+      readOnly: false,
+      inputSchema: { label: labelRef },
+    },
+    async (args) => {
+      const id = await resolveLabel(principal, args.label);
+      const actions = await deleteLabel(principal, id);
+      await publish(actions);
+      return { deleted: id };
+    },
+  );
+}
+
+function registerStateTools(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'create_state',
+      title: 'Create a workflow state',
+      description:
+        'Add a status to a team board. The category drives what the product infers from it, so pick the one that matches the meaning. The new status lands at the end; use reorder_states to place it.',
+      readOnly: false,
+      inputSchema: {
+        team: teamRef,
+        name: z.string().trim().min(1).max(48).describe('Status name such as "Blocked".'),
+        category: z.enum(STATE_CATEGORIES).describe('Which lifecycle stage this status means.'),
+        color: hexColor.optional().describe('Hex colour such as "#7c3aed".'),
+      },
+    },
+    async (args) => {
+      const team = await resolveTeam(principal, args.team);
+      const saved = await createWorkflowState(principal, {
+        teamId: team.id,
+        name: args.name,
+        category: args.category,
+        color: args.color ?? DEFAULT_STATE_COLOR,
+      });
+      await publish(saved.actions);
+      return {
+        state: {
+          id: saved.state.id,
+          name: saved.state.name,
+          category: saved.state.category,
+          position: saved.state.position,
+        },
+      };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'update_state',
+      title: 'Update a workflow state',
+      description:
+        'Rename a status, recolour it, or move it to another category. Changing the category re-derives the started, completed and canceled timestamps of every issue sitting in it.',
+      readOnly: false,
+      inputSchema: {
+        team: teamRef,
+        state: stateRef,
+        name: z.string().trim().min(1).max(48).optional(),
+        category: z.enum(STATE_CATEGORIES).optional(),
+        color: hexColor.optional(),
+      },
+    },
+    async (args) => {
+      const team = await resolveTeam(principal, args.team);
+      const stateId = await resolveStateId(principal, team.id, args.state);
+      const saved = await updateWorkflowState(principal, stateId, {
+        ...(args.name === undefined ? {} : { name: args.name }),
+        ...(args.category === undefined ? {} : { category: args.category }),
+        ...(args.color === undefined ? {} : { color: args.color }),
+      });
+      await publish(saved.actions);
+      return {
+        state: {
+          id: saved.state.id,
+          name: saved.state.name,
+          category: saved.state.category,
+          position: saved.state.position,
+        },
+      };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'delete_state',
+      title: 'Delete a workflow state',
+      description:
+        'Remove a status from a team board. A status that still holds issues is refused unless moveTo names another status on the same team to carry them.',
+      readOnly: false,
+      inputSchema: {
+        team: teamRef,
+        state: stateRef,
+        moveTo: stateRef.optional().describe('The status the issues in it move to.'),
+      },
+    },
+    async (args) => {
+      const team = await resolveTeam(principal, args.team);
+      const stateId = await resolveStateId(principal, team.id, args.state);
+      const moveToStateId =
+        args.moveTo === undefined
+          ? undefined
+          : await resolveStateId(principal, team.id, args.moveTo);
+      const actions = await deleteWorkflowState(
+        principal,
+        stateId,
+        moveToStateId === undefined ? {} : { moveToStateId },
+      );
+      await publish(actions);
+      return { deleted: stateId, movedIssues: actions.filter((a) => a.model === 'issue').length };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'reorder_states',
+      title: 'Reorder the workflow states of a team',
+      description:
+        'Set the board order of a team. Name every status on the team exactly once, first column first. Call list_states to see the current order.',
+      readOnly: false,
+      inputSchema: {
+        team: teamRef,
+        order: z
+          .array(stateRef)
+          .min(1)
+          .max(200)
+          .describe('Every status on the team, in the order they should appear.'),
+      },
+    },
+    async (args) => {
+      const team = await resolveTeam(principal, args.team);
+      const stateIds: string[] = [];
+      for (const ref of args.order) {
+        stateIds.push(await resolveStateId(principal, team.id, ref));
+      }
+      const saved = await reorderWorkflowStates(principal, { teamId: team.id, stateIds });
+      await publish(saved.actions);
+      const states = await listWorkflowStates(principal, team.id);
+      return {
+        teamId: team.id,
+        states: states.map((state) => ({
+          id: state.id,
+          name: state.name,
+          category: state.category,
+          position: state.position,
+        })),
+      };
+    },
+  );
+}
+
+export function registerTaxonomyTools(server: McpServer, principal: Principal): void {
+  registerLabelTools(server, principal);
+  registerStateTools(server, principal);
+}

--- a/packages/mcp-server/src/tools/workspace.ts
+++ b/packages/mcp-server/src/tools/workspace.ts
@@ -2,23 +2,18 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
   archiveIssue,
   archiveProject,
-  createLabel,
   deleteComment,
   deleteCycle,
   deleteIssue,
-  deleteLabel,
   deleteMilestone,
   deleteProject,
   getIssue,
-  listLabels,
   listMilestones,
   unarchiveIssue,
   updateComment,
-  updateLabel,
   updateMilestone,
   updateProject,
 } from '@orbit/core';
-import { notFound } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import { z } from 'zod';
 import { resolveCycle, resolveProject, resolveTeam } from '../resolve.ts';
@@ -26,19 +21,6 @@ import { defineTool, publish } from './support.ts';
 
 const issueRef = z.string().min(1).describe('An issue identifier like "ENG-42", or an issue id.');
 const projectRef = z.string().min(1).describe('Project name, slug or id.');
-
-const DEFAULT_LABEL_COLOR = '#5a63c8';
-
-async function resolveLabel(principal: Principal, ref: string): Promise<string> {
-  const needle = ref.trim();
-  const labels = await listLabels(principal, {});
-  const lowered = needle.toLowerCase();
-  const found = labels.find(
-    (label) => label.id === needle || label.name.trim().toLowerCase() === lowered,
-  );
-  if (found === undefined) throw notFound(`No label matches "${ref}".`);
-  return found.id;
-}
 
 export function registerWorkspaceTools(server: McpServer, principal: Principal): void {
   defineTool(
@@ -126,76 +108,6 @@ export function registerWorkspaceTools(server: McpServer, principal: Principal):
       const actions = await deleteComment(principal, args.commentId);
       await publish(actions);
       return { deleted: args.commentId };
-    },
-  );
-
-  defineTool(
-    server,
-    {
-      name: 'create_label',
-      title: 'Create a label',
-      description: 'Create a workspace label that can be applied to issues.',
-      readOnly: false,
-      inputSchema: {
-        name: z.string().trim().min(1).max(60).describe('Label name.'),
-        color: z
-          .string()
-          .regex(/^#[0-9a-fA-F]{6}$/)
-          .optional()
-          .describe('Hex colour such as "#7c3aed". Defaults to the Orbit accent.'),
-      },
-    },
-    async (args) => {
-      const saved = await createLabel(principal, {
-        name: args.name,
-        color: args.color ?? DEFAULT_LABEL_COLOR,
-      });
-      await publish(saved.actions);
-      return { label: { id: saved.label.id, name: saved.label.name } };
-    },
-  );
-
-  defineTool(
-    server,
-    {
-      name: 'update_label',
-      title: 'Update a label',
-      description: 'Rename a label or change its colour.',
-      readOnly: false,
-      inputSchema: {
-        label: z.string().min(1).describe('Label name or id.'),
-        name: z.string().trim().min(1).max(60).optional(),
-        color: z
-          .string()
-          .regex(/^#[0-9a-fA-F]{6}$/)
-          .optional(),
-      },
-    },
-    async (args) => {
-      const id = await resolveLabel(principal, args.label);
-      const saved = await updateLabel(principal, id, {
-        ...(args.name === undefined ? {} : { name: args.name }),
-        ...(args.color === undefined ? {} : { color: args.color }),
-      });
-      await publish(saved.actions);
-      return { label: { id: saved.label.id, name: saved.label.name } };
-    },
-  );
-
-  defineTool(
-    server,
-    {
-      name: 'delete_label',
-      title: 'Delete a label',
-      description: 'Remove a label from the workspace and from every issue carrying it.',
-      readOnly: false,
-      inputSchema: { label: z.string().min(1).describe('Label name or id.') },
-    },
-    async (args) => {
-      const id = await resolveLabel(principal, args.label);
-      const actions = await deleteLabel(principal, id);
-      await publish(actions);
-      return { deleted: args.label };
     },
   );
 

--- a/packages/mcp-server/tests/resolve.test.ts
+++ b/packages/mcp-server/tests/resolve.test.ts
@@ -5,6 +5,7 @@ import {
   createLabel,
   createProject,
   createTeam,
+  deleteLabel,
   listCycles,
   listProjects,
   listTeams,
@@ -185,6 +186,18 @@ describe('resolveLabelIds', () => {
   it('returns nothing for an empty request and refuses an unknown label', async () => {
     expect(await resolveLabelIds(admin, [])).toEqual([]);
     expect(await errorOf(() => resolveLabelIds(admin, ['Sturdy', 'Nonesuch']))).toBe('not_found');
+  });
+
+  it('refuses to guess when a workspace label and a team label share a name', async () => {
+    const twin = await createLabel(admin, { name: 'Flaky', color: '#0000ff', teamId: designId });
+
+    expect(await errorOf(() => resolveLabelIds(admin, ['Flaky']))).toBe('conflict');
+    expect(await errorOf(() => resolveLabelIds(admin, ['Flaky'], designId))).toBe('conflict');
+    expect(await resolveLabelIds(admin, [twin.label.id])).toEqual([twin.label.id]);
+    expect(await resolveLabelIds(admin, ['Flaky'], engineeringId)).toEqual([flakyLabelId]);
+    expect(await resolveLabelIds(admin, ['Sturdy'])).toEqual([sturdyLabelId]);
+
+    await deleteLabel(admin, twin.label.id);
   });
 });
 

--- a/packages/mcp-server/tests/taxonomy.test.ts
+++ b/packages/mcp-server/tests/taxonomy.test.ts
@@ -1,0 +1,226 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { createTeam, listLabels, listWorkflowStates } from '@orbit/core';
+import { db, eq, schema } from '@orbit/db';
+import {
+  addMember,
+  connect,
+  createWorkspace,
+  errorPayload,
+  MCP_TEST_SCOPES,
+  mintToken,
+  resetDatabase,
+  type TestClient,
+  type TestWorkspace,
+} from '../src/test-helpers.ts';
+
+let workspace: TestWorkspace;
+let admin: TestClient;
+let guest: TestClient;
+let readOnly: TestClient;
+let designKey: string;
+
+interface StateShape {
+  readonly id: string;
+  readonly name: string;
+  readonly category: string;
+  readonly position: number;
+}
+
+function statesOf(payload: Record<string, unknown>): StateShape[] {
+  return payload['states'] as StateShape[];
+}
+
+function stateOf(payload: Record<string, unknown>): StateShape {
+  return payload['state'] as StateShape;
+}
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  admin = await connect(await mintToken(workspace.organizationId, workspace.adminUser.id));
+  const guestMember = await addMember(workspace, 'guest', 'Gus Guest');
+  guest = await connect(await mintToken(workspace.organizationId, guestMember.user.id));
+  readOnly = await connect(
+    await mintToken(
+      workspace.organizationId,
+      workspace.adminUser.id,
+      'Reader',
+      MCP_TEST_SCOPES.replace(' orbit.write', ''),
+    ),
+  );
+  designKey = (await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' })).team.key;
+});
+
+afterAll(async () => {
+  await admin.close();
+  await guest.close();
+  await readOnly.close();
+});
+
+describe('the taxonomy tools are advertised and classified', () => {
+  it('offers every label and state tool to a client holding both scopes', async () => {
+    const { tools } = await admin.client.listTools();
+    const names = tools.map((tool) => tool.name);
+
+    expect(names).toContain('create_state');
+    expect(names).toContain('update_state');
+    expect(names).toContain('delete_state');
+    expect(names).toContain('reorder_states');
+    expect(names).toContain('create_label');
+    expect(names).toContain('update_label');
+    expect(names).toContain('delete_label');
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('withholds every write from a client that only holds orbit.read', async () => {
+    const { tools } = await readOnly.client.listTools();
+    const names = tools.map((tool) => tool.name);
+
+    expect(names).toContain('list_states');
+    expect(names).toContain('list_labels');
+    expect(names).not.toContain('create_state');
+    expect(names).not.toContain('update_state');
+    expect(names).not.toContain('delete_state');
+    expect(names).not.toContain('reorder_states');
+    expect(names).not.toContain('create_label');
+  });
+
+  it('marks the reads read only and the writes not', async () => {
+    const { tools } = await admin.client.listTools();
+    const byName = new Map(tools.map((tool) => [tool.name, tool]));
+
+    expect(byName.get('list_states')?.annotations?.readOnlyHint).toBe(true);
+    expect(byName.get('create_state')?.annotations?.readOnlyHint).toBe(false);
+    expect(byName.get('reorder_states')?.annotations?.readOnlyHint).toBe(false);
+    expect(byName.get('create_label')?.annotations?.readOnlyHint).toBe(false);
+  });
+});
+
+describe('the state tools reach the same service the app does', () => {
+  it('creates a status at the end of the board and lists it back', async () => {
+    const created = stateOf(
+      await admin.result('create_state', {
+        team: workspace.teamKey,
+        name: 'Blocked',
+        category: 'started',
+      }),
+    );
+
+    expect(created.position).toBe(7);
+    const listed = statesOf(await admin.result('list_states', { team: workspace.teamKey }));
+    expect(listed.map((state) => state.name)).toContain('Blocked');
+  });
+
+  it('renames a status by name and keeps its category', async () => {
+    const renamed = stateOf(
+      await admin.result('update_state', {
+        team: workspace.teamKey,
+        state: 'Blocked',
+        name: 'On hold',
+      }),
+    );
+
+    expect(renamed.name).toBe('On hold');
+    expect(renamed.category).toBe('started');
+  });
+
+  it('reorders a board only when every status is named', async () => {
+    const before = statesOf(await admin.result('list_states', { team: workspace.teamKey }));
+
+    const partial = await admin.call('reorder_states', {
+      team: workspace.teamKey,
+      order: before.slice(0, 3).map((state) => state.name),
+    });
+    expect(errorPayload(partial).code).toBe('conflict');
+
+    const full = statesOf(
+      await admin.result('reorder_states', {
+        team: workspace.teamKey,
+        order: before.map((state) => state.name).reverse(),
+      }),
+    );
+    expect(full.map((state) => state.name)).toEqual(before.map((state) => state.name).reverse());
+    expect(full.map((state) => state.position)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it('refuses to delete a status that still holds issues until moveTo names one', async () => {
+    await admin.result('create_issue', {
+      team: workspace.teamKey,
+      title: 'Parked',
+      state: 'Todo',
+    });
+
+    const refused = await admin.call('delete_state', {
+      team: workspace.teamKey,
+      state: 'Todo',
+    });
+    expect(errorPayload(refused).code).toBe('conflict');
+
+    const moved = await admin.result('delete_state', {
+      team: workspace.teamKey,
+      state: 'Todo',
+      moveTo: 'Done',
+    });
+    expect(moved['movedIssues']).toBe(1);
+
+    const after = statesOf(await admin.result('list_states', { team: workspace.teamKey }));
+    expect(after.map((state) => state.name)).not.toContain('Todo');
+  });
+
+  it('refuses a guest every state write, because the server checks the role', async () => {
+    const created = await guest.call('create_state', {
+      team: workspace.teamKey,
+      name: 'Sneaky',
+      category: 'started',
+    });
+    const renamed = await guest.call('update_state', {
+      team: workspace.teamKey,
+      state: 'Done',
+      name: 'Sneaky',
+    });
+    const removed = await guest.call('delete_state', { team: workspace.teamKey, state: 'Triage' });
+
+    expect(errorPayload(created).code).toBe('forbidden');
+    expect(errorPayload(renamed).code).toBe('forbidden');
+    expect(errorPayload(removed).code).toBe('forbidden');
+    const survivors = await listWorkflowStates(workspace.admin, workspace.teamId);
+    expect(survivors.map((state) => state.name)).not.toContain('Sneaky');
+    expect(survivors.map((state) => state.name)).toContain('Triage');
+  });
+});
+
+describe('the label tools carry the team scope through', () => {
+  it('pins a label to a team and reports it back', async () => {
+    const payload = await admin.result('create_label', {
+      name: 'Pixel polish',
+      color: '#ec4899',
+      team: designKey,
+    });
+    const label = payload['label'] as { id: string; teamId: string | null };
+
+    expect(label.teamId).not.toBeNull();
+    const [row] = await db.select().from(schema.label).where(eq(schema.label.id, label.id));
+    expect(row?.teamId).toBe(label.teamId ?? '');
+  });
+
+  it('widens a team label back to the whole workspace', async () => {
+    const payload = await admin.result('update_label', {
+      label: 'Pixel polish',
+      team: null,
+    });
+    const label = payload['label'] as { id: string; teamId: string | null };
+
+    expect(label.teamId).toBeNull();
+  });
+
+  it('refuses a guest every label write', async () => {
+    const created = await guest.call('create_label', { name: 'Sneaky' });
+    const removed = await guest.call('delete_label', { label: 'Pixel polish' });
+
+    expect(errorPayload(created).code).toBe('forbidden');
+    expect(errorPayload(removed).code).toBe('forbidden');
+    const survivors = await listLabels(workspace.admin, {});
+    expect(survivors.map((label) => label.name)).not.toContain('Sneaky');
+    expect(survivors.map((label) => label.name)).toContain('Pixel polish');
+  });
+});

--- a/packages/mcp-server/tests/taxonomy.test.ts
+++ b/packages/mcp-server/tests/taxonomy.test.ts
@@ -213,6 +213,26 @@ describe('the label tools carry the team scope through', () => {
     expect(label.teamId).toBeNull();
   });
 
+  it('refuses to guess when a workspace label and a team label share a name', async () => {
+    await admin.result('create_label', { name: 'Regression', color: '#ef4444' });
+    await admin.result('create_label', {
+      name: 'Regression',
+      color: '#22c55e',
+      team: designKey,
+    });
+
+    const ambiguous = await admin.call('update_label', { label: 'Regression', color: '#3b82f6' });
+    expect(errorPayload(ambiguous).code).toBe('conflict');
+
+    const rows = await db.select().from(schema.label).where(eq(schema.label.name, 'Regression'));
+    expect(rows.map((row) => row.color).sort()).toEqual(['#22c55e', '#ef4444']);
+
+    const byId = rows[0];
+    if (byId === undefined) throw new Error('the labels vanished');
+    const named = await admin.result('update_label', { label: byId.id, color: '#3b82f6' });
+    expect((named['label'] as { id: string }).id).toBe(byId.id);
+  });
+
   it('refuses a guest every label write', async () => {
     const created = await guest.call('create_label', { name: 'Sneaky' });
     const removed = await guest.call('delete_label', { label: 'Pixel polish' });

--- a/packages/mcp-server/tests/taxonomy.test.ts
+++ b/packages/mcp-server/tests/taxonomy.test.ts
@@ -233,6 +233,28 @@ describe('the label tools carry the team scope through', () => {
     expect((named['label'] as { id: string }).id).toBe(byId.id);
   });
 
+  it('refuses to guess on the issue tools too, not only on the label tools', async () => {
+    const created = await admin.call('create_issue', {
+      team: designKey,
+      title: 'Which regression',
+      labels: ['Regression'],
+    });
+    expect(errorPayload(created).code).toBe('conflict');
+
+    const searched = await admin.call('search_issues', { label: 'Regression' });
+    expect(errorPayload(searched).code).toBe('conflict');
+
+    const rows = await db.select().from(schema.label).where(eq(schema.label.name, 'Regression'));
+    const named = rows.find((row) => row.teamId !== null);
+    if (named === undefined) throw new Error('the team label vanished');
+    const accepted = await admin.result('create_issue', {
+      team: designKey,
+      title: 'That regression',
+      labels: [named.id],
+    });
+    expect((accepted['issue'] as { title: string }).title).toBe('That regression');
+  });
+
   it('refuses a guest every label write', async () => {
     const created = await guest.call('create_label', { name: 'Sneaky' });
     const removed = await guest.call('delete_label', { label: 'Pixel polish' });

--- a/packages/mcp-server/tests/tools-smoke.test.ts
+++ b/packages/mcp-server/tests/tools-smoke.test.ts
@@ -157,6 +157,38 @@ const SMOKE: readonly SmokeCase[] = [
     args: () => ({ milestoneId: state['milestone'] }),
     expect: hasKey('deleted'),
   },
+  {
+    tool: 'create_state',
+    args: () => ({ team: state['team'], name: 'Blocked', category: 'started' }),
+    expect: hasKey('state'),
+  },
+  {
+    tool: 'update_state',
+    args: () => ({ team: state['team'], state: 'Blocked', color: '#123456' }),
+    expect: hasKey('state'),
+  },
+  {
+    tool: 'reorder_states',
+    args: () => ({
+      team: state['team'],
+      order: [
+        'Blocked',
+        'Triage',
+        'Backlog',
+        'Todo',
+        'In Progress',
+        'In Review',
+        'Done',
+        'Canceled',
+      ],
+    }),
+    expect: hasRows('states'),
+  },
+  {
+    tool: 'delete_state',
+    args: () => ({ team: state['team'], state: 'Blocked' }),
+    expect: hasKey('deleted'),
+  },
   { tool: 'archive_doc', args: () => ({ doc: state['doc'] }), expect: hasKey('archived') },
   {
     tool: 'archive_project',

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -6,6 +6,7 @@ export * from './notification.ts';
 export * from './onboarding.ts';
 export * from './ordering.ts';
 export * from './organization.ts';
+export * from './palette.ts';
 export * from './pattern.ts';
 export * from './project.ts';
 export * from './upload.ts';

--- a/packages/shared/src/constants/palette.ts
+++ b/packages/shared/src/constants/palette.ts
@@ -1,0 +1,17 @@
+export const SWATCH_COLORS: readonly string[] = [
+  '#EF4444',
+  '#F97316',
+  '#E2A03F',
+  '#F2C94C',
+  '#22C55E',
+  '#14B8A6',
+  '#3B82F6',
+  '#5A63C8',
+  '#8B5CF6',
+  '#A855F7',
+  '#EC4899',
+  '#6B7280',
+];
+
+export const DEFAULT_LABEL_COLOR = '#5A63C8';
+export const DEFAULT_STATE_COLOR = '#6B7280';

--- a/packages/shared/src/constants/workflow-state.ts
+++ b/packages/shared/src/constants/workflow-state.ts
@@ -20,6 +20,16 @@ export const STATE_CATEGORY_ORDER: Record<StateCategory, number> = {
   canceled: 6,
 };
 
+export const STATE_CATEGORY_LABELS: Record<StateCategory, string> = {
+  triage: 'Triage',
+  backlog: 'Backlog',
+  unstarted: 'Unstarted',
+  started: 'Started',
+  review: 'In review',
+  completed: 'Completed',
+  canceled: 'Canceled',
+};
+
 export const OPEN_STATE_CATEGORIES: readonly StateCategory[] = [
   'triage',
   'backlog',

--- a/packages/shared/src/constants/workflow-state.ts
+++ b/packages/shared/src/constants/workflow-state.ts
@@ -37,3 +37,7 @@ export const OPEN_STATE_CATEGORIES: readonly StateCategory[] = [
   'started',
   'review',
 ];
+
+export function isOpenCategory(category: string): boolean {
+  return OPEN_STATE_CATEGORIES.some((open) => open === category);
+}

--- a/packages/shared/src/validators/label.ts
+++ b/packages/shared/src/validators/label.ts
@@ -14,3 +14,7 @@ export const labelUpdateSchema = z
     teamId: idSchema.nullable(),
   })
   .partial();
+
+export const labelListQuerySchema = z.object({
+  teamId: idSchema.optional(),
+});

--- a/packages/shared/src/validators/workflow-state.ts
+++ b/packages/shared/src/validators/workflow-state.ts
@@ -7,7 +7,25 @@ export const workflowStateCreateSchema = z.object({
   name: z.string().trim().min(1).max(48),
   category: z.enum(STATE_CATEGORIES),
   color: colorSchema,
-  position: z.number().int().min(0).max(10_000).optional(),
 });
 
-export const workflowStateUpdateSchema = workflowStateCreateSchema.partial().omit({ teamId: true });
+export const workflowStateUpdateSchema = z
+  .object({
+    name: z.string().trim().min(1).max(48),
+    category: z.enum(STATE_CATEGORIES),
+    color: colorSchema,
+  })
+  .partial();
+
+export const workflowStateListQuerySchema = z.object({
+  teamId: idSchema,
+});
+
+export const workflowStateReorderSchema = z.object({
+  teamId: idSchema,
+  stateIds: z.array(idSchema).min(1).max(200),
+});
+
+export const workflowStateDeleteQuerySchema = z.object({
+  moveToStateId: idSchema.optional(),
+});


### PR DESCRIPTION
## Apply the catchup first

`packages/db/catchup/label-and-state-name-uniqueness-catchup.sql` must be applied to the
target database before this ships.

```
psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f packages/db/catchup/label-and-state-name-uniqueness-catchup.sql
```

It adds no table and no column. It guarantees `label_org_name_unique`,
`label_team_name_unique` and `workflow_state_team_name_unique`, all three of which have been in
the Drizzle schema since the first migration, so on a database built by `db:push` it is a no-op.
It exists because the new routes turn a duplicate name into a 409, and a database missing an
index would quietly accept two labels of the same name in one workspace instead.

## What was frozen

A workspace was stuck with whatever the seed gave it. There was no `/api/labels`, no
`/api/workflow-states`, and no settings page for either, so nobody could add a label or change a
status column, ever, even though `label-service.ts` and `workflow-state-service.ts` had exported
`create` all along.

## What was also wrong underneath

Opening the routes surfaced three holes that had no test:

- **A team label was not a team label.** `label.teamId` is nullable, and nothing respected it.
  The realtime action went out on the organization scope whichever it was, so a team label
  reached everyone in the workspace. Any member could pin a label to a team they had never
  joined, or to a team in *another workspace*, because nothing checked the team at all. And any
  issue could carry any label id, including one from another workspace.
- **Reordering could collide.** `reorderWorkflowStates` accepted a subset and renumbered it from
  zero, landing two columns on the same position as the statuses it left out.
- **A duplicate name was a 500.** Both partial unique indexes existed; nothing turned a violation
  into an answer.

## Labels: workspace or team

A label with no team fans out on `org:<id>`. A team label fans out on `team:<id>` **and nothing
else**, so it never reaches the rest of the workspace. Moving one publishes to both audiences, so
the side losing it hears about it too. Reads and writes go through one clause: admins see every
label in their workspace, everyone else sees the workspace-wide ones plus their own teams'.
`createLabel` and `updateLabel` put the team through `requireTeam`. `createIssue`, `updateIssue`
and the bulk path refuse a label the issue's team is not allowed.

The workspace clause that `getLabel`, `updateLabel` and `deleteLabel` gained recently is still
there, now folded into that same clause, and `label-scope.test.ts` and the route tests both hold
it in place.

## Workflow states: ordered, and the category is load bearing

**Position is derived, never accepted.** `position` came out of the create schema entirely. A new
status lands after the last one. `reorderWorkflowStates` takes a body, not a loose array, and only
accepts the whole set of that team's statuses with each named exactly once.

**Renaming and reordering cannot touch the category**, because neither writes it.

**Changing the category re-derives what reads it.** `startedAt`, `completedAt` and `canceledAt`
are stamped from the category, so moving a status from `unstarted` to `completed` now re-dates
every issue sitting in it, in the same transaction, through the same `applyStateTimestamps` the
issue service uses, and publishes those issues. A rename or a recolour leaves them alone.

**Deleting a status that still holds issues: refuse, unless a target is named.** Both, and this is
the deliberate answer. Silently deleting loses where the work was; silently moving picks a column
on the user's behalf and the categories mean different things. So the default is a 409 that says
so, and `?moveToStateId=` moves them, re-dates them from the target's category, and writes the
move into each issue's history. A team also always keeps at least one status, because issue
creation falls back to whatever is left.

## Routes

Six handlers, each parsing with a Zod schema from `@orbit/shared`, calling a service, and
publishing what comes back. No rule lives in a handler.

```
GET  POST            /api/labels
GET  PATCH  DELETE   /api/labels/[id]
GET  POST            /api/workflow-states
     PATCH  DELETE   /api/workflow-states/[id]      DELETE takes ?moveToStateId=
     POST            /api/workflow-states/reorder
```

## Settings

**Settings, Labels** and **Settings, Workflow**. Order is changed with buttons rather than a drag,
so it stays keyboard operable and needs no layout animation. Deleting a status asks the server
first: the picker for where the issues go only appears once the server has refused, so the flow is
driven by the refusal rather than by the client guessing. `canManage` hides buttons and is a
courtesy; the tests prove the server is the gate. The swatch lift is a shared token in
`interaction.ts`, transform only, 80ms, and respects `prefers-reduced-motion`.

## MCP parity

`create_state`, `update_state`, `delete_state` and `reorder_states` join the label tools in one
taxonomy module, calling the very functions the routes call, so the two cannot drift.
`create_label` and `update_label` gained `team`, which the API allowed and the tool did not. Every
one is `readOnly: false`, and a test asserts an `orbit.read` token is never offered any of them.

## Tests, and the mutation that proves each one bites

Every test below was watched failing before the code existed, then the production code was broken
deliberately to confirm RED, then restored.

| Test | Mutation that turned it red |
| --- | --- |
| `label-scope`: workspace label gets the org scope, team label the team scope, never both | `labelScopes` restored to pushing org then team |
| `label-scope`: a move reaches the audience losing it and the one gaining it | `bothAudiences(current, row)` narrowed to `labelScopes(row)` |
| `label-scope`: a team delete goes to that team | same `labelScopes` mutation |
| `label-scope`: a team label is hidden from a member of another team, on list, read, edit and delete | `readableLabels` reduced to the org clause |
| `label-scope`: create refuses a team in another workspace, and one in this workspace the writer never joined | the `requireTeam` line deleted from `createLabel` |
| `label-scope`: update refuses a foreign team and leaves the label workspace wide | same |
| `label-scope`: an issue refuses a label pinned to another team or owned by another workspace, on create and on update | `assertLabelsUsable`'s length check disabled |
| `label-scope`: a duplicate name is a conflict, not a server fault | the `isUniqueViolation` branch deleted |
| `workflow-state-lifecycle`: a new status appends and a caller-sent position is ignored | `nextPosition(...)` replaced with `0` |
| `workflow-state-lifecycle`: reorder refuses a partial order, and one smuggling in another team's status | the full-set guard disabled |
| `workflow-state-lifecycle`: reorder refuses one status named twice | the dedupe check disabled |
| `workflow-state-lifecycle`: a category change re-dates the issues in that status, both directions | the `recategorised` condition forced to `false` |
| `workflow-state-lifecycle`: a rename leaves the issues alone | the same condition forced to `true` |
| `workflow-state-lifecycle`: a status change publishes to the team only | `stateScopes` given an org scope as well |
| `workflow-state-lifecycle`: delete refuses without a target, and refuses a target on another team | the refusal branch disabled and the team clause dropped from `targetForMove` |
| `workflow-state-lifecycle`: a team cannot be emptied of statuses | the last-status guard disabled |
| `workflow-state-lifecycle`: a contributor is refused every write | `assertCan` removed from `createWorkflowState` |
| `workflow-state-lifecycle`: a member not on the team is refused | `assertInTeam` removed from `ownedState` |
| `api/labels`: a contributor gets 403 and nothing is written | `assertCan` removed from `createLabel` |
| `api/labels`: another workspace's label is 404 on read, patch and delete | the workspace clause replaced with `isNotNull` |
| `api/workflow-states`: delete with `?moveToStateId=` moves the issues; a target on another team is 422 | the route stopped passing `moveToStateId` through |
| `mcp/taxonomy`: an `orbit.read` token is offered no state write, and the hints match | `create_state` marked `readOnly: true` |
| `mcp/taxonomy`: `delete_state` refuses until `moveTo` is given | the tool made to pick a target itself |
| `mcp/taxonomy`: a guest is refused every state write | `assertCan` removed from `createWorkflowState` |

The route tests run the real handlers against the real Postgres with only the session mocked, so
the refusal comes from the server rather than from a stubbed service. `publishDeltas` is the only
thing replaced, and only to capture the scopes an action was published on.

## Not done here

Nothing about labels or statuses is left in a component. `bun run verify` is green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds workspace-managed labels and team workflow columns across the API, settings UI, core services, realtime events, and MCP tools. One body-error handling change leaves routes that parse outside the common wrapper returning server errors instead of validation responses.
- Adds scoped label and workflow-state CRUD, ordering, category lifecycle handling, and migration catch-up support.
- Adds settings panels and shared API/MCP service paths.
- Tightens malformed and unreadable JSON handling, but not all existing route shapes safely map the resulting errors.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until unreadable and malformed bodies are consistently converted to validation responses for routes that parse before entering the common handler wrapper.

The new readJson exceptions correctly map to validation responses only when raised inside handleRoute; several current route handlers invoke readJson first, allowing the same client error to escape as an unhandled server failure.

**Files Needing Attention:** apps/web/src/lib/api/handler.ts and routes that call readJson before handle or handleRoute

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/api/handler.ts | Improves malformed-body handling, but thrown validation errors bypass HTTP mapping when callers invoke readJson outside handleRoute. |
| packages/core/src/work/issue-service.ts | Team moves now remove destination-incompatible labels before constructing the updated realtime payload. |
| packages/core/src/work/label-service.ts | Adds workspace/team label scoping, uniqueness handling, and helpers that enforce label usability. |
| packages/core/src/work/workflow-state-service.ts | Adds guarded workflow-state lifecycle operations, complete-set reordering, timestamp reconciliation, and safe deletion moves. |
| packages/mcp-server/src/tools/taxonomy.ts | Exposes label and workflow mutations through the same validated core services used by HTTP routes. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fweb%2Fsrc%2Flib%2Fapi%2Fhandler.ts%3A124-126%0A**Body%20errors%20bypass%20response%20mapping**%0A%0AWhen%20a%20route%20calls%20%60readJson%60%20before%20entering%20%60handle%60%20or%20%60handleRoute%60%2C%20a%20malformed%20or%20unreadable%20body%20throws%20%60validationFailed%60%20outside%20the%20common%20error-mapping%20wrapper%2C%20causing%20an%20unhandled%20server%20error%20instead%20of%20the%20intended%20422%20validation%20response.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=noveum%2Forbit&pr=147&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/lib/api/handler.ts:124-126
**Body errors bypass response mapping**

When a route calls `readJson` before entering `handle` or `handleRoute`, a malformed or unreadable body throws `validationFailed` outside the common error-mapping wrapper, causing an unhandled server error instead of the intended 422 validation response.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (12): Last reviewed commit: ["fix(api): refuse a request body that cou..."](https://github.com/noveum/orbit/commit/e91e095e9df5cf095af6e3c9836056a6a7a24a87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51116222)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->