### PR TITLE
Say what actually lands in the inbox

### DIFF
--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -380,7 +380,7 @@ export function InboxView({ items, unreadCount, unreadMentions, userId }: InboxV
         <EmptyState
           icon={<Bell strokeWidth={1.75} aria-hidden="true" />}
           title="Inbox zero"
-          description="Assignments, mentions, reviews, and PR updates land here."
+          description="When somebody assigns you an issue, mentions you, replies to you, or changes something you follow, it lands here. Your own actions do not."
           className="flex-1"
         />
       ) : (


### PR DESCRIPTION
## Why

Someone looked at an empty inbox and could not tell whether notifications were broken or the inbox was simply quiet. The empty state was part of the reason:

> Assignments, mentions, reviews, and PR updates land here.

**Reviews and PR updates cannot land there.** `pr_review_requested`, `pr_review_submitted`, `pr_approved`, `pr_merged`, `pr_closed` and `pr_checks_failed` are declared in `NOTIFICATION_TYPES`, but nothing in `packages/core` or `packages/services` emits any of them, because the GitHub pull request sync is not built yet.

## What the inbox really does

Checked against production: 294 notifications exist, all delivered, across five people. The types that actually fire today are `issue_assigned`, `issue_status_changed`, `comment_created`, `comment_replied`, `mention`, `reaction` and `subscription_activity`.

The surprising part, and the reason one workspace owner saw nothing at all, is that **the actor is excluded from their own notifications**. `dedupeAudience(groups, [principal.userId])` in `issue-service.ts` does that deliberately, and it is right: you should not be told about work you just did yourself. But somebody who created and self-assigned 182 of their own issues, and who was the actor on all 294 notifications everyone else received, correctly ends up with an empty inbox and no explanation.

The new copy names what arrives and states that plainly.

## Not changed here

The "Pull requests" tab stays. It is scaffolding for the sync that is coming, and the six types already exist in the schema. Once that lands the tab populates and the copy should mention reviews again.

The eight declared-but-never-emitted notification types are tracked separately rather than fixed here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the inbox empty-state description to reflect the notifications users currently receive and clarify that actions performed by the user do not notify them.
- Replaces references to reviews and PR updates with assignments, mentions, replies, and followed-item activity.
- Explains actor exclusion directly in the empty state.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only changes static inbox copy and introduces no actionable defect.

The revised description remains consistent with the current notification and actor-exclusion behavior, and the change does not affect application logic.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/inbox/inbox-view.tsx | Updates static empty-state copy without changing rendering, state, or notification behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(inbox): describe what actually lands..."](https://github.com/noveum/orbit/commit/3a3f61ef9b04c6ba48ffda73cf5dadf4c70b6105) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51403500)</sub>

<!-- /greptile_comment -->