### PR TITLE
Show the issues a saved view promises

### DIFF
--- a/apps/web/src/features/filters/filter-bar.tsx
+++ b/apps/web/src/features/filters/filter-bar.tsx
@@ -14,7 +14,7 @@ import type { FilterFieldDefinition } from './filter-fields.tsx';
 import { buildFilterFields, operatorLabel, valueLabel } from './filter-fields.tsx';
 import { FilterMenu } from './filter-menu.tsx';
 import { SaveViewDialog } from './save-view-dialog.tsx';
-import type { ViewConfig, ViewLayoutMode } from './view-config.ts';
+import type { ViewConfig, ViewLayoutMode, ViewScope } from './view-config.ts';
 import { viewConfigToState } from './view-config.ts';
 import type { ViewControls } from './view-controls.tsx';
 
@@ -29,6 +29,7 @@ export interface FilterBarProps {
   readonly controls: ViewControls;
   readonly facets?: IssueFacets['facets'] | undefined;
   readonly savedView?: View | null;
+  readonly savedViewScope?: ViewScope | null;
   readonly dirty?: boolean;
   readonly showSaveView?: boolean;
 }
@@ -42,6 +43,7 @@ export function FilterBar({
   controls,
   facets,
   savedView = null,
+  savedViewScope = null,
   dirty = false,
   showSaveView = true,
 }: FilterBarProps) {
@@ -163,7 +165,7 @@ export function FilterBar({
                   filter: viewConfigToState(
                     config,
                     layout,
-                    { teamId, projectId: null },
+                    savedViewScope ?? { teamId, projectId: null },
                     {
                       visibility: savedView.filter.visibility,
                       locked: savedView.filter.locked,

--- a/apps/web/src/features/views/saved-view-page.tsx
+++ b/apps/web/src/features/views/saved-view-page.tsx
@@ -9,7 +9,7 @@ import { FilterBar } from '@/features/filters/filter-bar.tsx';
 import type { IssueGroup } from '@/features/filters/grouping.ts';
 import { HiddenFooter } from '@/features/filters/hidden-footer.tsx';
 import { LayoutToggle } from '@/features/filters/layout-toggle.tsx';
-import type { ViewConfig, ViewLayoutMode, ViewPage } from '@/features/filters/view-config.ts';
+import type { ViewConfig, ViewLayoutMode } from '@/features/filters/view-config.ts';
 import {
   applyCapabilities,
   viewConfigFromState,
@@ -20,9 +20,9 @@ import { Board } from '@/features/issues/board.tsx';
 import { IssueList } from '@/features/issues/issue-list.tsx';
 import { ListSkeleton } from '@/features/issues/list-skeleton.tsx';
 import { useIssueViewModel } from '@/features/issues/use-issue-view-model.ts';
-import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
 import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
 import { viewLayoutMode } from '@/features/views/view-href.ts';
+import { resolveViewScope } from '@/features/views/view-scope.ts';
 import { ViewsSkeleton } from '@/features/views/views-skeleton.tsx';
 import type { View, WorkflowState } from '@/lib/query/schemas.ts';
 import { useAllIssues } from '@/lib/query/use-issues.ts';
@@ -34,9 +34,10 @@ export interface SavedViewPageProps {
 
 export function SavedViewPage({ viewId }: SavedViewPageProps) {
   const views = useViews();
+  const workspace = useWorkspace();
   const view = (views.data ?? []).find((entry) => entry.id === viewId);
 
-  if (views.isPending) return <ViewsSkeleton />;
+  if (views.isPending || !workspace.ready) return <ViewsSkeleton />;
   if (view === undefined) {
     return (
       <EmptyState
@@ -49,26 +50,6 @@ export function SavedViewPage({ viewId }: SavedViewPageProps) {
   return <SavedViewBody key={view.id} view={view} />;
 }
 
-export function scopeRecord(view: View): Record<string, string> {
-  const scope: Record<string, string> = {};
-  if (view.filter.teamId !== null) scope['teamId'] = view.filter.teamId;
-  if (view.filter.projectId !== null) scope['projectId'] = view.filter.projectId;
-  return scope;
-}
-
-export function scopeLabelOf(view: View, workspace: WorkspaceData): string {
-  const project = workspace.projects.find((entry) => entry.id === view.filter.projectId);
-  if (project !== undefined) return project.name;
-  const team = workspace.teams.find((entry) => entry.id === view.filter.teamId);
-  if (team !== undefined) return team.name;
-  return 'Workspace';
-}
-
-export function viewPageOf(view: View): ViewPage {
-  if (view.filter.projectId !== null) return 'project';
-  return 'saved_view';
-}
-
 function SavedViewBody({ view }: { view: View }) {
   const workspace = useWorkspace();
   const [layout, setLayout] = useState<ViewLayoutMode>(viewLayoutMode(view.layout));
@@ -79,30 +60,28 @@ function SavedViewBody({ view }: { view: View }) {
     setLayout(viewLayoutMode(view.layout));
   }, [view.layout]);
 
-  const page = viewPageOf(view);
+  const scope = useMemo(() => resolveViewScope(view, workspace), [view, workspace]);
+  const page = scope.page;
   const config = useMemo(
     () => applyCapabilities(edited ?? viewConfigFromState(view.filter), page, layout),
     [edited, view.filter, page, layout],
   );
   const controls = useProvideViewControls(page, layout, config);
 
-  const scope = useMemo(() => scopeRecord(view), [view]);
-  const issues = useAllIssues({ filter: config.filter, orderBy: config.orderBy }, scope);
+  const issues = useAllIssues({ filter: config.filter, orderBy: config.orderBy }, scope.params);
   const rows = useMemo(() => issues.data ?? [], [issues.data]);
 
   const model = useIssueViewModel({
-    teamId: view.filter.teamId,
+    teamId: scope.teamId,
     config,
     issues: rows,
     scopeToTeam: false,
-    scope,
+    scope: scope.params,
   });
 
-  const scopeLabel = scopeLabelOf(view, workspace);
-  const pending = viewConfigToState(config, layout, {
-    teamId: view.filter.teamId,
-    projectId: view.filter.projectId,
-  });
+  const scopeLabel = scope.label;
+  const stored = { teamId: view.filter.teamId, projectId: view.filter.projectId };
+  const pending = viewConfigToState(config, layout, stored);
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="saved-view-page">
@@ -120,7 +99,7 @@ function SavedViewBody({ view }: { view: View }) {
       </div>
 
       <FilterBar
-        teamId={view.filter.teamId}
+        teamId={scope.teamId}
         teamName={scopeLabel}
         layout={layout}
         config={config}
@@ -128,6 +107,7 @@ function SavedViewBody({ view }: { view: View }) {
         controls={controls}
         facets={model.facets}
         savedView={view}
+        savedViewScope={stored}
         dirty={viewStateDirty(pending, view.filter)}
       />
 

--- a/apps/web/src/features/views/view-href.ts
+++ b/apps/web/src/features/views/view-href.ts
@@ -1,7 +1,9 @@
 import { withViewParam } from '@/features/filters/use-view-config.ts';
 import type { ViewLayoutMode } from '@/features/filters/view-config.ts';
 import { viewConfigFromState, viewConfigSearch } from '@/features/filters/view-config.ts';
-import type { Team, View } from '@/lib/query/schemas.ts';
+import type { ViewScopeSource } from '@/features/views/view-scope.ts';
+import { resolveViewScope } from '@/features/views/view-scope.ts';
+import type { View } from '@/lib/query/schemas.ts';
 
 export const STANDUP_VIEW_ID = 'virtual:standup';
 
@@ -13,12 +15,11 @@ export function savedViewPath(viewId: string): string {
   return `/views/${encodeURIComponent(viewId)}`;
 }
 
-export function viewHref(view: View, teams: readonly Team[]): string {
+export function viewHref(view: View, source: ViewScopeSource): string {
   if (view.id === STANDUP_VIEW_ID) return '/standup';
 
-  const teamId = view.filter.teamId;
-  const team = teamId === null ? undefined : teams.find((entry) => entry.id === teamId);
-  if (team === undefined) return savedViewPath(view.id);
+  const team = resolveViewScope(view, source).team;
+  if (team === null) return savedViewPath(view.id);
 
   const layout = viewLayoutMode(view.layout);
   const search = viewConfigSearch(viewConfigFromState(view.filter), layout);

--- a/apps/web/src/features/views/view-scope.ts
+++ b/apps/web/src/features/views/view-scope.ts
@@ -1,0 +1,40 @@
+import type { ViewPage } from '@/features/filters/view-config.ts';
+import type { Project, Team, View } from '@/lib/query/schemas.ts';
+
+const WORKSPACE_SCOPE_LABEL = 'Workspace';
+
+export interface ViewScopeSource {
+  readonly teams: readonly Team[];
+  readonly projects: readonly Project[];
+}
+
+export interface ResolvedViewScope {
+  readonly team: Team | null;
+  readonly teamId: string | null;
+  readonly params: Readonly<Record<string, string>>;
+  readonly label: string;
+  readonly page: ViewPage;
+}
+
+function reachable<T extends { readonly id: string }>(
+  entries: readonly T[],
+  id: string | null,
+): T | null {
+  if (id === null) return null;
+  return entries.find((entry) => entry.id === id) ?? null;
+}
+
+export function resolveViewScope(view: View, source: ViewScopeSource): ResolvedViewScope {
+  const project = reachable(source.projects, view.filter.projectId);
+  const team = project === null ? reachable(source.teams, view.filter.teamId) : null;
+  const params: Record<string, string> = {};
+  if (project !== null) params['projectId'] = project.id;
+  if (team !== null) params['teamId'] = team.id;
+  return {
+    team,
+    teamId: team?.id ?? null,
+    params,
+    label: project?.name ?? team?.name ?? WORKSPACE_SCOPE_LABEL,
+    page: project === null ? 'saved_view' : 'project',
+  };
+}

--- a/apps/web/src/features/views/views-page.tsx
+++ b/apps/web/src/features/views/views-page.tsx
@@ -173,7 +173,7 @@ function ViewRow({ view }: { view: View }) {
   const layout = viewLayoutMode(view.layout);
   const owner = workspace.members.find((member) => member.id === view.ownerId);
   const editable = !(view.virtual || view.locked) && view.ownerId === workspace.userId;
-  const href = viewHref(view, workspace.teams);
+  const href = viewHref(view, workspace);
 
   const submitRename = () => {
     const trimmed = name.trim();

--- a/apps/web/tests/app/views/saved-view-route.test.tsx
+++ b/apps/web/tests/app/views/saved-view-route.test.tsx
@@ -1,0 +1,422 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { addMember, createWorkspace, type Workspace } from '@orbit/core/test-support';
+import type { SyncAction } from '@orbit/shared/events';
+import type { Principal } from '@orbit/shared/policy';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement, ReactNode } from 'react';
+import { ToastProvider } from '@/components/ui/toast.tsx';
+import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+
+const core = await import('@orbit/core');
+
+let actor: Principal = { userId: 'nobody', organizationId: 'nobody', role: 'admin', teamIds: [] };
+
+function activeSession() {
+  return Promise.resolve({
+    user: { id: actor.userId, name: 'Signed in', email: 'signed-in@orbit.test' },
+    session: { activeOrganizationId: actor.organizationId },
+  });
+}
+
+function signInAsTheActor(): void {
+  mock.module('@orbit/core', () => ({
+    ...core,
+    publishDeltas: (_actions: readonly SyncAction[]) => Promise.resolve(undefined),
+  }));
+  mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
+  mock.module('next/navigation', () => ({
+    useRouter: () => ({ push: mock(), replace: mock(), refresh: mock(), prefetch: mock() }),
+    usePathname: () => '/views',
+    useSearchParams: () => new URLSearchParams(),
+    redirect: (to: string) => {
+      throw new Error(`redirected to ${to}`);
+    },
+  }));
+  mock.module('@/lib/auth/session.ts', () => ({
+    getSession: activeSession,
+    requireSession: activeSession,
+  }));
+}
+
+signInAsTheActor();
+
+const issuesRoute = await import('@/app/api/issues/route.ts');
+const summaryRoute = await import('@/app/api/issues/summary/route.ts');
+const facetsRoute = await import('@/app/api/issues/facets/route.ts');
+const bootstrapRoute = await import('@/app/api/bootstrap/route.ts');
+const viewsRoute = await import('@/app/api/views/route.ts');
+const viewRoute = await import('@/app/api/views/[id]/route.ts');
+const savedViewRoute = await import('@/app/(app)/views/[id]/page.tsx');
+const workspaceProvider = await import('@/features/issues/workspace-provider.tsx');
+const { bootstrapSchema } = await import('@/lib/query/schemas.ts');
+
+let workspace = workspaceProvider.workspaceFrom(undefined, () => undefined);
+
+mock.module('@/features/issues/workspace-provider.tsx', () => ({
+  ...workspaceProvider,
+  useWorkspace: () => workspace,
+}));
+
+const { CreateViewDialog } = await import('@/features/views/create-view-dialog.tsx');
+
+async function loadWorkspaceFromTheServer(): Promise<void> {
+  const response = await bootstrapRoute.GET(new Request('http://localhost:3000/api/bootstrap'));
+  const payload = bootstrapSchema.parse(await response.json());
+  workspace = workspaceProvider.workspaceFrom(payload, () => undefined);
+}
+
+const requested: string[] = [];
+let realFetch: typeof globalThis.fetch | null = null;
+
+function routeFor(path: string, request: Request): Promise<Response> {
+  if (path.startsWith('/api/issues/summary')) return summaryRoute.GET(request);
+  if (path.startsWith('/api/issues/facets')) return facetsRoute.GET(request);
+  if (path.startsWith('/api/issues')) return issuesRoute.GET(request);
+  if (path.startsWith('/api/bootstrap')) return bootstrapRoute.GET(request);
+  if (path.startsWith('/api/views/')) {
+    const id = path.slice('/api/views/'.length);
+    return viewRoute.PATCH(request, { params: Promise.resolve({ id }) });
+  }
+  if (path.startsWith('/api/views')) {
+    return request.method === 'POST' ? viewsRoute.POST(request) : viewsRoute.GET();
+  }
+  throw new Error(`the page asked for ${path}, which no route in this test serves`);
+}
+
+function serveFromTheRealRoutes(): void {
+  if (realFetch === null) realFetch = globalThis.fetch;
+  globalThis.fetch = ((path: string, init?: RequestInit) => {
+    requested.push(path);
+    return routeFor(path, new Request(`http://localhost:3000${path}`, init));
+  }) as unknown as typeof fetch;
+}
+
+function issueListUrl(): string {
+  const found = requested.find((url) => url.startsWith('/api/issues?'));
+  if (found === undefined) throw new Error(`no issue list request: ${requested.join(' ')}`);
+  return found;
+}
+
+function issueListParams(): URLSearchParams {
+  return new URLSearchParams(issueListUrl().slice('/api/issues?'.length));
+}
+
+function providers(children: ReactNode): ReactElement {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <HotkeyProvider>{children}</HotkeyProvider>
+      </ToastProvider>
+    </QueryClientProvider>
+  );
+}
+
+const SETTLE = { timeout: 15_000, interval: 50 };
+
+async function openView(id: string): Promise<void> {
+  const page = (await savedViewRoute.default({
+    params: Promise.resolve({ id: encodeURIComponent(id) }),
+  })) as ReactElement;
+  await loadWorkspaceFromTheServer();
+  requested.length = 0;
+  render(providers(page));
+  await waitFor(() => {
+    expect(screen.queryByTestId('saved-view-page') !== null).toBe(true);
+  }, SETTLE);
+  await waitFor(() => {
+    expect(requested.some((url) => url.startsWith('/api/issues?'))).toBe(true);
+  }, SETTLE);
+  await waitFor(() => {
+    const painted =
+      screen.queryByTestId('saved-view-list') !== null ||
+      screen.queryByTestId('saved-view-board') !== null ||
+      screen.queryByText('No issues match this view') !== null;
+    expect(painted).toBe(true);
+  }, SETTLE);
+}
+
+function titlesOnScreen(candidates: readonly string[]): string[] {
+  return candidates.filter((title) => screen.queryByText(title) !== null);
+}
+
+function scopeBadge(): string {
+  return screen.getByTestId('view-scope').textContent ?? '';
+}
+
+const ADA_ASSIGNED = 'Ada owns this';
+const ADA_CREATED = 'Ada opened this';
+const BO_ONLY = 'Bo owns and opened this';
+const NOBODY_OWNS = 'Nobody owns this';
+const OVERDUE = 'Due last week';
+const NOT_DUE_YET = 'Due next month';
+const ADA_FOLLOWS = 'Ada follows this';
+const DESIGN_ISSUE = 'Design system tokens';
+
+const NOVA_ISSUES: string[] = [
+  ADA_ASSIGNED,
+  ADA_CREATED,
+  BO_ONLY,
+  NOBODY_OWNS,
+  OVERDUE,
+  NOT_DUE_YET,
+  ADA_FOLLOWS,
+];
+
+const EVERY_ISSUE: string[] = [...NOVA_ISSUES, DESIGN_ISSUE];
+
+let nova: Workspace;
+let designTeamId: string;
+let designViewId: string;
+let projectViewId: string;
+let rebrandProjectId: string;
+let outsider: Principal;
+
+function daysFromNow(days: number): Date {
+  return new Date(Date.now() + days * 86_400_000);
+}
+
+const realWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+const realHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+
+beforeAll(async () => {
+  serveFromTheRealRoutes();
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get: () => 1200,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get: () => 2400,
+  });
+
+  nova = await createWorkspace('Nova');
+  const admin = nova.admin;
+
+  const design = await core.createTeam(admin, { name: 'Design', key: 'DSG' });
+  designTeamId = design.team.id;
+
+  const builder = await addMember(nova, 'member', {
+    name: 'Bo Builder',
+    teamIds: [nova.teamId, designTeamId],
+  });
+  const bo = builder.principal;
+  outsider = (await addMember(nova, 'member', { name: 'Cam Contributor' })).principal;
+
+  const seed = async (author: Principal, title: string, extra: Record<string, unknown> = {}) => {
+    const { issue } = await core.createIssue(author, {
+      teamId: nova.teamId,
+      title,
+      ...extra,
+    });
+    return issue.id;
+  };
+
+  await seed(bo, ADA_ASSIGNED, { assigneeId: admin.userId });
+  await seed(admin, ADA_CREATED, { assigneeId: bo.userId });
+  await seed(bo, BO_ONLY, { assigneeId: bo.userId });
+  await seed(bo, NOBODY_OWNS);
+  await seed(bo, OVERDUE, { assigneeId: bo.userId, dueDate: daysFromNow(-7) });
+  await seed(bo, NOT_DUE_YET, { assigneeId: bo.userId, dueDate: daysFromNow(30) });
+  const followed = await seed(bo, ADA_FOLLOWS, { assigneeId: bo.userId });
+  await core.subscribe(admin, followed);
+
+  const { project } = await core.createProject(admin, {
+    name: 'Rebrand',
+    teamIds: [designTeamId],
+  });
+
+  await core.createIssue(bo, {
+    teamId: designTeamId,
+    title: DESIGN_ISSUE,
+    assigneeId: bo.userId,
+    projectId: project.id,
+  });
+
+  const { view } = await core.createView(admin, {
+    name: 'Design issues',
+    filter: {
+      filter: { kind: 'group', combinator: 'and', children: [] },
+      teamId: designTeamId,
+      visibility: 'workspace',
+    },
+    layout: 'list',
+    groupBy: 'state',
+    shared: true,
+  });
+  designViewId = view.id;
+
+  const rebrand = await core.createView(admin, {
+    name: 'Rebrand work',
+    filter: {
+      filter: { kind: 'group', combinator: 'and', children: [] },
+      projectId: project.id,
+      visibility: 'workspace',
+    },
+    layout: 'list',
+    groupBy: 'state',
+    shared: true,
+  });
+  projectViewId = rebrand.view.id;
+  rebrandProjectId = project.id;
+});
+
+afterAll(() => {
+  if (realFetch !== null) globalThis.fetch = realFetch;
+  if (realWidth !== undefined) {
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', realWidth);
+  }
+  if (realHeight !== undefined) {
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', realHeight);
+  }
+});
+
+beforeEach(() => {
+  serveFromTheRealRoutes();
+  requested.length = 0;
+  actor = nova.admin;
+});
+
+describe('the built in views every workspace ships with', () => {
+  it('shows every issue the reader can see under All issues', async () => {
+    await openView('virtual:all');
+
+    expect(titlesOnScreen(EVERY_ISSUE)).toEqual(EVERY_ISSUE);
+  });
+
+  it('shows only what is assigned to the reader under Assigned to me', async () => {
+    await openView('virtual:assigned');
+
+    expect(titlesOnScreen(EVERY_ISSUE)).toEqual([ADA_ASSIGNED]);
+  });
+
+  it('shows only what the reader opened under Created by me', async () => {
+    await openView('virtual:created');
+
+    expect(titlesOnScreen(EVERY_ISSUE)).toEqual([ADA_CREATED]);
+  });
+
+  it('shows what the reader follows under Subscribed', async () => {
+    await openView('virtual:subscribed');
+
+    expect(titlesOnScreen(EVERY_ISSUE)).toEqual([ADA_ASSIGNED, ADA_CREATED, ADA_FOLLOWS]);
+  });
+
+  it('shows only issues nobody owns under Unassigned', async () => {
+    await openView('virtual:unassigned');
+
+    expect(titlesOnScreen(EVERY_ISSUE)).toEqual([NOBODY_OWNS]);
+  });
+
+  it('shows only issues past their due date under Overdue', async () => {
+    await openView('virtual:overdue');
+
+    expect(titlesOnScreen(EVERY_ISSUE)).toEqual([OVERDUE]);
+  });
+});
+
+describe('a saved view scoped to a team', () => {
+  it('narrows to that team for a reader whose workspace has it', async () => {
+    await openView(designViewId);
+
+    expect(issueListParams().get('teamId')).toBe(designTeamId);
+    expect(requested.filter((url) => url.startsWith('/api/issues?'))).toHaveLength(1);
+    expect(titlesOnScreen(EVERY_ISSUE)).toEqual([DESIGN_ISSUE]);
+    expect(scopeBadge()).toBe('Design');
+  });
+
+  it('falls back to the workspace when the view names a team the reader cannot see', async () => {
+    actor = outsider;
+
+    await openView(designViewId);
+
+    expect(issueListParams().get('teamId')).toBeNull();
+    expect(titlesOnScreen(EVERY_ISSUE)).toEqual(NOVA_ISSUES);
+    expect(scopeBadge()).toBe('Workspace');
+  });
+
+  it('never hands the reader an issue from the team they are not on', async () => {
+    actor = outsider;
+
+    await openView(designViewId);
+
+    expect(titlesOnScreen([DESIGN_ISSUE])).toEqual([]);
+  });
+
+  it('keeps the team the owner stored when they save a change from that page', async () => {
+    actor = outsider;
+    const { view } = await core.createView(outsider, {
+      name: 'My old team',
+      filter: {
+        filter: { kind: 'group', combinator: 'and', children: [] },
+        teamId: designTeamId,
+        visibility: 'private',
+      },
+      layout: 'list',
+      groupBy: 'state',
+      shared: false,
+    });
+
+    await openView(view.id);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('layout-board'));
+    await user.click(await screen.findByTestId('update-view'));
+
+    const reread = await waitFor(async () => {
+      const row = await core.getView(outsider, view.id);
+      if (row.layout !== 'board') throw new Error('the save has not landed yet');
+      return row;
+    }, SETTLE);
+    expect(reread.state.teamId).toBe(designTeamId);
+  });
+});
+
+describe('a saved view scoped to a project', () => {
+  it('narrows to that project for a reader whose workspace has it', async () => {
+    await openView(projectViewId);
+
+    expect(issueListParams().get('projectId')).toBe(rebrandProjectId);
+    expect(titlesOnScreen(EVERY_ISSUE)).toEqual([DESIGN_ISSUE]);
+    expect(scopeBadge()).toBe('Rebrand');
+  });
+
+  it('falls back to the workspace when the reader cannot reach the project', async () => {
+    actor = outsider;
+
+    await openView(projectViewId);
+
+    expect(issueListParams().get('projectId')).toBeNull();
+    expect(titlesOnScreen(EVERY_ISSUE)).toEqual(NOVA_ISSUES);
+    expect(scopeBadge()).toBe('Workspace');
+  });
+});
+
+describe('a view built in the New view dialog', () => {
+  it('opens on the issues the scope it was given actually holds', async () => {
+    const user = userEvent.setup();
+    render(providers(<CreateViewDialog open onOpenChange={() => undefined} />));
+
+    await user.type(await screen.findByTestId('create-view-name'), 'Engineering triage');
+    await user.click(screen.getByTestId('create-view-scope'));
+    await user.click(await screen.findByRole('option', { name: 'Nova' }));
+    await user.click(screen.getByTestId('create-view-submit'));
+
+    const saved = await waitFor(async () => {
+      const rows = await core.listViews(nova.admin);
+      const row = rows.find((entry) => entry.name === 'Engineering triage');
+      if (row === undefined) throw new Error('the dialog has not saved the view yet');
+      return row;
+    }, SETTLE);
+    expect(saved.state.teamId).toBe(nova.teamId);
+
+    requested.length = 0;
+    await openView(saved.id);
+
+    expect(issueListParams().get('teamId')).toBe(nova.teamId);
+    expect(titlesOnScreen(EVERY_ISSUE)).toEqual(NOVA_ISSUES);
+  });
+});

--- a/apps/web/tests/features/views/saved-view-page.test.tsx
+++ b/apps/web/tests/features/views/saved-view-page.test.tsx
@@ -298,4 +298,19 @@ describe('opening a saved view', () => {
 
     expect(screen.getByText('No such view')).toBeInTheDocument();
   });
+
+  it('asks for nothing until the workspace it has to scope against arrives', async () => {
+    workspace = { ...buildWorkspace(), ready: false, teams: [] };
+    const teamView = savedView({
+      id: 'view-team',
+      filter: { ...savedView().filter, teamId: 'team-eng' },
+    });
+
+    renderView([teamView], 'view-team');
+    await waitFor(() => {
+      expect(screen.getByTestId('views-skeleton')).toBeInTheDocument();
+    });
+
+    expect(requested).toEqual([]);
+  });
 });

--- a/apps/web/tests/features/views/view-href.test.ts
+++ b/apps/web/tests/features/views/view-href.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'bun:test';
 import { defaultViewState, inCondition, virtualViewState } from '@orbit/shared/filters';
 import { savedViewPath, viewHref, viewLayoutMode } from '@/features/views/view-href.ts';
+import type { ViewScopeSource } from '@/features/views/view-scope.ts';
 import type { Team, View } from '@/lib/query/schemas.ts';
 
 const TEAMS: readonly Team[] = [
   { id: 'team-ai', name: 'AI', key: 'AI', icon: 'circle', color: '#5b6cf9' },
   { id: 'team-eng', name: 'Engineering', key: 'ENG', icon: 'circle', color: '#f95b6c' },
 ];
+
+const WORKSPACE: ViewScopeSource = { teams: TEAMS, projects: [] };
 
 function view(overrides: Partial<View> = {}): View {
   return {
@@ -37,7 +40,7 @@ function builtIn(id: 'virtual:all' | 'virtual:assigned'): View {
 
 describe('a view that covers the whole workspace', () => {
   it('opens a workspace destination rather than the first team', () => {
-    const href = viewHref(builtIn('virtual:all'), TEAMS);
+    const href = viewHref(builtIn('virtual:all'), WORKSPACE);
 
     expect(href).toBe(savedViewPath('virtual:all'));
     expect(href.startsWith('/team/')).toBe(false);
@@ -51,7 +54,7 @@ describe('a view that covers the whole workspace', () => {
       layout: 'board',
     });
 
-    expect(viewHref(workspaceWide, TEAMS)).toBe('/views/view-77');
+    expect(viewHref(workspaceWide, WORKSPACE)).toBe('/views/view-77');
   });
 
   it('does the same for a project view, which no single team owns', () => {
@@ -60,7 +63,7 @@ describe('a view that covers the whole workspace', () => {
       filter: { ...defaultViewState('list'), teamId: null, projectId: 'project-atlas' },
     });
 
-    expect(viewHref(projectView, TEAMS)).toBe('/views/view-88');
+    expect(viewHref(projectView, WORKSPACE)).toBe('/views/view-88');
   });
 
   it('refuses to guess a team when the stored one is gone', () => {
@@ -69,7 +72,7 @@ describe('a view that covers the whole workspace', () => {
       filter: { ...defaultViewState('list'), teamId: 'team-deleted' },
     });
 
-    expect(viewHref(orphan, TEAMS)).toBe('/views/view-99');
+    expect(viewHref(orphan, WORKSPACE)).toBe('/views/view-99');
   });
 
   it('escapes the colon in a built-in id so the path stays one segment', () => {
@@ -94,7 +97,7 @@ describe('a view scoped to one team', () => {
       },
     });
 
-    const href = viewHref(teamView, TEAMS);
+    const href = viewHref(teamView, WORKSPACE);
 
     expect(href.startsWith('/team/eng/issues?')).toBe(true);
     const search = new URLSearchParams(href.slice(href.indexOf('?') + 1));
@@ -110,7 +113,7 @@ describe('a view scoped to one team', () => {
       filter: { ...defaultViewState('board'), teamId: 'team-ai' },
     });
 
-    expect(viewHref(boardView, TEAMS).startsWith('/team/ai/board')).toBe(true);
+    expect(viewHref(boardView, WORKSPACE).startsWith('/team/ai/board')).toBe(true);
   });
 });
 
@@ -122,7 +125,7 @@ describe('the standup view', () => {
       filter: virtualViewState('virtual:standup', 'user-1'),
     });
 
-    expect(viewHref(standup, TEAMS)).toBe('/standup');
+    expect(viewHref(standup, WORKSPACE)).toBe('/standup');
   });
 });
 

--- a/apps/web/tests/features/views/view-scope.test.ts
+++ b/apps/web/tests/features/views/view-scope.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'bun:test';
+import { defaultViewState } from '@orbit/shared/filters';
+import { savedViewPath, viewHref } from '@/features/views/view-href.ts';
+import type { ViewScopeSource } from '@/features/views/view-scope.ts';
+import { resolveViewScope } from '@/features/views/view-scope.ts';
+import type { View } from '@/lib/query/schemas.ts';
+
+const SOURCE: ViewScopeSource = {
+  teams: [{ id: 'team-eng', name: 'Engineering', key: 'ENG', icon: 'circle', color: '#f95b6c' }],
+  projects: [
+    {
+      id: 'project-atlas',
+      name: 'Atlas',
+      status: 'planned',
+      color: '#5a63c8',
+      icon: 'box',
+      teamIds: [],
+    },
+  ],
+};
+
+function view(teamId: string | null, projectId: string | null, id = 'view-1'): View {
+  return {
+    id,
+    ownerId: 'user-1',
+    name: 'Saved',
+    filter: { ...defaultViewState('list'), teamId, projectId },
+    layout: 'list',
+    groupBy: 'state',
+    shared: false,
+    virtual: false,
+    locked: false,
+    favorite: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+const CASES: readonly View[] = [
+  view(null, null, 'workspace-wide'),
+  view('team-eng', null, 'known-team'),
+  view('team-gone', null, 'missing-team'),
+  view(null, 'project-atlas', 'known-project'),
+  view(null, 'project-gone', 'missing-project'),
+  view('team-gone', 'project-atlas', 'missing-team-known-project'),
+  view('team-eng', 'project-atlas', 'known-team-and-project'),
+];
+
+describe('the scope a saved view is opened with', () => {
+  it('asks the server only for a team the workspace actually lists', () => {
+    expect(resolveViewScope(view('team-eng', null), SOURCE).params).toEqual({ teamId: 'team-eng' });
+    expect(resolveViewScope(view('team-gone', null), SOURCE).params).toEqual({});
+  });
+
+  it('asks the server only for a project the workspace actually lists', () => {
+    expect(resolveViewScope(view(null, 'project-atlas'), SOURCE).params).toEqual({
+      projectId: 'project-atlas',
+    });
+    expect(resolveViewScope(view(null, 'project-gone'), SOURCE).params).toEqual({});
+  });
+
+  it('names what it narrowed to, and says Workspace only when it narrowed to nothing', () => {
+    expect(resolveViewScope(view('team-eng', null), SOURCE).label).toBe('Engineering');
+    expect(resolveViewScope(view(null, 'project-atlas'), SOURCE).label).toBe('Atlas');
+    expect(resolveViewScope(view('team-gone', null), SOURCE).label).toBe('Workspace');
+    expect(resolveViewScope(view(null, 'project-gone'), SOURCE).label).toBe('Workspace');
+    expect(resolveViewScope(view(null, null), SOURCE).label).toBe('Workspace');
+  });
+
+  it('offers project filters only while the project is the scope it can honour', () => {
+    expect(resolveViewScope(view(null, 'project-atlas'), SOURCE).page).toBe('project');
+    expect(resolveViewScope(view(null, 'project-gone'), SOURCE).page).toBe('saved_view');
+  });
+
+  it('lets the project win over the team, the way the query and the badge both read it', () => {
+    const both = resolveViewScope(view('team-eng', 'project-atlas'), SOURCE);
+
+    expect(both.params).toEqual({ projectId: 'project-atlas' });
+    expect(both.label).toBe('Atlas');
+    expect(both.teamId).toBeNull();
+  });
+});
+
+describe('where a view opens and what it then asks for', () => {
+  it('never routes to a team page without querying that same team', () => {
+    for (const entry of CASES) {
+      const scope = resolveViewScope(entry, SOURCE);
+      const href = viewHref(entry, SOURCE);
+      if (href === savedViewPath(entry.id)) {
+        expect(scope.teamId).toBeNull();
+        continue;
+      }
+      expect(scope.team).not.toBeNull();
+      expect(href).toBe(`/team/${scope.team?.key.toLowerCase() ?? ''}/issues?view=${entry.id}`);
+      expect(scope.params).toEqual({ teamId: scope.team?.id ?? '' });
+    }
+  });
+});


### PR DESCRIPTION
## The bug

Opening a saved view from `/views` could paint a full header, a count of 0 and a scope
badge reading "Workspace", with no issues under it.

Two functions disagreed about what a saved view is scoped to.

`viewHref` sent a view to `/views/<id>` **only when** `filter.teamId` was not one of
`workspace.teams`; anything resolvable went to `/team/<key>/issues` instead. So every
team scoped view that reached `SavedViewPage` carried a team the reader's workspace
did not list: archived, in another workspace, or one they are not a member of.

`scopeRecord` then forwarded that same id as the issue scope, and the server ANDs it
with the organisation and the reader's own teams in `buildScopeFilters`. The predicate
can never match, so `/api/issues`, `/api/issues/summary` and `/api/issues/facets` all
answer empty. `scopeLabelOf` could not resolve the team either, so it fell through to
"Workspace": the page told the reader it was showing the whole workspace while asking
the server for one team the reader cannot see.

The same disagreement existed for `filter.projectId`, which `scopeRecord` forwarded
whether or not the project was one the reader can reach.

## The fix

One resolution, `resolveViewScope(view, workspace)` in
`apps/web/src/features/views/view-scope.ts`, now answers every question about a saved
view's scope: where its link points, which scope parameters the queries carry, what the
badge says, and which filter capabilities the page offers. A scope the workspace does
not list resolves to the workspace, so the page asks for something the server can
answer and says so truthfully.

Two things fell out of that:

- `SavedViewPage` waits for the workspace before it renders. It cannot know its own
  scope until bootstrap lands, and without the wait a team view fires one workspace
  wide request and then a second scoped one.
- "Save changes" on the saved view page now persists the scope the view was stored
  with, through a new `savedViewScope` on `FilterBar`. It used to write
  `{ teamId, projectId: null }`, which silently dropped a project view's project, and
  after this change would also have dropped a team the page could not resolve.

The server is untouched. `issue-service.ts` was right: the client was sending an
impossible scope. Team visibility from #133 is unchanged and is asserted directly.

## Tests

`apps/web/tests/app/views/saved-view-route.test.tsx` drives the real route
(`app/(app)/views/[id]/page.tsx`), hydrates it the way Next does, renders the client
page inside the real workspace provider, and serves `/api/issues`,
`/api/issues/summary`, `/api/issues/facets`, `/api/bootstrap` and `/api/views` from the
real route handlers against real Postgres. It asserts the search string the page builds
and then that the server answers it with the issues the view promises.

`apps/web/tests/features/views/view-scope.test.ts` pins the contract of the shared
resolution and asserts that routing and scoping cannot disagree.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes saved-view scope resolution so routing, query parameters, labels, capabilities, and updates consistently reflect the resources visible in the current workspace.
- Adds shared team, project, and workspace scope resolution.
- Defers saved-view rendering until workspace bootstrap is ready.
- Preserves stored scope when updating a saved view.
- Adds route-level and unit coverage for visible and inaccessible scopes.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking test-harness issue where an interactive dialog ignores open-state changes.

The production scope-resolution paths are internally consistent and covered across reachable and inaccessible resources; the remaining concern is limited to inaccurate dialog lifecycle behavior in an integration test.

**Files Needing Attention:** apps/web/tests/app/views/saved-view-route.test.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/views/view-scope.ts | Introduces the shared resolution contract that maps stored project or team identifiers to reachable query scope, label, and page capabilities. |
| apps/web/src/features/views/saved-view-page.tsx | Waits for workspace data, applies resolved scope consistently to queries and presentation, and preserves the stored scope on updates. |
| apps/web/src/features/filters/filter-bar.tsx | Adds an explicit saved-view scope for update serialization, preventing project or inaccessible team scope from being dropped. |
| apps/web/src/features/views/view-href.ts | Reuses the common scope resolver when choosing between a team route and the saved-view route. |
| apps/web/tests/app/views/saved-view-route.test.tsx | Adds broad real-route coverage, but renders an interactive create-view dialog with a no-op open-state callback. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  V[Saved view] --> W{Workspace ready?}
  W -- No --> S[Show loading skeleton]
  W -- Yes --> P{Stored project reachable?}
  P -- Yes --> PS[Project scope and projectId query]
  P -- No --> T{Stored team reachable?}
  T -- Yes --> TS[Team scope and teamId query]
  T -- No --> WS[Workspace scope with no scope parameter]
  PS --> R[Render saved-view results]
  TS --> R
  WS --> R
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fweb%2Ftests%2Fapp%2Fviews%2Fsaved-view-route.test.tsx%3A393%0A**No-op%20dialog%20state%20callback**%0A%0A%60CreateViewDialog%60%20is%20rendered%20as%20an%20interactive%20open%20dialog%20while%20%60onOpenChange%60%20silently%20ignores%20state%20changes%2C%20so%20this%20integration%20setup%20cannot%20exercise%20or%20accurately%20represent%20the%20dialog's%20open-state%20lifecycle.%20Model%20the%20state%20transition%20or%20disable%20the%20corresponding%20affordance.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=noveum%2Forbit&pr=154&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/tests/app/views/saved-view-route.test.tsx:393
**No-op dialog state callback**

`CreateViewDialog` is rendered as an interactive open dialog while `onOpenChange` silently ignores state changes, so this integration setup cannot exercise or accurately represent the dialog's open-state lifecycle. Model the state transition or disable the corresponding affordance.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(views): open every built in and sav..."](https://github.com/noveum/orbit/commit/c6e5b06e95167f895eca157f95b288c47d5401ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51157659)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Flag interactive event handler props (`onClick`, `... ([source](https://app.greptile.com/noveum-ai/github/Noveum/orbit/-/custom-context?memory=f997c777-2305-4f26-8379-ab591f935113))

<!-- /greptile_comment -->