### PR TITLE
Unblock main: stop auth module mocks leaking between test files

### DIFF
--- a/apps/web/tests-support.ts
+++ b/apps/web/tests-support.ts
@@ -1,0 +1,31 @@
+import { afterAll, mock } from 'bun:test';
+import type { MembershipContext } from '@/lib/auth/principal.ts';
+import * as principalModule from '@/lib/auth/principal.ts';
+import * as sessionModule from '@/lib/auth/session.ts';
+
+export const SESSION_MODULE = '@/lib/auth/session.ts';
+export const PRINCIPAL_MODULE = '@/lib/auth/principal.ts';
+
+const realSession = { ...sessionModule };
+const realPrincipal = { ...principalModule };
+
+export function mockSession<T>(read: () => T | null): void {
+  mock.module(SESSION_MODULE, () => ({
+    ...realSession,
+    getSession: () => Promise.resolve(read()),
+    requireSession: () => Promise.resolve(read()),
+  }));
+  afterAll(() => {
+    mock.module(SESSION_MODULE, () => realSession);
+  });
+}
+
+export function mockMembership(read: () => MembershipContext | null): void {
+  mock.module(PRINCIPAL_MODULE, () => ({
+    ...realPrincipal,
+    resolveMembership: () => Promise.resolve(read()),
+  }));
+  afterAll(() => {
+    mock.module(PRINCIPAL_MODULE, () => realPrincipal);
+  });
+}

--- a/apps/web/tests/app/api/cycles/route.test.ts
+++ b/apps/web/tests/app/api/cycles/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { completeCycle, createCycle, createTeam, listCycles } from '@orbit/core';
 import {
   addMember,
@@ -8,6 +8,7 @@ import {
 } from '@orbit/core/test-support';
 import { db, eq, schema } from '@orbit/db';
 import { z } from 'zod';
+import { mockSession } from '../../../../tests-support.ts';
 
 let workspace: Workspace;
 let contributorUserId: string;
@@ -20,10 +21,7 @@ interface Signed {
 
 const signedIn: { value: Signed | null } = { value: null };
 
-mock.module('@/lib/auth/session.ts', () => ({
-  getSession: () => Promise.resolve(signedIn.value),
-  requireSession: () => Promise.resolve(signedIn.value),
-}));
+mockSession(() => signedIn.value);
 
 const cycles = await import('../../../../src/app/api/cycles/route.ts');
 const cycleById = await import('../../../../src/app/api/cycles/[id]/route.ts');

--- a/apps/web/tests/app/api/docs/duplicate.test.ts
+++ b/apps/web/tests/app/api/docs/duplicate.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { SyncAction } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
 import { z } from 'zod';
+import { mockMembership, mockSession } from '../../../../tests-support.ts';
 
 const coreModule = await import('@orbit/core');
 
@@ -61,10 +62,7 @@ const session = {
 
 mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
 
-mock.module('@/lib/auth/session.ts', () => ({
-  getSession: () => Promise.resolve(session),
-  requireSession: () => Promise.resolve(session),
-}));
+mockSession(() => session);
 
 const principal: Principal = {
   userId: 'user_1',
@@ -73,14 +71,11 @@ const principal: Principal = {
   teamIds: ['team_1'],
 };
 
-mock.module('@/lib/auth/principal.ts', () => ({
-  resolveMembership: () =>
-    Promise.resolve({
-      principal,
-      memberId: 'member_1',
-      organizationName: 'Nova',
-      organizationSlug: 'nova',
-    }),
+mockMembership(() => ({
+  principal,
+  memberId: 'member_1',
+  organizationName: 'Nova',
+  organizationSlug: 'nova',
 }));
 
 const { POST } = await import('../../../../src/app/api/docs/[id]/duplicate/route.ts');

--- a/apps/web/tests/app/api/docs/home.test.ts
+++ b/apps/web/tests/app/api/docs/home.test.ts
@@ -4,6 +4,7 @@ import type { SyncAction } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
 import { docFavoriteSchema } from '@orbit/shared/validators';
 import { z } from 'zod';
+import { mockMembership, mockSession } from '../../../../tests-support.ts';
 
 const coreModule = await import('@orbit/core');
 
@@ -79,10 +80,7 @@ const session = {
 
 mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
 
-mock.module('@/lib/auth/session.ts', () => ({
-  getSession: () => Promise.resolve(session),
-  requireSession: () => Promise.resolve(session),
-}));
+mockSession(() => session);
 
 const principal: Principal = {
   userId: 'user_1',
@@ -91,14 +89,11 @@ const principal: Principal = {
   teamIds: ['team_1'],
 };
 
-mock.module('@/lib/auth/principal.ts', () => ({
-  resolveMembership: () =>
-    Promise.resolve({
-      principal,
-      memberId: 'member_1',
-      organizationName: 'Nova',
-      organizationSlug: 'nova',
-    }),
+mockMembership(() => ({
+  principal,
+  memberId: 'member_1',
+  organizationName: 'Nova',
+  organizationSlug: 'nova',
 }));
 
 const { GET } = await import('../../../../src/app/api/docs/home/route.ts');

--- a/apps/web/tests/app/api/issues/delete-issue.test.ts
+++ b/apps/web/tests/app/api/issues/delete-issue.test.ts
@@ -9,6 +9,7 @@ import { db, eq, schema } from '@orbit/db';
 import type { SyncAction } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
 import { z } from 'zod';
+import { mockMembership, mockSession } from '../../../../tests-support.ts';
 
 const published: SyncAction[][] = [];
 const core = await import('@orbit/core');
@@ -29,26 +30,16 @@ let actor: Principal = {
   teamIds: [],
 };
 
-function activeSession() {
-  return Promise.resolve({
-    user: { id: actor.userId, name: 'Ada Admin', email: 'ada@orbit.test' },
-    session: { activeOrganizationId: actor.organizationId },
-  });
-}
-
-mock.module('@/lib/auth/session.ts', () => ({
-  getSession: activeSession,
-  requireSession: activeSession,
+mockSession(() => ({
+  user: { id: actor.userId, name: 'Ada Admin', email: 'ada@orbit.test' },
+  session: { activeOrganizationId: actor.organizationId },
 }));
 
-mock.module('@/lib/auth/principal.ts', () => ({
-  resolveMembership: () =>
-    Promise.resolve({
-      principal: actor,
-      memberId: 'member_1',
-      organizationName: 'Nova',
-      organizationSlug: 'nova',
-    }),
+mockMembership(() => ({
+  principal: actor,
+  memberId: 'member_1',
+  organizationName: 'Nova',
+  organizationSlug: 'nova',
 }));
 
 const { DELETE } = await import('@/app/api/issues/[id]/route.ts');

--- a/apps/web/tests/app/api/projects/milestones.test.ts
+++ b/apps/web/tests/app/api/projects/milestones.test.ts
@@ -3,6 +3,7 @@ import { db, eq, schema } from '@orbit/db';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import { z } from 'zod';
+import { mockSession } from '../../../../tests-support.ts';
 
 const coreModule = await import('@orbit/core');
 
@@ -31,10 +32,7 @@ let session: Session | null = null;
 
 mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
 
-mock.module('@/lib/auth/session.ts', () => ({
-  getSession: () => Promise.resolve(session),
-  requireSession: () => Promise.resolve(session),
-}));
+mockSession(() => session);
 
 const listRoute = await import('../../../../src/app/api/projects/[id]/milestones/route.ts');
 const reorderRoute = await import(

--- a/apps/web/tests/app/api/projects/route.test.ts
+++ b/apps/web/tests/app/api/projects/route.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { SyncAction } from '@orbit/shared/events';
 import { z } from 'zod';
+import { mockSession } from '../../../../tests-support.ts';
 
 const coreModule = await import('@orbit/core');
 
@@ -28,10 +29,7 @@ let session: Session | null = null;
 
 mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
 
-mock.module('@/lib/auth/session.ts', () => ({
-  getSession: () => Promise.resolve(session),
-  requireSession: () => Promise.resolve(session),
-}));
+mockSession(() => session);
 
 const route = await import('../../../../src/app/api/projects/route.ts');
 

--- a/apps/web/tests/app/api/standup-board.test.ts
+++ b/apps/web/tests/app/api/standup-board.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { db, eq, schema } from '@orbit/db';
 import type { Principal } from '@orbit/shared/policy';
 import { z } from 'zod';
+import { mockSession } from '../../../tests-support.ts';
 
 const coreModule = await import('@orbit/core');
 
@@ -115,10 +116,7 @@ const session = {
 };
 const sessionHolder: { value: typeof session | null } = { value: session };
 
-mock.module('@/lib/auth/session.ts', () => ({
-  getSession: () => Promise.resolve(sessionHolder.value),
-  requireSession: () => Promise.resolve(sessionHolder.value),
-}));
+mockSession(() => sessionHolder.value);
 
 const { GET } = await import('../../../src/app/api/standup/board/route.ts');
 

--- a/apps/web/tests/app/page.test.tsx
+++ b/apps/web/tests/app/page.test.tsx
@@ -1,13 +1,11 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import { render, screen } from '@testing-library/react';
 import * as navigation from 'next/navigation';
+import { mockSession } from '../../tests-support.ts';
 
 const sessionHolder: { value: { user: { id: string } } | null } = { value: null };
 
-mock.module('@/lib/auth/session.ts', () => ({
-  getSession: () => Promise.resolve(sessionHolder.value),
-  requireSession: () => Promise.resolve(sessionHolder.value),
-}));
+mockSession(() => sessionHolder.value);
 
 mock.module('next/navigation', () => ({
   ...navigation,

--- a/apps/web/tests/lib/auth/mock-isolation.test.ts
+++ b/apps/web/tests/lib/auth/mock-isolation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test';
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PRINCIPAL_MODULE, SESSION_MODULE } from '../../../tests-support.ts';
+
+const TEST_TREE = fileURLToPath(new URL('../..', import.meta.url));
+
+const GUARDED = [SESSION_MODULE, PRINCIPAL_MODULE] as const;
+
+async function testFiles(): Promise<string[]> {
+  const entries = await readdir(TEST_TREE, { recursive: true });
+  return entries.filter((entry) => entry.endsWith('.test.ts') || entry.endsWith('.test.tsx'));
+}
+
+async function directMocksIn(file: string): Promise<string[]> {
+  const source = await readFile(join(TEST_TREE, file), 'utf8');
+  return GUARDED.filter((specifier) => source.includes(`mock.module('${specifier}'`));
+}
+
+describe('module mock isolation', () => {
+  it('routes every auth module mock through the shared helper', async () => {
+    const files = await testFiles();
+    expect(files.length).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      for (const specifier of await directMocksIn(file)) {
+        offenders.push(
+          `${file} mocks ${specifier} directly, so the mock outlives the file and every later test file sees it. Call mockSession or mockMembership from tests-support.ts instead.`,
+        );
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -22,6 +22,7 @@
     "bench/**/*.ts",
     "e2e/**/*.ts",
     "tests-preload.ts",
+    "tests-support.ts",
     "playwright.config.ts",
     "next.config.ts",
     ".next/types/**/*.ts",


### PR DESCRIPTION
Main has been red since #148. At `6729d1e` the test job fails 29 tests across
`app/api/projects/route.test.ts`, `app/api/projects/milestones.test.ts` and
`app/api/cycles/route.test.ts`. Every one of them passes locally on the same
commit, which is what made this hard to place.

## What was actually wrong

Bun runs every test file of a package in a single process, and `mock.module`
replaces a module for the rest of that process rather than for the file that
installed it.

`app/api/issues/delete-issue.test.ts`, `app/api/docs/duplicate.test.ts` and
`app/api/docs/home.test.ts` each replaced `@/lib/auth/principal.ts` with a
`resolveMembership` that returns a fixed admin membership, and none of them put
the real one back. Every test file that ran afterwards and went through
`apiContext()` got that stale principal instead of reading the database.

The projects and cycles tests do not mock the membership resolver, on purpose:
they create real members with real roles and rely on the real resolver so that
the 403 and 404 cases mean something. With the leaked mock in place they ran as
an admin of an organisation that their own `resetDatabase()` had already
truncated, which is why the symptoms looked so unrelated to each other:

- `POST /api/projects` reached the insert and died on
  `project_organization_id_organization_id_fk`, because the organisation on the
  principal no longer existed.
- The milestone routes returned 404 where the tests wanted 200 or 403, because
  `assertProjectInOrganization` could not match the project to the leaked
  organisation. These services answer 404 for anything invisible, so a
  visibility failure wore a 404.

## Why CI saw it and a laptop did not

Bun discovers test files in directory-read order. It does not sort them, and it
ignores the order of paths given on the command line. That order is not the
same on the CI runner as it is on macOS:

| | file order |
|---|---|
| CI (Linux) | `issues/delete-issue` → `projects/milestones` → `projects/route` |
| local (macOS) | `projects/route` → `projects/milestones` → ... → `issues/delete-issue` |

Locally the projects tests run *before* anything that mocks the membership
resolver, so they never see the leak. On CI they run straight after it. Nothing
about the CI database or the workflow was involved: the schema push, the
per-package databases and the seed data were all fine.

Reproduced locally by copying `delete-issue.test.ts` into a directory that Bun
reads earlier, which gives the same 18 failures as the `5ddbb49` run, name for
name.

## The fix

`apps/web/tests-support.ts` adds `mockSession` and `mockMembership`. Each
installs the mock and registers the matching `afterAll` restore in one call, so
a file cannot install one and forget the other. All eight files that mock the
auth modules now go through them.

One detail worth recording: the restore has to hand back a **snapshot** of the
real exports, not the module namespace. Bun mutates the live namespace in place
when you call `mock.module`, so a namespace captured before the call already
reflects the mock and restoring from it does nothing. My first attempt at this
fix restored from the namespace and changed nothing at all.

That also means the existing `afterAll(() => mock.module('@orbit/core', () => coreModule))`
idiom used in about seventeen files is a no-op today. It is not breaking
anything right now, because the files that mock `@orbit/core` only stub
`publishDeltas`, and the next file to mock it overwrites the stub. I have left
it alone rather than widen a PR whose job is to get main green, but it is worth
a follow-up.

## Guard

`tests/lib/auth/mock-isolation.test.ts` fails if any test file calls
`mock.module` on the session or membership module directly. A behavioural test
cannot catch this class of bug, because whether it bites depends on which file
the filesystem happens to hand Bun first, so the check reads the sources
instead.

## Verification

- `bun run verify` exits 0.
- The forced-order reproduction that produced the 18 CI failures now passes 44/44.
- A stronger probe, with all three membership-mocking files forced ahead of the
  projects and cycles tests, passes 55/55.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes session and membership mocking so each test file restores the real auth exports after completion, preventing process-wide Bun mocks from contaminating later tests.

- Adds snapshot-based `mockSession` and `mockMembership` helpers with file-level cleanup.
- Migrates the affected API and page tests to the shared helpers.
- Adds a source-level guard against direct auth-module mocks and includes the helper in TypeScript checking.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed tests consistently restoring auth mocks and no actionable regressions identified.

The shared helpers capture real auth exports before installing mocks, restore those exports after each importing test file, and all affected direct auth mocks were migrated consistently.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/tests-support.ts | Adds centralized auth mock helpers that snapshot real exports before mocking and restore them in file-scoped teardown. |
| apps/web/tests/lib/auth/mock-isolation.test.ts | Adds a repository guard requiring test files to route direct session and principal mocking through the shared helpers. |
| apps/web/tests/app/api/issues/delete-issue.test.ts | Replaces process-leaking session and membership mocks with the isolated helpers while preserving mutable actor behavior. |
| apps/web/tests/app/api/docs/home.test.ts | Migrates session and membership setup to the shared isolation helpers without changing test behavior. |
| apps/web/tests/app/api/docs/duplicate.test.ts | Migrates session and membership setup to the shared isolation helpers without changing test behavior. |
| apps/web/tsconfig.json | Includes the new test-support module in strict TypeScript checking. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Test file imports tests-support] --> B[Snapshot real auth exports]
  B --> C[Install file-specific auth mock]
  C --> D[Run route and page tests]
  D --> E[File afterAll]
  E --> F[Restore real auth exports]
  F --> G[Next test file starts without leaked auth state]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(web): fail when a test file mocks a..."](https://github.com/noveum/orbit/commit/521effef66e59d8b40e792653a45c64c54c74d0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51171670)</sub>

<!-- /greptile_comment -->