### PR TITLE
Create projects, and manage milestones from the UI and MCP

### DIFF
--- a/apps/web/src/app/(app)/projects/[slug]/layout.tsx
+++ b/apps/web/src/app/(app)/projects/[slug]/layout.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge.tsx';
 import { Donut } from '@/features/charts/donut.tsx';
 import { LineChart } from '@/features/charts/line-chart.tsx';
 import { findProjectDetail } from '@/features/projects/data.ts';
+import { formatDay } from '@/features/projects/dates.ts';
 import { HealthChip, STATUS_LABELS } from '@/features/projects/health-chip.tsx';
 import { ProjectTabs } from '@/features/projects/project-tabs.tsx';
 import { pageContext } from '@/lib/api/handler.ts';
@@ -21,12 +22,7 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
 }
 
 function formatDate(value: string | null): string {
-  if (value === null) return 'Not set';
-  return new Date(value).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  });
+  return formatDay(value, { withYear: true, missing: 'Not set' });
 }
 
 export default async function ProjectLayout({ params, children }: LayoutProps) {

--- a/apps/web/src/app/(app)/projects/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[slug]/page.tsx
@@ -1,10 +1,7 @@
 import { can } from '@orbit/shared/policy';
 import { notFound } from 'next/navigation';
 import { findProjectDetail } from '@/features/projects/data.ts';
-import {
-  MilestoneBoard,
-  type MilestoneProgressView,
-} from '@/features/projects/milestone-board.tsx';
+import { MilestoneBoard } from '@/features/projects/milestone-board.tsx';
 import { pageContext } from '@/lib/api/handler.ts';
 import type { Milestone } from '@/lib/query/schemas.ts';
 
@@ -25,11 +22,9 @@ export default async function ProjectOverviewPage({ params }: PageProps) {
     description: milestone.description,
     targetDate: milestone.targetDate,
     sortOrder: milestone.sortOrder,
+    scope: milestone.scope,
+    completed: milestone.completed,
   }));
-  const progress: Record<string, MilestoneProgressView> = {};
-  for (const milestone of detail.milestones) {
-    progress[milestone.id] = { scope: milestone.scope, completed: milestone.completed };
-  }
 
   return (
     <>
@@ -43,7 +38,6 @@ export default async function ProjectOverviewPage({ params }: PageProps) {
       <MilestoneBoard
         projectId={detail.summary.id}
         milestones={milestones}
-        progress={progress}
         canManage={can(principal, 'milestone:manage')}
       />
     </>

--- a/apps/web/src/app/(app)/projects/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[slug]/page.tsx
@@ -1,21 +1,15 @@
+import { can } from '@orbit/shared/policy';
 import { notFound } from 'next/navigation';
-import { ProgressBar } from '@/features/charts/donut.tsx';
 import { findProjectDetail } from '@/features/projects/data.ts';
+import {
+  MilestoneBoard,
+  type MilestoneProgressView,
+} from '@/features/projects/milestone-board.tsx';
 import { pageContext } from '@/lib/api/handler.ts';
-import { cn } from '@/lib/cn.ts';
-import { cardHover } from '@/lib/interaction.ts';
+import type { Milestone } from '@/lib/query/schemas.ts';
 
 interface PageProps {
   readonly params: Promise<{ slug: string }>;
-}
-
-function formatDate(value: string | null): string {
-  if (value === null) return 'Not set';
-  return new Date(value).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  });
 }
 
 export default async function ProjectOverviewPage({ params }: PageProps) {
@@ -23,6 +17,19 @@ export default async function ProjectOverviewPage({ params }: PageProps) {
   const { principal } = await pageContext();
   const detail = await findProjectDetail(principal, slug);
   if (detail === null) notFound();
+
+  const milestones: Milestone[] = detail.milestones.map((milestone) => ({
+    id: milestone.id,
+    projectId: milestone.projectId,
+    name: milestone.name,
+    description: milestone.description,
+    targetDate: milestone.targetDate,
+    sortOrder: milestone.sortOrder,
+  }));
+  const progress: Record<string, MilestoneProgressView> = {};
+  for (const milestone of detail.milestones) {
+    progress[milestone.id] = { scope: milestone.scope, completed: milestone.completed };
+  }
 
   return (
     <>
@@ -33,36 +40,12 @@ export default async function ProjectOverviewPage({ params }: PageProps) {
         </section>
       )}
 
-      <section className="flex flex-col gap-3">
-        <h2 className="font-medium text-dense text-text">Milestones</h2>
-        {detail.milestones.length === 0 ? (
-          <p className="text-faint text-xs">No milestones yet.</p>
-        ) : (
-          <ul className="flex flex-col gap-3">
-            {detail.milestones.map((milestone) => (
-              <li
-                key={milestone.id}
-                className={cn('flex flex-col gap-2 rounded-lg border border-border p-3', cardHover)}
-              >
-                <div className="flex flex-wrap items-baseline justify-between gap-2">
-                  <span className="text-dense text-text">{milestone.name}</span>
-                  <span className="text-2xs text-faint tabular">
-                    {milestone.completed}/{milestone.scope} · {formatDate(milestone.targetDate)}
-                  </span>
-                </div>
-                {milestone.description.length === 0 ? null : (
-                  <p className="text-muted text-xs">{milestone.description}</p>
-                )}
-                <ProgressBar
-                  completed={milestone.completed}
-                  scope={milestone.scope}
-                  label={`${milestone.name} completion`}
-                />
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+      <MilestoneBoard
+        projectId={detail.summary.id}
+        milestones={milestones}
+        progress={progress}
+        canManage={can(principal, 'milestone:manage')}
+      />
     </>
   );
 }

--- a/apps/web/src/app/(app)/projects/page.tsx
+++ b/apps/web/src/app/(app)/projects/page.tsx
@@ -1,3 +1,5 @@
+import { listTeams } from '@orbit/core';
+import { can } from '@orbit/shared/policy';
 import { FolderKanban } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
@@ -6,6 +8,7 @@ import { EmptyState } from '@/components/ui/empty-state.tsx';
 import { Donut } from '@/features/charts/donut.tsx';
 import { listProjectSummaries } from '@/features/projects/data.ts';
 import { HealthChip, STATUS_LABELS } from '@/features/projects/health-chip.tsx';
+import { NewProjectDialog } from '@/features/projects/new-project-dialog.tsx';
 import { pageContext } from '@/lib/api/handler.ts';
 import { cn } from '@/lib/cn.ts';
 import { rowHover } from '@/lib/interaction.ts';
@@ -19,7 +22,12 @@ function formatDate(value: string | null): string {
 
 export default async function ProjectsPage() {
   const { principal } = await pageContext();
-  const projects = await listProjectSummaries(principal);
+  const [projects, teams] = await Promise.all([
+    listProjectSummaries(principal),
+    listTeams(principal),
+  ]);
+  const canManage = can(principal, 'project:manage');
+  const teamOptions = teams.map((team) => ({ id: team.id, key: team.key, name: team.name }));
 
   if (projects.length === 0) {
     return (
@@ -27,17 +35,27 @@ export default async function ProjectsPage() {
         icon={<FolderKanban strokeWidth={1.75} aria-hidden="true" />}
         title="No projects yet"
         description="Projects group issues around an outcome, with milestones and a health signal."
+        action={
+          <NewProjectDialog
+            teams={teamOptions}
+            canManage={canManage}
+            label="Create the first project"
+          />
+        }
       />
     );
   }
 
   return (
     <div className="flex flex-col gap-4 px-6 py-6">
-      <header className="flex flex-col gap-1">
-        <h1 className="font-semibold text-lg text-text">Projects</h1>
-        <p className="text-muted text-xs">
-          {projects.length} active {projects.length === 1 ? 'project' : 'projects'}.
-        </p>
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h1 className="font-semibold text-lg text-text">Projects</h1>
+          <p className="text-muted text-xs">
+            {projects.length} active {projects.length === 1 ? 'project' : 'projects'}.
+          </p>
+        </div>
+        <NewProjectDialog teams={teamOptions} canManage={canManage} />
       </header>
 
       <div className="overflow-x-auto rounded-lg border border-border">

--- a/apps/web/src/app/(app)/projects/page.tsx
+++ b/apps/web/src/app/(app)/projects/page.tsx
@@ -7,6 +7,7 @@ import { Avatar } from '@/components/ui/avatar.tsx';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
 import { Donut } from '@/features/charts/donut.tsx';
 import { listProjectSummaries } from '@/features/projects/data.ts';
+import { formatDay } from '@/features/projects/dates.ts';
 import { HealthChip, STATUS_LABELS } from '@/features/projects/health-chip.tsx';
 import { NewProjectDialog } from '@/features/projects/new-project-dialog.tsx';
 import { pageContext } from '@/lib/api/handler.ts';
@@ -16,8 +17,7 @@ import { rowHover } from '@/lib/interaction.ts';
 export const metadata: Metadata = { title: 'Projects' };
 
 function formatDate(value: string | null): string {
-  if (value === null) return 'No target';
-  return new Date(value).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+  return formatDay(value, { withYear: false, missing: 'No target' });
 }
 
 export default async function ProjectsPage() {

--- a/apps/web/src/app/api/milestones/[id]/route.ts
+++ b/apps/web/src/app/api/milestones/[id]/route.ts
@@ -1,0 +1,25 @@
+import { deleteMilestone, updateMilestone } from '@orbit/core';
+import { apiContext, handleRoute, publish, readJson, routeId } from '@/lib/api/handler.ts';
+
+interface RouteParams {
+  readonly params: Promise<{ id: string }>;
+}
+
+export async function PATCH(request: Request, { params }: RouteParams): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const id = routeId((await params).id, 'milestone');
+    const result = await updateMilestone(principal, id, await readJson(request));
+    await publish(result.actions);
+    return { milestone: result.milestone };
+  });
+}
+
+export async function DELETE(_request: Request, { params }: RouteParams): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const id = routeId((await params).id, 'milestone');
+    await publish(await deleteMilestone(principal, id));
+    return { deleted: true };
+  });
+}

--- a/apps/web/src/app/api/milestones/[id]/route.ts
+++ b/apps/web/src/app/api/milestones/[id]/route.ts
@@ -1,4 +1,5 @@
 import { deleteMilestone, updateMilestone } from '@orbit/core';
+import { milestoneUpdateSchema } from '@orbit/shared/validators';
 import { apiContext, handleRoute, publish, readJson, routeId } from '@/lib/api/handler.ts';
 
 interface RouteParams {
@@ -9,7 +10,8 @@ export async function PATCH(request: Request, { params }: RouteParams): Promise<
   return await handleRoute(async () => {
     const { principal } = await apiContext();
     const id = routeId((await params).id, 'milestone');
-    const result = await updateMilestone(principal, id, await readJson(request));
+    const patch = milestoneUpdateSchema.parse(await readJson(request));
+    const result = await updateMilestone(principal, id, patch);
     await publish(result.actions);
     return { milestone: result.milestone };
   });

--- a/apps/web/src/app/api/projects/[id]/milestones/reorder/route.ts
+++ b/apps/web/src/app/api/projects/[id]/milestones/reorder/route.ts
@@ -1,0 +1,18 @@
+import { reorderMilestones } from '@orbit/core';
+import { milestoneReorderSchema } from '@orbit/shared/validators';
+import { apiContext, handleRoute, publish, readJson, routeId } from '@/lib/api/handler.ts';
+
+interface RouteParams {
+  readonly params: Promise<{ id: string }>;
+}
+
+export async function POST(request: Request, { params }: RouteParams): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const projectId = routeId((await params).id, 'project');
+    const { milestoneIds } = milestoneReorderSchema.parse(await readJson(request));
+    const result = await reorderMilestones(principal, projectId, milestoneIds);
+    await publish(result.actions);
+    return { milestones: result.milestones };
+  });
+}

--- a/apps/web/src/app/api/projects/[id]/milestones/route.ts
+++ b/apps/web/src/app/api/projects/[id]/milestones/route.ts
@@ -1,0 +1,26 @@
+import { createMilestone, listMilestones } from '@orbit/core';
+import { apiContext, handleRoute, publish, readJson, routeId } from '@/lib/api/handler.ts';
+
+interface RouteParams {
+  readonly params: Promise<{ id: string }>;
+}
+
+export async function GET(_request: Request, { params }: RouteParams): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const projectId = routeId((await params).id, 'project');
+    return { milestones: await listMilestones(principal, projectId) };
+  });
+}
+
+export async function POST(request: Request, { params }: RouteParams): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const projectId = routeId((await params).id, 'project');
+    const body = await readJson(request);
+    const input = typeof body === 'object' && body !== null ? body : {};
+    const result = await createMilestone(principal, { ...input, projectId });
+    await publish(result.actions);
+    return { milestone: result.milestone };
+  });
+}

--- a/apps/web/src/app/api/projects/[id]/milestones/route.ts
+++ b/apps/web/src/app/api/projects/[id]/milestones/route.ts
@@ -1,4 +1,5 @@
-import { createMilestone, listMilestones } from '@orbit/core';
+import { createMilestone, listMilestonesWithProgress } from '@orbit/core';
+import { milestoneCreateBodySchema } from '@orbit/shared/validators';
 import { apiContext, handleRoute, publish, readJson, routeId } from '@/lib/api/handler.ts';
 
 interface RouteParams {
@@ -9,7 +10,14 @@ export async function GET(_request: Request, { params }: RouteParams): Promise<R
   return await handleRoute(async () => {
     const { principal } = await apiContext();
     const projectId = routeId((await params).id, 'project');
-    return { milestones: await listMilestones(principal, projectId) };
+    const rows = await listMilestonesWithProgress(principal, projectId);
+    return {
+      milestones: rows.map((row) => ({
+        ...row.milestone,
+        scope: row.scope,
+        completed: row.completed,
+      })),
+    };
   });
 }
 
@@ -17,9 +25,8 @@ export async function POST(request: Request, { params }: RouteParams): Promise<R
   return await handleRoute(async () => {
     const { principal } = await apiContext();
     const projectId = routeId((await params).id, 'project');
-    const body = await readJson(request);
-    const input = typeof body === 'object' && body !== null ? body : {};
-    const result = await createMilestone(principal, { ...input, projectId });
+    const draft = milestoneCreateBodySchema.parse(await readJson(request));
+    const result = await createMilestone(principal, { ...draft, projectId });
     await publish(result.actions);
     return { milestone: result.milestone };
   });

--- a/apps/web/src/features/issues/issue-properties.tsx
+++ b/apps/web/src/features/issues/issue-properties.tsx
@@ -8,12 +8,21 @@ import { Kbd } from '@/components/ui/kbd.tsx';
 import { useHotkey } from '@/lib/keyboard/index.ts';
 import type { Issue } from '@/lib/query/schemas.ts';
 import { useUpdateIssue } from '@/lib/query/use-issues.ts';
+import { useMilestones } from '@/lib/query/use-milestones.ts';
 import { PriorityGlyph, priorityLabel } from './priority-glyph.tsx';
 import { PropertyMenu } from './property-menu.tsx';
 import { StateGlyph } from './state-glyph.tsx';
 import { statesForTeam, useWorkspace } from './workspace-provider.tsx';
 
-type MenuKey = 'status' | 'priority' | 'assignee' | 'project' | 'cycle' | 'labels' | 'estimate';
+type MenuKey =
+  | 'status'
+  | 'priority'
+  | 'assignee'
+  | 'project'
+  | 'milestone'
+  | 'cycle'
+  | 'labels'
+  | 'estimate';
 
 const rowClassName =
   'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-dense text-text transition-colors duration-[var(--duration-fast)] hover:bg-surface-2';
@@ -32,6 +41,9 @@ export function IssueProperties({ issue }: IssuePropertiesProps) {
   const assignee =
     issue.assigneeId === null ? undefined : workspace.memberById.get(issue.assigneeId);
   const project = workspace.projects.find((entry) => entry.id === issue.projectId);
+  const milestonesQuery = useMilestones(issue.projectId);
+  const milestones = milestonesQuery.data ?? [];
+  const milestone = milestones.find((entry) => entry.id === issue.milestoneId);
   const cycles = workspace.cycles.filter((cycle) => cycle.teamId === issue.teamId);
   const cycle = cycles.find((entry) => entry.id === issue.cycleId);
   const teamLabels = workspace.labels.filter(
@@ -71,6 +83,11 @@ export function IssueProperties({ issue }: IssuePropertiesProps) {
   });
   useHotkey('shift+e', () => setOpenMenu('estimate'), {
     label: 'Change estimate',
+    section: 'Issues',
+    scope: 'issues',
+  });
+  useHotkey('m', () => setOpenMenu('milestone'), {
+    label: 'Change milestone',
     section: 'Issues',
     scope: 'issues',
   });
@@ -221,6 +238,31 @@ export function IssueProperties({ issue }: IssuePropertiesProps) {
             {project?.name ?? 'No project'}
           </button>
         </PropertyMenu>
+      </PropertyRow>
+
+      <PropertyRow label="Milestone" shortcut="m">
+        {issue.projectId === null ? (
+          <p className="px-2 py-1.5 text-dense text-faint" data-testid="property-milestone-empty">
+            Pick a project first
+          </p>
+        ) : (
+          <PropertyMenu
+            title="Milestone"
+            open={openMenu === 'milestone'}
+            onOpenChange={toggle('milestone')}
+            options={[
+              { id: 'none', label: 'No milestone' },
+              ...milestones.map((entry) => ({ id: entry.id, label: entry.name })),
+            ]}
+            selected={issue.milestoneId === null ? ['none'] : [issue.milestoneId]}
+            onSelect={(value) => patch({ milestoneId: value === 'none' ? null : value })}
+            testId="menu-milestone"
+          >
+            <button type="button" className={rowClassName} data-testid="property-milestone">
+              {milestone?.name ?? 'No milestone'}
+            </button>
+          </PropertyMenu>
+        )}
       </PropertyRow>
 
       <PropertyRow label="Sprint">

--- a/apps/web/src/features/issues/issue-properties.tsx
+++ b/apps/web/src/features/issues/issue-properties.tsx
@@ -90,6 +90,7 @@ export function IssueProperties({ issue }: IssuePropertiesProps) {
     label: 'Change milestone',
     section: 'Issues',
     scope: 'issues',
+    enabled: issue.projectId !== null,
   });
 
   return (

--- a/apps/web/src/features/issues/issue-properties.tsx
+++ b/apps/web/src/features/issues/issue-properties.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import { Avatar } from '@/components/ui/avatar.tsx';
 import { Kbd } from '@/components/ui/kbd.tsx';
 import { useHotkey } from '@/lib/keyboard/index.ts';
-import type { Issue } from '@/lib/query/schemas.ts';
+import type { Issue, Milestone } from '@/lib/query/schemas.ts';
 import { useUpdateIssue } from '@/lib/query/use-issues.ts';
 import { useMilestones } from '@/lib/query/use-milestones.ts';
 import { PriorityGlyph, priorityLabel } from './priority-glyph.tsx';
@@ -43,7 +43,6 @@ export function IssueProperties({ issue }: IssuePropertiesProps) {
   const project = workspace.projects.find((entry) => entry.id === issue.projectId);
   const milestonesQuery = useMilestones(issue.projectId);
   const milestones = milestonesQuery.data ?? [];
-  const milestone = milestones.find((entry) => entry.id === issue.milestoneId);
   const cycles = workspace.cycles.filter((cycle) => cycle.teamId === issue.teamId);
   const cycle = cycles.find((entry) => entry.id === issue.cycleId);
   const teamLabels = workspace.labels.filter(
@@ -241,30 +240,13 @@ export function IssueProperties({ issue }: IssuePropertiesProps) {
         </PropertyMenu>
       </PropertyRow>
 
-      <PropertyRow label="Milestone" shortcut="m">
-        {issue.projectId === null ? (
-          <p className="px-2 py-1.5 text-dense text-faint" data-testid="property-milestone-empty">
-            Pick a project first
-          </p>
-        ) : (
-          <PropertyMenu
-            title="Milestone"
-            open={openMenu === 'milestone'}
-            onOpenChange={toggle('milestone')}
-            options={[
-              { id: 'none', label: 'No milestone' },
-              ...milestones.map((entry) => ({ id: entry.id, label: entry.name })),
-            ]}
-            selected={issue.milestoneId === null ? ['none'] : [issue.milestoneId]}
-            onSelect={(value) => patch({ milestoneId: value === 'none' ? null : value })}
-            testId="menu-milestone"
-          >
-            <button type="button" className={rowClassName} data-testid="property-milestone">
-              {milestone?.name ?? 'No milestone'}
-            </button>
-          </PropertyMenu>
-        )}
-      </PropertyRow>
+      <MilestoneProperty
+        issue={issue}
+        milestones={milestones}
+        open={openMenu === 'milestone'}
+        onOpenChange={toggle('milestone')}
+        onSelect={(milestoneId) => patch({ milestoneId })}
+      />
 
       <PropertyRow label="Sprint">
         <PropertyMenu
@@ -287,6 +269,51 @@ export function IssueProperties({ issue }: IssuePropertiesProps) {
         </PropertyMenu>
       </PropertyRow>
     </aside>
+  );
+}
+
+function MilestoneProperty({
+  issue,
+  milestones,
+  open,
+  onOpenChange,
+  onSelect,
+}: {
+  readonly issue: Issue;
+  readonly milestones: readonly Milestone[];
+  readonly open: boolean;
+  readonly onOpenChange: (next: boolean) => void;
+  readonly onSelect: (milestoneId: string | null) => void;
+}) {
+  if (issue.projectId === null) {
+    return (
+      <PropertyRow label="Milestone">
+        <p className="px-2 py-1.5 text-dense text-faint" data-testid="property-milestone-empty">
+          Pick a project first
+        </p>
+      </PropertyRow>
+    );
+  }
+  const current = milestones.find((entry) => entry.id === issue.milestoneId);
+  return (
+    <PropertyRow label="Milestone" shortcut="m">
+      <PropertyMenu
+        title="Milestone"
+        open={open}
+        onOpenChange={onOpenChange}
+        options={[
+          { id: 'none', label: 'No milestone' },
+          ...milestones.map((entry) => ({ id: entry.id, label: entry.name })),
+        ]}
+        selected={issue.milestoneId === null ? ['none'] : [issue.milestoneId]}
+        onSelect={(value) => onSelect(value === 'none' ? null : value)}
+        testId="menu-milestone"
+      >
+        <button type="button" className={rowClassName} data-testid="property-milestone">
+          {current?.name ?? 'No milestone'}
+        </button>
+      </PropertyMenu>
+    </PropertyRow>
   );
 }
 

--- a/apps/web/src/features/projects/data.ts
+++ b/apps/web/src/features/projects/data.ts
@@ -91,9 +91,11 @@ export async function listProjectSummaries(principal: Principal): Promise<Projec
 
 export interface MilestoneView {
   readonly id: string;
+  readonly projectId: string;
   readonly name: string;
   readonly description: string;
   readonly targetDate: string | null;
+  readonly sortOrder: number;
   readonly scope: number;
   readonly completed: number;
 }
@@ -168,9 +170,11 @@ export async function getProjectDetail(principal: Principal, slug: string): Prom
     progress,
     milestones: milestones.map((milestone) => ({
       id: milestone.id,
+      projectId: milestone.projectId,
       name: milestone.name,
       description: milestone.description,
       targetDate: milestone.targetDate,
+      sortOrder: milestone.sortOrder,
       scope: milestoneProgress.get(milestone.id)?.scope ?? 0,
       completed: milestoneProgress.get(milestone.id)?.completed ?? 0,
     })),

--- a/apps/web/src/features/projects/dates.ts
+++ b/apps/web/src/features/projects/dates.ts
@@ -1,0 +1,33 @@
+const DAY_ONLY = /^(\d{4})-(\d{2})-(\d{2})/;
+
+export interface DayFormat {
+  readonly withYear: boolean;
+  readonly missing: string;
+}
+
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const;
+
+export function formatDay(value: string | null, format: DayFormat): string {
+  if (value === null) return format.missing;
+  const parts = DAY_ONLY.exec(value);
+  if (parts === null) return format.missing;
+  const year = parts[1];
+  const month = MONTHS[Number(parts[2]) - 1];
+  const day = parts[3];
+  if (year === undefined || month === undefined || day === undefined) return format.missing;
+  const plainDay = String(Number(day));
+  return format.withYear ? `${plainDay} ${month} ${year}` : `${plainDay} ${month}`;
+}

--- a/apps/web/src/features/projects/milestone-board.tsx
+++ b/apps/web/src/features/projects/milestone-board.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button.tsx';
 import { Input } from '@/components/ui/input.tsx';
 import { Textarea } from '@/components/ui/textarea.tsx';
 import { ProgressBar } from '@/features/charts/donut.tsx';
+import { formatDay } from '@/features/projects/dates.ts';
 import { cn } from '@/lib/cn.ts';
 import { cardHover } from '@/lib/interaction.ts';
 import type { Milestone } from '@/lib/query/schemas.ts';
@@ -18,25 +19,14 @@ import {
   useUpdateMilestone,
 } from '@/lib/query/use-milestones.ts';
 
-export interface MilestoneProgressView {
-  readonly scope: number;
-  readonly completed: number;
-}
-
 export interface MilestoneBoardProps {
   readonly projectId: string;
   readonly milestones: readonly Milestone[];
-  readonly progress: Readonly<Record<string, MilestoneProgressView>>;
   readonly canManage: boolean;
 }
 
 function formatDate(value: string | null): string {
-  if (value === null) return 'No target';
-  return new Date(value).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  });
+  return formatDay(value, { withYear: true, missing: 'No target' });
 }
 
 function draftFrom(milestone: Milestone): MilestoneFormValues {
@@ -135,7 +125,6 @@ function MilestoneForm({
 
 function MilestoneRow({
   milestone,
-  progress,
   canManage,
   index,
   total,
@@ -145,7 +134,6 @@ function MilestoneRow({
   busy,
 }: {
   readonly milestone: Milestone;
-  readonly progress: MilestoneProgressView;
   readonly canManage: boolean;
   readonly index: number;
   readonly total: number;
@@ -162,15 +150,15 @@ function MilestoneRow({
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <span className="text-dense text-text">{milestone.name}</span>
         <span className="text-2xs text-faint tabular">
-          {progress.completed}/{progress.scope} · {formatDate(milestone.targetDate)}
+          {milestone.completed}/{milestone.scope} · {formatDate(milestone.targetDate)}
         </span>
       </div>
       {milestone.description.length === 0 ? null : (
         <p className="text-muted text-xs">{milestone.description}</p>
       )}
       <ProgressBar
-        completed={progress.completed}
-        scope={progress.scope}
+        completed={milestone.completed}
+        scope={milestone.scope}
         label={`${milestone.name} completion`}
       />
       {canManage ? (
@@ -225,14 +213,7 @@ function MilestoneRow({
   );
 }
 
-const NO_PROGRESS: MilestoneProgressView = { scope: 0, completed: 0 };
-
-export function MilestoneBoard({
-  projectId,
-  milestones,
-  progress,
-  canManage,
-}: MilestoneBoardProps) {
+export function MilestoneBoard({ projectId, milestones, canManage }: MilestoneBoardProps) {
   const query = useMilestones(projectId);
   const create = useCreateMilestone(projectId);
   const update = useUpdateMilestone(projectId);
@@ -328,7 +309,6 @@ export function MilestoneBoard({
               <MilestoneRow
                 key={milestone.id}
                 milestone={milestone}
-                progress={progress[milestone.id] ?? NO_PROGRESS}
                 canManage={canManage}
                 index={index}
                 total={rows.length}

--- a/apps/web/src/features/projects/milestone-board.tsx
+++ b/apps/web/src/features/projects/milestone-board.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+import { ChevronDown, ChevronUp, Pencil, Plus, Trash2 } from 'lucide-react';
+import { type FormEvent, useState } from 'react';
+import { Button } from '@/components/ui/button.tsx';
+import { Input } from '@/components/ui/input.tsx';
+import { Textarea } from '@/components/ui/textarea.tsx';
+import { ProgressBar } from '@/features/charts/donut.tsx';
+import { cn } from '@/lib/cn.ts';
+import { cardHover } from '@/lib/interaction.ts';
+import type { Milestone } from '@/lib/query/schemas.ts';
+import {
+  type MilestoneDraft,
+  useCreateMilestone,
+  useDeleteMilestone,
+  useMilestones,
+  useReorderMilestones,
+  useUpdateMilestone,
+} from '@/lib/query/use-milestones.ts';
+
+export interface MilestoneProgressView {
+  readonly scope: number;
+  readonly completed: number;
+}
+
+export interface MilestoneBoardProps {
+  readonly projectId: string;
+  readonly milestones: readonly Milestone[];
+  readonly progress: Readonly<Record<string, MilestoneProgressView>>;
+  readonly canManage: boolean;
+}
+
+function formatDate(value: string | null): string {
+  if (value === null) return 'No target';
+  return new Date(value).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function draftFrom(milestone: Milestone): MilestoneFormValues {
+  return {
+    name: milestone.name,
+    description: milestone.description,
+    targetDate: milestone.targetDate === null ? '' : milestone.targetDate.slice(0, 10),
+  };
+}
+
+export interface MilestoneFormValues {
+  readonly name: string;
+  readonly description: string;
+  readonly targetDate: string;
+}
+
+const EMPTY_FORM: MilestoneFormValues = { name: '', description: '', targetDate: '' };
+
+export function milestonePayload(values: MilestoneFormValues): MilestoneDraft {
+  return {
+    name: values.name.trim(),
+    description: values.description.trim(),
+    targetDate: values.targetDate.length === 0 ? null : values.targetDate,
+  };
+}
+
+function MilestoneForm({
+  values,
+  onChange,
+  onSubmit,
+  onCancel,
+  submitLabel,
+  pending,
+  testId,
+}: {
+  readonly values: MilestoneFormValues;
+  readonly onChange: (next: MilestoneFormValues) => void;
+  readonly onSubmit: () => void;
+  readonly onCancel: () => void;
+  readonly submitLabel: string;
+  readonly pending: boolean;
+  readonly testId: string;
+}) {
+  function submit(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    if (values.name.trim().length === 0) return;
+    onSubmit();
+  }
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-2" data-testid={testId}>
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <Input
+          value={values.name}
+          maxLength={120}
+          placeholder="Milestone name"
+          aria-label="Milestone name"
+          data-testid={`${testId}-name`}
+          onChange={(event) => onChange({ ...values, name: event.target.value })}
+        />
+        <Input
+          type="date"
+          value={values.targetDate}
+          aria-label="Milestone target date"
+          data-testid={`${testId}-target`}
+          className="sm:w-44"
+          onChange={(event) => onChange({ ...values, targetDate: event.target.value })}
+        />
+      </div>
+      <Textarea
+        rows={2}
+        maxLength={2000}
+        value={values.description}
+        placeholder="What has to be true when this milestone lands?"
+        aria-label="Milestone description"
+        data-testid={`${testId}-description`}
+        onChange={(event) => onChange({ ...values, description: event.target.value })}
+      />
+      <div className="flex justify-end gap-2">
+        <Button type="button" size="sm" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          size="sm"
+          variant="primary"
+          data-testid={`${testId}-submit`}
+          disabled={pending || values.name.trim().length === 0}
+        >
+          {submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function MilestoneRow({
+  milestone,
+  progress,
+  canManage,
+  index,
+  total,
+  onEdit,
+  onDelete,
+  onMove,
+  busy,
+}: {
+  readonly milestone: Milestone;
+  readonly progress: MilestoneProgressView;
+  readonly canManage: boolean;
+  readonly index: number;
+  readonly total: number;
+  readonly onEdit: () => void;
+  readonly onDelete: () => void;
+  readonly onMove: (direction: -1 | 1) => void;
+  readonly busy: boolean;
+}) {
+  return (
+    <li
+      className={cn('flex flex-col gap-2 rounded-lg border border-border p-3', cardHover)}
+      data-testid={`milestone-${milestone.id}`}
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <span className="text-dense text-text">{milestone.name}</span>
+        <span className="text-2xs text-faint tabular">
+          {progress.completed}/{progress.scope} · {formatDate(milestone.targetDate)}
+        </span>
+      </div>
+      {milestone.description.length === 0 ? null : (
+        <p className="text-muted text-xs">{milestone.description}</p>
+      )}
+      <ProgressBar
+        completed={progress.completed}
+        scope={progress.scope}
+        label={`${milestone.name} completion`}
+      />
+      {canManage ? (
+        <div className="flex flex-wrap justify-end gap-1">
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            aria-label={`Move ${milestone.name} up`}
+            data-testid={`milestone-up-${milestone.id}`}
+            disabled={busy || index === 0}
+            onClick={() => onMove(-1)}
+          >
+            <ChevronUp className="size-3.5" aria-hidden="true" />
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            aria-label={`Move ${milestone.name} down`}
+            data-testid={`milestone-down-${milestone.id}`}
+            disabled={busy || index === total - 1}
+            onClick={() => onMove(1)}
+          >
+            <ChevronDown className="size-3.5" aria-hidden="true" />
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            aria-label={`Edit ${milestone.name}`}
+            data-testid={`milestone-edit-${milestone.id}`}
+            disabled={busy}
+            onClick={onEdit}
+          >
+            <Pencil className="size-3.5" aria-hidden="true" />
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            aria-label={`Delete ${milestone.name}`}
+            data-testid={`milestone-delete-${milestone.id}`}
+            disabled={busy}
+            onClick={onDelete}
+          >
+            <Trash2 className="size-3.5" aria-hidden="true" />
+          </Button>
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+const NO_PROGRESS: MilestoneProgressView = { scope: 0, completed: 0 };
+
+export function MilestoneBoard({
+  projectId,
+  milestones,
+  progress,
+  canManage,
+}: MilestoneBoardProps) {
+  const query = useMilestones(projectId);
+  const create = useCreateMilestone(projectId);
+  const update = useUpdateMilestone(projectId);
+  const remove = useDeleteMilestone(projectId);
+  const reorder = useReorderMilestones(projectId);
+
+  const [adding, setAdding] = useState(false);
+  const [addDraft, setAddDraft] = useState<MilestoneFormValues>(EMPTY_FORM);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<MilestoneFormValues>(EMPTY_FORM);
+
+  const rows = query.data ?? milestones;
+  const busy = create.isPending || update.isPending || remove.isPending || reorder.isPending;
+
+  function move(index: number, direction: -1 | 1): void {
+    const target = index + direction;
+    const moving = rows[index];
+    const swapped = rows[target];
+    if (moving === undefined || swapped === undefined) return;
+    const next = rows.map((entry) => entry.id);
+    next[index] = swapped.id;
+    next[target] = moving.id;
+    reorder.mutate(next);
+  }
+
+  return (
+    <section className="flex flex-col gap-3" data-testid="milestone-board">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="font-medium text-dense text-text">Milestones</h2>
+        {canManage && !adding ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            data-testid="milestone-add"
+            onClick={() => {
+              setAddDraft(EMPTY_FORM);
+              setAdding(true);
+            }}
+          >
+            <Plus className="size-3.5" aria-hidden="true" />
+            Add milestone
+          </Button>
+        ) : null}
+      </div>
+
+      {adding ? (
+        <MilestoneForm
+          values={addDraft}
+          onChange={setAddDraft}
+          onCancel={() => setAdding(false)}
+          pending={create.isPending}
+          submitLabel="Add milestone"
+          testId="milestone-new"
+          onSubmit={() => {
+            create.mutate(milestonePayload(addDraft), {
+              onSuccess: () => {
+                setAddDraft(EMPTY_FORM);
+                setAdding(false);
+              },
+            });
+          }}
+        />
+      ) : null}
+
+      {rows.length === 0 && !adding ? (
+        <p className="text-faint text-xs">No milestones yet.</p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {rows.map((milestone, index) =>
+            editingId === milestone.id ? (
+              <li
+                key={milestone.id}
+                className="rounded-lg border border-border p-3"
+                data-testid={`milestone-editor-${milestone.id}`}
+              >
+                <MilestoneForm
+                  values={editDraft}
+                  onChange={setEditDraft}
+                  onCancel={() => setEditingId(null)}
+                  pending={update.isPending}
+                  submitLabel="Save milestone"
+                  testId="milestone-edit"
+                  onSubmit={() => {
+                    update.mutate(
+                      { id: milestone.id, patch: milestonePayload(editDraft) },
+                      { onSuccess: () => setEditingId(null) },
+                    );
+                  }}
+                />
+              </li>
+            ) : (
+              <MilestoneRow
+                key={milestone.id}
+                milestone={milestone}
+                progress={progress[milestone.id] ?? NO_PROGRESS}
+                canManage={canManage}
+                index={index}
+                total={rows.length}
+                busy={busy}
+                onEdit={() => {
+                  setEditDraft(draftFrom(milestone));
+                  setEditingId(milestone.id);
+                }}
+                onDelete={() => remove.mutate(milestone.id)}
+                onMove={(direction) => move(index, direction)}
+              />
+            ),
+          )}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/projects/new-project-dialog.tsx
+++ b/apps/web/src/features/projects/new-project-dialog.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { Plus } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { type FormEvent, useState } from 'react';
+import { z } from 'zod';
+import { Button } from '@/components/ui/button.tsx';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog.tsx';
+import { Input } from '@/components/ui/input.tsx';
+import { Textarea } from '@/components/ui/textarea.tsx';
+import { useToast } from '@/components/ui/toast.tsx';
+import { apiRequest, messageOf } from '@/lib/api/client.ts';
+import type { ProjectTeamOption } from './project-settings-form.tsx';
+
+const createdSchema = z.object({
+  project: z.object({ id: z.string(), slug: z.string(), name: z.string() }),
+});
+
+export interface NewProjectDialogProps {
+  readonly teams: readonly ProjectTeamOption[];
+  readonly canManage: boolean;
+  readonly label?: string;
+}
+
+const EMPTY_DRAFT = { name: '', summary: '', targetDate: '' };
+
+export function NewProjectDialog({
+  teams,
+  canManage,
+  label = 'New project',
+}: NewProjectDialogProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(EMPTY_DRAFT);
+  const [teamIds, setTeamIds] = useState<readonly string[]>([]);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!canManage) return null;
+
+  function reset(): void {
+    setDraft(EMPTY_DRAFT);
+    setTeamIds([]);
+    setError(null);
+  }
+
+  function toggleTeam(id: string): void {
+    setTeamIds((current) =>
+      current.includes(id) ? current.filter((entry) => entry !== id) : [...current, id],
+    );
+  }
+
+  async function submit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    if (pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      const created = await apiRequest<unknown>('/api/projects', {
+        method: 'POST',
+        body: {
+          name: draft.name.trim(),
+          summary: draft.summary.trim(),
+          teamIds: [...teamIds],
+          targetDate: draft.targetDate.length === 0 ? null : draft.targetDate,
+        },
+      });
+      const { project } = createdSchema.parse(created);
+      toast({ title: `Created "${project.name}"`, tone: 'success' });
+      setOpen(false);
+      reset();
+      router.push(`/projects/${project.slug}`);
+      router.refresh();
+    } catch (caught) {
+      setError(messageOf(caught));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        size="sm"
+        variant="primary"
+        data-testid="new-project"
+        onClick={() => {
+          reset();
+          setOpen(true);
+        }}
+      >
+        <Plus className="size-3.5" aria-hidden="true" />
+        {label}
+      </Button>
+
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) reset();
+        }}
+      >
+        <DialogContent data-testid="new-project-dialog">
+          <DialogHeader>
+            <DialogTitle className="font-medium text-base text-text">New project</DialogTitle>
+            <DialogDescription className="text-muted text-xs">
+              A project groups issues around an outcome, with milestones and a health signal.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={submit} className="flex flex-col gap-4">
+            <label
+              className="flex flex-col gap-1.5 text-2xs text-faint"
+              htmlFor="new-project-name-field"
+            >
+              Name
+              <Input
+                id="new-project-name-field"
+                autoFocus
+                required
+                minLength={2}
+                maxLength={120}
+                value={draft.name}
+                data-testid="new-project-name"
+                placeholder="Realtime delta protocol"
+                onChange={(event) => setDraft({ ...draft, name: event.target.value })}
+              />
+            </label>
+
+            <label
+              className="flex flex-col gap-1.5 text-2xs text-faint"
+              htmlFor="new-project-summary-field"
+            >
+              Summary
+              <Textarea
+                id="new-project-summary-field"
+                rows={2}
+                maxLength={500}
+                value={draft.summary}
+                data-testid="new-project-summary"
+                placeholder="One line on what done looks like."
+                onChange={(event) => setDraft({ ...draft, summary: event.target.value })}
+              />
+            </label>
+
+            <label
+              className="flex flex-col gap-1.5 text-2xs text-faint"
+              htmlFor="new-project-target-field"
+            >
+              Target date
+              <Input
+                id="new-project-target-field"
+                type="date"
+                value={draft.targetDate}
+                data-testid="new-project-target"
+                onChange={(event) => setDraft({ ...draft, targetDate: event.target.value })}
+              />
+            </label>
+
+            {teams.length === 0 ? null : (
+              <fieldset className="flex flex-col gap-2">
+                <legend className="text-2xs text-faint">Teams</legend>
+                <div className="flex flex-wrap gap-2">
+                  {teams.map((team) => (
+                    <label
+                      key={team.id}
+                      className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-dense text-muted"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={teamIds.includes(team.id)}
+                        data-testid={`new-project-team-${team.key}`}
+                        onChange={() => toggleTeam(team.id)}
+                      />
+                      {team.name}
+                    </label>
+                  ))}
+                </div>
+                <p className="text-2xs text-faint">
+                  Leave every team unticked to make the project visible to the whole workspace.
+                </p>
+              </fieldset>
+            )}
+
+            {error === null ? null : (
+              <p role="alert" className="text-danger text-dense" data-testid="new-project-error">
+                {error}
+              </p>
+            )}
+
+            <DialogFooter>
+              <Button type="button" size="sm" variant="ghost" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                size="sm"
+                variant="primary"
+                data-testid="new-project-submit"
+                disabled={pending || draft.name.trim().length < 2}
+              >
+                {pending ? 'Creating' : 'Create project'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/features/projects/update-composer.tsx
+++ b/apps/web/src/features/projects/update-composer.tsx
@@ -25,11 +25,13 @@ export function UpdateComposer({ projectId, currentHealth, canPost }: UpdateComp
   const router = useRouter();
   const [health, setHealth] = useState<ProjectHealth>(currentHealth);
   const [body, setBody] = useState('');
+  const [composerKey, setComposerKey] = useState(0);
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   async function onSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
+    if (pending || body.trim().length === 0) return;
     setPending(true);
     setError(null);
     try {
@@ -38,6 +40,7 @@ export function UpdateComposer({ projectId, currentHealth, canPost }: UpdateComp
         body: { health, body },
       });
       setBody('');
+      setComposerKey((value) => value + 1);
       router.refresh();
     } catch (caught) {
       setError(messageOf(caught));
@@ -50,6 +53,7 @@ export function UpdateComposer({ projectId, currentHealth, canPost }: UpdateComp
     <form onSubmit={onSubmit} className="flex flex-col gap-2.5">
       <div className="rounded-lg border border-border bg-surface px-3 py-2 focus-within:border-border-strong">
         <RichTextEditor
+          key={composerKey}
           value={body}
           onChange={setBody}
           placeholder="What moved this week?"

--- a/apps/web/src/lib/query/keys.ts
+++ b/apps/web/src/lib/query/keys.ts
@@ -24,6 +24,7 @@ export const queryKeys = {
   doc: (docId: string) => ['doc', docId] as const,
   docVersions: (docId: string) => ['doc', docId, 'versions'] as const,
   views: () => ['views'] as const,
+  milestones: (projectId: string) => ['milestones', projectId] as const,
   standupBoard: (since: string) => ['standup', 'board', since] as const,
 } as const;
 
@@ -39,6 +40,7 @@ export const DOC_SEARCH_ROOT = 'doc-search';
 export const DOCS_HOME_ROOT = 'docs-home';
 export const DOC_ROOT = 'doc';
 export const VIEWS_ROOT = 'views';
+export const MILESTONES_ROOT = 'milestones';
 export const STANDUP_ROOT = 'standup';
 export const SEARCH_ROOT = 'search';
 export const VIEW_PREFERENCES_ROOT = 'view-preferences';

--- a/apps/web/src/lib/query/schemas.ts
+++ b/apps/web/src/lib/query/schemas.ts
@@ -415,6 +415,8 @@ export const milestoneSchema = z.object({
   description: z.string().default(''),
   targetDate: z.string().nullable(),
   sortOrder: z.number(),
+  scope: z.number().default(0),
+  completed: z.number().default(0),
 });
 
 export type Milestone = z.infer<typeof milestoneSchema>;

--- a/apps/web/src/lib/query/schemas.ts
+++ b/apps/web/src/lib/query/schemas.ts
@@ -408,6 +408,20 @@ export type View = z.infer<typeof viewSchema>;
 export const viewListSchema = z.object({ views: z.array(viewSchema) });
 export const viewEnvelopeSchema = z.object({ view: viewSchema });
 
+export const milestoneSchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  name: z.string(),
+  description: z.string().default(''),
+  targetDate: z.string().nullable(),
+  sortOrder: z.number(),
+});
+
+export type Milestone = z.infer<typeof milestoneSchema>;
+
+export const milestoneListSchema = z.object({ milestones: z.array(milestoneSchema) });
+export const milestoneEnvelopeSchema = z.object({ milestone: milestoneSchema });
+
 export const commentListSchema = z.object({
   comments: z.array(commentSchema),
   nextCursor: z.string().nullable().default(null),

--- a/apps/web/src/lib/query/use-issues.ts
+++ b/apps/web/src/lib/query/use-issues.ts
@@ -273,6 +273,7 @@ export interface IssuePatch {
   readonly priority?: number;
   readonly assigneeId?: string | null;
   readonly projectId?: string | null;
+  readonly milestoneId?: string | null;
   readonly cycleId?: string | null;
   readonly estimate?: number | null;
   readonly labelIds?: readonly string[];

--- a/apps/web/src/lib/query/use-milestones.ts
+++ b/apps/web/src/lib/query/use-milestones.ts
@@ -1,0 +1,147 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useToast } from '@/components/ui/toast.tsx';
+import { apiFetch, messageOf } from './fetcher.ts';
+import { queryKeys } from './keys.ts';
+import type { Milestone } from './schemas.ts';
+import { deletedSchema, milestoneEnvelopeSchema, milestoneListSchema } from './schemas.ts';
+
+const NO_MILESTONES: readonly Milestone[] = [];
+
+export function useMilestones(projectId: string | null) {
+  return useQuery({
+    queryKey: queryKeys.milestones(projectId ?? 'none'),
+    enabled: projectId !== null,
+    queryFn: async ({ signal }): Promise<readonly Milestone[]> => {
+      if (projectId === null) return NO_MILESTONES;
+      const payload = await apiFetch(`/api/projects/${projectId}/milestones`, milestoneListSchema, {
+        signal,
+      });
+      return payload.milestones;
+    },
+    staleTime: 30_000,
+  });
+}
+
+export interface MilestoneDraft {
+  readonly name: string;
+  readonly description?: string;
+  readonly targetDate?: string | null;
+}
+
+function useMilestoneRefresh(projectId: string) {
+  const client = useQueryClient();
+  return async (): Promise<void> => {
+    await client.invalidateQueries({ queryKey: queryKeys.milestones(projectId) });
+  };
+}
+
+export function useCreateMilestone(projectId: string) {
+  const refresh = useMilestoneRefresh(projectId);
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (draft: MilestoneDraft): Promise<Milestone> => {
+      const payload = await apiFetch(
+        `/api/projects/${projectId}/milestones`,
+        milestoneEnvelopeSchema,
+        { method: 'POST', body: draft },
+      );
+      return payload.milestone;
+    },
+    onError: (error) => {
+      toast({
+        title: 'Could not add that milestone',
+        description: messageOf(error),
+        tone: 'danger',
+      });
+    },
+    onSuccess: refresh,
+  });
+}
+
+export function useUpdateMilestone(projectId: string) {
+  const refresh = useMilestoneRefresh(projectId);
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (input: { id: string; patch: MilestoneDraft }): Promise<Milestone> => {
+      const payload = await apiFetch(`/api/milestones/${input.id}`, milestoneEnvelopeSchema, {
+        method: 'PATCH',
+        body: input.patch,
+      });
+      return payload.milestone;
+    },
+    onError: (error) => {
+      toast({
+        title: 'Could not save that milestone',
+        description: messageOf(error),
+        tone: 'danger',
+      });
+    },
+    onSuccess: refresh,
+  });
+}
+
+export function useDeleteMilestone(projectId: string) {
+  const refresh = useMilestoneRefresh(projectId);
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (milestoneId: string): Promise<boolean> => {
+      const payload = await apiFetch(`/api/milestones/${milestoneId}`, deletedSchema, {
+        method: 'DELETE',
+      });
+      return payload.deleted;
+    },
+    onError: (error) => {
+      toast({
+        title: 'Could not delete that milestone',
+        description: messageOf(error),
+        tone: 'danger',
+      });
+    },
+    onSuccess: refresh,
+  });
+}
+
+export function useReorderMilestones(projectId: string) {
+  const client = useQueryClient();
+  const refresh = useMilestoneRefresh(projectId);
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (milestoneIds: readonly string[]): Promise<readonly Milestone[]> => {
+      const payload = await apiFetch(
+        `/api/projects/${projectId}/milestones/reorder`,
+        milestoneListSchema,
+        { method: 'POST', body: { milestoneIds: [...milestoneIds] } },
+      );
+      return payload.milestones;
+    },
+    onMutate: (milestoneIds) => {
+      const key = queryKeys.milestones(projectId);
+      const previous = client.getQueryData<readonly Milestone[]>(key);
+      if (previous === undefined) return { previous };
+      const byId = new Map(previous.map((entry) => [entry.id, entry]));
+      const next = milestoneIds.flatMap((id) => {
+        const found = byId.get(id);
+        return found === undefined ? [] : [found];
+      });
+      if (next.length === previous.length) client.setQueryData(key, next);
+      return { previous };
+    },
+    onError: (error, _ids, context) => {
+      if (context?.previous !== undefined) {
+        client.setQueryData(queryKeys.milestones(projectId), context.previous);
+      }
+      toast({
+        title: 'Could not reorder the milestones',
+        description: messageOf(error),
+        tone: 'danger',
+      });
+    },
+    onSuccess: refresh,
+  });
+}

--- a/apps/web/src/lib/realtime/delta-bridge.tsx
+++ b/apps/web/src/lib/realtime/delta-bridge.tsx
@@ -25,6 +25,7 @@ import {
   ISSUE_ROOT,
   ISSUE_SUMMARY_ROOT,
   ISSUES_ROOT,
+  MILESTONES_ROOT,
   PROJECT_SCOPE,
   STANDUP_ROOT,
   VIEWS_ROOT,
@@ -53,7 +54,6 @@ const BOOTSTRAP_MODELS: ReadonlySet<SyncModel> = new Set<SyncModel>([
   'workflow_state',
   'label',
   'project',
-  'milestone',
   'cycle',
 ]);
 
@@ -69,6 +69,7 @@ interface RootInvalidations {
   bootstrap: boolean;
   views: boolean;
   docs: boolean;
+  milestones: boolean;
   docIds: Set<string>;
 }
 
@@ -194,6 +195,10 @@ function routeAction(
     roots.views = true;
     return;
   }
+  if (action.model === 'milestone') {
+    roots.milestones = true;
+    return;
+  }
   if (BOOTSTRAP_MODELS.has(action.model)) roots.bootstrap = true;
 }
 
@@ -205,6 +210,7 @@ function flushRoots(client: QueryClient, roots: RootInvalidations): void {
   if (roots.standupBoard) client.invalidateQueries({ queryKey: [STANDUP_ROOT] }).catch(noop);
   if (roots.bootstrap) client.invalidateQueries({ queryKey: [BOOTSTRAP_ROOT] }).catch(noop);
   if (roots.views) client.invalidateQueries({ queryKey: [VIEWS_ROOT] }).catch(noop);
+  if (roots.milestones) client.invalidateQueries({ queryKey: [MILESTONES_ROOT] }).catch(noop);
   if (roots.docs) {
     client.invalidateQueries({ queryKey: [DOCS_ROOT] }).catch(noop);
     client.invalidateQueries({ queryKey: [DOCS_HOME_ROOT] }).catch(noop);
@@ -243,6 +249,7 @@ export function DeltaBridge({ organizationId, teamIds }: DeltaBridgeProps) {
         bootstrap: false,
         views: false,
         docs: false,
+        milestones: false,
         docIds: new Set<string>(),
       };
 

--- a/apps/web/src/lib/realtime/delta-bridge.tsx
+++ b/apps/web/src/lib/realtime/delta-bridge.tsx
@@ -168,6 +168,7 @@ function routeAction(
     patchIssueCaches(client, action);
     roots.counts = true;
     roots.standupBoard = true;
+    roots.milestones = true;
     return;
   }
   if (action.model === 'comment') {

--- a/apps/web/tests/app/api/projects/milestones.test.ts
+++ b/apps/web/tests/app/api/projects/milestones.test.ts
@@ -16,7 +16,8 @@ mock.module('@orbit/core', () => ({
   },
 }));
 
-const { createMilestone, createProject, createTeam, listMilestones } = coreModule;
+const { createIssue, createMilestone, createProject, createTeam, listMilestones, updateIssue } =
+  coreModule;
 const { addMember, createWorkspace, resetDatabase } = await import('@orbit/core/test-support');
 
 type Workspace = Awaited<ReturnType<typeof createWorkspace>>;
@@ -45,7 +46,14 @@ const milestoneShape = z.object({
   milestone: z.object({ id: z.string(), name: z.string(), projectId: z.string() }),
 });
 const listShape = z.object({
-  milestones: z.array(z.object({ id: z.string(), name: z.string() })),
+  milestones: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      scope: z.number(),
+      completed: z.number(),
+    }),
+  ),
 });
 const errorShape = z.object({ error: z.object({ code: z.string(), message: z.string() }) });
 
@@ -188,6 +196,41 @@ describe('GET /api/projects/[id]/milestones', () => {
     const payload = listShape.parse(await response.json());
 
     expect(payload.milestones.map((row) => row.name)).toEqual(['One', 'Two', 'Three']);
+  });
+
+  it('counts the issues on each milestone on the server, never in the browser', async () => {
+    const { project } = await createProject(workspace.admin, {
+      name: 'Counted',
+      teamIds: [workspace.teamId],
+    });
+    const { milestone } = await createMilestone(workspace.admin, {
+      projectId: project.id,
+      name: 'Alpha',
+    });
+    const done = workspace.states.find((state) => state.category === 'completed');
+    if (done === undefined) throw new Error('missing a completed state');
+
+    for (const title of ['Open work', 'Finished work']) {
+      const { issue } = await createIssue(workspace.admin, {
+        teamId: workspace.teamId,
+        title,
+        projectId: project.id,
+        milestoneId: milestone.id,
+      });
+      if (title === 'Finished work') {
+        await updateIssue(workspace.admin, issue.id, { stateId: done.id });
+      }
+    }
+
+    const response = await listRoute.GET(
+      new Request('http://localhost:3000/api/projects/x/milestones'),
+      params(project.id),
+    );
+    const payload = listShape.parse(await response.json());
+
+    expect(payload.milestones).toEqual([
+      expect.objectContaining({ id: milestone.id, scope: 2, completed: 1 }),
+    ]);
   });
 
   it('hides a project the reader teams do not reach', async () => {

--- a/apps/web/tests/app/api/projects/milestones.test.ts
+++ b/apps/web/tests/app/api/projects/milestones.test.ts
@@ -1,0 +1,373 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { db, eq, schema } from '@orbit/db';
+import type { SyncAction } from '@orbit/shared/events';
+import { scopes } from '@orbit/shared/events';
+import { z } from 'zod';
+
+const coreModule = await import('@orbit/core');
+
+const published: SyncAction[][] = [];
+
+mock.module('@orbit/core', () => ({
+  ...coreModule,
+  publishDeltas: (actions: SyncAction[]) => {
+    published.push(actions);
+    return Promise.resolve();
+  },
+}));
+
+const { createMilestone, createProject, createTeam, listMilestones } = coreModule;
+const { addMember, createWorkspace, resetDatabase } = await import('@orbit/core/test-support');
+
+type Workspace = Awaited<ReturnType<typeof createWorkspace>>;
+
+interface Session {
+  readonly user: { id: string; name: string; email: string };
+  readonly session: { activeOrganizationId: string };
+}
+
+let session: Session | null = null;
+
+mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
+
+mock.module('@/lib/auth/session.ts', () => ({
+  getSession: () => Promise.resolve(session),
+  requireSession: () => Promise.resolve(session),
+}));
+
+const listRoute = await import('../../../../src/app/api/projects/[id]/milestones/route.ts');
+const reorderRoute = await import(
+  '../../../../src/app/api/projects/[id]/milestones/reorder/route.ts'
+);
+const milestoneRoute = await import('../../../../src/app/api/milestones/[id]/route.ts');
+
+const milestoneShape = z.object({
+  milestone: z.object({ id: z.string(), name: z.string(), projectId: z.string() }),
+});
+const listShape = z.object({
+  milestones: z.array(z.object({ id: z.string(), name: z.string() })),
+});
+const errorShape = z.object({ error: z.object({ code: z.string(), message: z.string() }) });
+
+let workspace: Workspace;
+let projectId: string;
+
+function params(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function post(body: unknown): Request {
+  return new Request('http://localhost:3000/api/projects/x/milestones', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+function signIn(user: { id: string; name: string; email: string }): void {
+  session = { user, session: { activeOrganizationId: workspace.organizationId } };
+}
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  const { project } = await createProject(workspace.admin, {
+    name: 'Launch',
+    teamIds: [workspace.teamId],
+  });
+  projectId = project.id;
+});
+
+beforeEach(() => {
+  published.length = 0;
+  signIn(workspace.adminUser);
+});
+
+afterAll(() => {
+  mock.module('@orbit/core', () => coreModule);
+});
+
+describe('POST /api/projects/[id]/milestones', () => {
+  it('creates the milestone against the project in the path', async () => {
+    const response = await listRoute.POST(post({ name: 'Alpha' }), params(projectId));
+    const payload = milestoneShape.parse(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(payload.milestone.projectId).toBe(projectId);
+    expect((await listMilestones(workspace.admin, projectId)).map((row) => row.name)).toContain(
+      'Alpha',
+    );
+  });
+
+  it('ignores a projectId in the body and uses the one in the path', async () => {
+    const { project: other } = await createProject(workspace.admin, {
+      name: 'Somewhere else',
+      teamIds: [workspace.teamId],
+    });
+
+    const response = await listRoute.POST(
+      post({ name: 'Smuggled', projectId: other.id }),
+      params(projectId),
+    );
+    const payload = milestoneShape.parse(await response.json());
+
+    expect(payload.milestone.projectId).toBe(projectId);
+    expect(await listMilestones(workspace.admin, other.id)).toHaveLength(0);
+  });
+
+  it('publishes a delta that stops at the teams of the project', async () => {
+    await listRoute.POST(post({ name: 'Fanned out' }), params(projectId));
+
+    const [batch] = published;
+    const action = batch?.[0];
+    expect(action?.model).toBe('milestone');
+    expect(action?.scopes).toContain(scopes.team(workspace.teamId));
+    expect(action?.scopes).not.toContain(scopes.organization(workspace.organizationId));
+  });
+
+  it('refuses a guest, whose role cannot manage milestones', async () => {
+    const guest = await addMember(workspace, 'guest', {
+      name: 'Gus Guest',
+      teamIds: [workspace.teamId],
+    });
+    signIn(guest.user);
+
+    const response = await listRoute.POST(post({ name: 'Guest milestone' }), params(projectId));
+
+    expect(response.status).toBe(403);
+    expect(errorShape.parse(await response.json()).error.code).toBe('forbidden');
+    expect(published).toEqual([]);
+    expect((await listMilestones(workspace.admin, projectId)).map((row) => row.name)).not.toContain(
+      'Guest milestone',
+    );
+  });
+
+  it('refuses a member whose teams do not reach the project', async () => {
+    const { team } = await createTeam(workspace.admin, { name: 'Outside', key: 'OUT' });
+    const outsider = await addMember(workspace, 'member', {
+      name: 'Olive Outsider',
+      teamIds: [team.id],
+    });
+    signIn(outsider.user);
+
+    const response = await listRoute.POST(post({ name: 'Sneaked in' }), params(projectId));
+
+    expect(response.status).toBe(404);
+    expect(published).toEqual([]);
+  });
+
+  it('refuses a signed out caller', async () => {
+    session = null;
+
+    const response = await listRoute.POST(post({ name: 'Anonymous' }), params(projectId));
+
+    expect(response.status).toBe(401);
+    expect(published).toEqual([]);
+  });
+
+  it('rejects a nameless milestone with 422', async () => {
+    const response = await listRoute.POST(post({ name: '   ' }), params(projectId));
+
+    expect(response.status).toBe(422);
+  });
+});
+
+describe('GET /api/projects/[id]/milestones', () => {
+  it('lists the milestones of the project in sort order', async () => {
+    const { project } = await createProject(workspace.admin, {
+      name: 'Listed',
+      teamIds: [workspace.teamId],
+    });
+    for (const name of ['One', 'Two', 'Three']) {
+      await createMilestone(workspace.admin, { projectId: project.id, name });
+    }
+
+    const response = await listRoute.GET(
+      new Request('http://localhost:3000/api/projects/x/milestones'),
+      params(project.id),
+    );
+    const payload = listShape.parse(await response.json());
+
+    expect(payload.milestones.map((row) => row.name)).toEqual(['One', 'Two', 'Three']);
+  });
+
+  it('hides a project the reader teams do not reach', async () => {
+    const { team } = await createTeam(workspace.admin, { name: 'Hidden', key: 'HID' });
+    const outsider = await addMember(workspace, 'member', {
+      name: 'Ida Outsider',
+      teamIds: [team.id],
+    });
+    signIn(outsider.user);
+
+    const response = await listRoute.GET(
+      new Request('http://localhost:3000/api/projects/x/milestones'),
+      params(projectId),
+    );
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('PATCH and DELETE /api/milestones/[id]', () => {
+  async function seeded(name: string): Promise<string> {
+    const { milestone } = await createMilestone(workspace.admin, { projectId, name });
+    return milestone.id;
+  }
+
+  it('renames a milestone', async () => {
+    const id = await seeded('Before');
+
+    const response = await milestoneRoute.PATCH(
+      new Request('http://localhost:3000/api/milestones/x', {
+        method: 'PATCH',
+        body: JSON.stringify({ name: 'After' }),
+      }),
+      params(id),
+    );
+    const payload = milestoneShape.parse(await response.json());
+
+    expect(payload.milestone.name).toBe('After');
+  });
+
+  it('deletes a milestone', async () => {
+    const id = await seeded('Doomed');
+
+    const response = await milestoneRoute.DELETE(
+      new Request('http://localhost:3000/api/milestones/x', { method: 'DELETE' }),
+      params(id),
+    );
+
+    expect(response.status).toBe(200);
+    const rows = await db
+      .select({ id: schema.milestone.id })
+      .from(schema.milestone)
+      .where(eq(schema.milestone.id, id));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('refuses a contributor, whose role cannot manage milestones', async () => {
+    const id = await seeded('Protected');
+    const contributor = await addMember(workspace, 'contributor', {
+      name: 'Cass Contributor',
+      teamIds: [workspace.teamId],
+    });
+    signIn(contributor.user);
+
+    const patched = await milestoneRoute.PATCH(
+      new Request('http://localhost:3000/api/milestones/x', {
+        method: 'PATCH',
+        body: JSON.stringify({ name: 'Renamed by a contributor' }),
+      }),
+      params(id),
+    );
+    const removed = await milestoneRoute.DELETE(
+      new Request('http://localhost:3000/api/milestones/x', { method: 'DELETE' }),
+      params(id),
+    );
+
+    expect(patched.status).toBe(403);
+    expect(removed.status).toBe(403);
+    signIn(workspace.adminUser);
+    const still = await listMilestones(workspace.admin, projectId);
+    expect(still.map((row) => row.name)).toContain('Protected');
+  });
+});
+
+describe('POST /api/projects/[id]/milestones/reorder', () => {
+  async function threeMilestones(): Promise<{ id: string; names: string[]; ids: string[] }> {
+    const { project } = await createProject(workspace.admin, {
+      name: `Ordered ${published.length}${Math.random()}`,
+      teamIds: [workspace.teamId],
+    });
+    const ids: string[] = [];
+    const names = ['First', 'Second', 'Third'];
+    for (const name of names) {
+      const { milestone } = await createMilestone(workspace.admin, {
+        projectId: project.id,
+        name,
+      });
+      ids.push(milestone.id);
+    }
+    return { id: project.id, names, ids };
+  }
+
+  function reorderRequest(milestoneIds: unknown): Request {
+    return new Request('http://localhost:3000/api/projects/x/milestones/reorder', {
+      method: 'POST',
+      body: JSON.stringify({ milestoneIds }),
+    });
+  }
+
+  it('writes the order it is given', async () => {
+    const project = await threeMilestones();
+    const [first, second, third] = project.ids;
+    if (first === undefined || second === undefined || third === undefined) {
+      throw new Error('missing seeded milestones');
+    }
+
+    const response = await reorderRoute.POST(
+      reorderRequest([third, first, second]),
+      params(project.id),
+    );
+
+    expect(response.status).toBe(200);
+    const stored = await listMilestones(workspace.admin, project.id);
+    expect(stored.map((row) => row.name)).toEqual(['Third', 'First', 'Second']);
+  });
+
+  it('refuses an order that leaves a milestone of the project out', async () => {
+    const project = await threeMilestones();
+    const [first, second] = project.ids;
+    if (first === undefined || second === undefined) throw new Error('missing seeded milestones');
+
+    const response = await reorderRoute.POST(reorderRequest([second, first]), params(project.id));
+
+    expect(response.status).toBe(409);
+    const stored = await listMilestones(workspace.admin, project.id);
+    expect(stored.map((row) => row.name)).toEqual(['First', 'Second', 'Third']);
+  });
+
+  it('refuses an order that pulls in a milestone of another project', async () => {
+    const project = await threeMilestones();
+    const stray = await createMilestone(workspace.admin, { projectId, name: 'Stray' });
+    const [first, second] = project.ids;
+    if (first === undefined || second === undefined) throw new Error('missing seeded milestones');
+
+    const response = await reorderRoute.POST(
+      reorderRequest([stray.milestone.id, first, second]),
+      params(project.id),
+    );
+
+    expect(response.status).toBe(409);
+  });
+
+  it('rejects a body that is not a list of ids with 422', async () => {
+    const project = await threeMilestones();
+
+    const response = await reorderRoute.POST(reorderRequest('First'), params(project.id));
+
+    expect(response.status).toBe(422);
+  });
+
+  it('refuses a guest, whose role cannot manage milestones', async () => {
+    const project = await threeMilestones();
+    const [first, second, third] = project.ids;
+    if (first === undefined || second === undefined || third === undefined) {
+      throw new Error('missing seeded milestones');
+    }
+    const guest = await addMember(workspace, 'guest', {
+      name: 'Gil Guest',
+      teamIds: [workspace.teamId],
+    });
+    signIn(guest.user);
+
+    const response = await reorderRoute.POST(
+      reorderRequest([third, second, first]),
+      params(project.id),
+    );
+
+    expect(response.status).toBe(403);
+    signIn(workspace.adminUser);
+    const stored = await listMilestones(workspace.admin, project.id);
+    expect(stored.map((row) => row.name)).toEqual(['First', 'Second', 'Third']);
+  });
+});

--- a/apps/web/tests/app/api/projects/route.test.ts
+++ b/apps/web/tests/app/api/projects/route.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { SyncAction } from '@orbit/shared/events';
+import { z } from 'zod';
+
+const coreModule = await import('@orbit/core');
+
+const published: SyncAction[][] = [];
+
+mock.module('@orbit/core', () => ({
+  ...coreModule,
+  publishDeltas: (actions: SyncAction[]) => {
+    published.push(actions);
+    return Promise.resolve();
+  },
+}));
+
+const { listProjects, listProjectTeams } = coreModule;
+const { addMember, createWorkspace, resetDatabase } = await import('@orbit/core/test-support');
+
+type Workspace = Awaited<ReturnType<typeof createWorkspace>>;
+
+interface Session {
+  readonly user: { id: string; name: string; email: string };
+  readonly session: { activeOrganizationId: string };
+}
+
+let session: Session | null = null;
+
+mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
+
+mock.module('@/lib/auth/session.ts', () => ({
+  getSession: () => Promise.resolve(session),
+  requireSession: () => Promise.resolve(session),
+}));
+
+const route = await import('../../../../src/app/api/projects/route.ts');
+
+const createdShape = z.object({
+  project: z.object({
+    id: z.string(),
+    name: z.string(),
+    slug: z.string(),
+    summary: z.string(),
+    targetDate: z.string().nullable(),
+  }),
+});
+const errorShape = z.object({ error: z.object({ code: z.string() }) });
+
+let workspace: Workspace;
+
+function signIn(user: { id: string; name: string; email: string }): void {
+  session = { user, session: { activeOrganizationId: workspace.organizationId } };
+}
+
+function post(body: unknown): Request {
+  return new Request('http://localhost:3000/api/projects', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+});
+
+beforeEach(() => {
+  published.length = 0;
+  signIn(workspace.adminUser);
+});
+
+afterAll(() => {
+  mock.module('@orbit/core', () => coreModule);
+});
+
+describe('POST /api/projects', () => {
+  it('creates a project the projects page can then link to', async () => {
+    const response = await route.POST(
+      post({
+        name: 'Realtime delta protocol',
+        summary: 'Fan writes out to every open tab.',
+        targetDate: '2031-03-01',
+        teamIds: [workspace.teamId],
+      }),
+    );
+    const payload = createdShape.parse(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(payload.project.slug).toBe('realtime-delta-protocol');
+    expect(payload.project.summary).toBe('Fan writes out to every open tab.');
+    expect(payload.project.targetDate).toBe('2031-03-01');
+    expect(
+      (await listProjectTeams(workspace.admin, payload.project.id)).map((row) => row.teamId),
+    ).toEqual([workspace.teamId]);
+  });
+
+  it('derives the slug on the server and never takes one from the body', async () => {
+    const response = await route.POST(
+      post({ name: 'Slug from the body', slug: 'attacker-chosen', teamIds: [] }),
+    );
+    const payload = createdShape.parse(await response.json());
+
+    expect(payload.project.slug).toBe('slug-from-the-body');
+  });
+
+  it('refuses a contributor, whose role cannot manage projects', async () => {
+    const contributor = await addMember(workspace, 'contributor', {
+      name: 'Cass Contributor',
+      teamIds: [workspace.teamId],
+    });
+    signIn(contributor.user);
+
+    const response = await route.POST(post({ name: 'Contributor project', teamIds: [] }));
+
+    expect(response.status).toBe(403);
+    expect(errorShape.parse(await response.json()).error.code).toBe('forbidden');
+    expect(published).toEqual([]);
+    signIn(workspace.adminUser);
+    expect((await listProjects(workspace.admin)).map((row) => row.name)).not.toContain(
+      'Contributor project',
+    );
+  });
+
+  it('refuses a guest, whose role cannot manage projects', async () => {
+    const guest = await addMember(workspace, 'guest', {
+      name: 'Gwen Guest',
+      teamIds: [workspace.teamId],
+    });
+    signIn(guest.user);
+
+    const response = await route.POST(post({ name: 'Guest project', teamIds: [] }));
+
+    expect(response.status).toBe(403);
+    expect(published).toEqual([]);
+  });
+
+  it('refuses a signed out caller', async () => {
+    session = null;
+
+    const response = await route.POST(post({ name: 'Anonymous project', teamIds: [] }));
+
+    expect(response.status).toBe(401);
+    expect(published).toEqual([]);
+  });
+
+  it('refuses a team from another workspace', async () => {
+    const elsewhere = await createWorkspace('Elsewhere');
+
+    const response = await route.POST(
+      post({ name: 'Cross workspace', teamIds: [elsewhere.teamId] }),
+    );
+
+    expect(response.status).toBe(404);
+    signIn(workspace.adminUser);
+    expect((await listProjects(workspace.admin)).map((row) => row.name)).not.toContain(
+      'Cross workspace',
+    );
+  });
+
+  it('rejects a name that is too short with 422', async () => {
+    const response = await route.POST(post({ name: 'a', teamIds: [] }));
+
+    expect(response.status).toBe(422);
+  });
+});

--- a/apps/web/tests/features/issues/issue-properties.test.tsx
+++ b/apps/web/tests/features/issues/issue-properties.test.tsx
@@ -219,6 +219,10 @@ describe('the milestone row on the issue properties panel', () => {
     const names = await screen.findByTestId('hotkey-names');
     expect(names).not.toHaveTextContent('Change milestone');
     expect(names).toHaveTextContent('Change project');
+
+    const row = screen.getByTestId('property-milestone-empty').parentElement;
+    expect(row?.textContent).toContain('Milestone');
+    expect(row?.querySelector('kbd')).toBeNull();
   });
 
   it('advertises the m shortcut once the issue is on a project', async () => {

--- a/apps/web/tests/features/issues/issue-properties.test.tsx
+++ b/apps/web/tests/features/issues/issue-properties.test.tsx
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { ToastProvider } from '@/components/ui/toast.tsx';
+import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
+import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
+import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+import { createQueryClient } from '@/lib/query/provider.tsx';
+import type { Issue, Milestone } from '@/lib/query/schemas.ts';
+
+const patches: Record<string, unknown>[] = [];
+
+mock.module('@/lib/query/use-issues.ts', () => ({
+  useUpdateIssue: () => ({
+    mutate: (input: { issue: Issue; patch: Record<string, unknown> }) => {
+      patches.push(input.patch);
+    },
+  }),
+}));
+
+const workspace: WorkspaceData = {
+  ...({} as WorkspaceData),
+  ready: true,
+  userId: 'user_1',
+  teams: [{ id: 'team_eng', name: 'Engineering', key: 'ENG', icon: 'e', color: '#5a63c8' }],
+  states: [
+    {
+      id: 'state_todo',
+      teamId: 'team_eng',
+      name: 'Todo',
+      category: 'unstarted',
+      color: '#5a63c8',
+      position: 1,
+    },
+  ],
+  labels: [],
+  members: [],
+  projects: [
+    {
+      id: 'project_launch',
+      name: 'Launch',
+      status: 'started',
+      color: '#5a63c8',
+      icon: 'box',
+      teamIds: ['team_eng'],
+    },
+  ],
+  cycles: [],
+  seedIssues: [],
+  stateById: new Map(),
+  labelById: new Map(),
+  memberById: new Map(),
+  openQuickCreate: () => undefined,
+};
+
+mock.module('@/features/issues/workspace-provider.tsx', () => ({
+  ...workspaceProvider,
+  useWorkspace: () => workspace,
+}));
+
+const { IssueProperties } = await import('@/features/issues/issue-properties.tsx');
+
+const milestones: readonly Milestone[] = [
+  {
+    id: 'milestone_alpha',
+    projectId: 'project_launch',
+    name: 'Alpha',
+    description: '',
+    targetDate: null,
+    sortOrder: 1,
+  },
+  {
+    id: 'milestone_beta',
+    projectId: 'project_launch',
+    name: 'Beta',
+    description: '',
+    targetDate: null,
+    sortOrder: 2,
+  },
+];
+
+const requested: string[] = [];
+const originalFetch = globalThis.fetch;
+
+function stubFetch(): void {
+  globalThis.fetch = mock((input: string | URL | Request) => {
+    requested.push(String(input));
+    return Promise.resolve(Response.json({ milestones }));
+  }) as unknown as typeof fetch;
+}
+
+function issue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'issue_1',
+    organizationId: 'org_1',
+    teamId: 'team_eng',
+    number: 1,
+    identifier: 'ENG-1',
+    title: 'Ship the importer',
+    description: '',
+    stateId: 'state_todo',
+    priority: 0,
+    creatorId: 'user_1',
+    assigneeId: null,
+    projectId: 'project_launch',
+    milestoneId: null,
+    cycleId: null,
+    parentId: null,
+    estimate: null,
+    dueDate: null,
+    sortOrder: 1024,
+    startedAt: null,
+    completedAt: null,
+    canceledAt: null,
+    stateEnteredAt: '2026-06-08T00:00:00.000Z',
+    syncId: 1,
+    createdAt: '2026-06-08T00:00:00.000Z',
+    updatedAt: '2026-06-08T00:00:00.000Z',
+    archivedAt: null,
+    labelIds: [],
+    ...overrides,
+  };
+}
+
+function Providers({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={createQueryClient()}>
+      <ToastProvider>
+        <HotkeyProvider>{children}</HotkeyProvider>
+      </ToastProvider>
+    </QueryClientProvider>
+  );
+}
+
+function mountProperties(row: Issue) {
+  render(
+    <Providers>
+      <IssueProperties issue={row} />
+    </Providers>,
+  );
+}
+
+beforeEach(() => {
+  patches.length = 0;
+  requested.length = 0;
+  stubFetch();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('the milestone row on the issue properties panel', () => {
+  it('reads the milestones of the project the issue is on', async () => {
+    mountProperties(issue());
+
+    await waitFor(() => expect(requested).toContain('/api/projects/project_launch/milestones'));
+  });
+
+  it('sets a milestone the user picks', async () => {
+    const user = userEvent.setup();
+    mountProperties(issue());
+    await waitFor(() => expect(requested.length).toBeGreaterThan(0));
+
+    await user.click(screen.getByTestId('property-milestone'));
+    const menu = await screen.findByTestId('menu-milestone');
+    await user.click(await within(menu).findByText('Beta'));
+
+    await waitFor(() => expect(patches).toEqual([{ milestoneId: 'milestone_beta' }]));
+  });
+
+  it('clears the milestone when the user picks none', async () => {
+    const user = userEvent.setup();
+    mountProperties(issue({ milestoneId: 'milestone_alpha' }));
+    await waitFor(() => expect(requested.length).toBeGreaterThan(0));
+    expect(screen.getByTestId('property-milestone')).toHaveTextContent('Alpha');
+
+    await user.click(screen.getByTestId('property-milestone'));
+    const menu = await screen.findByTestId('menu-milestone');
+    await user.click(await within(menu).findByText('No milestone'));
+
+    await waitFor(() => expect(patches).toEqual([{ milestoneId: null }]));
+  });
+
+  it('asks for nothing and offers nothing when the issue is on no project', async () => {
+    mountProperties(issue({ projectId: null }));
+
+    expect(await screen.findByTestId('property-milestone-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('property-milestone')).toBeNull();
+    expect(requested).toEqual([]);
+  });
+});

--- a/apps/web/tests/features/issues/issue-properties.test.tsx
+++ b/apps/web/tests/features/issues/issue-properties.test.tsx
@@ -3,10 +3,11 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
+import { resolvedHotkeys } from '@/components/shortcuts-overlay.tsx';
 import { ToastProvider } from '@/components/ui/toast.tsx';
 import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
-import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+import { HotkeyProvider, useHotkeyList } from '@/lib/keyboard/index.ts';
 import { createQueryClient } from '@/lib/query/provider.tsx';
 import type { Issue, Milestone } from '@/lib/query/schemas.ts';
 
@@ -70,6 +71,8 @@ const milestones: readonly Milestone[] = [
     description: '',
     targetDate: null,
     sortOrder: 1,
+    scope: 0,
+    completed: 0,
   },
   {
     id: 'milestone_beta',
@@ -78,6 +81,8 @@ const milestones: readonly Milestone[] = [
     description: '',
     targetDate: null,
     sortOrder: 2,
+    scope: 0,
+    completed: 0,
   },
 ];
 
@@ -131,6 +136,17 @@ function Providers({ children }: { children: ReactNode }) {
         <HotkeyProvider>{children}</HotkeyProvider>
       </ToastProvider>
     </QueryClientProvider>
+  );
+}
+
+function HotkeyNames() {
+  const live = resolvedHotkeys(useHotkeyList());
+  return (
+    <ul data-testid="hotkey-names">
+      {live.map((entry) => (
+        <li key={entry.id}>{entry.label}</li>
+      ))}
+    </ul>
   );
 }
 
@@ -190,5 +206,29 @@ describe('the milestone row on the issue properties panel', () => {
     expect(await screen.findByTestId('property-milestone-empty')).toBeInTheDocument();
     expect(screen.queryByTestId('property-milestone')).toBeNull();
     expect(requested).toEqual([]);
+  });
+
+  it('stops advertising the m shortcut when there is no milestone menu to open', async () => {
+    render(
+      <Providers>
+        <IssueProperties issue={issue({ projectId: null })} />
+        <HotkeyNames />
+      </Providers>,
+    );
+
+    const names = await screen.findByTestId('hotkey-names');
+    expect(names).not.toHaveTextContent('Change milestone');
+    expect(names).toHaveTextContent('Change project');
+  });
+
+  it('advertises the m shortcut once the issue is on a project', async () => {
+    render(
+      <Providers>
+        <IssueProperties issue={issue()} />
+        <HotkeyNames />
+      </Providers>,
+    );
+
+    expect(await screen.findByTestId('hotkey-names')).toHaveTextContent('Change milestone');
   });
 });

--- a/apps/web/tests/features/projects/dates.test.ts
+++ b/apps/web/tests/features/projects/dates.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { formatDay } from '../../../src/features/projects/dates.ts';
+
+const originalTimezone = process.env['TZ'] ?? '';
+
+function restoreTimezone(): void {
+  process.env['TZ'] = originalTimezone;
+}
+
+function inTimezone(zone: string, run: () => void): void {
+  process.env['TZ'] = zone;
+  try {
+    run();
+  } finally {
+    restoreTimezone();
+  }
+}
+
+beforeEach(restoreTimezone);
+
+afterEach(restoreTimezone);
+
+describe('formatDay', () => {
+  it('names the day the server stored, west of UTC as well as east of it', () => {
+    for (const zone of ['UTC', 'America/Los_Angeles', 'Pacific/Kiritimati', 'Asia/Kolkata']) {
+      inTimezone(zone, () => {
+        expect(formatDay('2026-06-08', { withYear: true, missing: 'Not set' })).toBe('8 Jun 2026');
+      });
+    }
+  });
+
+  it('drops the year when the caller does not want one', () => {
+    expect(formatDay('2026-01-01', { withYear: false, missing: 'No target' })).toBe('1 Jan');
+    expect(formatDay('2026-12-31', { withYear: false, missing: 'No target' })).toBe('31 Dec');
+  });
+
+  it('reads the day off a full timestamp too', () => {
+    expect(formatDay('2026-06-08T23:30:00.000Z', { withYear: true, missing: 'Not set' })).toBe(
+      '8 Jun 2026',
+    );
+  });
+
+  it('falls back to the missing label for null and for anything that is not a date', () => {
+    expect(formatDay(null, { withYear: true, missing: 'Not set' })).toBe('Not set');
+    expect(formatDay('soon', { withYear: true, missing: 'No target' })).toBe('No target');
+    expect(formatDay('2026-13-01', { withYear: true, missing: 'No target' })).toBe('No target');
+  });
+});

--- a/apps/web/tests/features/projects/milestone-board.test.tsx
+++ b/apps/web/tests/features/projects/milestone-board.test.tsx
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { ToastProvider } from '@/components/ui/toast.tsx';
+import { createQueryClient } from '@/lib/query/provider.tsx';
+import type { Milestone } from '@/lib/query/schemas.ts';
+import { MilestoneBoard } from '../../../src/features/projects/milestone-board.tsx';
+
+const PROJECT_ID = 'project_launch';
+
+function milestone(id: string, name: string, sortOrder: number): Milestone {
+  return {
+    id,
+    projectId: PROJECT_ID,
+    name,
+    description: '',
+    targetDate: null,
+    sortOrder,
+  };
+}
+
+let served: Milestone[] = [];
+
+interface Call {
+  readonly method: string;
+  readonly url: string;
+  readonly body: unknown;
+}
+
+const calls: Call[] = [];
+const originalFetch = globalThis.fetch;
+
+function stubFetch(): void {
+  globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    const body: unknown = typeof init?.body === 'string' ? JSON.parse(init.body) : undefined;
+    calls.push({ method, url, body });
+
+    if (method === 'GET') return Promise.resolve(Response.json({ milestones: served }));
+    if (url.endsWith('/reorder')) {
+      const ids = (body as { milestoneIds: string[] }).milestoneIds;
+      served = ids.flatMap((id) => served.filter((entry) => entry.id === id));
+      return Promise.resolve(Response.json({ milestones: served }));
+    }
+    if (method === 'DELETE') {
+      served = served.filter((entry) => !url.endsWith(entry.id));
+      return Promise.resolve(Response.json({ deleted: true }));
+    }
+    if (method === 'PATCH') {
+      const patch = body as { name: string };
+      served = served.map((entry) =>
+        url.endsWith(entry.id) ? { ...entry, name: patch.name } : entry,
+      );
+      return Promise.resolve(Response.json({ milestone: served[0] }));
+    }
+    const draft = body as { name: string };
+    const created = milestone(`milestone_${served.length + 1}`, draft.name, served.length + 1);
+    served = [...served, created];
+    return Promise.resolve(Response.json({ milestone: created }));
+  }) as unknown as typeof fetch;
+}
+
+function Providers({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={createQueryClient()}>
+      <ToastProvider>{children}</ToastProvider>
+    </QueryClientProvider>
+  );
+}
+
+function mountBoard(canManage = true) {
+  render(
+    <Providers>
+      <MilestoneBoard
+        projectId={PROJECT_ID}
+        milestones={served}
+        progress={{}}
+        canManage={canManage}
+      />
+    </Providers>,
+  );
+}
+
+function names(): string[] {
+  return screen
+    .getAllByTestId(/^milestone-milestone_/)
+    .map((row) => row.querySelector('span')?.textContent ?? '');
+}
+
+function writes(): Call[] {
+  return calls.filter((call) => call.method !== 'GET');
+}
+
+function firstWrite(): Call {
+  const [call] = writes();
+  if (call === undefined) throw new Error('the board sent no write');
+  return call;
+}
+
+function writtenName(): string {
+  return (firstWrite().body as { name: string }).name;
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  served = [
+    milestone('milestone_1', 'One', 1),
+    milestone('milestone_2', 'Two', 2),
+    milestone('milestone_3', 'Three', 3),
+  ];
+  stubFetch();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('MilestoneBoard', () => {
+  it('adds a milestone against the project it was mounted on', async () => {
+    mountBoard();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('milestone-add'));
+    await user.type(screen.getByTestId('milestone-new-name'), 'Cut over');
+    await user.click(screen.getByTestId('milestone-new-submit'));
+
+    await waitFor(() => expect(writes()).toHaveLength(1));
+    expect(firstWrite()).toMatchObject({
+      method: 'POST',
+      url: `/api/projects/${PROJECT_ID}/milestones`,
+    });
+    expect(writtenName()).toBe('Cut over');
+  });
+
+  it('renames a milestone through the milestone route', async () => {
+    mountBoard();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('milestone-edit-milestone_2'));
+    const field = screen.getByTestId('milestone-edit-name');
+    await user.clear(field);
+    await user.type(field, 'Second pass');
+    await user.click(screen.getByTestId('milestone-edit-submit'));
+
+    await waitFor(() => expect(writes()).toHaveLength(1));
+    expect(firstWrite()).toMatchObject({
+      method: 'PATCH',
+      url: '/api/milestones/milestone_2',
+    });
+    expect(writtenName()).toBe('Second pass');
+  });
+
+  it('deletes a milestone and drops it from the list', async () => {
+    mountBoard();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('milestone-delete-milestone_1'));
+
+    await waitFor(() => expect(writes()).toHaveLength(1));
+    expect(firstWrite()).toMatchObject({
+      method: 'DELETE',
+      url: '/api/milestones/milestone_1',
+    });
+    await waitFor(() => expect(names()).toEqual(['Two', 'Three']));
+  });
+
+  it('sends the whole order when a milestone moves down, not just the pair', async () => {
+    mountBoard();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('milestone-down-milestone_1'));
+
+    await waitFor(() => expect(writes()).toHaveLength(1));
+    expect(firstWrite()).toMatchObject({
+      method: 'POST',
+      url: `/api/projects/${PROJECT_ID}/milestones/reorder`,
+      body: { milestoneIds: ['milestone_2', 'milestone_1', 'milestone_3'] },
+    });
+    await waitFor(() => expect(names()).toEqual(['Two', 'One', 'Three']));
+  });
+
+  it('sends the whole order when a milestone moves up', async () => {
+    mountBoard();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('milestone-up-milestone_3'));
+
+    await waitFor(() => expect(writes()).toHaveLength(1));
+    expect(firstWrite()).toMatchObject({
+      body: { milestoneIds: ['milestone_1', 'milestone_3', 'milestone_2'] },
+    });
+  });
+
+  it('cannot move the first one up or the last one down', () => {
+    mountBoard();
+
+    expect(screen.getByTestId('milestone-up-milestone_1')).toBeDisabled();
+    expect(screen.getByTestId('milestone-down-milestone_3')).toBeDisabled();
+    expect(screen.getByTestId('milestone-down-milestone_1')).not.toBeDisabled();
+  });
+
+  it('offers no controls at all to somebody who cannot manage milestones', async () => {
+    mountBoard(false);
+    await waitFor(() => expect(names()).toEqual(['One', 'Two', 'Three']));
+
+    expect(screen.queryByTestId('milestone-add')).toBeNull();
+    expect(screen.queryByTestId('milestone-delete-milestone_1')).toBeNull();
+    expect(screen.queryByTestId('milestone-up-milestone_2')).toBeNull();
+    expect(screen.queryByTestId('milestone-edit-milestone_2')).toBeNull();
+    expect(writes()).toEqual([]);
+  });
+});

--- a/apps/web/tests/features/projects/milestone-board.test.tsx
+++ b/apps/web/tests/features/projects/milestone-board.test.tsx
@@ -18,6 +18,8 @@ function milestone(id: string, name: string, sortOrder: number): Milestone {
     description: '',
     targetDate: null,
     sortOrder,
+    scope: 0,
+    completed: 0,
   };
 }
 
@@ -74,12 +76,7 @@ function Providers({ children }: { children: ReactNode }) {
 function mountBoard(canManage = true) {
   render(
     <Providers>
-      <MilestoneBoard
-        projectId={PROJECT_ID}
-        milestones={served}
-        progress={{}}
-        canManage={canManage}
-      />
+      <MilestoneBoard projectId={PROJECT_ID} milestones={served} canManage={canManage} />
     </Providers>,
   );
 }
@@ -192,6 +189,15 @@ describe('MilestoneBoard', () => {
     expect(firstWrite()).toMatchObject({
       body: { milestoneIds: ['milestone_1', 'milestone_3', 'milestone_2'] },
     });
+  });
+
+  it('shows the counts the server sent rather than any it worked out itself', async () => {
+    served = [{ ...milestone('milestone_1', 'One', 1), scope: 7, completed: 3 }];
+    mountBoard();
+
+    const row = await screen.findByTestId('milestone-milestone_1');
+    await waitFor(() => expect(row).toHaveTextContent('3/7'));
+    expect(screen.getByLabelText('One completion')).toHaveAttribute('aria-valuenow', '43');
   });
 
   it('cannot move the first one up or the last one down', () => {

--- a/apps/web/tests/features/projects/new-project-dialog.test.tsx
+++ b/apps/web/tests/features/projects/new-project-dialog.test.tsx
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { ToastProvider } from '@/components/ui/toast.tsx';
+
+const pushes: string[] = [];
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({
+    push: (href: string) => pushes.push(href),
+    replace: () => undefined,
+    prefetch: () => undefined,
+    back: () => undefined,
+    refresh: () => undefined,
+  }),
+  usePathname: () => '/projects',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const { NewProjectDialog } = await import('../../../src/features/projects/new-project-dialog.tsx');
+
+const teams = [
+  { id: 'team_eng', key: 'ENG', name: 'Engineering' },
+  { id: 'team_dsgn', key: 'DSGN', name: 'Design' },
+];
+
+interface Call {
+  readonly url: string;
+  readonly method: string;
+  readonly body: Record<string, unknown>;
+}
+
+const calls: Call[] = [];
+const originalFetch = globalThis.fetch;
+let failure: { status: number; code: string; message: string } | null = null;
+
+function stubFetch(): void {
+  globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+    const body: Record<string, unknown> =
+      typeof init?.body === 'string' ? JSON.parse(init.body) : {};
+    calls.push({ url: String(input), method: init?.method ?? 'GET', body });
+    if (failure !== null) {
+      return Promise.resolve(
+        Response.json(
+          { error: { code: failure.code, message: failure.message } },
+          { status: failure.status },
+        ),
+      );
+    }
+    return Promise.resolve(
+      Response.json({
+        project: {
+          id: 'project_new',
+          slug: 'realtime-delta-protocol',
+          name: String(body['name']),
+        },
+      }),
+    );
+  }) as unknown as typeof fetch;
+}
+
+function Providers({ children }: { children: ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}
+
+function mountDialog(canManage = true) {
+  render(
+    <Providers>
+      <NewProjectDialog teams={teams} canManage={canManage} />
+    </Providers>,
+  );
+}
+
+async function openAndName(user: ReturnType<typeof userEvent.setup>, name: string): Promise<void> {
+  await user.click(screen.getByTestId('new-project'));
+  await screen.findByTestId('new-project-dialog');
+  await user.type(screen.getByTestId('new-project-name'), name);
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  pushes.length = 0;
+  failure = null;
+  stubFetch();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('NewProjectDialog', () => {
+  it('posts the draft to the projects route and follows the slug the server picked', async () => {
+    const user = userEvent.setup();
+    mountDialog();
+
+    await openAndName(user, 'Realtime delta protocol');
+    await user.click(screen.getByTestId('new-project-team-ENG'));
+    await user.click(screen.getByTestId('new-project-submit'));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0]).toMatchObject({ url: '/api/projects', method: 'POST' });
+    expect(calls[0]?.body).toMatchObject({
+      name: 'Realtime delta protocol',
+      teamIds: ['team_eng'],
+      targetDate: null,
+    });
+    await waitFor(() => expect(pushes).toEqual(['/projects/realtime-delta-protocol']));
+  });
+
+  it('sends no slug of its own, so the server is the one that names the address', async () => {
+    const user = userEvent.setup();
+    mountDialog();
+
+    await openAndName(user, 'Realtime delta protocol');
+    await user.click(screen.getByTestId('new-project-submit'));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(Object.keys(calls[0]?.body ?? {}).sort()).toEqual([
+      'name',
+      'summary',
+      'targetDate',
+      'teamIds',
+    ]);
+  });
+
+  it('shows the reason the server refused and stays put', async () => {
+    failure = { status: 403, code: 'forbidden', message: 'Your role cannot project manage.' };
+    const user = userEvent.setup();
+    mountDialog();
+
+    await openAndName(user, 'Refused project');
+    await user.click(screen.getByTestId('new-project-submit'));
+
+    expect(await screen.findByTestId('new-project-error')).toHaveTextContent(
+      'Your role cannot project manage.',
+    );
+    expect(pushes).toEqual([]);
+  });
+
+  it('will not submit a name shorter than the server accepts', async () => {
+    const user = userEvent.setup();
+    mountDialog();
+
+    await openAndName(user, 'a');
+
+    expect(screen.getByTestId('new-project-submit')).toBeDisabled();
+    expect(calls).toEqual([]);
+  });
+
+  it('offers nothing at all to somebody who cannot manage projects', () => {
+    mountDialog(false);
+
+    expect(screen.queryByTestId('new-project')).toBeNull();
+  });
+});

--- a/apps/web/tests/features/projects/update-composer.test.tsx
+++ b/apps/web/tests/features/projects/update-composer.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { ToastProvider } from '@/components/ui/toast.tsx';
+
+const refreshes: number[] = [];
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({
+    push: () => undefined,
+    replace: () => undefined,
+    prefetch: () => undefined,
+    back: () => undefined,
+    refresh: () => refreshes.push(1),
+  }),
+  usePathname: () => '/projects/launch',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const { UpdateComposer } = await import('../../../src/features/projects/update-composer.tsx');
+
+interface PostedUpdate {
+  readonly health: string;
+  readonly body: string;
+}
+
+const posted: PostedUpdate[] = [];
+const originalFetch = globalThis.fetch;
+
+function stubFetch(): void {
+  globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+    if (typeof init?.body === 'string') posted.push(JSON.parse(init.body) as PostedUpdate);
+    return Promise.resolve(Response.json({ update: { id: 'update_1' } }));
+  }) as unknown as typeof fetch;
+}
+
+function Providers({ children }: { children: ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}
+
+function editorText(): string {
+  return screen.getByTestId('project-update-body').textContent ?? '';
+}
+
+async function writeAndPost(user: ReturnType<typeof userEvent.setup>, text: string): Promise<void> {
+  await user.click(screen.getByRole('textbox', { name: 'Project update' }));
+  await user.paste(text);
+  await waitFor(() => expect(editorText()).toBe(text));
+  const submit = screen.getByRole('button', { name: /Post update|Posting/ });
+  await waitFor(() => expect(submit).not.toBeDisabled());
+  await user.click(submit);
+}
+
+beforeEach(() => {
+  posted.length = 0;
+  refreshes.length = 0;
+  stubFetch();
+  render(
+    <Providers>
+      <UpdateComposer projectId="project_launch" currentHealth="on_track" canPost />
+    </Providers>,
+  );
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('UpdateComposer', () => {
+  it('posts what was written and empties the editor afterwards', async () => {
+    const user = userEvent.setup();
+
+    await writeAndPost(user, 'Shipped the importer');
+
+    await waitFor(() => expect(posted).toHaveLength(1));
+    expect(posted[0]?.body).toContain('Shipped the importer');
+    expect(posted[0]?.health).toBe('on_track');
+    await waitFor(() => expect(editorText()).toBe(''));
+    expect(refreshes).toHaveLength(1);
+  });
+
+  it('does not carry the posted text into the next update', async () => {
+    const user = userEvent.setup();
+
+    await writeAndPost(user, 'Shipped the importer');
+    await waitFor(() => expect(posted).toHaveLength(1));
+    await waitFor(() => expect(editorText()).toBe(''));
+
+    await writeAndPost(user, 'Started the socket');
+
+    await waitFor(() => expect(posted).toHaveLength(2));
+    expect(posted[1]?.body).toContain('Started the socket');
+    expect(posted[1]?.body).not.toContain('Shipped the importer');
+  });
+
+  it('will not post an empty update', () => {
+    expect(screen.getByRole('button', { name: 'Post update' })).toBeDisabled();
+    expect(posted).toEqual([]);
+  });
+});

--- a/apps/web/tests/lib/realtime/delta-bridge.test.tsx
+++ b/apps/web/tests/lib/realtime/delta-bridge.test.tsx
@@ -10,6 +10,7 @@ import {
   DOCS_ROOT,
   ISSUE_FACETS_ROOT,
   ISSUE_SUMMARY_ROOT,
+  MILESTONES_ROOT,
   queryKeys,
   STANDUP_ROOT,
   VIEWS_ROOT,
@@ -179,6 +180,18 @@ describe('DeltaBridge root invalidation', () => {
       ]),
     );
     expect(seen).toEqual([[BOOTSTRAP_ROOT]]);
+  });
+
+  it('invalidates the milestones root, and nothing else, for a milestone delta', () => {
+    const client = mount();
+    const seen = trackInvalidations(client);
+    act(() =>
+      capturedHandler?.([
+        action({ model: 'milestone', modelId: 'milestone_1', data: { id: 'milestone_1' } }),
+        action({ model: 'milestone', modelId: 'milestone_2', data: { id: 'milestone_2' } }),
+      ]),
+    );
+    expect(seen).toEqual([[MILESTONES_ROOT]]);
   });
 
   it('invalidates the views root for a view delta', () => {

--- a/apps/web/tests/lib/realtime/delta-bridge.test.tsx
+++ b/apps/web/tests/lib/realtime/delta-bridge.test.tsx
@@ -213,11 +213,16 @@ describe('DeltaBridge root invalidation', () => {
     expect(seen).toEqual([[DOCS_ROOT], [DOCS_HOME_ROOT], [DOC_ROOT, 'doc_1']]);
   });
 
-  it('refreshes only the counts and the standup board for an issue delta it patches in place', () => {
+  it('refreshes the counts, the standup board and the milestone counts for an issue delta', () => {
     const client = mount();
     const seen = trackInvalidations(client);
     act(() => capturedHandler?.([action()]));
-    expect(seen).toEqual([[ISSUE_SUMMARY_ROOT], [ISSUE_FACETS_ROOT], [STANDUP_ROOT]]);
+    expect(seen).toEqual([
+      [ISSUE_SUMMARY_ROOT],
+      [ISSUE_FACETS_ROOT],
+      [STANDUP_ROOT],
+      [MILESTONES_ROOT],
+    ]);
   });
 });
 
@@ -287,7 +292,12 @@ describe('DeltaBridge reconnect backfill', () => {
     expect(requested).toEqual(['/api/sync?since=17']);
     expect(titleIn(client)).toBe('Caught up');
     expect(observed).toContain(42);
-    expect(seen).toEqual([[ISSUE_SUMMARY_ROOT], [ISSUE_FACETS_ROOT], [STANDUP_ROOT]]);
+    expect(seen).toEqual([
+      [ISSUE_SUMMARY_ROOT],
+      [ISSUE_FACETS_ROOT],
+      [STANDUP_ROOT],
+      [MILESTONES_ROOT],
+    ]);
   });
 });
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -75,6 +75,7 @@ Selecting several issues and then pressing <kbd>s</kbd>, <kbd>p</kbd>,
 | <kbd>a</kbd> | Assign |
 | <kbd>l</kbd> | Change labels |
 | <kbd>i</kbd> | Change project |
+| <kbd>m</kbd> | Change milestone |
 | <kbd>Shift</kbd> <kbd>e</kbd> | Change estimate |
 
 Each opens a menu you then drive with the keyboard, so `a` then a few letters of

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -150,6 +150,7 @@ them.
 | `create_project`, `update_project` | write | |
 | `archive_project`, `delete_project` | write | |
 | `create_milestone`, `update_milestone`, `delete_milestone` | write | |
+| `reorder_milestones` | write | The whole order of a project milestones |
 
 ### Sprints and cycles
 

--- a/packages/core/src/work/issue-service.ts
+++ b/packages/core/src/work/issue-service.ts
@@ -681,7 +681,7 @@ async function assertMilestoneInTeam(
   if (milestone.organizationId !== organizationId) {
     throw validationFailed('That milestone belongs to another workspace.');
   }
-  if (projectId !== undefined && projectId !== null && projectId !== milestone.projectId) {
+  if (projectId !== undefined && projectId !== milestone.projectId) {
     throw validationFailed('That milestone belongs to another project.');
   }
   const teams = await projectTeamIds(executor, milestone.projectId);
@@ -723,6 +723,7 @@ async function assertAssignableToTeam(
   organizationId: string,
   teamId: string,
   values: Pick<IssueValues, 'cycleId' | 'projectId' | 'milestoneId'>,
+  currentProjectId?: string | null,
 ): Promise<void> {
   const { cycleId, projectId, milestoneId } = values;
   if (cycleId !== undefined && cycleId !== null) {
@@ -732,7 +733,8 @@ async function assertAssignableToTeam(
     await assertProjectInTeam(executor, organizationId, teamId, projectId);
   }
   if (milestoneId !== undefined && milestoneId !== null) {
-    await assertMilestoneInTeam(executor, organizationId, teamId, milestoneId, projectId);
+    const onProject = projectId === undefined ? currentProjectId : projectId;
+    await assertMilestoneInTeam(executor, organizationId, teamId, milestoneId, onProject);
   }
 }
 
@@ -885,7 +887,13 @@ async function applyIssueUpdates(
       Object.assign(values, applyStateTimestamps(current, state.category, now));
     }
     await assertMemberOfWorkspace(tx, principal.organizationId, values.assigneeId);
-    await assertAssignableToTeam(tx, principal.organizationId, current.teamId, values);
+    await assertAssignableToTeam(
+      tx,
+      principal.organizationId,
+      current.teamId,
+      values,
+      current.projectId,
+    );
     pending.push({ current, values, changes });
   }
 

--- a/packages/core/src/work/milestone-service.ts
+++ b/packages/core/src/work/milestone-service.ts
@@ -4,7 +4,11 @@ import { conflict } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan } from '@orbit/shared/policy';
-import { milestoneCreateSchema, milestoneUpdateSchema } from '@orbit/shared/validators';
+import {
+  milestoneCreateSchema,
+  milestoneOrderSchema,
+  milestoneUpdateSchema,
+} from '@orbit/shared/validators';
 import { principalActor } from '../activity/activity-service.ts';
 import { type Executor, newId, requireRow, toDateString } from '../internal.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
@@ -186,9 +190,10 @@ export async function listMilestones(
 export async function reorderMilestones(
   principal: Principal,
   projectId: string,
-  orderedMilestoneIds: readonly string[],
+  input: readonly string[],
 ): Promise<{ milestones: MilestoneRow[]; actions: SyncAction[] }> {
   assertCan(principal, 'milestone:manage');
+  const orderedMilestoneIds = milestoneOrderSchema.parse(input);
   if (orderedMilestoneIds.length === 0) throw conflict('Provide the milestones to reorder.');
 
   return await db.transaction(async (tx) => {

--- a/packages/core/src/work/milestone-service.ts
+++ b/packages/core/src/work/milestone-service.ts
@@ -13,7 +13,12 @@ import { principalActor } from '../activity/activity-service.ts';
 import { type Executor, newId, requireRow, toDateString } from '../internal.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
-import { assertProjectVisible, projectReachScopes, projectTeamIds } from './project-service.ts';
+import {
+  assertProjectVisible,
+  projectProgress,
+  projectReachScopes,
+  projectTeamIds,
+} from './project-service.ts';
 
 export type MilestoneRow = typeof schema.milestone.$inferSelect;
 
@@ -185,6 +190,28 @@ export async function listMilestones(
       ),
     )
     .orderBy(asc(schema.milestone.sortOrder), asc(schema.milestone.createdAt));
+}
+
+export interface MilestoneWithProgress {
+  readonly milestone: MilestoneRow;
+  readonly scope: number;
+  readonly completed: number;
+}
+
+export async function listMilestonesWithProgress(
+  principal: Principal,
+  projectId: string,
+): Promise<MilestoneWithProgress[]> {
+  const [milestones, progress] = await Promise.all([
+    listMilestones(principal, projectId),
+    projectProgress(principal, projectId),
+  ]);
+  const counted = new Map(progress.milestones.map((entry) => [entry.milestoneId, entry]));
+  return milestones.map((milestone) => ({
+    milestone,
+    scope: counted.get(milestone.id)?.scope ?? 0,
+    completed: counted.get(milestone.id)?.completed ?? 0,
+  }));
 }
 
 export async function reorderMilestones(

--- a/packages/core/tests/work/issue-service.test.ts
+++ b/packages/core/tests/work/issue-service.test.ts
@@ -33,6 +33,7 @@ import {
   unsubscribe,
   updateIssue,
 } from '../../src/work/issue-service.ts';
+import { createMilestone } from '../../src/work/milestone-service.ts';
 import { createProject } from '../../src/work/project-service.ts';
 
 let workspace: Workspace;
@@ -925,5 +926,70 @@ describe('tenancy', () => {
     await expect(listSubscribers(guest.principal, issue.id)).rejects.toMatchObject({
       code: 'not_found',
     });
+  });
+});
+
+describe('an issue milestone has to belong to the project the issue is on', () => {
+  async function projectWithMilestone(
+    name: string,
+  ): Promise<{ projectId: string; milestoneId: string }> {
+    const { project } = await createProject(workspace.admin, {
+      name,
+      teamIds: [workspace.teamId],
+    });
+    const { milestone } = await createMilestone(workspace.admin, {
+      projectId: project.id,
+      name: `${name} alpha`,
+    });
+    return { projectId: project.id, milestoneId: milestone.id };
+  }
+
+  it('refuses a milestone from a sibling project on the same team', async () => {
+    const here = await projectWithMilestone('Here');
+    const elsewhere = await projectWithMilestone('Elsewhere');
+    const issue = await newIssue('Grouped work', { projectId: here.projectId });
+
+    await expect(
+      updateIssue(workspace.admin, issue.id, { milestoneId: elsewhere.milestoneId }),
+    ).rejects.toMatchObject({ code: 'validation_failed' });
+
+    const [stored] = await db
+      .select({ milestoneId: schema.issue.milestoneId })
+      .from(schema.issue)
+      .where(eq(schema.issue.id, issue.id));
+    expect(stored?.milestoneId).toBeNull();
+  });
+
+  it('refuses a milestone on an issue that is on no project at all', async () => {
+    const orphan = await projectWithMilestone('Orphan');
+    const issue = await newIssue('Loose work');
+
+    await expect(
+      updateIssue(workspace.admin, issue.id, { milestoneId: orphan.milestoneId }),
+    ).rejects.toMatchObject({ code: 'validation_failed' });
+  });
+
+  it('takes the milestone of the project the same patch moves the issue onto', async () => {
+    const here = await projectWithMilestone('Landing');
+    const issue = await newIssue('Moving in');
+
+    const updated = await updateIssue(workspace.admin, issue.id, {
+      projectId: here.projectId,
+      milestoneId: here.milestoneId,
+    });
+
+    expect(updated.issue.projectId).toBe(here.projectId);
+    expect(updated.issue.milestoneId).toBe(here.milestoneId);
+  });
+
+  it('still takes a milestone of the project the issue is already on', async () => {
+    const here = await projectWithMilestone('Steady');
+    const issue = await newIssue('Already here', { projectId: here.projectId });
+
+    const updated = await updateIssue(workspace.admin, issue.id, {
+      milestoneId: here.milestoneId,
+    });
+
+    expect(updated.issue.milestoneId).toBe(here.milestoneId);
   });
 });

--- a/packages/core/tests/work/milestone-service.test.ts
+++ b/packages/core/tests/work/milestone-service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { db, eq, schema } from '@orbit/db';
 import { scopes } from '@orbit/shared/events';
+import { ZodError } from 'zod';
 import { createTeam } from '../../src/org/team-service.ts';
 import {
   addMember,
@@ -137,6 +138,18 @@ describe('milestone project relationship invariant', () => {
     const listed = await listMilestones(workspace.admin, projectId);
     expect(listed.map((row) => row.name)).toEqual(['Three', 'One', 'Two']);
     expect(new Set(listed.map((row) => row.sortOrder)).size).toBe(3);
+  });
+
+  it('refuses an order carrying something that is not an id', async () => {
+    const projectId = await newProject('Validated');
+    await createMilestone(workspace.admin, { projectId, name: 'Only' });
+
+    await expect(
+      reorderMilestones(workspace.admin, projectId, ['x'.repeat(65)]),
+    ).rejects.toBeInstanceOf(ZodError);
+    await expect(
+      reorderMilestones(workspace.admin, projectId, [42 as unknown as string]),
+    ).rejects.toBeInstanceOf(ZodError);
   });
 
   it('refuses a milestone on a project outside the organization', async () => {

--- a/packages/mcp-server/src/resolve.ts
+++ b/packages/mcp-server/src/resolve.ts
@@ -12,7 +12,7 @@ import {
   type ProjectRow,
   type TeamRow,
 } from '@orbit/core';
-import { notFound } from '@orbit/shared/errors';
+import { conflict, notFound } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 
 function matches(candidates: readonly (string | null | undefined)[], ref: string): boolean {
@@ -88,7 +88,16 @@ export async function resolveMilestone(
   ref: string,
 ): Promise<MilestoneRow> {
   const milestones = await listMilestones(principal, projectId);
-  const found = pick(milestones, ref, (milestone) => [milestone.id, milestone.name]);
+  const byId = pick(milestones, ref, (milestone) => [milestone.id]);
+  if (byId !== undefined) return byId;
+  const byName = milestones.filter((milestone) => matches([milestone.name], ref));
+  if (byName.length > 1) {
+    throw conflict(
+      `That project has ${byName.length} milestones named "${ref}". Name it by id instead.`,
+      { details: { milestoneIds: byName.map((milestone) => milestone.id) } },
+    );
+  }
+  const found = byName[0];
   if (found === undefined) throw notFound(`No milestone matches "${ref}" on that project.`);
   return found;
 }

--- a/packages/mcp-server/src/resolve.ts
+++ b/packages/mcp-server/src/resolve.ts
@@ -4,9 +4,11 @@ import {
   listCycles,
   listLabels,
   listMembers,
+  listMilestones,
   listProjects,
   listTeams,
   listWorkflowStates,
+  type MilestoneRow,
   type ProjectRow,
   type TeamRow,
 } from '@orbit/core';
@@ -77,6 +79,17 @@ export async function resolveProject(principal: Principal, ref: string): Promise
   const projects = await listProjects(principal, { includeArchived: true });
   const found = pick(projects, ref, (project) => [project.id, project.slug, project.name]);
   if (found === undefined) throw notFound(`No project matches "${ref}".`);
+  return found;
+}
+
+export async function resolveMilestone(
+  principal: Principal,
+  projectId: string,
+  ref: string,
+): Promise<MilestoneRow> {
+  const milestones = await listMilestones(principal, projectId);
+  const found = pick(milestones, ref, (milestone) => [milestone.id, milestone.name]);
+  if (found === undefined) throw notFound(`No milestone matches "${ref}" on that project.`);
   return found;
 }
 

--- a/packages/mcp-server/src/tools/issues.ts
+++ b/packages/mcp-server/src/tools/issues.ts
@@ -20,6 +20,7 @@ import { z } from 'zod';
 import {
   resolveCycle,
   resolveLabelIds,
+  resolveMilestone,
   resolveProject,
   resolveStateId,
   resolveTeam,
@@ -157,6 +158,14 @@ function registerUpdateIssue(server: McpServer, principal: Principal): void {
           .nullable()
           .optional()
           .describe('Project name, slug, id or null.'),
+        milestone: z
+          .string()
+          .min(1)
+          .nullable()
+          .optional()
+          .describe(
+            'Milestone name or id on the project the issue is in, or null to take it off the milestone.',
+          ),
         cycle: z.string().min(1).nullable().optional().describe('Sprint name, number, id or null.'),
         labels: labelsRef.optional(),
         estimate: z.number().int().min(0).max(100).nullable().optional(),
@@ -165,7 +174,7 @@ function registerUpdateIssue(server: McpServer, principal: Principal): void {
     },
     async (args) => {
       const issue = await getIssue(principal, args.issue);
-      const patch = await buildIssuePatch(principal, issue.teamId, args);
+      const patch = await buildIssuePatch(principal, issue.teamId, args, issue.projectId);
       const updated = await updateIssue(principal, issue.id, patch);
       await publish(updated.actions);
       return {
@@ -184,23 +193,43 @@ interface IssuePatchArgs {
   readonly priority?: keyof typeof PRIORITY_VALUES | undefined;
   readonly assignee?: string | null | undefined;
   readonly project?: string | null | undefined;
+  readonly milestone?: string | null | undefined;
   readonly cycle?: string | null | undefined;
   readonly labels?: string[] | undefined;
   readonly estimate?: number | null | undefined;
   readonly dueDate?: string | null | undefined;
 }
 
-async function buildIssuePatch(
+async function milestoneIdFor(
   principal: Principal,
-  teamId: string,
-  args: IssuePatchArgs,
-): Promise<Record<string, unknown>> {
+  patch: Record<string, unknown>,
+  currentProjectId: string | null,
+  ref: string,
+): Promise<string> {
+  const target = 'projectId' in patch ? patch['projectId'] : currentProjectId;
+  if (typeof target !== 'string') {
+    throw validationFailed('Put the issue on a project before giving it a milestone.');
+  }
+  return (await resolveMilestone(principal, target, ref)).id;
+}
+
+function literalIssueFields(args: IssuePatchArgs): Record<string, unknown> {
   const patch: Record<string, unknown> = {};
   if (args.title !== undefined) patch['title'] = args.title;
   if (args.description !== undefined) patch['description'] = args.description;
   if (args.estimate !== undefined) patch['estimate'] = args.estimate;
   if (args.dueDate !== undefined) patch['dueDate'] = args.dueDate;
   if (args.priority !== undefined) patch['priority'] = PRIORITY_VALUES[args.priority];
+  return patch;
+}
+
+async function buildIssuePatch(
+  principal: Principal,
+  teamId: string,
+  args: IssuePatchArgs,
+  currentProjectId: string | null = null,
+): Promise<Record<string, unknown>> {
+  const patch = literalIssueFields(args);
   if (args.state !== undefined)
     patch['stateId'] = await resolveStateId(principal, teamId, args.state);
   if (args.labels !== undefined)
@@ -212,6 +241,12 @@ async function buildIssuePatch(
   if (args.project !== undefined) {
     patch['projectId'] =
       args.project === null ? null : (await resolveProject(principal, args.project)).id;
+  }
+  if (args.milestone !== undefined) {
+    patch['milestoneId'] =
+      args.milestone === null
+        ? null
+        : await milestoneIdFor(principal, patch, currentProjectId, args.milestone);
   }
   if (args.cycle !== undefined) {
     patch['cycleId'] =

--- a/packages/mcp-server/src/tools/scrum.ts
+++ b/packages/mcp-server/src/tools/scrum.ts
@@ -13,6 +13,7 @@ import {
   type MilestoneRow,
   openBlockers,
   openStandup,
+  reorderMilestones,
   resolveBlocker,
   type StandupDetail,
   setRotation,
@@ -25,7 +26,7 @@ import {
 } from '@orbit/core';
 import type { Principal } from '@orbit/shared/policy';
 import { z } from 'zod';
-import { resolveProject, resolveTeam, resolveUserId } from '../resolve.ts';
+import { resolveMilestone, resolveProject, resolveTeam, resolveUserId } from '../resolve.ts';
 import { defineTool, publish } from './support.ts';
 
 const teamRef = z.string().min(1).describe('Team key like "ENG", team name, or team id.');
@@ -478,6 +479,35 @@ function registerMilestoneTools(server: McpServer, principal: Principal): void {
       });
       await publish(result.actions);
       return { milestone: milestoneView(result.milestone) };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'reorder_milestones',
+      title: 'Reorder the milestones on a project',
+      description:
+        'Put the milestones of a project into the order given. The list has to name every milestone on the project exactly once, so read them with list_milestones first.',
+      readOnly: false,
+      inputSchema: {
+        project: z.string().min(1).describe('Project name, slug, or id.'),
+        milestones: z
+          .array(z.string().min(1))
+          .min(1)
+          .max(200)
+          .describe('Every milestone on the project, by name or id, in the order you want.'),
+      },
+    },
+    async (input) => {
+      const projectId = (await resolveProject(principal, input.project)).id;
+      const ordered: string[] = [];
+      for (const ref of input.milestones) {
+        ordered.push((await resolveMilestone(principal, projectId, ref)).id);
+      }
+      const result = await reorderMilestones(principal, projectId, ordered);
+      await publish(result.actions);
+      return { milestones: result.milestones.map(milestoneView) };
     },
   );
 }

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -22,6 +22,7 @@ interface IssueShape {
   readonly priority: string;
   readonly assignee: string | null;
   readonly cycleId: string | null;
+  readonly milestoneId: string | null;
 }
 
 interface DeltaShape {
@@ -75,6 +76,7 @@ describe('discovery', () => {
     expect(names).toContain('run_standup');
     expect(names).toContain('complete_cycle');
     expect(names).toContain('create_milestone');
+    expect(names).toContain('reorder_milestones');
 
     expect(names).toContain('create_doc');
     expect(names).toContain('update_doc');
@@ -383,6 +385,119 @@ describe('planning', () => {
   it('lists cycles for a team', async () => {
     const payload = await admin.result('list_cycles', { team: workspace.teamKey });
     expect((payload['cycles'] as unknown[]).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+interface MilestoneShape {
+  readonly id: string;
+  readonly name: string;
+  readonly projectId: string;
+}
+
+function milestonesOf(payload: Record<string, unknown>): MilestoneShape[] {
+  return payload['milestones'] as MilestoneShape[];
+}
+
+describe('milestones over mcp', () => {
+  async function projectWithMilestones(
+    name: string,
+    milestoneNames: readonly string[],
+  ): Promise<string> {
+    await admin.result('create_project', { name, teams: [workspace.teamKey] });
+    for (const milestoneName of milestoneNames) {
+      await admin.result('create_milestone', { project: name, name: milestoneName });
+    }
+    return name;
+  }
+
+  it('reorders the milestones of a project by name', async () => {
+    const project = await projectWithMilestones('Reordered launch', ['One', 'Two', 'Three']);
+
+    const reordered = await admin.result('reorder_milestones', {
+      project,
+      milestones: ['Three', 'One', 'Two'],
+    });
+
+    expect(milestonesOf(reordered).map((row) => row.name)).toEqual(['Three', 'One', 'Two']);
+    const listed = await admin.result('list_milestones', { project });
+    expect(milestonesOf(listed).map((row) => row.name)).toEqual(['Three', 'One', 'Two']);
+  });
+
+  it('refuses an order that leaves one of the milestones out', async () => {
+    const project = await projectWithMilestones('Partial order', ['Alpha', 'Beta']);
+
+    const failed = await admin.call('reorder_milestones', { project, milestones: ['Alpha'] });
+
+    expect(failed.isError).toBe(true);
+    expect(errorPayload(failed).code).toBe('conflict');
+    const listed = await admin.result('list_milestones', { project });
+    expect(milestonesOf(listed).map((row) => row.name)).toEqual(['Alpha', 'Beta']);
+  });
+
+  it('refuses a guest, whose role cannot manage milestones', async () => {
+    const project = await projectWithMilestones('Guarded order', ['First', 'Second']);
+
+    const created = await guest.call('create_milestone', { project, name: 'Guest milestone' });
+    const reordered = await guest.call('reorder_milestones', {
+      project,
+      milestones: ['Second', 'First'],
+    });
+
+    expect(created.isError).toBe(true);
+    expect(errorPayload(created).code).toBe('forbidden');
+    expect(reordered.isError).toBe(true);
+    expect(errorPayload(reordered).code).toBe('forbidden');
+    const listed = await admin.result('list_milestones', { project });
+    expect(milestonesOf(listed).map((row) => row.name)).toEqual(['First', 'Second']);
+  });
+
+  it('puts an issue on a milestone of its own project and takes it back off', async () => {
+    const project = await projectWithMilestones('Milestone bearing', ['Cut over']);
+    const issue = await newIssue('Do the cut over', { project });
+    const listed = milestonesOf(await admin.result('list_milestones', { project }));
+    const target = listed[0];
+    if (target === undefined) throw new Error('missing seeded milestone');
+
+    const attached = await admin.result('update_issue', {
+      issue: issue.identifier,
+      project,
+      milestone: 'Cut over',
+    });
+    expect(attached['changed']).toContain('milestoneId');
+    expect(issueOf(attached).milestoneId).toBe(target.id);
+
+    const detached = await admin.result('update_issue', {
+      issue: issue.identifier,
+      milestone: null,
+    });
+    expect(issueOf(detached).milestoneId).toBeNull();
+  });
+
+  it('refuses a milestone that belongs to another project', async () => {
+    const here = await projectWithMilestones('Milestone here', ['Ours']);
+    await projectWithMilestones('Milestone elsewhere', ['Theirs']);
+    const issue = await newIssue('Cross project attempt', { project: here });
+
+    const failed = await admin.call('update_issue', {
+      issue: issue.identifier,
+      milestone: 'Theirs',
+    });
+
+    expect(failed.isError).toBe(true);
+    expect(errorPayload(failed).code).toBe('not_found');
+  });
+
+  it('refuses a milestone on an issue that is on no project', async () => {
+    await projectWithMilestones('Unreachable milestone', ['Orphaned']);
+    const issue = await newIssue('No project at all');
+
+    const failed = await admin.call('update_issue', {
+      issue: issue.identifier,
+      milestone: 'Orphaned',
+    });
+
+    expect(failed.isError).toBe(true);
+    expect(errorPayload(failed).code).toBe('validation_failed');
   });
 });
 

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -487,6 +487,28 @@ describe('milestones over mcp', () => {
     expect(errorPayload(failed).code).toBe('not_found');
   });
 
+  it('refuses a name that two milestones on the project share, rather than guessing', async () => {
+    const project = await projectWithMilestones('Twice named', ['Cut over', 'Cut over']);
+    const listed = milestonesOf(await admin.result('list_milestones', { project }));
+    const [first, second] = listed;
+    if (first === undefined || second === undefined) throw new Error('missing seeded milestones');
+    const issue = await newIssue('Ambiguous target', { project });
+
+    const failed = await admin.call('update_issue', {
+      issue: issue.identifier,
+      milestone: 'Cut over',
+    });
+
+    expect(failed.isError).toBe(true);
+    expect(errorPayload(failed).code).toBe('conflict');
+
+    const resolved = await admin.result('update_issue', {
+      issue: issue.identifier,
+      milestone: second.id,
+    });
+    expect(issueOf(resolved).milestoneId).toBe(second.id);
+  });
+
   it('refuses a milestone on an issue that is on no project', async () => {
     await projectWithMilestones('Unreachable milestone', ['Orphaned']);
     const issue = await newIssue('No project at all');

--- a/packages/shared/src/validators/milestone.ts
+++ b/packages/shared/src/validators/milestone.ts
@@ -16,6 +16,8 @@ export const milestoneUpdateSchema = z
   })
   .partial();
 
+export const milestoneCreateBodySchema = milestoneCreateSchema.omit({ projectId: true });
+
 export const milestoneOrderSchema = z.array(idSchema).max(200);
 
 export const milestoneReorderSchema = z.object({

--- a/packages/shared/src/validators/milestone.ts
+++ b/packages/shared/src/validators/milestone.ts
@@ -15,3 +15,9 @@ export const milestoneUpdateSchema = z
     targetDate: z.coerce.date().nullable(),
   })
   .partial();
+
+export const milestoneOrderSchema = z.array(idSchema).max(200);
+
+export const milestoneReorderSchema = z.object({
+  milestoneIds: milestoneOrderSchema,
+});


### PR DESCRIPTION
## No catchup SQL

Nothing in this branch touches the schema. `milestone` and `project` already
exist with every column used here, so there is no new file under
`packages/db/catchup/` and nothing to apply before the code ships.

## What was broken

`/projects` rendered a table and nothing else: a sweep of every button and
anchor inside `<main>` came back empty, so `POST /api/projects` worked and no
client ever called it. `packages/core/src/work/milestone-service.ts` had
create, update, delete, list and reorder, and `apps/web/src/app/api` had no
`milestones` directory at all, so milestones had no HTTP surface. The filter
menu offered "Milestone" and the display menu offered a Milestone column, both
of which could only ever match seed data because nothing could set
`issue.milestoneId`. And `update-composer.tsx` kept its text after a successful
post, so the next edit reposted the same update.

## Backend first

Every rule below is enforced on the server. The client hides what the policy
forbids, and every test that matters proves the refusal against the route.

- **Five new handlers**, each one parsing with a schema from `@orbit/shared`,
  calling a service, and publishing the actions the service returned:
  `GET`/`POST /api/projects/[id]/milestones`,
  `POST /api/projects/[id]/milestones/reorder`,
  `PATCH`/`DELETE /api/milestones/[id]`.
- **Create takes its project from the path.** A `projectId` in the body is
  ignored, and there is a test for it.
- **`reorderMilestones` parses its own input** with `milestoneOrderSchema` from
  `@orbit/shared`, so the service is a gate on its own and not only the route.
  It already refused an order that does not cover exactly the milestones of the
  project; that is now reachable over HTTP and over MCP.
- **A milestone has to belong to the project the issue is on.**
  `assertMilestoneInTeam` used to skip the project check whenever the patch did
  not also set `projectId`, so an issue on project A could take a milestone from
  a sibling project B on the same team, and an issue on no project could take a
  milestone at all. `applyIssueUpdates` now hands it the project the issue will
  actually be on, and the null case is refused.

## MCP parity

Everything the UI gained goes through the same service function.

| UI | MCP |
| --- | --- |
| New project dialog | `create_project` (already there) |
| Add, edit, delete a milestone | `create_milestone`, `update_milestone`, `delete_milestone` (already there) |
| Move a milestone up or down | `reorder_milestones` (new) |
| Milestone row on the issue panel | `milestone` on `update_issue` (new) |

`reorder_milestones` is `readOnly: false`, so a token holding only `orbit.read`
never sees it. It resolves each name against the project it names, then hands
the whole order to `reorderMilestones`.

## UI

- **New project** on the `/projects` header and on the empty state. Name,
  summary, target date and teams; the slug comes back from the server and the
  dialog follows it.
- **Milestones on the project overview**: add, edit, delete, and move up or
  move down. Reorder posts the whole order, never a pair, so the server can
  check it covers the project. Move buttons are real buttons with labels, so
  the order is keyboard operable. Progress per milestone still comes from
  `projectProgress`.
- **Milestone row on the issue properties panel**, under Project, on <kbd>m</kbd>.
  It reads the milestones of the project the issue is on through a query keyed
  by that project, and says "Pick a project first" when there is none.
- **Update composer** remounts its editor after a successful post and refuses a
  submit while one is in flight.

Milestone deltas now invalidate the milestones query instead of the bootstrap
payload, which never carried milestones.

## Tests, and the mutation that makes each one bite

Every test below was watched failing before the code existed, then the
production code was broken deliberately and confirmed RED, then restored.

| Test | Break that turns it red |
| --- | --- |
| `issue-service.test.ts` refuses a sibling project milestone | drop the `current.projectId` argument to `assertAssignableToTeam` |
| `issue-service.test.ts` refuses a milestone with no project | put `projectId !== null` back in `assertMilestoneInTeam` |
| `milestone-service.test.ts` refuses an order that is not ids | drop `milestoneOrderSchema.parse` |
| `milestones.test.ts` ignores a body `projectId` | spread the body after the path id |
| `milestones.test.ts` refuses a guest and a contributor (3 cases) | drop `assertCan(principal, 'milestone:manage')` |
| `milestones.test.ts` refuses a member off the project teams | drop `assertProjectVisible` from `createMilestone` |
| `milestones.test.ts` 422 on a malformed reorder body | drop both the route parse and the service parse |
| `route.test.ts` refuses a contributor and a guest creating a project | drop `assertCan(principal, 'project:manage')` |
| `tools.test.ts` reorder over MCP (3 cases) + discovery | rename the `reorder_milestones` tool |
| `tools.test.ts` milestone on `update_issue` (3 cases) | drop the `args.milestone` branch in `buildIssuePatch` |
| `milestone-board.test.tsx` sends the whole order (2 cases) | send only the swapped pair |
| `issue-properties.test.tsx` reads the right project (3 cases) | pass `null` instead of `issue.projectId` |
| `update-composer.test.tsx` empties the editor (2 cases) | drop the `key` on the editor |

The route tests seed a real workspace with `@orbit/core/test-support`, mock only
the session, and let the real `resolveMembership` read the role and teams out of
Postgres, so the refusals come from the server and not from a stub.

`bun run verify` exits 0.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds UI and HTTP support for project and milestone management, exposes milestone ordering and issue assignment through MCP, and refreshes milestone progress from current issue data.
- Adds project creation and milestone management interfaces.
- Adds validated milestone CRUD and reorder routes backed by core services.
- Adds MCP milestone reordering and issue milestone assignment.
- Fixes project-aware milestone assignment and clears successful update submissions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/projects/milestone-board.tsx | Adds milestone creation, editing, deletion, ordering, and query-backed progress rendering; the prior stale-progress path is addressed. |
| apps/web/src/lib/realtime/delta-bridge.tsx | Invalidates milestone queries when issue changes can affect their progress totals. |
| apps/web/src/app/api/projects/[id]/milestones/route.ts | Adds validated list and create handlers while retaining the path as the authoritative project identifier. |
| apps/web/src/app/api/milestones/[id]/route.ts | Adds shared-schema-validated milestone update and delete handlers. |
| packages/mcp-server/src/resolve.ts | Resolves milestone identifiers before names and rejects ambiguous duplicate-name references. |
| packages/core/src/work/issue-service.ts | Validates milestone assignment against the issue's resulting project rather than only an explicitly patched project. |
| packages/core/src/work/milestone-service.ts | Adds validated milestone ordering and current progress aggregation for HTTP and UI consumers. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  UI[Project and issue UI] --> HTTP[Validated project and milestone routes]
  MCP[MCP tools] --> Core[Core project, milestone, and issue services]
  HTTP --> Core
  Core --> DB[(Database)]
  Core --> Events[Published actions]
  Events --> Cache[Query invalidation]
  Cache --> UI
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(issues): hide the milestone shortcut..."](https://github.com/noveum/orbit/commit/8fe5d28dc04acfbb2384be3f3e67f42f1a2cb979) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51117172)</sub>

<!-- /greptile_comment -->

## After review

Seven threads, five fixed and two answered.

- **Milestone counts went stale.** They were server-rendered once and never
  refreshed. `GET /api/projects/[id]/milestones` now carries `scope` and
  `completed` from `listMilestonesWithProgress`, the board takes no progress
  prop at all, and an issue delta invalidates the milestones query along with
  everything else that counts issues.
- **A duplicate milestone name resolved to whichever came first over MCP.**
  `resolveMilestone` matches an id first and refuses an ambiguous name with a
  conflict that names the candidate ids.
- **The milestone routes handed raw JSON to the services.** They now parse
  first, with `milestoneUpdateSchema` and a new `milestoneCreateBodySchema`
  which is the create schema without `projectId`, so the path stays the only
  source of the project.
- **The `m` shortcut was registered even with no project to hang a milestone
  on.** It is registered `enabled: issue.projectId !== null`, and the `<Kbd>`
  hint goes with it. The repository hint invariant test caught the hint half of
  that on CI before this branch was near merge, which is exactly what it is for.
- **A date only target date showed the previous day west of UTC**, because
  `new Date('2026-06-08')` is UTC midnight. `formatDay` in
  `apps/web/src/features/projects/dates.ts` reads the digits and never builds a
  Date. The projects table and the project header carried the same bug and now
  share the fix.

Two were answered rather than applied: moving the MCP milestone cases out of
`tests/tools.test.ts` would not land on a mirrored path either, since the
milestone tools live across three source files; and there is no rollback test
wrapper in this repository for `apps/web` to adopt, only the lane cloned
database every other database backed test already uses.

New tests for the round, each watched failing first:

| Test | Break that turns it red |
| --- | --- |
| route counts issues per milestone | return zeroed counts from the list handler |
| board shows the counts the server sent | n/a, it reads them straight off the payload |
| MCP refuses an ambiguous milestone name | let `pick` match a name and take the first |
| `formatDay` names the same day in four zones | go back to `new Date(...).toLocaleDateString` |
| the `m` shortcut is not advertised without a project | drop `enabled` from the binding |
| the milestone row hides its hint without a project | make `shortcut="m"` unconditional |
