### PR TITLE
fix: wire clear filters callback on My Issues view

### DIFF
--- a/apps/web/src/features/issues/my-issues-view.tsx
+++ b/apps/web/src/features/issues/my-issues-view.tsx
@@ -127,7 +127,7 @@ export function MyIssuesView() {
       <HiddenFooter
         hiddenByFilters={model.hiddenByFilters}
         hiddenByDisplay={model.hiddenByDisplay}
-        onClearFilters={() => undefined}
+        onClearFilters={() => setConfig({ ...config, filter: { ...config.filter, children: [] } })}
         onRevealDisplay={() =>
           setConfig({
             ...config,


### PR DESCRIPTION
## What

Wired the onClearFilters callback in MyIssuesView to actually clear filters, matching the behavior already implemented in StandupBoard and SavedViewPage.

## Why

The HiddenFooter component shows a Clear filters action when hiddenByFilters > 0, but on My Issues the callback was () => undefined, making the button inert. Users could click it but nothing happened.

## Testing

Changed onClearFilters={() => undefined} to onClearFilters={() => setConfig({ ...config, filter: { ...config.filter, children: [] } })}, following the exact same pattern used by the standup board and saved views.

Closes #152

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the “Clear filters” action functional in the My Issues hidden-items footer.
- Replaces the no-op callback with a configuration update that empties the filter group.
- Preserves the filter group’s existing kind and combinator.
- Matches the established clear-filter behavior used by sibling issue views.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable regressions identified.

The callback now performs the expected clear-filter operation using the same configuration transformation as sibling views, while preserving unrelated filter and display settings.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/issues/my-issues-view.tsx | Correctly wires the footer action to clear active filter conditions without changing unrelated view configuration. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: wire clear filters callback on My I..."](https://github.com/noveum/orbit/commit/3d49658f4fa7b9856a1eaf29f9b47d18a86f1f6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51265863)</sub>

<!-- /greptile_comment -->