### PR TITLE
build: let Vercel trace the output instead of building standalone

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -18,11 +18,15 @@ const workspacePackages = [
 
 const devServerOnlyBundledPackages = ['@react-email/render', '@react-email/components', 'prettier'];
 
+function standaloneOutputUnlessVercelTracesItItself(): Pick<NextConfig, 'output'> {
+  return process.env['VERCEL'] === '1' ? {} : { output: 'standalone' };
+}
+
 export default function config(phase: string): NextConfig {
   const isDevServer = phase === PHASE_DEVELOPMENT_SERVER;
   return {
     reactStrictMode: true,
-    output: 'standalone',
+    ...standaloneOutputUnlessVercelTracesItItself(),
     outputFileTracingRoot: workspaceRoot,
     turbopack: {
       root: workspaceRoot,

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "rm -rf node_modules && bun install --frozen-lockfile"
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "rm -rf node_modules && bun install --frozen-lockfile"
+  "installCommand": "rm -rf ../../node_modules node_modules && bun install --frozen-lockfile"
 }


### PR DESCRIPTION
## Production has not deployed since 8 August

Every push to `main` since **#135 bumped Next from 16.2.11 to 16.3.0** has failed to deploy. The last green production deploy is `90477b1`. Everything merged after it, including the whole standup rebuild, is sitting in `main` and not on `orbit.noveum.ai`.

**Nothing surfaced it.** `next build` succeeds, so the CI Build job is green. The failure is in Vercel's own post-build step, which CI never runs:

```
✓ Compiled successfully in 32.7s
Finished TypeScript in 31.6s
✓ Generating static pages (91/91)
Running onBuildComplete from Vercel

> Build error occurred
Error: ENOENT: no such file or directory,
  open '/vercel/path0/apps/web/.next/next-server.js.nft.json'
```

The build works. Vercel then goes looking for a trace manifest and it is not there.

## The change

`output: 'standalone'` now applies everywhere except a Vercel build.

Standalone exists so the app can run on your own server behind nginx, which `docs/self-hosting.md` documents. Vercel traces and packages the app itself, and asking it for standalone hands it an output shaped differently from the one its post-build step opens.

## What I verified, and what I did not

Locally, with the change:

- `VERCEL=1 next build` writes `.next/next-server.js.nft.json`, the file the deploy could not open
- a plain `next build` still writes `.next/standalone/apps/web/server.js`, so self-hosting keeps what it needs

**The control did not reproduce the failure.** Forcing `output: 'standalone'` under `VERCEL=1` locally still produced `next-server.js.nft.json`. So the reproduction lives somewhere in Vercel's build environment, not in the flag by itself, and I cannot claim from a local run that this is the whole story.

**The preview deployment on this pull request is the real test.** If Vercel goes green here, the fix holds. If it does not, the cause is elsewhere and this should not be merged on the strength of the reasoning alone.

## Why it is worth landing anyway

Even setting the deploy aside, `output: 'standalone'` on Vercel is asking for an artefact nobody consumes. Vercel does its own tracing. The flag only ever mattered for the self-hosted path, and that path still gets it.

## Risk

If this does not fix the deploy, it changes nothing that CI covers: no source, no schema, no runtime behaviour. Self-hosting is the one thing that could regress, and the standalone server file is confirmed still produced.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR delegates output tracing to Vercel while preserving standalone output for self-hosted builds.
- Conditionally omits Next.js standalone output when `VERCEL=1`.
- Adds a clean, frozen-lockfile Bun installation command for Vercel builds.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/next.config.ts | Selects the Next.js output mode according to the canonical Vercel environment indicator while retaining standalone output elsewhere. |
| apps/web/vercel.json | Configures Vercel to clear workspace dependency directories and perform a frozen Bun installation. |

</details>

<sub>Reviews (3): Last reviewed commit: ["build: clear the workspace root node\_mod..."](https://github.com/noveum/orbit/commit/c1a8c9f9e4fac2e3bb46b46be8be0127a24386f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51405809)</sub>

<!-- /greptile_comment -->