### PR TITLE
Run each package's tests in sequence so CI stops killing its own database

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "bun run --filter '*' build",
     "dev": "bun run --filter '*' dev",
     "typecheck": "tsc -p scripts/tsconfig.json --noEmit && bun run --filter '*' typecheck",
-    "test": "bun run --filter '*' test",
+    "test": "bun scripts/run-tests.ts",
     "test:e2e": "bun run --filter '@orbit/web' test:e2e",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
@@ -53,7 +53,8 @@
     "infra:down": "docker compose down",
     "infra:reset": "docker compose down -v && docker compose up -d",
     "prepare": "lefthook install || true",
-    "db:test-lanes-drop": "bun run --filter '@orbit/db' test-lanes-drop"
+    "db:test-lanes-drop": "bun run --filter '@orbit/db' test-lanes-drop",
+    "test:parallel": "bun run --filter '*' test"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.5",

--- a/packages/db/tests/run-tests.test.ts
+++ b/packages/db/tests/run-tests.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'bun:test';
+import { hasTestScript, packageName, summarise } from '../../../scripts/run-tests.ts';
+
+describe('choosing which packages to test', () => {
+  it('takes a package that declares a test script', () => {
+    expect(hasTestScript({ name: '@orbit/core', scripts: { test: 'bun test' } })).toBe(true);
+  });
+
+  it('skips a package with no test script', () => {
+    expect(hasTestScript({ name: '@orbit/ui', scripts: { build: 'tsc' } })).toBe(false);
+  });
+
+  it('skips a package with no scripts at all', () => {
+    expect(hasTestScript({ name: '@orbit/ui' })).toBe(false);
+  });
+
+  it('treats an unreadable manifest as untestable rather than throwing', () => {
+    expect(hasTestScript(null)).toBe(false);
+    expect(hasTestScript('not a manifest')).toBe(false);
+  });
+
+  it('does not mistake a non-string test entry for a script', () => {
+    expect(hasTestScript({ scripts: { test: true } })).toBe(false);
+  });
+});
+
+describe('naming a package', () => {
+  it('uses the declared name', () => {
+    expect(packageName({ name: '@orbit/web' }, 'apps/web')).toBe('@orbit/web');
+  });
+
+  it('falls back to the directory when the manifest has no usable name', () => {
+    expect(packageName({}, 'apps/web')).toBe('apps/web');
+    expect(packageName({ name: '' }, 'apps/web')).toBe('apps/web');
+    expect(packageName(null, 'apps/web')).toBe('apps/web');
+  });
+});
+
+describe('reporting the run', () => {
+  it('reports success without naming packages', () => {
+    expect(summarise([], 9)).toBe('9 packages passed');
+  });
+
+  it('names every package that failed, which is what a red build needs to say', () => {
+    expect(summarise(['@orbit/web', '@orbit/core'], 9)).toBe(
+      '2 of 9 packages failed: @orbit/web, @orbit/core',
+    );
+  });
+});

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -1,0 +1,77 @@
+import { readdir, readFile } from 'node:fs/promises';
+
+const WORKSPACE_ROOTS = ['packages', 'apps'] as const;
+
+export interface TestablePackage {
+  readonly name: string;
+  readonly directory: string;
+}
+
+export function hasTestScript(manifest: unknown): boolean {
+  if (manifest === null || typeof manifest !== 'object') return false;
+  const scripts = (manifest as { scripts?: unknown }).scripts;
+  if (scripts === null || scripts === undefined || typeof scripts !== 'object') return false;
+  return typeof (scripts as Record<string, unknown>)['test'] === 'string';
+}
+
+export function packageName(manifest: unknown, fallback: string): string {
+  if (manifest === null || typeof manifest !== 'object') return fallback;
+  const name = (manifest as { name?: unknown }).name;
+  return typeof name === 'string' && name.length > 0 ? name : fallback;
+}
+
+export function summarise(failures: readonly string[], total: number): string {
+  if (failures.length === 0) return `${total} packages passed`;
+  return `${failures.length} of ${total} packages failed: ${failures.join(', ')}`;
+}
+
+async function readManifest(path: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(path, 'utf8')) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+async function testablePackages(): Promise<TestablePackage[]> {
+  const found: TestablePackage[] = [];
+  for (const root of WORKSPACE_ROOTS) {
+    const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const directory = `${root}/${entry.name}`;
+      const manifest = await readManifest(`${directory}/package.json`);
+      if (!hasTestScript(manifest)) continue;
+      found.push({ name: packageName(manifest, directory), directory });
+    }
+  }
+  return found.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+async function runPackageTests(target: TestablePackage): Promise<boolean> {
+  const started = performance.now();
+  console.log(`\n> ${target.name}`);
+  const child = Bun.spawn(['bun', 'run', 'test'], {
+    cwd: target.directory,
+    stdout: 'inherit',
+    stderr: 'inherit',
+    env: process.env,
+  });
+  const code = await child.exited;
+  const seconds = ((performance.now() - started) / 1000).toFixed(1);
+  console.log(code === 0 ? `✓ ${target.name} (${seconds}s)` : `✗ ${target.name} (${seconds}s)`);
+  return code === 0;
+}
+
+async function main(): Promise<void> {
+  const packages = await testablePackages();
+  const failures: string[] = [];
+  for (const target of packages) {
+    if (!(await runPackageTests(target))) failures.push(target.name);
+  }
+
+  console.log(`\n${summarise(failures, packages.length)}`);
+  process.exit(failures.length === 0 ? 0 : 1);
+}
+
+if (import.meta.main) await main();


### PR DESCRIPTION
## The failure

Main and every open PR have been failing `Unit and integration tests` intermittently. The failures looked like unrelated route regressions: milestone routes returning 404 instead of 200, `insert into "doc_comment"` failing, tests passing locally and on a re-run of the same commit.

They are all one thing. A single failed run on `main` contained:

```
180  ECONNREFUSED
  6  error: Failed query
  2  Redis is down
```

The service containers die partway through the run. Whichever package is executing when they go reports the failure, which is why the symptom moved around and why nothing reproduced locally.

## Why they die

The root `test` script was `bun run --filter '*' test`. `--filter` runs matching packages **in parallel**, and nine workspace packages declare a `test` script. Nine `bun test` processes, one of them compiling Next.js, plus the Postgres and Redis service containers, on a two core runner. The box runs out of memory and Docker reclaims it from the containers.

## The change

`scripts/run-tests.ts` runs each package's tests one at a time and names every package that failed. The parallel form is kept as `test:parallel` for a machine with the headroom.

This is also the arrangement the isolated per package test databases were designed for: `orbit_test_core`, `orbit_test_svc` and the rest exist so packages do not contend, and running them concurrently against one Postgres is what the test lane mechanism in `CLAUDE.md` warns about.

## Verification

Full suite, serial, locally: `@orbit/web` 1312 pass / 0 fail, and the runner correctly reported the one package that failed rather than swallowing it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces parallel workspace test execution with a deterministic sequential runner to reduce CI resource contention while retaining the previous behavior as `test:parallel`.
- Discovers all test-bearing packages under the configured `apps/*` and `packages/*` workspace roots.
- Runs each package’s existing test script sequentially and reports every failing package.
- Adds unit coverage for manifest filtering, package naming, and summary formatting.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the sequential runner covering the same nine current workspace test scripts as the previous command.

The configured workspace roots, package test scripts, CI working directory, environment handling, and aggregate failure status align with the repository’s current test setup, and no actionable changed-code failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Changes the default test command to the sequential runner and preserves the former parallel command under `test:parallel`. |
| scripts/run-tests.ts | Implements deterministic workspace discovery, sequential package test execution, failure aggregation, and a final process status. |
| packages/db/tests/run-tests.test.ts | Covers test-script detection, package-name fallback behavior, and success/failure summary formatting. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Root as Root test script
    participant Runner as scripts/run-tests.ts
    participant Package as Workspace package
    Root->>Runner: bun scripts/run-tests.ts
    Runner->>Runner: Discover and sort testable packages
    loop One package at a time
        Runner->>Package: bun run test
        Package-->>Runner: Exit code
        Runner->>Runner: Record failure if nonzero
    end
    Runner-->>Root: Summary and aggregate exit status
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): run each package&#39;s tests in seq..."](https://github.com/noveum/orbit/commit/2515a05e26a2e7ecf2ae13a424336b21da1a0964) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51173714)</sub>

<!-- /greptile_comment -->