### PR TITLE
docs: add NEXT_PUBLIC_MCP_URL to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 NEXT_PUBLIC_REALTIME_URL=ws://localhost:3100
 REALTIME_PORT=3100
+# Overrides the advertised MCP endpoint. Defaults to <app>/mcp.
+# NEXT_PUBLIC_MCP_URL=
 
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=


### PR DESCRIPTION
Closes #131

## Summary

Adds the missing `NEXT_PUBLIC_MCP_URL` to `.env.example`, commented out with an empty value next to the other `NEXT_PUBLIC_` entries. The app already reads it in `apps/web/src/lib/env.ts` and falls back to `<app>/mcp` when unset, so the default remains correct for almost everyone.

## Verification

- Confirmed `apps/web/src/lib/env.ts` reads `NEXT_PUBLIC_MCP_URL`.
- Confirmed the variable is already documented in `docs/configuration.md`.
- Swept `process.env[...]` reads in `apps/web/src` and `packages`; the other main runtime variables in the sweep are already present in `.env.example`.

Docs-only change.

Signed off with DCO.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the previously missing `NEXT_PUBLIC_MCP_URL` entry to the environment template without changing the application's default behavior.

- Documents that the variable overrides the advertised MCP endpoint.
- Leaves the optional variable commented out and defaults to `<app>/mcp`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The new environment-template entry accurately reflects existing behavior, and leaving it commented or empty preserves the established MCP endpoint fallback.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .env.example | Adds an accurate commented example for the optional MCP URL override; no runtime or configuration issue identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add NEXT\_PUBLIC\_MCP\_URL to env exa..."](https://github.com/noveum/orbit/commit/f102cccb4aae23cf1b6d95320b1365f71cdb92f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51186319)</sub>

<!-- /greptile_comment -->