### PR TITLE
fix: stop the production catch-up creating standup tables, and say task manager over MCP

### DIFF
--- a/packages/db/catchup/production-schema-catchup.sql
+++ b/packages/db/catchup/production-schema-catchup.sql
@@ -1,6 +1,5 @@
--- Brings a database created before the standup and doc sharing work up to the current schema.
--- Adds six tables: standup, standup_turn, standup_blocker, standup_rotation, doc_access
--- and view_preference.
+-- Brings a database created before the doc sharing work up to the current schema.
+-- Adds two tables: doc_access and view_preference.
 -- Nothing else in the schema changed, so no existing table or column is touched.
 --
 -- Safe to run more than once: every statement checks first, and the whole thing is one
@@ -24,62 +23,6 @@ create table if not exists public.doc_access (
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
-create table if not exists public.standup (
-    id text NOT NULL,
-    organization_id text NOT NULL,
-    team_id text NOT NULL,
-    cycle_id text,
-    held_on date NOT NULL,
-    facilitator_id text,
-    status text DEFAULT 'scheduled'::text NOT NULL,
-    current_turn_id text,
-    started_at timestamp with time zone,
-    ended_at timestamp with time zone,
-    sync_id bigint DEFAULT 0 NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-create table if not exists public.standup_blocker (
-    id text NOT NULL,
-    organization_id text NOT NULL,
-    turn_id text NOT NULL,
-    issue_id text,
-    summary text NOT NULL,
-    owner_id text,
-    resolved_at timestamp with time zone,
-    sync_id bigint DEFAULT 0 NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-create table if not exists public.standup_rotation (
-    id text NOT NULL,
-    organization_id text NOT NULL,
-    team_id text NOT NULL,
-    user_id text NOT NULL,
-    "position" integer NOT NULL,
-    facilitates smallint DEFAULT 1 NOT NULL,
-    sync_id bigint DEFAULT 0 NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-create table if not exists public.standup_turn (
-    id text NOT NULL,
-    organization_id text NOT NULL,
-    standup_id text NOT NULL,
-    user_id text NOT NULL,
-    "position" integer NOT NULL,
-    attendance text DEFAULT 'unknown'::text NOT NULL,
-    status text DEFAULT 'waiting'::text NOT NULL,
-    notes text DEFAULT ''::text NOT NULL,
-    blockers text DEFAULT ''::text NOT NULL,
-    spoke_at timestamp with time zone,
-    duration_seconds integer,
-    sync_id bigint DEFAULT 0 NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
 create table if not exists public.view_preference (
   id text primary key,
   organization_id text not null,
@@ -98,15 +41,6 @@ create unique index if not exists view_preference_unique
 
 create index if not exists doc_access_subject_idx on public.doc_access USING btree (subject_type, subject_id);
 create unique index if not exists doc_access_unique on public.doc_access USING btree (doc_id, subject_type, subject_id);
-create index if not exists standup_blocker_issue_idx on public.standup_blocker USING btree (issue_id);
-create index if not exists standup_blocker_turn_idx on public.standup_blocker USING btree (turn_id);
-create index if not exists standup_cycle_idx on public.standup USING btree (cycle_id);
-create index if not exists standup_org_day_idx on public.standup USING btree (organization_id, held_on);
-create unique index if not exists standup_rotation_member_unique on public.standup_rotation USING btree (team_id, user_id);
-create index if not exists standup_rotation_order_idx on public.standup_rotation USING btree (team_id, "position");
-create unique index if not exists standup_team_day_unique on public.standup USING btree (team_id, held_on);
-create index if not exists standup_turn_order_idx on public.standup_turn USING btree (standup_id, "position");
-create unique index if not exists standup_turn_person_unique on public.standup_turn USING btree (standup_id, user_id);
 
 do $$
 begin
@@ -115,30 +49,6 @@ begin
     where conname = 'doc_access_pkey' and conrelid = 'public.doc_access'::regclass
   ) then
     alter table public.doc_access add constraint doc_access_pkey PRIMARY KEY (id);
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_blocker_pkey' and conrelid = 'public.standup_blocker'::regclass
-  ) then
-    alter table public.standup_blocker add constraint standup_blocker_pkey PRIMARY KEY (id);
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_pkey' and conrelid = 'public.standup'::regclass
-  ) then
-    alter table public.standup add constraint standup_pkey PRIMARY KEY (id);
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_rotation_pkey' and conrelid = 'public.standup_rotation'::regclass
-  ) then
-    alter table public.standup_rotation add constraint standup_rotation_pkey PRIMARY KEY (id);
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_turn_pkey' and conrelid = 'public.standup_turn'::regclass
-  ) then
-    alter table public.standup_turn add constraint standup_turn_pkey PRIMARY KEY (id);
   end if;
   if not exists (
     select 1 from pg_constraint
@@ -157,90 +67,6 @@ begin
     where conname = 'doc_access_organization_id_organization_id_fk' and conrelid = 'public.doc_access'::regclass
   ) then
     alter table public.doc_access add constraint doc_access_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_blocker_issue_id_issue_id_fk' and conrelid = 'public.standup_blocker'::regclass
-  ) then
-    alter table public.standup_blocker add constraint standup_blocker_issue_id_issue_id_fk FOREIGN KEY (issue_id) REFERENCES public.issue(id) ON DELETE CASCADE;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_blocker_organization_id_organization_id_fk' and conrelid = 'public.standup_blocker'::regclass
-  ) then
-    alter table public.standup_blocker add constraint standup_blocker_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_blocker_owner_id_user_id_fk' and conrelid = 'public.standup_blocker'::regclass
-  ) then
-    alter table public.standup_blocker add constraint standup_blocker_owner_id_user_id_fk FOREIGN KEY (owner_id) REFERENCES public."user"(id) ON DELETE SET NULL;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_blocker_turn_id_standup_turn_id_fk' and conrelid = 'public.standup_blocker'::regclass
-  ) then
-    alter table public.standup_blocker add constraint standup_blocker_turn_id_standup_turn_id_fk FOREIGN KEY (turn_id) REFERENCES public.standup_turn(id) ON DELETE CASCADE;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_cycle_id_cycle_id_fk' and conrelid = 'public.standup'::regclass
-  ) then
-    alter table public.standup add constraint standup_cycle_id_cycle_id_fk FOREIGN KEY (cycle_id) REFERENCES public.cycle(id) ON DELETE SET NULL;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_facilitator_id_user_id_fk' and conrelid = 'public.standup'::regclass
-  ) then
-    alter table public.standup add constraint standup_facilitator_id_user_id_fk FOREIGN KEY (facilitator_id) REFERENCES public."user"(id) ON DELETE SET NULL;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_organization_id_organization_id_fk' and conrelid = 'public.standup'::regclass
-  ) then
-    alter table public.standup add constraint standup_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_rotation_organization_id_organization_id_fk' and conrelid = 'public.standup_rotation'::regclass
-  ) then
-    alter table public.standup_rotation add constraint standup_rotation_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_rotation_team_id_team_id_fk' and conrelid = 'public.standup_rotation'::regclass
-  ) then
-    alter table public.standup_rotation add constraint standup_rotation_team_id_team_id_fk FOREIGN KEY (team_id) REFERENCES public.team(id) ON DELETE CASCADE;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_rotation_user_id_user_id_fk' and conrelid = 'public.standup_rotation'::regclass
-  ) then
-    alter table public.standup_rotation add constraint standup_rotation_user_id_user_id_fk FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_team_id_team_id_fk' and conrelid = 'public.standup'::regclass
-  ) then
-    alter table public.standup add constraint standup_team_id_team_id_fk FOREIGN KEY (team_id) REFERENCES public.team(id) ON DELETE CASCADE;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_turn_organization_id_organization_id_fk' and conrelid = 'public.standup_turn'::regclass
-  ) then
-    alter table public.standup_turn add constraint standup_turn_organization_id_organization_id_fk FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_turn_standup_id_standup_id_fk' and conrelid = 'public.standup_turn'::regclass
-  ) then
-    alter table public.standup_turn add constraint standup_turn_standup_id_standup_id_fk FOREIGN KEY (standup_id) REFERENCES public.standup(id) ON DELETE CASCADE;
-  end if;
-  if not exists (
-    select 1 from pg_constraint
-    where conname = 'standup_turn_user_id_user_id_fk' and conrelid = 'public.standup_turn'::regclass
-  ) then
-    alter table public.standup_turn add constraint standup_turn_user_id_user_id_fk FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
   end if;
   if not exists (
     select 1 from pg_constraint

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -14,7 +14,7 @@ const SERVER_VERSION = '0.0.0';
 const JSONRPC_SERVER_ERROR = -32000;
 
 const INSTRUCTIONS = [
-  'Orbit is a work tracker. Issues live on teams and carry identifiers such as ENG-42.',
+  'Orbit is a task manager. Issues live on teams and carry identifiers such as ENG-42.',
   'Call get_me first to learn the caller role and teams, then list_teams, list_states and list_labels before writing.',
   'Every tool acts as the user who owns the API key, so a request can fail with a forbidden error when their role does not allow it.',
 ].join(' ');


### PR DESCRIPTION
Two leftovers found by auditing whether #149 and #153 finished the job. Both are small, both are wrong in a way nobody would notice until it mattered.

## The catch-up created tables that no longer exist

`packages/db/catchup/production-schema-catchup.sql` brings a database created before the doc sharing work up to the current schema. It still created `standup`, `standup_turn`, `standup_blocker` and `standup_rotation`, which #149 dropped.

Run it on an old database today and you get four tables nothing reads, no migration removes, and the next person to open the schema has to work out why they are there.

Removed, along with **9 indexes and 18 constraints** that referenced them. The header promised six tables; it now promises the two that still exist.

### Verified by running it, not by reading it

Removing the tables while leaving their indexes would have produced a script that fails on the first index. So I checked properly, against a scratch database:

1. Created `orbit_catchup_check` and pushed the current schema
2. Dropped `doc_access` and `view_preference`, the two tables the catch-up exists to add
3. Ran the edited script with `ON_ERROR_STOP=1`

Result: commits cleanly, restores both tables with **25 constraints**, creates **zero** standup tables, and a second run is still a no-op, so it stays safe to run more than once. Scratch database dropped afterwards.

## MCP told every client Orbit was a work tracker

`INSTRUCTIONS` in `packages/mcp-server/src/server.ts` opens with "Orbit is a work tracker." That string is handed to every MCP client on connect, so it is the first thing an assistant learns about the product.

#153 changed the wording everywhere else and missed this one. It was the last "work tracker" left in the repository, and `grep -rn "work tracker"` now returns nothing.

## How you know it works

`bun run verify` green: 2907 tests passing, zero failures. Plus the catch-up execution above, which is the part tests cannot cover.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns the production catch-up script with the current database schema and updates the MCP-facing product description.
- Removes obsolete standup table, index, and constraint creation from the production catch-up.
- Changes MCP initialization guidance from “work tracker” to the canonical “task manager” wording.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge after addressing the non-blocking repository-policy issue in the SQL header.

The functional changes align the catch-up with the canonical schema and standardize MCP wording; the only accepted concern is the newly revised SQL commentary prohibited by repository policy.

**Files Needing Attention:** packages/db/catchup/production-schema-catchup.sql

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/db/catchup/production-schema-catchup.sql | Correctly removes obsolete standup DDL, but the revised header retains comments prohibited by repository policy. |
| packages/mcp-server/src/server.ts | Aligns the MCP instruction string with the repository's canonical product terminology without affecting server behavior. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fdb%2Fcatchup%2Fproduction-schema-catchup.sql%3A1-2%0A**Revised%20header%20retains%20comments**%0A%0AThe%20updated%20SQL%20header%20remains%20inconsistent%20with%20the%20repository's%20prohibition%20on%20comments%20in%20code%2C%20retaining%20a%20comment-policy%20violation%20in%20the%20catch-up%20script.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=noveum%2Forbit&pr=160&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/db/catchup/production-schema-catchup.sql:1-2
**Revised header retains comments**

The updated SQL header remains inconsistent with the repository's prohibition on comments in code, retaining a comment-policy violation in the catch-up script.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop the catch-up creating tables t..."](https://github.com/noveum/orbit/commit/aabcee24cebe827a5a3df3d088d22f427e9ce381) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51240519)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/noveum/orbit/blob/main/CLAUDE.md))

<!-- /greptile_comment -->