### PR TITLE
chore(keyboard): drop the standup scope and section nothing registers

### DIFF
--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -2,15 +2,7 @@
 
 import { Command } from 'cmdk';
 import type { LucideIcon } from 'lucide-react';
-import {
-  ArrowRight,
-  CircleDot,
-  FileText,
-  Search,
-  SlidersHorizontal,
-  Terminal,
-  Users,
-} from 'lucide-react';
+import { ArrowRight, CircleDot, FileText, Search, SlidersHorizontal, Terminal } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useTheme } from 'next-themes';
 import type { MouseEvent as ReactMouseEvent } from 'react';
@@ -39,7 +31,6 @@ const SECTION_ICONS: Record<HotkeySection, LucideIcon> = {
   Navigation: ArrowRight,
   Issues: CircleDot,
   View: SlidersHorizontal,
-  Standup: Users,
   General: Terminal,
 };
 

--- a/apps/web/src/lib/keyboard/registry.ts
+++ b/apps/web/src/lib/keyboard/registry.ts
@@ -1,8 +1,8 @@
 import { type BufferedStep, bufferMatches, type HotkeyStep, parseBinding } from './binding.ts';
 
-export type HotkeySection = 'Navigation' | 'General' | 'Issues' | 'View' | 'Standup';
+export type HotkeySection = 'Navigation' | 'General' | 'Issues' | 'View';
 
-export type HotkeyScope = 'global' | 'issues' | 'docs' | 'inbox' | 'filters' | 'standup';
+export type HotkeyScope = 'global' | 'issues' | 'docs' | 'inbox' | 'filters';
 
 export const HOTKEY_PRIORITY = {
   global: 0,

--- a/apps/web/tests/components/command-palette.test.tsx
+++ b/apps/web/tests/components/command-palette.test.tsx
@@ -69,11 +69,11 @@ function ArchiveIssue({ enabled }: { readonly enabled: boolean }) {
   return null;
 }
 
-function StandupTimer({ run }: { readonly run: () => void }) {
+function CompetingSingleKey({ run }: { readonly run: () => void }) {
   useHotkey('t', run, {
-    label: 'Toggle timer',
-    section: 'Standup',
-    scope: 'standup',
+    label: 'A surface binding on the same key',
+    section: 'Issues',
+    scope: 'issues',
     priority: HOTKEY_PRIORITY.surface,
   });
   return null;
@@ -126,11 +126,11 @@ describe('command palette', () => {
 
   it('routes to sprints when the binding gt is pressed, even with a competing t binding', async () => {
     const user = userEvent.setup();
-    const toggleTimer = mock();
+    const competing = mock();
 
     render(
       <Palette startOpen>
-        <StandupTimer run={toggleTimer} />
+        <CompetingSingleKey run={competing} />
       </Palette>,
     );
 
@@ -140,13 +140,13 @@ describe('command palette', () => {
     push.mockClear();
 
     await user.keyboard('t');
-    expect(toggleTimer).toHaveBeenCalledTimes(1);
+    expect(competing).toHaveBeenCalledTimes(1);
 
-    toggleTimer.mockClear();
+    competing.mockClear();
 
     await user.keyboard('gt');
     expect(push).toHaveBeenCalledWith('/sprints');
-    expect(toggleTimer).not.toHaveBeenCalled();
+    expect(competing).not.toHaveBeenCalled();
   });
 
   it('runs the toggles it advertises', async () => {


### PR DESCRIPTION
## What this changes

Removes three leftovers from #149, which deleted the standup meeting machinery:

- `'Standup'` from `HotkeySection`
- `'standup'` from `HotkeyScope`
- The `Standup: Users` entry in the command palette's section icon map, and the now unused `Users` import

## Why

Nothing in `apps/web/src` registers a hotkey in either. `grep -rn "scope: 'standup'" apps/web/src` and `grep -rn "section: 'Standup'" apps/web/src` both return nothing.

An empty scope is worse than no scope: it reads like a surface somebody forgot to wire up, and the next person adding a hotkey has to work out whether it is dead or just unused today.

## The test fixture

`command-palette.test.tsx` had a `StandupTimer` component registering `t` at surface priority, to prove that a `g t` sequence still routes to Sprints rather than firing the competing single key.

**That behaviour is worth keeping** and has nothing to do with standup, so the fixture is renamed `CompetingSingleKey` and moved to the `issues` scope. The assertions are unchanged.

## How you know it works

`bun run verify` green: 2907 tests passing, zero failures. The palette suite still covers sequence-beats-single-key, which is the only thing that fixture ever existed for.

Found while auditing whether #149 left anything behind.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes obsolete standup keyboard scope and section definitions after the standup meeting machinery was deleted.
- Removes the corresponding command-palette icon mapping and unused icon import.
- Renames and re-scopes the competing-single-key test fixture while preserving its sequence-precedence assertions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The removed union members have no remaining callers, the command-palette mapping remains exhaustive, and the updated fixture continues to exercise the same sequence-versus-single-key dispatch behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/command-palette.tsx | Removes the obsolete Standup section icon and now-unused Users import while preserving the exhaustive icon map. |
| apps/web/src/lib/keyboard/registry.ts | Narrows the hotkey section and scope unions to values still used by repository registrations. |
| apps/web/tests/components/command-palette.test.tsx | Renames the standup-specific fixture and assigns existing Issues metadata without changing the tested dispatch behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(keyboard): drop the standup scope ..."](https://github.com/noveum/orbit/commit/6cd4e2b2a5e727ec019365d11c898bfa7dd8df0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51235725)</sub>

<!-- /greptile_comment -->