### PR TITLE
Make sprints operable: start, complete, edit and delete from the product

### DIFF
--- a/apps/web/src/app/(app)/sprints/page.tsx
+++ b/apps/web/src/app/(app)/sprints/page.tsx
@@ -1,3 +1,4 @@
+import { can } from '@orbit/shared/policy';
 import { RefreshCcw } from 'lucide-react';
 import type { Metadata } from 'next';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
@@ -27,6 +28,7 @@ export default async function SprintsPage() {
     );
   }
 
+  const canManage = can(principal, 'cycle:manage');
   const panels = await Promise.all(
     teams.map(async (team) => ({
       team,
@@ -46,7 +48,13 @@ export default async function SprintsPage() {
       </header>
       {panels.map((panel) => (
         <section key={panel.team.id} className="flex flex-col gap-4">
-          <CyclePanel cycle={panel.cycle} upcoming={panel.upcoming} teamName={panel.team.name} />
+          <CyclePanel
+            cycle={panel.cycle}
+            upcoming={panel.upcoming}
+            team={panel.team}
+            canManage={canManage}
+            runningSprintId={panel.cycle?.id ?? null}
+          />
           <div className="flex flex-col gap-2">
             <h3 className="font-medium text-dense text-text">Past sprints</h3>
             <SprintHistory sprints={panel.past} />

--- a/apps/web/src/app/(app)/team/[key]/sprint/[number]/page.tsx
+++ b/apps/web/src/app/(app)/team/[key]/sprint/[number]/page.tsx
@@ -1,7 +1,8 @@
+import { can } from '@orbit/shared/policy';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { CyclePanel } from '@/features/cycles/cycle-board.tsx';
-import { getSprintView, listUpcomingCycleViews } from '@/features/cycles/data.ts';
+import { getSprintView, listUpcomingCycleViews, runningSprintId } from '@/features/cycles/data.ts';
 import { pageContext } from '@/lib/api/handler.ts';
 import { listTeamsForPrincipal } from '@/lib/workspace.ts';
 
@@ -30,9 +31,10 @@ export default async function SprintPage({ params }: PageProps) {
   const team = teams.find((entry) => entry.key.toLowerCase() === key.toLowerCase());
   if (team === undefined) notFound();
 
-  const [sprint, upcoming] = await Promise.all([
+  const [sprint, upcoming, running] = await Promise.all([
     getSprintView(principal, team, wanted),
     listUpcomingCycleViews(principal, team),
+    runningSprintId(principal, team),
   ]);
   if (sprint === null) notFound();
 
@@ -53,7 +55,13 @@ export default async function SprintPage({ params }: PageProps) {
           </p>
         )}
       </header>
-      <CyclePanel cycle={sprint} upcoming={upcoming} teamName={team.name} />
+      <CyclePanel
+        cycle={sprint}
+        upcoming={upcoming}
+        team={team}
+        canManage={can(principal, 'cycle:manage')}
+        runningSprintId={running}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/(app)/team/[key]/sprint/active/page.tsx
+++ b/apps/web/src/app/(app)/team/[key]/sprint/active/page.tsx
@@ -1,3 +1,4 @@
+import { can } from '@orbit/shared/policy';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { CyclePanel } from '@/features/cycles/cycle-board.tsx';
@@ -32,7 +33,13 @@ export default async function ActiveSprintPage({ params }: PageProps) {
         <h1 className="font-semibold text-lg text-text">{team.name} sprint</h1>
         <p className="text-muted text-xs">Scope, pace, and who is carrying what this sprint.</p>
       </header>
-      <CyclePanel cycle={cycle} upcoming={upcoming} teamName={team.name} />
+      <CyclePanel
+        cycle={cycle}
+        upcoming={upcoming}
+        team={team}
+        canManage={can(principal, 'cycle:manage')}
+        runningSprintId={cycle?.id ?? null}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/api/cycles/[id]/start/route.ts
+++ b/apps/web/src/app/api/cycles/[id]/start/route.ts
@@ -1,0 +1,16 @@
+import { startCycle } from '@orbit/core';
+import { apiContext, handleRoute, publish, routeId } from '@/lib/api/handler.ts';
+
+interface RouteParams {
+  readonly params: Promise<{ id: string }>;
+}
+
+export async function POST(_request: Request, { params }: RouteParams): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const id = routeId((await params).id, 'sprint');
+    const result = await startCycle(principal, id);
+    await publish(result.actions);
+    return { cycle: result.cycle };
+  });
+}

--- a/apps/web/src/features/cycles/cycle-board.tsx
+++ b/apps/web/src/features/cycles/cycle-board.tsx
@@ -9,6 +9,13 @@ import { cn } from '@/lib/cn.ts';
 import { cardHover, rowHover } from '@/lib/interaction.ts';
 import { buildBurnUp, burnUpMetric } from './burn-up.ts';
 import type { CycleView, UpcomingCycleView } from './data.ts';
+import {
+  CompleteSprintButton,
+  DeleteSprintButton,
+  EditSprintButton,
+  NewSprintButton,
+  StartSprintButton,
+} from './sprint-actions.tsx';
 
 function formatDay(value: string): string {
   return new Date(value).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
@@ -162,20 +169,31 @@ export function CycleIssueList({ cycle }: { readonly cycle: CycleView }) {
   );
 }
 
+export interface SprintTeam {
+  readonly id: string;
+  readonly key: string;
+  readonly name: string;
+}
+
 export interface CyclePanelProps {
   readonly cycle: CycleView | null;
   readonly upcoming: readonly UpcomingCycleView[];
-  readonly teamName: string;
+  readonly team: SprintTeam;
+  readonly canManage: boolean;
+  readonly runningSprintId: string | null;
 }
 
-export function CyclePanel({ cycle, upcoming, teamName }: CyclePanelProps) {
+export function CyclePanel({ cycle, upcoming, team, canManage, runningSprintId }: CyclePanelProps) {
+  const open = cycle !== null && cycle.completedAt === null;
+
   return (
     <div className="flex flex-col gap-6">
       {cycle === null ? (
         <EmptyState
           icon={<RefreshCcw strokeWidth={1.75} aria-hidden="true" />}
           title="No active sprint"
-          description={`${teamName} has no sprint running right now.`}
+          description={`${team.name} has no sprint running right now.`}
+          action={canManage ? <NewSprintButton teamId={team.id} /> : null}
         />
       ) : (
         <>
@@ -185,6 +203,12 @@ export function CyclePanel({ cycle, upcoming, teamName }: CyclePanelProps) {
             <span className="text-faint text-xs tabular">
               {formatDay(cycle.startsAt)} to {formatDay(cycle.endsAt)}
             </span>
+            {canManage && open ? (
+              <div className="ml-auto flex flex-wrap items-center gap-1.5">
+                <EditSprintButton sprint={cycle} />
+                <CompleteSprintButton sprint={cycle} />
+              </div>
+            ) : null}
           </header>
           <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
             <CycleIssueList cycle={cycle} />
@@ -194,7 +218,10 @@ export function CyclePanel({ cycle, upcoming, teamName }: CyclePanelProps) {
       )}
 
       <section className="flex flex-col gap-2">
-        <h3 className="font-medium text-dense text-text">Upcoming sprints</h3>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="font-medium text-dense text-text">Upcoming sprints</h3>
+          {canManage && cycle !== null ? <NewSprintButton teamId={team.id} /> : null}
+        </div>
         {upcoming.length === 0 ? (
           <p className="text-faint text-xs">Nothing scheduled after this one.</p>
         ) : (
@@ -203,7 +230,7 @@ export function CyclePanel({ cycle, upcoming, teamName }: CyclePanelProps) {
               <li
                 key={entry.id}
                 className={cn(
-                  'flex items-center justify-between gap-2 rounded-md border border-border px-3 py-1.5',
+                  'flex flex-wrap items-center justify-between gap-2 rounded-md border border-border px-3 py-1.5',
                   cardHover,
                 )}
               >
@@ -211,8 +238,17 @@ export function CyclePanel({ cycle, upcoming, teamName }: CyclePanelProps) {
                   <Badge tone="outline">{entry.teamKey}</Badge>
                   {entry.name}
                 </span>
-                <span className="text-2xs text-faint tabular">
-                  {formatDay(entry.startsAt)} to {formatDay(entry.endsAt)}
+                <span className="flex items-center gap-1.5">
+                  <span className="text-2xs text-faint tabular">
+                    {formatDay(entry.startsAt)} to {formatDay(entry.endsAt)}
+                  </span>
+                  {canManage ? (
+                    <>
+                      {runningSprintId === null ? <StartSprintButton sprint={entry} /> : null}
+                      <EditSprintButton sprint={entry} />
+                      <DeleteSprintButton sprint={entry} />
+                    </>
+                  ) : null}
                 </span>
               </li>
             ))}

--- a/apps/web/src/features/cycles/data.ts
+++ b/apps/web/src/features/cycles/data.ts
@@ -48,6 +48,7 @@ export interface CycleView {
   readonly teamName: string;
   readonly startsAt: string;
   readonly endsAt: string;
+  readonly completedAt: string | null;
   readonly progress: CycleProgress;
   readonly groups: StateGroup[];
   readonly assignees: AssigneeTally[];
@@ -176,10 +177,20 @@ export async function getActiveCycleView(
     teamName: team.name,
     startsAt: cycle.startsAt.toISOString(),
     endsAt: cycle.endsAt.toISOString(),
+    completedAt: cycle.completedAt?.toISOString() ?? null,
     progress,
     groups: issues.groups,
     assignees: issues.assignees,
   };
+}
+
+export async function runningSprintId(
+  principal: Principal,
+  team: { id: string },
+  now: Date = new Date(),
+): Promise<string | null> {
+  const cycle = await activeCycle(principal, team.id, now);
+  return cycle?.id ?? null;
 }
 
 export async function listUpcomingCycleViews(
@@ -248,6 +259,7 @@ export async function getSprintView(
     teamName: team.name,
     startsAt: cycle.startsAt.toISOString(),
     endsAt: cycle.endsAt.toISOString(),
+    completedAt: cycle.completedAt?.toISOString() ?? null,
     progress,
     groups: issues.groups,
     assignees: issues.assignees,

--- a/apps/web/src/features/cycles/sprint-actions.tsx
+++ b/apps/web/src/features/cycles/sprint-actions.tsx
@@ -201,6 +201,20 @@ function draftFrom(teamId: string, values: SprintFormValues) {
   };
 }
 
+function movedDay(day: string, was: string): boolean {
+  return day.length > 0 && day !== was;
+}
+
+function editFrom(sprint: SprintSummary, values: SprintFormValues) {
+  const before = formOf(sprint);
+  return {
+    id: sprint.id,
+    ...(values.name.length === 0 ? {} : { name: values.name }),
+    ...(movedDay(values.startsAt, before.startsAt) ? { startsAt: values.startsAt } : {}),
+    ...(movedDay(values.endsAt, before.endsAt) ? { endsAt: values.endsAt } : {}),
+  };
+}
+
 export function NewSprintButton({ teamId }: { readonly teamId: string }) {
   const [open, setOpen] = useState(false);
   const create = useCreateSprint();
@@ -256,15 +270,7 @@ export function EditSprintButton({ sprint }: { readonly sprint: SprintSummary })
           pending={update.isPending}
           testId="sprint-edit-dialog"
           onSubmit={(values) => {
-            update.mutate(
-              {
-                id: sprint.id,
-                ...(values.name.length === 0 ? {} : { name: values.name }),
-                ...(values.startsAt.length === 0 ? {} : { startsAt: values.startsAt }),
-                ...(values.endsAt.length === 0 ? {} : { endsAt: values.endsAt }),
-              },
-              { onSuccess: () => setOpen(false) },
-            );
+            update.mutate(editFrom(sprint, values), { onSuccess: () => setOpen(false) });
           }}
         />
       ) : null}

--- a/apps/web/src/features/cycles/sprint-actions.tsx
+++ b/apps/web/src/features/cycles/sprint-actions.tsx
@@ -1,0 +1,358 @@
+'use client';
+
+import { CheckCheck, Pencil, Play, Plus, Trash2 } from 'lucide-react';
+import { type FormEvent, useState } from 'react';
+import { Button } from '@/components/ui/button.tsx';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog.tsx';
+import { Input } from '@/components/ui/input.tsx';
+import {
+  useCompleteSprint,
+  useCreateSprint,
+  useDeleteSprint,
+  useStartSprint,
+  useUpdateSprint,
+} from '@/lib/query/use-sprints.ts';
+
+export interface SprintSummary {
+  readonly id: string;
+  readonly name: string;
+  readonly startsAt: string;
+  readonly endsAt: string;
+}
+
+interface SprintFormValues {
+  readonly name: string;
+  readonly startsAt: string;
+  readonly endsAt: string;
+}
+
+const EMPTY_FORM: SprintFormValues = { name: '', startsAt: '', endsAt: '' };
+
+function utcDay(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+function formOf(sprint: SprintSummary): SprintFormValues {
+  return { name: sprint.name, startsAt: utcDay(sprint.startsAt), endsAt: utcDay(sprint.endsAt) };
+}
+
+interface SprintDialogProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly title: string;
+  readonly description: string;
+  readonly submitLabel: string;
+  readonly initial: SprintFormValues;
+  readonly pending: boolean;
+  readonly testId: string;
+  readonly onSubmit: (values: SprintFormValues) => void;
+}
+
+function SprintDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  submitLabel,
+  initial,
+  pending,
+  testId,
+  onSubmit,
+}: SprintDialogProps) {
+  const [values, setValues] = useState(initial);
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSubmit({
+      name: values.name.trim(),
+      startsAt: values.startsAt,
+      endsAt: values.endsAt,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm" data-testid={testId}>
+        <DialogHeader>
+          <DialogTitle className="font-medium text-base text-text">{title}</DialogTitle>
+          <DialogDescription className="text-muted text-xs">{description}</DialogDescription>
+        </DialogHeader>
+
+        <form className="flex flex-col gap-3" onSubmit={submit}>
+          <label className="flex flex-col gap-1.5 text-2xs text-faint" htmlFor={`${testId}-name`}>
+            Name
+            <Input
+              id={`${testId}-name`}
+              autoFocus
+              maxLength={120}
+              value={values.name}
+              data-testid={`${testId}-name`}
+              placeholder="Sprint 12"
+              onChange={(event) => setValues({ ...values, name: event.target.value })}
+            />
+          </label>
+
+          <div className="grid grid-cols-2 gap-3">
+            <label
+              className="flex flex-col gap-1.5 text-2xs text-faint"
+              htmlFor={`${testId}-starts`}
+            >
+              Starts
+              <Input
+                id={`${testId}-starts`}
+                type="date"
+                value={values.startsAt}
+                data-testid={`${testId}-starts`}
+                onChange={(event) => setValues({ ...values, startsAt: event.target.value })}
+              />
+            </label>
+            <label className="flex flex-col gap-1.5 text-2xs text-faint" htmlFor={`${testId}-ends`}>
+              Ends
+              <Input
+                id={`${testId}-ends`}
+                type="date"
+                value={values.endsAt}
+                data-testid={`${testId}-ends`}
+                onChange={(event) => setValues({ ...values, endsAt: event.target.value })}
+              />
+            </label>
+          </div>
+
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={pending}
+              data-testid={`${testId}-submit`}
+            >
+              {submitLabel}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface ConfirmDialogProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly title: string;
+  readonly description: string;
+  readonly confirmLabel: string;
+  readonly tone: 'primary' | 'danger';
+  readonly pending: boolean;
+  readonly testId: string;
+  readonly onConfirm: () => void;
+}
+
+function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel,
+  tone,
+  pending,
+  testId,
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm" data-testid={testId}>
+        <DialogHeader>
+          <DialogTitle className="font-medium text-base text-text">{title}</DialogTitle>
+          <DialogDescription className="text-muted text-xs">{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant={tone}
+            disabled={pending}
+            data-testid={`${testId}-confirm`}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function draftFrom(teamId: string, values: SprintFormValues) {
+  return {
+    teamId,
+    ...(values.name.length === 0 ? {} : { name: values.name }),
+    ...(values.startsAt.length === 0 ? {} : { startsAt: values.startsAt }),
+    ...(values.endsAt.length === 0 ? {} : { endsAt: values.endsAt }),
+  };
+}
+
+export function NewSprintButton({ teamId }: { readonly teamId: string }) {
+  const [open, setOpen] = useState(false);
+  const create = useCreateSprint();
+
+  return (
+    <>
+      <Button size="sm" data-testid={`sprint-new-${teamId}`} onClick={() => setOpen(true)}>
+        <Plus className="size-3.5" aria-hidden="true" />
+        New sprint
+      </Button>
+      {open ? (
+        <SprintDialog
+          open={open}
+          onOpenChange={setOpen}
+          title="New sprint"
+          description="Leave the dates empty and Orbit adds a two week sprint straight after the last one."
+          submitLabel="Create sprint"
+          initial={EMPTY_FORM}
+          pending={create.isPending}
+          testId="sprint-create-dialog"
+          onSubmit={(values) => {
+            create.mutate(draftFrom(teamId, values), { onSuccess: () => setOpen(false) });
+          }}
+        />
+      ) : null}
+    </>
+  );
+}
+
+export function EditSprintButton({ sprint }: { readonly sprint: SprintSummary }) {
+  const [open, setOpen] = useState(false);
+  const update = useUpdateSprint();
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="ghost"
+        data-testid={`sprint-edit-${sprint.id}`}
+        onClick={() => setOpen(true)}
+      >
+        <Pencil className="size-3.5" aria-hidden="true" />
+        Edit
+      </Button>
+      {open ? (
+        <SprintDialog
+          open={open}
+          onOpenChange={setOpen}
+          title={`Edit ${sprint.name}`}
+          description="Rename the sprint or move its dates. Sprints on a team may not overlap."
+          submitLabel="Save sprint"
+          initial={formOf(sprint)}
+          pending={update.isPending}
+          testId="sprint-edit-dialog"
+          onSubmit={(values) => {
+            update.mutate(
+              {
+                id: sprint.id,
+                ...(values.name.length === 0 ? {} : { name: values.name }),
+                ...(values.startsAt.length === 0 ? {} : { startsAt: values.startsAt }),
+                ...(values.endsAt.length === 0 ? {} : { endsAt: values.endsAt }),
+              },
+              { onSuccess: () => setOpen(false) },
+            );
+          }}
+        />
+      ) : null}
+    </>
+  );
+}
+
+export function StartSprintButton({ sprint }: { readonly sprint: SprintSummary }) {
+  const start = useStartSprint();
+
+  return (
+    <Button
+      size="sm"
+      variant="secondary"
+      disabled={start.isPending}
+      data-testid={`sprint-start-${sprint.id}`}
+      onClick={() => start.mutate(sprint.id)}
+    >
+      <Play className="size-3.5" aria-hidden="true" />
+      Start
+    </Button>
+  );
+}
+
+export function CompleteSprintButton({ sprint }: { readonly sprint: SprintSummary }) {
+  const [open, setOpen] = useState(false);
+  const complete = useCompleteSprint();
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="primary"
+        data-testid={`sprint-complete-${sprint.id}`}
+        onClick={() => setOpen(true)}
+      >
+        <CheckCheck className="size-3.5" aria-hidden="true" />
+        Complete sprint
+      </Button>
+      {open ? (
+        <ConfirmDialog
+          open={open}
+          onOpenChange={setOpen}
+          title={`Complete ${sprint.name}`}
+          description="Everything still open rolls into the next sprint, and what shipped is recorded against this one."
+          confirmLabel="Complete sprint"
+          tone="primary"
+          pending={complete.isPending}
+          testId="sprint-complete-dialog"
+          onConfirm={() => {
+            complete.mutate(sprint.id, { onSuccess: () => setOpen(false) });
+          }}
+        />
+      ) : null}
+    </>
+  );
+}
+
+export function DeleteSprintButton({ sprint }: { readonly sprint: SprintSummary }) {
+  const [open, setOpen] = useState(false);
+  const remove = useDeleteSprint();
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="ghost"
+        aria-label={`Delete ${sprint.name}`}
+        data-testid={`sprint-delete-${sprint.id}`}
+        onClick={() => setOpen(true)}
+      >
+        <Trash2 className="size-3.5" aria-hidden="true" />
+      </Button>
+      {open ? (
+        <ConfirmDialog
+          open={open}
+          onOpenChange={setOpen}
+          title={`Delete ${sprint.name}`}
+          description="The sprint goes, its issues stay and fall back to no sprint."
+          confirmLabel="Delete sprint"
+          tone="danger"
+          pending={remove.isPending}
+          testId="sprint-delete-dialog"
+          onConfirm={() => {
+            remove.mutate(sprint.id, { onSuccess: () => setOpen(false) });
+          }}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/lib/query/use-sprints.ts
+++ b/apps/web/src/lib/query/use-sprints.ts
@@ -1,0 +1,157 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useCallback } from 'react';
+import { z } from 'zod';
+import { useToast } from '@/components/ui/toast.tsx';
+import { apiFetch, messageOf } from './fetcher.ts';
+
+const sprintSchema = z.object({
+  id: z.string(),
+  teamId: z.string(),
+  number: z.number(),
+  name: z.string(),
+  startsAt: z.string(),
+  endsAt: z.string(),
+  completedAt: z.string().nullable(),
+});
+
+export type Sprint = z.infer<typeof sprintSchema>;
+
+const sprintEnvelope = z.object({ cycle: sprintSchema });
+const closedEnvelope = z.object({
+  cycle: sprintSchema,
+  nextCycle: sprintSchema,
+  rolledOverIssueIds: z.array(z.string()),
+});
+const deletedEnvelope = z.object({ deleted: z.boolean() });
+
+export interface SprintDraft {
+  readonly teamId: string;
+  readonly name?: string;
+  readonly startsAt?: string;
+  readonly endsAt?: string;
+}
+
+export interface SprintEdit {
+  readonly id: string;
+  readonly name?: string;
+  readonly startsAt?: string;
+  readonly endsAt?: string;
+}
+
+function useRefreshSprints(): () => void {
+  const router = useRouter();
+  return useCallback(() => {
+    router.refresh();
+  }, [router]);
+}
+
+function useFailureToast(title: string): (error: unknown) => void {
+  const { toast } = useToast();
+  return useCallback(
+    (error: unknown) => {
+      toast({ title, description: messageOf(error), tone: 'danger' });
+    },
+    [toast, title],
+  );
+}
+
+export function useCreateSprint() {
+  const refresh = useRefreshSprints();
+  const { toast } = useToast();
+  const onError = useFailureToast('Could not create that sprint');
+
+  return useMutation({
+    mutationFn: async (draft: SprintDraft): Promise<Sprint> => {
+      const payload = await apiFetch('/api/cycles', sprintEnvelope, {
+        method: 'POST',
+        body: draft,
+      });
+      return payload.cycle;
+    },
+    onSuccess: (cycle) => {
+      toast({ title: `Created ${cycle.name}` });
+      refresh();
+    },
+    onError,
+  });
+}
+
+export function useUpdateSprint() {
+  const refresh = useRefreshSprints();
+  const onError = useFailureToast('Could not save that sprint');
+
+  return useMutation({
+    mutationFn: async ({ id, ...patch }: SprintEdit): Promise<Sprint> => {
+      const payload = await apiFetch(`/api/cycles/${id}`, sprintEnvelope, {
+        method: 'PATCH',
+        body: patch,
+      });
+      return payload.cycle;
+    },
+    onSuccess: refresh,
+    onError,
+  });
+}
+
+export function useStartSprint() {
+  const refresh = useRefreshSprints();
+  const { toast } = useToast();
+  const onError = useFailureToast('Could not start that sprint');
+
+  return useMutation({
+    mutationFn: async (id: string): Promise<Sprint> => {
+      const payload = await apiFetch(`/api/cycles/${id}/start`, sprintEnvelope, {
+        method: 'POST',
+      });
+      return payload.cycle;
+    },
+    onSuccess: (cycle) => {
+      toast({ title: `${cycle.name} is running` });
+      refresh();
+    },
+    onError,
+  });
+}
+
+export function useCompleteSprint() {
+  const refresh = useRefreshSprints();
+  const { toast } = useToast();
+  const onError = useFailureToast('Could not complete that sprint');
+
+  return useMutation({
+    mutationFn: async (id: string) =>
+      await apiFetch(`/api/cycles/${id}/complete`, closedEnvelope, { method: 'POST' }),
+    onSuccess: (result) => {
+      const rolled = result.rolledOverIssueIds.length;
+      toast({
+        title: `Closed ${result.cycle.name}`,
+        description:
+          rolled === 0
+            ? 'Nothing was left unfinished.'
+            : `${rolled} ${rolled === 1 ? 'issue' : 'issues'} rolled into ${result.nextCycle.name}.`,
+      });
+      refresh();
+    },
+    onError,
+  });
+}
+
+export function useDeleteSprint() {
+  const refresh = useRefreshSprints();
+  const { toast } = useToast();
+  const onError = useFailureToast('Could not delete that sprint');
+
+  return useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      await apiFetch(`/api/cycles/${id}`, deletedEnvelope, { method: 'DELETE' });
+    },
+    onSuccess: () => {
+      toast({ title: 'Sprint deleted' });
+      refresh();
+    },
+    onError,
+  });
+}

--- a/apps/web/tests/app/api/cycles/route.test.ts
+++ b/apps/web/tests/app/api/cycles/route.test.ts
@@ -1,0 +1,335 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { completeCycle, createCycle, createTeam, listCycles } from '@orbit/core';
+import {
+  addMember,
+  createWorkspace,
+  resetDatabase,
+  type Workspace,
+} from '@orbit/core/test-support';
+import { db, eq, schema } from '@orbit/db';
+import { z } from 'zod';
+
+let workspace: Workspace;
+let contributorUserId: string;
+let outsiderUserId: string;
+
+interface Signed {
+  user: { id: string; name: string; email: string };
+  session: { activeOrganizationId: string };
+}
+
+const signedIn: { value: Signed | null } = { value: null };
+
+mock.module('@/lib/auth/session.ts', () => ({
+  getSession: () => Promise.resolve(signedIn.value),
+  requireSession: () => Promise.resolve(signedIn.value),
+}));
+
+const cycles = await import('../../../../src/app/api/cycles/route.ts');
+const cycleById = await import('../../../../src/app/api/cycles/[id]/route.ts');
+const start = await import('../../../../src/app/api/cycles/[id]/start/route.ts');
+const complete = await import('../../../../src/app/api/cycles/[id]/complete/route.ts');
+
+const cycleSchema = z.object({
+  id: z.string(),
+  teamId: z.string(),
+  name: z.string(),
+  startsAt: z.string(),
+  endsAt: z.string(),
+  completedAt: z.string().nullable(),
+});
+const cycleEnvelope = z.object({ cycle: cycleSchema });
+const errorEnvelope = z.object({ error: z.object({ code: z.string(), message: z.string() }) });
+
+function asUser(userId: string, name = 'Someone'): void {
+  signedIn.value = {
+    user: { id: userId, name, email: `${userId}@orbit.test` },
+    session: { activeOrganizationId: workspace.organizationId },
+  };
+}
+
+function routeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function postTo(url: string, body?: unknown): Request {
+  return new Request(url, {
+    method: 'POST',
+    ...(body === undefined
+      ? {}
+      : { headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) }),
+  });
+}
+
+function daysFromNow(days: number): Date {
+  return new Date(Date.now() + days * 86_400_000);
+}
+
+let teamCounter = 0;
+
+async function freshTeam(): Promise<{ teamId: string; runningCycleId: string }> {
+  teamCounter += 1;
+  const bootstrap = await createTeam(workspace.admin, {
+    name: `Squad ${teamCounter}`,
+    key: `SQ${teamCounter}`,
+  });
+  return { teamId: bootstrap.team.id, runningCycleId: bootstrap.cycle.id };
+}
+
+async function storedCycle(id: string) {
+  const [row] = await db.select().from(schema.cycle).where(eq(schema.cycle.id, id));
+  if (row === undefined) throw new Error(`no cycle ${id}`);
+  return row;
+}
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+
+  const contributor = await addMember(workspace, 'contributor', { name: 'Cass Contributor' });
+  contributorUserId = contributor.user.id;
+
+  const away = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+  const outsider = await addMember(workspace, 'member', {
+    name: 'Otto Outsider',
+    teamIds: [away.team.id],
+  });
+  outsiderUserId = outsider.user.id;
+});
+
+beforeEach(() => {
+  asUser(workspace.adminUser.id, 'Ada Admin');
+});
+
+describe('POST /api/cycles', () => {
+  it('appends a sprint after the last one when the client sends only a team', async () => {
+    const { teamId } = await freshTeam();
+    const before = await listCycles(workspace.admin, teamId);
+    const last = before.at(-1);
+    if (last === undefined) throw new Error('the new team has no sprint');
+
+    const response = await cycles.POST(postTo('http://localhost:3000/api/cycles', { teamId }));
+    const payload = cycleEnvelope.parse(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(payload.cycle.startsAt).toBe(last.endsAt.toISOString());
+    expect(Date.parse(payload.cycle.endsAt) - Date.parse(payload.cycle.startsAt)).toBe(
+      14 * 86_400_000,
+    );
+  });
+
+  it('refuses a role that cannot manage sprints', async () => {
+    const { teamId } = await freshTeam();
+    const before = await listCycles(workspace.admin, teamId);
+    asUser(contributorUserId, 'Cass Contributor');
+
+    const response = await cycles.POST(postTo('http://localhost:3000/api/cycles', { teamId }));
+
+    expect(response.status).toBe(403);
+    expect(errorEnvelope.parse(await response.json()).error.code).toBe('forbidden');
+    expect(await listCycles(workspace.admin, teamId)).toHaveLength(before.length);
+  });
+
+  it('refuses a member who is not on the team', async () => {
+    const { teamId } = await freshTeam();
+    const before = await listCycles(workspace.admin, teamId);
+    asUser(outsiderUserId, 'Otto Outsider');
+
+    const response = await cycles.POST(postTo('http://localhost:3000/api/cycles', { teamId }));
+
+    expect(response.status).toBe(403);
+    expect(await listCycles(workspace.admin, teamId)).toHaveLength(before.length);
+  });
+
+  it('answers 401 when nobody is signed in', async () => {
+    const { teamId } = await freshTeam();
+    signedIn.value = null;
+    const response = await cycles.POST(postTo('http://localhost:3000/api/cycles', { teamId }));
+    expect(response.status).toBe(401);
+  });
+});
+
+describe('POST /api/cycles/[id]/start', () => {
+  it('takes the start date off the server clock and ignores whatever the client sent', async () => {
+    const { teamId, runningCycleId } = await freshTeam();
+    const planned = await createCycle(workspace.admin, {
+      teamId,
+      name: 'Later',
+      startsAt: daysFromNow(40),
+      endsAt: daysFromNow(54),
+    });
+    await completeCycle(workspace.admin, runningCycleId);
+    const forged = new Date('1999-01-01T00:00:00.000Z').toISOString();
+
+    const response = await start.POST(
+      postTo(`http://localhost:3000/api/cycles/${planned.cycle.id}/start`, {
+        startsAt: forged,
+        endsAt: forged,
+        completedAt: forged,
+      }),
+      routeParams(planned.cycle.id),
+    );
+    const payload = cycleEnvelope.parse(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(payload.cycle.startsAt).not.toBe(forged);
+    expect(Math.abs(Date.parse(payload.cycle.startsAt) - Date.now())).toBeLessThan(60_000);
+    expect(payload.cycle.completedAt).toBeNull();
+    expect(payload.cycle.endsAt).toBe(planned.cycle.endsAt.toISOString());
+  });
+
+  it('refuses to start a second sprint while one is running', async () => {
+    const { teamId } = await freshTeam();
+    const planned = await createCycle(workspace.admin, { teamId, name: 'Queued' });
+
+    const response = await start.POST(
+      postTo(`http://localhost:3000/api/cycles/${planned.cycle.id}/start`),
+      routeParams(planned.cycle.id),
+    );
+
+    expect(response.status).toBe(409);
+    expect(errorEnvelope.parse(await response.json()).error.code).toBe('conflict');
+    expect((await storedCycle(planned.cycle.id)).startsAt.getTime()).toBe(
+      planned.cycle.startsAt.getTime(),
+    );
+  });
+
+  it('refuses a role that cannot manage sprints, leaving the dates alone', async () => {
+    const { teamId } = await freshTeam();
+    const planned = await createCycle(workspace.admin, { teamId, name: 'Hands off' });
+    asUser(contributorUserId, 'Cass Contributor');
+
+    const response = await start.POST(
+      postTo(`http://localhost:3000/api/cycles/${planned.cycle.id}/start`),
+      routeParams(planned.cycle.id),
+    );
+
+    expect(response.status).toBe(403);
+    expect((await storedCycle(planned.cycle.id)).startsAt.getTime()).toBe(
+      planned.cycle.startsAt.getTime(),
+    );
+  });
+
+  it('refuses a member of another team', async () => {
+    const { teamId } = await freshTeam();
+    const planned = await createCycle(workspace.admin, { teamId, name: 'Not yours' });
+    asUser(outsiderUserId, 'Otto Outsider');
+
+    const response = await start.POST(
+      postTo(`http://localhost:3000/api/cycles/${planned.cycle.id}/start`),
+      routeParams(planned.cycle.id),
+    );
+
+    expect(response.status).toBe(403);
+    expect((await storedCycle(planned.cycle.id)).startsAt.getTime()).toBe(
+      planned.cycle.startsAt.getTime(),
+    );
+  });
+
+  it('answers 404 for an id that is not an id', async () => {
+    const response = await start.POST(
+      postTo('http://localhost:3000/api/cycles/nope/start'),
+      routeParams('not an id'),
+    );
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('PATCH and DELETE /api/cycles/[id]', () => {
+  it('renames a sprint for someone who may manage sprints', async () => {
+    const { teamId } = await freshTeam();
+    const planned = await createCycle(workspace.admin, { teamId, name: 'Before' });
+
+    const response = await cycleById.PATCH(
+      new Request(`http://localhost:3000/api/cycles/${planned.cycle.id}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'After' }),
+      }),
+      routeParams(planned.cycle.id),
+    );
+
+    expect(response.status).toBe(200);
+    expect(cycleEnvelope.parse(await response.json()).cycle.name).toBe('After');
+  });
+
+  it('refuses a rename and a delete from a role that cannot manage sprints', async () => {
+    const { teamId } = await freshTeam();
+    const planned = await createCycle(workspace.admin, { teamId, name: 'Untouchable' });
+    asUser(contributorUserId, 'Cass Contributor');
+
+    const renamed = await cycleById.PATCH(
+      new Request(`http://localhost:3000/api/cycles/${planned.cycle.id}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Hijacked' }),
+      }),
+      routeParams(planned.cycle.id),
+    );
+    expect(renamed.status).toBe(403);
+
+    const deleted = await cycleById.DELETE(
+      new Request(`http://localhost:3000/api/cycles/${planned.cycle.id}`, { method: 'DELETE' }),
+      routeParams(planned.cycle.id),
+    );
+    expect(deleted.status).toBe(403);
+    expect((await storedCycle(planned.cycle.id)).name).toBe('Untouchable');
+  });
+});
+
+describe('POST /api/cycles/[id]/complete', () => {
+  it('closes the sprint and rolls the unfinished work into the next one', async () => {
+    const { teamId, runningCycleId } = await freshTeam();
+    const [state] = await db
+      .select()
+      .from(schema.workflowState)
+      .where(eq(schema.workflowState.teamId, teamId));
+    if (state === undefined) throw new Error('the team has no workflow state');
+    await db.insert(schema.issue).values({
+      id: 'issue_rolls_over',
+      organizationId: workspace.organizationId,
+      teamId,
+      number: 1,
+      identifier: 'SQ-1',
+      title: 'Carried',
+      stateId: state.id,
+      creatorId: workspace.adminUser.id,
+      cycleId: runningCycleId,
+    });
+
+    const response = await complete.POST(
+      postTo(`http://localhost:3000/api/cycles/${runningCycleId}/complete`),
+      routeParams(runningCycleId),
+    );
+    const payload = z
+      .object({
+        cycle: cycleSchema,
+        nextCycle: cycleSchema,
+        rolledOverIssueIds: z.array(z.string()),
+      })
+      .parse(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(payload.cycle.completedAt).not.toBeNull();
+    expect(payload.rolledOverIssueIds).toEqual(['issue_rolls_over']);
+
+    const [moved] = await db
+      .select()
+      .from(schema.issue)
+      .where(eq(schema.issue.id, 'issue_rolls_over'));
+    expect(moved?.cycleId).toBe(payload.nextCycle.id);
+  });
+
+  it('refuses a role that cannot manage sprints and leaves the sprint open', async () => {
+    const { runningCycleId } = await freshTeam();
+    asUser(contributorUserId, 'Cass Contributor');
+
+    const response = await complete.POST(
+      postTo(`http://localhost:3000/api/cycles/${runningCycleId}/complete`),
+      routeParams(runningCycleId),
+    );
+
+    expect(response.status).toBe(403);
+    expect((await storedCycle(runningCycleId)).completedAt).toBeNull();
+  });
+});

--- a/apps/web/tests/features/cycles/cycle-analytics.test.tsx
+++ b/apps/web/tests/features/cycles/cycle-analytics.test.tsx
@@ -29,6 +29,7 @@ function cycleWith(overrides: ProgressOverrides): CycleView {
     teamName: 'Engineering',
     startsAt: '2026-01-01T00:00:00.000Z',
     endsAt: '2026-01-15T00:00:00.000Z',
+    completedAt: null,
     groups: [],
     assignees: [{ id: 'member_1', name: 'Ada Lovelace', image: null, scope: 3, completed: 2 }],
     progress: {

--- a/apps/web/tests/features/cycles/sprint-actions.test.tsx
+++ b/apps/web/tests/features/cycles/sprint-actions.test.tsx
@@ -180,7 +180,7 @@ describe('sprint controls on the sprint panel', () => {
     expect(calls[0]?.body).toBe(JSON.stringify({ teamId: 'team_eng' }));
   });
 
-  it('sends the name and both dates when a sprint is edited', async () => {
+  it('sends only the name when a sprint is renamed and its dates are left alone', async () => {
     renderPanel({ cycle: RUNNING, canManage: true });
     const user = userEvent.setup();
 
@@ -193,9 +193,36 @@ describe('sprint controls on the sprint panel', () => {
     await waitFor(() => expect(calls).toHaveLength(1));
     expect(calls[0]?.url).toBe('/api/cycles/cycle_running');
     expect(calls[0]?.method).toBe('PATCH');
-    expect(calls[0]?.body).toBe(
-      JSON.stringify({ name: 'Renamed', startsAt: '2026-01-01', endsAt: '2026-01-15' }),
-    );
+    expect(calls[0]?.body).toBe(JSON.stringify({ name: 'Renamed' }));
+  });
+
+  it('never sends back a day that would drag a started sprint to midnight', async () => {
+    const started: CycleView = { ...RUNNING, startsAt: '2026-01-01T14:32:07.000Z' };
+    renderPanel({ cycle: started, canManage: true });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('sprint-edit-cycle_running'));
+    const name = await screen.findByTestId('sprint-edit-dialog-name');
+    await user.clear(name);
+    await user.type(name, 'Renamed');
+    await user.click(screen.getByTestId('sprint-edit-dialog-submit'));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(JSON.parse(calls[0]?.body ?? '{}')).not.toHaveProperty('startsAt');
+  });
+
+  it('sends the day the user actually moved', async () => {
+    renderPanel({ cycle: RUNNING, canManage: true });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('sprint-edit-cycle_running'));
+    const endsAt = await screen.findByTestId('sprint-edit-dialog-ends');
+    await user.clear(endsAt);
+    await user.type(endsAt, '2026-01-22');
+    await user.click(screen.getByTestId('sprint-edit-dialog-submit'));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0]?.body).toBe(JSON.stringify({ name: 'Sprint 4', endsAt: '2026-01-22' }));
   });
 
   it('deletes a planned sprint only after the confirmation is taken', async () => {

--- a/apps/web/tests/features/cycles/sprint-actions.test.tsx
+++ b/apps/web/tests/features/cycles/sprint-actions.test.tsx
@@ -1,0 +1,214 @@
+import { afterAll, afterEach, describe, expect, it, mock } from 'bun:test';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { ToastProvider } from '@/components/ui/toast.tsx';
+import type { CycleView, UpcomingCycleView } from '@/features/cycles/data.ts';
+
+const calls: { url: string; method: string; body: string | undefined }[] = [];
+const originalFetch = globalThis.fetch;
+
+globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+  calls.push({
+    url: String(input),
+    method: init?.method ?? 'GET',
+    body: typeof init?.body === 'string' ? init.body : undefined,
+  });
+  return Promise.resolve(
+    new Response(
+      JSON.stringify({
+        cycle: {
+          id: 'cycle_next',
+          teamId: 'team_eng',
+          number: 5,
+          name: 'Sprint 5',
+          startsAt: '2026-02-01T00:00:00.000Z',
+          endsAt: '2026-02-15T00:00:00.000Z',
+          completedAt: null,
+        },
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ),
+  );
+}) as typeof fetch;
+
+const refreshes: number[] = [];
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({
+    refresh: () => {
+      refreshes.push(Date.now());
+    },
+    push: () => undefined,
+  }),
+}));
+
+const { CyclePanel } = await import('@/features/cycles/cycle-board.tsx');
+
+const TEAM = { id: 'team_eng', key: 'ENG', name: 'Engineering' };
+
+const RUNNING: CycleView = {
+  id: 'cycle_running',
+  name: 'Sprint 4',
+  number: 4,
+  teamId: TEAM.id,
+  teamKey: TEAM.key,
+  teamName: TEAM.name,
+  startsAt: '2026-01-01T00:00:00.000Z',
+  endsAt: '2026-01-15T00:00:00.000Z',
+  completedAt: null,
+  groups: [],
+  assignees: [],
+  progress: {
+    cycleId: 'cycle_running',
+    scope: 0,
+    started: 0,
+    completed: 0,
+    canceled: 0,
+    estimated: 0,
+    points: { scope: 0, started: 0, completed: 0 },
+    changes: { added: 0, addedPoints: 0, removed: 0, removedPoints: 0 },
+    burnUp: [],
+  },
+};
+
+const CLOSED: CycleView = { ...RUNNING, completedAt: '2026-01-15T09:00:00.000Z' };
+
+const UPCOMING: UpcomingCycleView[] = [
+  {
+    id: 'cycle_next',
+    name: 'Sprint 5',
+    startsAt: '2026-02-01T00:00:00.000Z',
+    endsAt: '2026-02-15T00:00:00.000Z',
+    teamKey: TEAM.key,
+  },
+];
+
+function renderPanel(options: {
+  cycle: CycleView | null;
+  canManage: boolean;
+  upcoming?: UpcomingCycleView[];
+  runningSprintId?: string | null;
+}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <ToastProvider>{children}</ToastProvider>
+    </QueryClientProvider>
+  );
+  render(
+    <Wrapper>
+      <CyclePanel
+        cycle={options.cycle}
+        upcoming={options.upcoming ?? UPCOMING}
+        team={TEAM}
+        canManage={options.canManage}
+        runningSprintId={options.runningSprintId ?? null}
+      />
+    </Wrapper>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  calls.length = 0;
+  refreshes.length = 0;
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('sprint controls on the sprint panel', () => {
+  it('hides every control from somebody whose role cannot manage sprints', () => {
+    renderPanel({ cycle: RUNNING, canManage: false, runningSprintId: RUNNING.id });
+
+    expect(screen.queryByTestId('sprint-new-team_eng')).toBeNull();
+    expect(screen.queryByTestId('sprint-complete-cycle_running')).toBeNull();
+    expect(screen.queryByTestId('sprint-edit-cycle_running')).toBeNull();
+    expect(screen.queryByTestId('sprint-start-cycle_next')).toBeNull();
+    expect(screen.queryByTestId('sprint-delete-cycle_next')).toBeNull();
+  });
+
+  it('offers create, edit and complete while a sprint is running', () => {
+    renderPanel({ cycle: RUNNING, canManage: true, runningSprintId: RUNNING.id });
+
+    expect(screen.getByTestId('sprint-new-team_eng')).toBeVisible();
+    expect(screen.getByTestId('sprint-edit-cycle_running')).toBeVisible();
+    expect(screen.getByTestId('sprint-complete-cycle_running')).toBeVisible();
+    expect(screen.queryByTestId('sprint-start-cycle_next')).toBeNull();
+  });
+
+  it('offers start on a planned sprint once nothing is running', () => {
+    renderPanel({ cycle: null, canManage: true });
+
+    expect(screen.getByTestId('sprint-start-cycle_next')).toBeVisible();
+    expect(screen.getByTestId('sprint-new-team_eng')).toBeVisible();
+  });
+
+  it('leaves a closed sprint alone rather than offering to complete it again', () => {
+    renderPanel({ cycle: CLOSED, canManage: true, runningSprintId: 'cycle_elsewhere' });
+
+    expect(screen.queryByTestId('sprint-complete-cycle_running')).toBeNull();
+    expect(screen.queryByTestId('sprint-edit-cycle_running')).toBeNull();
+    expect(screen.queryByTestId('sprint-start-cycle_next')).toBeNull();
+  });
+
+  it('asks the server to start a sprint without sending a date of its own', async () => {
+    renderPanel({ cycle: null, canManage: true });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('sprint-start-cycle_next'));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0]?.url).toBe('/api/cycles/cycle_next/start');
+    expect(calls[0]?.method).toBe('POST');
+    expect(calls[0]?.body).toBeUndefined();
+    await waitFor(() => expect(refreshes).toHaveLength(1));
+  });
+
+  it('creates a sprint with nothing but the team when the dates are left empty', async () => {
+    renderPanel({ cycle: RUNNING, canManage: true });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('sprint-new-team_eng'));
+    await user.click(await screen.findByTestId('sprint-create-dialog-submit'));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0]?.url).toBe('/api/cycles');
+    expect(calls[0]?.body).toBe(JSON.stringify({ teamId: 'team_eng' }));
+  });
+
+  it('sends the name and both dates when a sprint is edited', async () => {
+    renderPanel({ cycle: RUNNING, canManage: true });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('sprint-edit-cycle_running'));
+    const name = await screen.findByTestId('sprint-edit-dialog-name');
+    await user.clear(name);
+    await user.type(name, 'Renamed');
+    await user.click(screen.getByTestId('sprint-edit-dialog-submit'));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0]?.url).toBe('/api/cycles/cycle_running');
+    expect(calls[0]?.method).toBe('PATCH');
+    expect(calls[0]?.body).toBe(
+      JSON.stringify({ name: 'Renamed', startsAt: '2026-01-01', endsAt: '2026-01-15' }),
+    );
+  });
+
+  it('deletes a planned sprint only after the confirmation is taken', async () => {
+    renderPanel({ cycle: RUNNING, canManage: true });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('sprint-delete-cycle_next'));
+    expect(calls).toHaveLength(0);
+
+    await user.click(await screen.findByTestId('sprint-delete-dialog-confirm'));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0]?.url).toBe('/api/cycles/cycle_next');
+    expect(calls[0]?.method).toBe('DELETE');
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -124,6 +124,7 @@
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
+        "postgres": "^3.4.9",
         "typescript": "5.9.3",
       },
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@types/bun": "1.3.14",
+    "postgres": "^3.4.9",
     "typescript": "5.9.3"
   }
 }

--- a/packages/core/src/work/cycle-service.ts
+++ b/packages/core/src/work/cycle-service.ts
@@ -43,6 +43,23 @@ async function lockTeamCycles(executor: Executor, teamId: string): Promise<void>
   await executor.execute(sql`select pg_advisory_xact_lock(hashtext(${`cycle:${teamId}`}))`);
 }
 
+async function requireCycleForUpdate(
+  executor: Executor,
+  principal: Principal,
+  cycleId: string,
+): Promise<CycleRow> {
+  const [found] = await executor
+    .select()
+    .from(schema.cycle)
+    .where(
+      and(eq(schema.cycle.id, cycleId), eq(schema.cycle.organizationId, principal.organizationId)),
+    )
+    .limit(1);
+  const cycle = requireRow(found, 'That cycle does not exist.');
+  assertInTeam(principal, teamScope(cycle));
+  return cycle;
+}
+
 async function assertCycleWindow(
   executor: Executor,
   window: { teamId: string; startsAt: Date; endsAt: Date; excludingCycleId: string | null },
@@ -154,18 +171,7 @@ export async function updateCycle(
   const parsed = cycleUpdateSchema.parse(input);
 
   return await db.transaction(async (tx) => {
-    const [found] = await tx
-      .select()
-      .from(schema.cycle)
-      .where(
-        and(
-          eq(schema.cycle.id, cycleId),
-          eq(schema.cycle.organizationId, principal.organizationId),
-        ),
-      )
-      .limit(1);
-    const current = requireRow(found, 'That cycle does not exist.');
-    assertInTeam(principal, teamScope(current));
+    const current = await requireCycleForUpdate(tx, principal, cycleId);
 
     const values: Partial<typeof schema.cycle.$inferInsert> = {};
     if (parsed.name !== undefined) values.name = parsed.name;
@@ -237,6 +243,14 @@ async function assertNothingRunning(
   }
 }
 
+function assertStartable(cycle: CycleRow, now: Date): void {
+  if (cycle.archivedAt !== null) throw conflict('That sprint has been archived.');
+  if (cycle.completedAt !== null) throw conflict('That sprint is already complete.');
+  if (cycle.startsAt.getTime() <= now.getTime()) {
+    throw conflict('That sprint is already under way.');
+  }
+}
+
 export async function startCycle(
   principal: Principal,
   cycleId: string,
@@ -245,31 +259,17 @@ export async function startCycle(
   assertCan(principal, 'cycle:manage');
 
   return await db.transaction(async (tx) => {
-    const [found] = await tx
-      .select()
-      .from(schema.cycle)
-      .where(
-        and(
-          eq(schema.cycle.id, cycleId),
-          eq(schema.cycle.organizationId, principal.organizationId),
-        ),
-      )
-      .limit(1);
-    const current = requireRow(found, 'That cycle does not exist.');
-    assertInTeam(principal, teamScope(current));
-    if (current.archivedAt !== null) throw conflict('That sprint has been archived.');
-    if (current.completedAt !== null) throw conflict('That sprint is already complete.');
-    if (current.startsAt.getTime() <= now.getTime()) {
-      throw conflict('That sprint is already under way.');
-    }
-
+    const current = await requireCycleForUpdate(tx, principal, cycleId);
     await lockTeamCycles(tx, current.teamId);
-    await assertNothingRunning(tx, current.teamId, current.id, now);
+    const locked = await requireCycleForUpdate(tx, principal, cycleId);
+
+    assertStartable(locked, now);
+    await assertNothingRunning(tx, locked.teamId, locked.id, now);
     await assertCycleWindow(tx, {
-      teamId: current.teamId,
+      teamId: locked.teamId,
       startsAt: now,
-      endsAt: current.endsAt,
-      excludingCycleId: current.id,
+      endsAt: locked.endsAt,
+      excludingCycleId: locked.id,
     });
 
     const syncId = await nextSyncId(tx);
@@ -277,7 +277,7 @@ export async function startCycle(
     const [updated] = await tx
       .update(schema.cycle)
       .set({ startsAt: now, syncId })
-      .where(eq(schema.cycle.id, current.id))
+      .where(eq(schema.cycle.id, locked.id))
       .returning();
     const cycle = requireRow(updated, 'That cycle does not exist.');
     return {
@@ -302,18 +302,7 @@ export async function deleteCycle(principal: Principal, cycleId: string): Promis
   assertCan(principal, 'cycle:manage');
 
   return await db.transaction(async (tx) => {
-    const [existing] = await tx
-      .select()
-      .from(schema.cycle)
-      .where(
-        and(
-          eq(schema.cycle.id, cycleId),
-          eq(schema.cycle.organizationId, principal.organizationId),
-        ),
-      )
-      .limit(1);
-    const cycle = requireRow(existing, 'That cycle does not exist.');
-    assertInTeam(principal, teamScope(cycle));
+    const cycle = await requireCycleForUpdate(tx, principal, cycleId);
 
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
@@ -860,26 +849,10 @@ export async function completeCycle(
   assertCan(principal, 'cycle:manage');
 
   return await db.transaction(async (tx) => {
-    const [found] = await tx
-      .select()
-      .from(schema.cycle)
-      .where(
-        and(
-          eq(schema.cycle.id, cycleId),
-          eq(schema.cycle.organizationId, principal.organizationId),
-        ),
-      )
-      .limit(1);
-    const cycle = requireRow(found, 'That cycle does not exist.');
-    assertInTeam(principal, teamScope(cycle));
-    await lockTeamCycles(tx, cycle.teamId);
-
-    const [locked] = await tx
-      .select({ completedAt: schema.cycle.completedAt })
-      .from(schema.cycle)
-      .where(eq(schema.cycle.id, cycleId))
-      .limit(1);
-    if (requireRow(locked, 'That cycle does not exist.').completedAt !== null) {
+    const found = await requireCycleForUpdate(tx, principal, cycleId);
+    await lockTeamCycles(tx, found.teamId);
+    const cycle = await requireCycleForUpdate(tx, principal, cycleId);
+    if (cycle.completedAt !== null) {
       throw conflict('That cycle is already complete.');
     }
 

--- a/packages/core/src/work/cycle-service.ts
+++ b/packages/core/src/work/cycle-service.ts
@@ -33,8 +33,14 @@ import { issueScopes } from './issue-service.ts';
 
 export type CycleRow = typeof schema.cycle.$inferSelect;
 
+export const DEFAULT_SPRINT_DAYS = 14;
+
 function cycleScopes(row: CycleRow): string[] {
   return [scopes.team(row.teamId)];
+}
+
+async function lockTeamCycles(executor: Executor, teamId: string): Promise<void> {
+  await executor.execute(sql`select pg_advisory_xact_lock(hashtext(${`cycle:${teamId}`}))`);
 }
 
 async function assertCycleWindow(
@@ -44,7 +50,7 @@ async function assertCycleWindow(
   if (window.endsAt.getTime() <= window.startsAt.getTime()) {
     throw conflict('A cycle has to end after it starts.');
   }
-  await executor.execute(sql`select pg_advisory_xact_lock(hashtext(${`cycle:${window.teamId}`}))`);
+  await lockTeamCycles(executor, window.teamId);
   const [clash] = await executor
     .select({ id: schema.cycle.id, name: schema.cycle.name })
     .from(schema.cycle)
@@ -52,6 +58,7 @@ async function assertCycleWindow(
       and(
         eq(schema.cycle.teamId, window.teamId),
         isNull(schema.cycle.archivedAt),
+        isNull(schema.cycle.completedAt),
         lt(schema.cycle.startsAt, window.endsAt),
         gt(schema.cycle.endsAt, window.startsAt),
         window.excludingCycleId === null ? undefined : ne(schema.cycle.id, window.excludingCycleId),
@@ -73,18 +80,34 @@ async function nextCycleNumber(executor: Executor, teamId: string): Promise<numb
   return (row?.number ?? 0) + 1;
 }
 
+async function afterTheLastSprint(executor: Executor, teamId: string, now: Date): Promise<Date> {
+  const [latest] = await executor
+    .select({ endsAt: schema.cycle.endsAt })
+    .from(schema.cycle)
+    .where(and(eq(schema.cycle.teamId, teamId), isNull(schema.cycle.archivedAt)))
+    .orderBy(desc(schema.cycle.endsAt))
+    .limit(1);
+  const today = startOfUtcDay(now);
+  if (latest === undefined) return today;
+  return latest.endsAt.getTime() > today.getTime() ? latest.endsAt : today;
+}
+
 export async function createCycle(
   principal: Principal,
   input: unknown,
+  now: Date = new Date(),
 ): Promise<{ cycle: CycleRow; actions: SyncAction[] }> {
   assertCan(principal, 'cycle:manage');
   const parsed = cycleCreateSchema.parse(input);
   return await db.transaction(async (tx) => {
     const team = await requireTeam(principal, parsed.teamId, tx);
+    await lockTeamCycles(tx, team.id);
+    const startsAt = parsed.startsAt ?? (await afterTheLastSprint(tx, team.id, now));
+    const endsAt = parsed.endsAt ?? addUtcDays(startsAt, DEFAULT_SPRINT_DAYS);
     await assertCycleWindow(tx, {
       teamId: parsed.teamId,
-      startsAt: parsed.startsAt,
-      endsAt: parsed.endsAt,
+      startsAt,
+      endsAt,
       excludingCycleId: null,
     });
     const syncId = await nextSyncId(tx);
@@ -98,8 +121,8 @@ export async function createCycle(
         teamId: team.id,
         number,
         name: parsed.name ?? `Sprint ${number}`,
-        startsAt: parsed.startsAt,
-        endsAt: parsed.endsAt,
+        startsAt,
+        endsAt,
         syncId,
       })
       .returning();
@@ -169,6 +192,92 @@ export async function updateCycle(
           eq(schema.cycle.organizationId, principal.organizationId),
         ),
       )
+      .returning();
+    const cycle = requireRow(updated, 'That cycle does not exist.');
+    return {
+      cycle,
+      actions: [
+        buildSyncAction({
+          syncId,
+          organizationId: principal.organizationId,
+          scopes: cycleScopes(cycle),
+          action: 'update',
+          model: 'cycle',
+          modelId: cycle.id,
+          data: cycle,
+          actor,
+        }),
+      ],
+    };
+  });
+}
+
+async function assertNothingRunning(
+  executor: Executor,
+  teamId: string,
+  exceptCycleId: string,
+  now: Date,
+): Promise<void> {
+  const [running] = await executor
+    .select({ name: schema.cycle.name })
+    .from(schema.cycle)
+    .where(
+      and(
+        eq(schema.cycle.teamId, teamId),
+        isNull(schema.cycle.archivedAt),
+        isNull(schema.cycle.completedAt),
+        ne(schema.cycle.id, exceptCycleId),
+        lte(schema.cycle.startsAt, now),
+        gt(schema.cycle.endsAt, now),
+      ),
+    )
+    .limit(1);
+  if (running !== undefined) {
+    throw conflict(`${running.name} is still running. Complete it before starting another.`);
+  }
+}
+
+export async function startCycle(
+  principal: Principal,
+  cycleId: string,
+  now: Date = new Date(),
+): Promise<{ cycle: CycleRow; actions: SyncAction[] }> {
+  assertCan(principal, 'cycle:manage');
+
+  return await db.transaction(async (tx) => {
+    const [found] = await tx
+      .select()
+      .from(schema.cycle)
+      .where(
+        and(
+          eq(schema.cycle.id, cycleId),
+          eq(schema.cycle.organizationId, principal.organizationId),
+        ),
+      )
+      .limit(1);
+    const current = requireRow(found, 'That cycle does not exist.');
+    assertInTeam(principal, teamScope(current));
+    if (current.archivedAt !== null) throw conflict('That sprint has been archived.');
+    if (current.completedAt !== null) throw conflict('That sprint is already complete.');
+    if (current.startsAt.getTime() <= now.getTime()) {
+      throw conflict('That sprint is already under way.');
+    }
+
+    await lockTeamCycles(tx, current.teamId);
+    await assertNothingRunning(tx, current.teamId, current.id, now);
+    await assertCycleWindow(tx, {
+      teamId: current.teamId,
+      startsAt: now,
+      endsAt: current.endsAt,
+      excludingCycleId: current.id,
+    });
+
+    const syncId = await nextSyncId(tx);
+    const actor = await principalActor(tx, principal);
+    const [updated] = await tx
+      .update(schema.cycle)
+      .set({ startsAt: now, syncId })
+      .where(eq(schema.cycle.id, current.id))
       .returning();
     const cycle = requireRow(updated, 'That cycle does not exist.');
     return {
@@ -763,7 +872,7 @@ export async function completeCycle(
       .limit(1);
     const cycle = requireRow(found, 'That cycle does not exist.');
     assertInTeam(principal, teamScope(cycle));
-    await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${`cycle:${cycle.teamId}`}))`);
+    await lockTeamCycles(tx, cycle.teamId);
 
     const [locked] = await tx
       .select({ completedAt: schema.cycle.completedAt })

--- a/packages/core/tests/support/interleave.ts
+++ b/packages/core/tests/support/interleave.ts
@@ -1,0 +1,81 @@
+import postgres from 'postgres';
+
+const POLL_INTERVAL_MS = 10;
+const WAIT_TIMEOUT_MS = 10_000;
+
+export type RawClient = ReturnType<typeof postgres>;
+
+export interface LockCrossing<T> {
+  readonly teamId: string;
+  readonly race: () => Promise<T>;
+  readonly interlope: (client: RawClient) => Promise<void>;
+}
+
+function requireDatabaseUrl(): string {
+  const url = process.env['DATABASE_URL'];
+  if (url === undefined || url.length === 0) {
+    throw new Error('DATABASE_URL is not set, so no second connection can be opened.');
+  }
+  return url;
+}
+
+function settle<T>(promise: Promise<T>): Promise<PromiseSettledResult<T>> {
+  return promise.then(
+    (value): PromiseSettledResult<T> => ({ status: 'fulfilled', value }),
+    (reason: unknown): PromiseSettledResult<T> => ({ status: 'rejected', reason }),
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function queuedBehindAnAdvisoryLock(client: RawClient): Promise<number> {
+  const rows = await client<{ waiting: number }[]>`
+    select count(*)::int as waiting
+    from pg_locks
+    where locktype = 'advisory'
+      and not granted
+      and database = (select oid from pg_database where datname = current_database())
+  `;
+  return rows[0]?.waiting ?? 0;
+}
+
+async function awaitOneWaiter(client: RawClient): Promise<void> {
+  const deadline = Date.now() + WAIT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if ((await queuedBehindAnAdvisoryLock(client)) > 0) return;
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    'Nothing ever queued behind the team lock. The racing call either finished without taking it or never reached it.',
+  );
+}
+
+export async function raceAcrossTeamCycleLock<T>(
+  crossing: LockCrossing<T>,
+): Promise<PromiseSettledResult<T>> {
+  const client = postgres(requireDatabaseUrl(), {
+    max: 1,
+    idle_timeout: 5,
+    onnotice: () => undefined,
+  });
+  try {
+    await client.unsafe('begin');
+    await client`select pg_advisory_xact_lock(hashtext(${`cycle:${crossing.teamId}`}))`;
+    const racing = settle(crossing.race());
+    try {
+      await awaitOneWaiter(client);
+      await crossing.interlope(client);
+      await client.unsafe('commit');
+    } finally {
+      await client.unsafe('rollback').catch(() => undefined);
+      await racing;
+    }
+    return await racing;
+  } finally {
+    await client.end();
+  }
+}

--- a/packages/core/tests/work/cycle-service.test.ts
+++ b/packages/core/tests/work/cycle-service.test.ts
@@ -28,6 +28,7 @@ import {
   updateCycle,
 } from '../../src/work/cycle-service.ts';
 import { createIssue, updateIssue } from '../../src/work/issue-service.ts';
+import { raceAcrossTeamCycleLock } from '../support/interleave.ts';
 
 let workspace: Workspace;
 
@@ -309,6 +310,62 @@ describe('startCycle', () => {
     const planned = await plannedSprint();
     const vega = await createWorkspace('Vega');
     await expect(startCycle(vega.admin, planned.id)).rejects.toMatchObject({ code: 'not_found' });
+  });
+
+  describe('when another transaction commits while it waits for the team lock', () => {
+    async function readyToStart() {
+      const planned = await plannedSprint();
+      await completeCycle(workspace.admin, (await firstCycle()).id);
+      return planned;
+    }
+
+    function reasonOf(outcome: PromiseSettledResult<unknown>): unknown {
+      return outcome.status === 'rejected' ? outcome.reason : undefined;
+    }
+
+    it('leaves the history of a sprint closed behind its back alone', async () => {
+      const planned = await readyToStart();
+      const closedAt = daysFromNow(1);
+
+      const outcome = await raceAcrossTeamCycleLock({
+        teamId: workspace.teamId,
+        race: () => startCycle(workspace.admin, planned.id, daysFromNow(20)),
+        interlope: async (client) => {
+          await client`update cycle set completed_at = ${closedAt} where id = ${planned.id}`;
+        },
+      });
+
+      expect(outcome.status).toBe('rejected');
+      expect(reasonOf(outcome)).toMatchObject({ code: 'conflict' });
+
+      const after = await getCycle(workspace.admin, planned.id);
+      expect(after.completedAt?.getTime()).toBe(closedAt.getTime());
+      expect(after.startsAt.getTime()).toBe(planned.startsAt.getTime());
+    });
+
+    it('checks the dates it finds after the lock, not the ones it read before', async () => {
+      const planned = await readyToStart();
+      const movedStart = daysFromNow(16);
+      const movedEnd = daysFromNow(18);
+
+      const outcome = await raceAcrossTeamCycleLock({
+        teamId: workspace.teamId,
+        race: () => startCycle(workspace.admin, planned.id, daysFromNow(20)),
+        interlope: async (client) => {
+          await client`
+            update cycle set starts_at = ${movedStart}, ends_at = ${movedEnd}
+            where id = ${planned.id}
+          `;
+        },
+      });
+
+      expect(outcome.status).toBe('rejected');
+      expect(reasonOf(outcome)).toMatchObject({ code: 'conflict' });
+
+      const after = await getCycle(workspace.admin, planned.id);
+      expect(after.startsAt.getTime()).toBe(movedStart.getTime());
+      expect(after.endsAt.getTime()).toBe(movedEnd.getTime());
+    });
   });
 });
 

--- a/packages/core/tests/work/cycle-service.test.ts
+++ b/packages/core/tests/work/cycle-service.test.ts
@@ -23,6 +23,7 @@ import {
   pastCycles,
   sprintOutcome,
   sprintOutcomes,
+  startCycle,
   upcomingCycles,
   updateCycle,
 } from '../../src/work/cycle-service.ts';
@@ -114,6 +115,52 @@ describe('cycle window invariant', () => {
     const { cycle } = await createCycle(workspace.admin, { teamId: other.team.id, ...window });
     expect(cycle.teamId).toBe(other.team.id);
   });
+
+  it('lets a finished sprint hand its calendar back', async () => {
+    const bootstrap = await firstCycle();
+    await completeCycle(workspace.admin, bootstrap.id);
+
+    const { cycle } = await createCycle(workspace.admin, {
+      teamId: workspace.teamId,
+      name: 'Second attempt',
+      startsAt: bootstrap.startsAt,
+      endsAt: bootstrap.endsAt,
+    });
+
+    expect(cycle.id).not.toBe(bootstrap.id);
+    expect(cycle.startsAt.getTime()).toBe(bootstrap.startsAt.getTime());
+  });
+
+  it('derives a two week window when no end date is given', async () => {
+    const startsAt = daysFromNow(30);
+    const { cycle } = await createCycle(workspace.admin, {
+      teamId: workspace.teamId,
+      startsAt,
+    });
+    expect(cycle.endsAt.getTime()).toBe(startsAt.getTime() + 14 * 86_400_000);
+  });
+
+  it('appends a sprint after the last one when no dates are given at all', async () => {
+    const bootstrap = await firstCycle();
+    const { cycle } = await createCycle(workspace.admin, { teamId: workspace.teamId });
+
+    expect(cycle.startsAt.getTime()).toBe(bootstrap.endsAt.getTime());
+    expect(cycle.endsAt.getTime()).toBe(bootstrap.endsAt.getTime() + 14 * 86_400_000);
+
+    const { cycle: third } = await createCycle(workspace.admin, { teamId: workspace.teamId });
+    expect(third.startsAt.getTime()).toBe(cycle.endsAt.getTime());
+  });
+
+  it('starts an appended sprint today when the team has no sprint left in the future', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Platform', key: 'PLAT' });
+    const now = new Date('2038-03-09T11:00:00.000Z');
+    const { cycle } = await createCycle(
+      workspace.admin,
+      { teamId: other.team.id, name: 'Way ahead' },
+      now,
+    );
+    expect(cycle.startsAt.toISOString()).toBe('2038-03-09T00:00:00.000Z');
+  });
 });
 
 describe('updateCycle', () => {
@@ -164,6 +211,104 @@ describe('updateCycle', () => {
       endsAt: new Date(cycle.endsAt.getTime() + 86_400_000),
     });
     expect(shifted.endsAt.getTime()).toBe(cycle.endsAt.getTime() + 86_400_000);
+  });
+});
+
+describe('startCycle', () => {
+  async function plannedSprint() {
+    const { cycle } = await createCycle(workspace.admin, {
+      teamId: workspace.teamId,
+      name: 'Planned',
+      startsAt: daysFromNow(30),
+      endsAt: daysFromNow(44),
+    });
+    return cycle;
+  }
+
+  it('pulls a planned sprint to the server clock so it becomes the running one', async () => {
+    const planned = await plannedSprint();
+    await completeCycle(workspace.admin, (await firstCycle()).id);
+    const at = daysFromNow(20);
+
+    const { cycle, actions } = await startCycle(workspace.admin, planned.id, at);
+
+    expect(cycle.startsAt.getTime()).toBe(at.getTime());
+    expect(cycle.endsAt.getTime()).toBe(planned.endsAt.getTime());
+    expect(actions[0]?.scopes).toEqual([scopes.team(workspace.teamId)]);
+
+    const running = await activeCycle(workspace.admin, workspace.teamId, at);
+    expect(running?.id).toBe(planned.id);
+  });
+
+  it('refuses to start a second sprint while one is still running', async () => {
+    const planned = await plannedSprint();
+    const running = await firstCycle();
+
+    await expect(startCycle(workspace.admin, planned.id)).rejects.toMatchObject({
+      code: 'conflict',
+    });
+
+    const untouched = await getCycle(workspace.admin, planned.id);
+    expect(untouched.startsAt.getTime()).toBe(planned.startsAt.getTime());
+    expect((await activeCycle(workspace.admin, workspace.teamId))?.id).toBe(running.id);
+  });
+
+  it('refuses a sprint that is already under way', async () => {
+    const running = await firstCycle();
+    await expect(startCycle(workspace.admin, running.id)).rejects.toMatchObject({
+      code: 'conflict',
+    });
+  });
+
+  it('refuses a closed sprint even when its start date is still ahead', async () => {
+    const first = await completeCycle(workspace.admin, (await firstCycle()).id);
+    const successor = first.nextCycle;
+    expect(successor.startsAt.getTime()).toBeGreaterThan(Date.now());
+    await completeCycle(workspace.admin, successor.id);
+
+    await expect(startCycle(workspace.admin, successor.id)).rejects.toMatchObject({
+      code: 'conflict',
+    });
+  });
+
+  it('refuses to swallow a sprint already scheduled in between', async () => {
+    const later = await plannedSprint();
+    await completeCycle(workspace.admin, (await firstCycle()).id);
+    await createCycle(workspace.admin, {
+      teamId: workspace.teamId,
+      name: 'In between',
+      startsAt: daysFromNow(16),
+      endsAt: daysFromNow(20),
+    });
+
+    await expect(startCycle(workspace.admin, later.id)).rejects.toMatchObject({
+      code: 'conflict',
+    });
+  });
+
+  it('refuses a role that cannot manage sprints, and a member of another team', async () => {
+    const planned = await plannedSprint();
+    await completeCycle(workspace.admin, (await firstCycle()).id);
+
+    const contributor = await addMember(workspace, 'contributor');
+    await expect(startCycle(contributor.principal, planned.id)).rejects.toMatchObject({
+      code: 'forbidden',
+    });
+
+    const other = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const outsider = await addMember(workspace, 'member', { teamIds: [other.team.id] });
+    await expect(startCycle(outsider.principal, planned.id)).rejects.toMatchObject({
+      code: 'forbidden',
+    });
+
+    const untouched = await getCycle(workspace.admin, planned.id);
+    expect(untouched.startsAt.getTime()).toBe(planned.startsAt.getTime());
+  });
+
+  it('refuses a sprint in another workspace', async () => {
+    const planned = await plannedSprint();
+    const vega = await createWorkspace('Vega');
+    await expect(startCycle(vega.admin, planned.id)).rejects.toMatchObject({ code: 'not_found' });
   });
 });
 

--- a/packages/mcp-server/src/tools/scrum.ts
+++ b/packages/mcp-server/src/tools/scrum.ts
@@ -17,6 +17,7 @@ import {
   type StandupDetail,
   setRotation,
   standupWorkload,
+  startCycle,
   startStandup,
   today,
   updateCycle,
@@ -368,13 +369,20 @@ function registerSprintTools(server: McpServer, principal: Principal): void {
     {
       name: 'create_cycle',
       title: 'Create a sprint',
-      description: 'Open a new sprint (cycle) for a team over a date range.',
+      description:
+        'Open a new sprint (cycle) for a team over a date range. Send neither date and the server appends a two week sprint straight after the last one the team has.',
       readOnly: false,
       inputSchema: {
         team: teamRef,
         name: z.string().optional(),
-        startsAt: instant.describe('ISO timestamp or date the sprint opens.'),
-        endsAt: instant.describe('ISO timestamp or date the sprint closes.'),
+        startsAt: instant
+          .optional()
+          .describe('ISO timestamp or date the sprint opens. Defaults to after the last sprint.'),
+        endsAt: instant
+          .optional()
+          .describe(
+            'ISO timestamp or date the sprint closes. Defaults to two weeks after it opens.',
+          ),
       },
     },
     async (input) => {
@@ -382,8 +390,8 @@ function registerSprintTools(server: McpServer, principal: Principal): void {
       const result = await createCycle(principal, {
         teamId,
         ...(input.name === undefined ? {} : { name: input.name }),
-        startsAt: input.startsAt,
-        endsAt: input.endsAt,
+        ...(input.startsAt === undefined ? {} : { startsAt: input.startsAt }),
+        ...(input.endsAt === undefined ? {} : { endsAt: input.endsAt }),
       });
       await publish(result.actions);
       return { cycle: cycleView(result.cycle) };
@@ -410,6 +418,23 @@ function registerSprintTools(server: McpServer, principal: Principal): void {
         ...(input.startsAt === undefined ? {} : { startsAt: input.startsAt }),
         ...(input.endsAt === undefined ? {} : { endsAt: input.endsAt }),
       });
+      await publish(result.actions);
+      return { cycle: cycleView(result.cycle) };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'start_cycle',
+      title: 'Start a sprint',
+      description:
+        'Start a sprint that has not begun yet, by pulling its start date to now. A sprint has no separate started flag: it runs whenever the clock sits inside its dates and it has not been completed. The sprint keeps its planned end date, and the team has to have no sprint running.',
+      readOnly: false,
+      inputSchema: { cycleId: z.string().min(1) },
+    },
+    async (input) => {
+      const result = await startCycle(principal, input.cycleId);
       await publish(result.actions);
       return { cycle: cycleView(result.cycle) };
     },

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -74,6 +74,7 @@ describe('discovery', () => {
     expect(names).toContain('open_standup');
     expect(names).toContain('run_standup');
     expect(names).toContain('complete_cycle');
+    expect(names).toContain('start_cycle');
     expect(names).toContain('create_milestone');
 
     expect(names).toContain('create_doc');
@@ -523,6 +524,72 @@ describe('sprints over mcp', () => {
     });
     expect((created['cycle'] as { name: string }).name).toBe('Sprint 100');
   });
+
+  it('closes a sprint two weeks out when no end date is given', async () => {
+    const created = await admin.result('create_cycle', {
+      team: workspace.teamKey,
+      name: 'Sprint 101',
+      startsAt: '2033-01-05',
+    });
+    const sprint = created['cycle'] as { startsAt: string; endsAt: string };
+    expect(Date.parse(sprint.endsAt) - Date.parse(sprint.startsAt)).toBe(14 * 86_400_000);
+  });
+
+  it('appends a sprint after the last one when it is given no dates', async () => {
+    const team = await admin.result('create_team', { name: 'Appender', key: 'APND' });
+    const teamKey = (team['team'] as { key: string }).key;
+    const before = await admin.result('list_cycles', { team: teamKey });
+    const last = (before['cycles'] as { endsAt: string }[]).at(-1);
+    if (last === undefined) throw new Error('the new team has no sprint');
+
+    const created = await admin.result('create_cycle', { team: teamKey });
+    const sprint = created['cycle'] as { startsAt: string; endsAt: string };
+
+    expect(sprint.startsAt).toBe(last.endsAt);
+    expect(Date.parse(sprint.endsAt) - Date.parse(sprint.startsAt)).toBe(14 * 86_400_000);
+  });
+
+  it('starts the sprint that follows the one it just closed, and refuses to start it twice', async () => {
+    const team = await admin.result('create_team', { name: 'Runway', key: 'RUNW' });
+    const teamKey = (team['team'] as { key: string }).key;
+
+    const opened = await admin.result('active_cycle', { team: teamKey });
+    const running = opened['cycle'] as { id: string };
+
+    const closed = await admin.result('complete_cycle', { cycleId: running.id });
+    const successor = closed['nextCycle'] as { id: string };
+
+    const between = await admin.result('active_cycle', { team: teamKey });
+    expect(between['cycle']).toBeNull();
+
+    const started = await admin.result('start_cycle', { cycleId: successor.id });
+    const startsAt = Date.parse((started['cycle'] as { startsAt: string }).startsAt);
+    expect(Math.abs(startsAt - Date.now())).toBeLessThan(60_000);
+
+    const after = await admin.result('active_cycle', { team: teamKey });
+    expect((after['cycle'] as { id: string }).id).toBe(successor.id);
+
+    const again = await admin.call('start_cycle', { cycleId: successor.id });
+    expect(again.isError).toBe(true);
+    expect(errorPayload(again).code).toBe('conflict');
+  });
+
+  it('refuses to start a sprint for somebody whose role cannot manage sprints', async () => {
+    const created = await admin.result('create_cycle', {
+      team: workspace.teamKey,
+      name: 'Sprint 102',
+      startsAt: '2034-01-05',
+    });
+    const sprint = created['cycle'] as { id: string; startsAt: string };
+
+    const denied = await guest.call('start_cycle', { cycleId: sprint.id });
+    expect(denied.isError).toBe(true);
+    expect(errorPayload(denied).code).toBe('forbidden');
+
+    const untouched = await admin.result('list_cycles', { team: workspace.teamKey });
+    const rows = untouched['cycles'] as { id: string; startsAt: string }[];
+    expect(rows.find((row) => row.id === sprint.id)?.startsAt).toBe(sprint.startsAt);
+  });
 });
 
 describe('what a token is allowed to do', () => {
@@ -542,6 +609,7 @@ describe('what a token is allowed to do', () => {
       expect(names).not.toContain('update_issue');
       expect(names).not.toContain('open_standup');
       expect(names).not.toContain('complete_cycle');
+      expect(names).not.toContain('start_cycle');
       expect(names).not.toContain('invite_member');
 
       for (const tool of tools) {

--- a/packages/shared/src/validators/cycle.ts
+++ b/packages/shared/src/validators/cycle.ts
@@ -6,8 +6,8 @@ const instantSchema = z.union([z.string().trim().min(1), z.date()]).pipe(z.coerc
 export const cycleCreateSchema = z.object({
   teamId: idSchema,
   name: z.string().trim().min(1).max(120).optional(),
-  startsAt: instantSchema,
-  endsAt: instantSchema,
+  startsAt: instantSchema.optional(),
+  endsAt: instantSchema.optional(),
 });
 
 export const cycleUpdateSchema = z


### PR DESCRIPTION
## No catchup SQL

This PR adds no table and no column, so there is nothing to apply by hand before it ships.

## What was wrong

Sprints were read only. `/sprints` and `/team/<key>/sprint/active` rendered no action control at
all: `grep -rn "api/cycles" apps/web/src` returned nothing outside `app/api`, so the routes and the
service existed but nothing in the product called them. Driving a sprint meant opening the console
and posting by hand.

## Is "start" a concept

No, and this PR does not invent one. There is no `started_at` column and no start transition. A
sprint is running whenever the clock sits inside `starts_at` and `ends_at` and `completed_at` is
still null, which is exactly what `activeCycle` asks. Completion is the only explicit transition
the model has.

So "Start sprint" means one thing the server can do honestly: pull `starts_at` forward to the
server clock so the sprint becomes the current one. `startCycle` does that and nothing else. The
sprint keeps its planned end date. It refuses an archived sprint, a completed sprint, a sprint that
is already under way, a start that would open a second sprint while one is running, and a start
that would swallow a sprint already scheduled in between.

## The calendar rule, narrowed to what it protects

Two sprints on a team still may not share a day, but the rule now ignores sprints that have been
completed. The invariant that matters is that at most one sprint is running at any instant, and a
completed sprint is not running. Without this, closing a sprint early left its dates blocking the
calendar, so the successor could never be started until its original date arrived.

## Everything the client no longer computes

- Creating a sprint with no end date closes it two weeks after it opens.
- Creating a sprint with no dates at all appends it straight after the team's last sprint, or
  today if the team has none left in the future.
- Starting a sprint takes the date off the server clock. The route reads no body, so a payload
  carrying `startsAt` changes nothing. There is a test for exactly that.

`cycleCreateSchema` now has both dates optional, which is additive: every existing caller still
parses.

## The UI

`/sprints`, `/team/<key>/sprint/active` and `/team/<key>/sprint/<n>` now carry New sprint, Start,
Edit, Complete sprint and Delete. Complete and Delete confirm first, and completing reports how
much rolled into the next sprint. Every one posts to a route and lets the server decide.

The controls are hidden from a role without `cycle:manage`, read from the same
`packages/shared/src/policy` the routes enforce. That is a courtesy. The refusal that counts is the
403 the route returns, and that is what the route tests assert.

## MCP parity

`start_cycle` is new and goes through the same `startCycle`, classified as a write so a read only
token never sees it. `create_cycle` takes the same optional dates as the API. `update_cycle`,
`complete_cycle` and `delete_sprint` already existed, so the full loop is now available to an
agent: create, start, edit, complete, delete.

## Tests, and the mutation that proves each one bites

Every test below was watched failing first, then the production code was broken deliberately and
confirmed RED, then restored.

| Test | Mutation that turns it red |
| --- | --- |
| `cycle window invariant > lets a finished sprint hand its calendar back` | drop `isNull(completedAt)` from the clash query |
| `... > derives a two week window when no end date is given` | default to 7 days |
| `... > appends a sprint after the last one when no dates are given at all` | ignore the last sprint and always start today |
| `... > starts an appended sprint today when the team has no sprint left in the future` | skip `startOfUtcDay` |
| `startCycle > pulls a planned sprint to the server clock ...` | stop writing `startsAt` |
| `startCycle > refuses to start a second sprint while one is still running` | drop the running check |
| `startCycle > refuses a sprint that is already under way` | drop the `startsAt <= now` guard |
| `startCycle > refuses a closed sprint even when its start date is still ahead` | drop the `completedAt` guard |
| `startCycle > refuses to swallow a sprint already scheduled in between` | drop the window check |
| `startCycle > refuses a role that cannot manage sprints, and a member of another team` | drop `assertCan`; drop `assertInTeam` |
| `POST /api/cycles/[id]/start > takes the start date off the server clock ...` | make the route honour `startsAt` from the body |
| `sprint controls > hides every control from somebody whose role cannot manage sprints` | render the header controls without `canManage` |
| `sprint controls > leaves a closed sprint alone ...` | offer Start while a sprint runs elsewhere |
| `sprint controls > asks the server to start a sprint without sending a date of its own` | send `{ startsAt }` from the hook |
| `sprint controls > creates a sprint with nothing but the team ...` | compute a start date in the form |
| `sprint controls > deletes a planned sprint only after the confirmation is taken` | mutate straight from the button |
| `sprints over mcp > starts the sprint that follows the one it just closed ...` | rename the tool |
| `what a token is allowed to do > hides every write tool ...` | mark `start_cycle` `readOnly: true` |

One earlier test, two concurrent appends, passed with the lock removed, so it proved nothing and
was deleted rather than kept.

The route tests exercise the real handlers against Postgres with a real session, and each
authorization test also asserts the row did not move, so a 403 that still wrote would fail.

## Not covered

No Playwright spec was added. The e2e suite reseeds the shared dev database and several agents are
using it right now, so a spec that could not be run locally would have been a guess. The existing
`sprints.spec.ts` still drives the API and still passes.

`bun run verify` exits 0 against `main` merged in: 2733 tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes sprint lifecycle operations available through the product UI, API, and MCP while centralizing calendar and start-time decisions in the server.
- Adds create, start, edit, complete, and delete controls with permission-aware rendering and confirmation flows.
- Adds a start endpoint and shared query hooks for sprint mutations.
- Adds server-side sprint defaults, lifecycle validation, team-level serialization, and post-lock row refreshes.
- Extends MCP sprint tooling and adds route, service, concurrency, and component coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported stale-row issue is addressed by re-reading the complete sprint row after acquiring the team advisory lock before start and completion validation.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/work/cycle-service.ts | Adds server-owned sprint defaults and start behavior, narrows overlap checks to open sprints, and refreshes start/completion state after acquiring the team lock. |
| apps/web/src/features/cycles/sprint-actions.tsx | Introduces permission-gated sprint creation, editing, starting, completion, and deletion dialogs and controls. |
| apps/web/src/lib/query/use-sprints.ts | Adds typed client mutations, refresh behavior, success notifications, and error reporting for sprint operations. |
| apps/web/src/app/api/cycles/[id]/start/route.ts | Exposes the authenticated start operation without accepting a client-selected start time. |
| packages/mcp-server/src/tools/scrum.ts | Adds start-cycle MCP support and aligns cycle creation inputs with server-side date defaults. |
| packages/core/tests/work/cycle-service.test.ts | Covers lifecycle invariants, date derivation, authorization, and genuine advisory-lock interleavings. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client as UI or MCP client
  participant API as Sprint API
  participant Service as Cycle service
  participant DB as PostgreSQL
  Client->>API: Start sprint
  API->>Service: startCycle(principal, cycleId)
  Service->>DB: Read cycle and acquire team advisory lock
  Service->>DB: Re-read cycle after lock
  Service->>Service: Validate permissions and lifecycle invariants
  Service->>DB: Update startsAt using server time
  DB-->>Service: Updated sprint
  Service-->>API: Sprint and publication actions
  API-->>Client: Updated sprint
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): stop an unedited sprint date s..."](https://github.com/noveum/orbit/commit/1b0bbda9be5cd50bd577677578f94b56c1e797e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51122988)</sub>

<!-- /greptile_comment -->