### PR TITLE
Record the GitHub App permissions the code actually uses

### DIFF
--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -1,0 +1,75 @@
+# The GitHub App
+
+Orbit talks to GitHub through a GitHub App, not a personal token. A workspace
+owner installs it, picks repositories, and Orbit exchanges the installation for a
+short lived token each time it needs one.
+
+## Permissions the App needs today
+
+**Repository permissions**
+
+| Permission | Access | Why |
+| --- | --- | --- |
+| Metadata | Read-only | Mandatory for every GitHub App, and required by `GET /installation/repositories`, which is how the connect flow lists what you may associate. |
+
+That is the whole list. Nothing else is used.
+
+**Organization permissions:** none.
+
+**Account permissions:** none.
+
+**Subscribe to events**
+
+| Event | Why |
+| --- | --- |
+| Repository | A repository being renamed, transferred, archived, made private or public, or deleted has to be reflected against the association Orbit stores, or a project ends up pointing at a repository that no longer answers to that name. |
+
+`installation` and `installation_repositories` are delivered to every App without
+being subscribed to, and Orbit handles both, so they do not appear in that list.
+
+## Why nothing else
+
+Every call the App makes is one of these five, and no other:
+
+```
+POST /app/installations/{id}/access_tokens   mint an installation token
+GET  /app/installations/{id}                 read the installation back
+GET  /installation/repositories              list what was installed on
+POST /login/oauth/access_token               exchange the OAuth code
+GET  /user/installations                     the installations this user can see
+```
+
+The first two authenticate as the App itself with a JWT and need no permission
+grant. The last two are the OAuth leg and run as the signing-in user. Only
+`GET /installation/repositories` consumes a permission, and Metadata covers it.
+
+There are exactly two `POST` requests in the integration and both are token
+exchanges. Orbit does not write to a repository, does not read file contents,
+does not read or write issues or pull requests, and does not read members. If the
+App is currently granted any of that, it is granting more than the code can use.
+
+`bun run check-bun-imports` and the rest of `verify` will not catch an
+over-permissioned App, so this file is the record. Keep it level with the code.
+
+## What pull request tracking will add
+
+Tracking pull requests against issues is not built yet. When it lands it will
+need, and this file should be updated at the same time:
+
+| Permission | Access | Why |
+| --- | --- | --- |
+| Pull requests | Read-only | Read a pull request's state, reviews and merge status. |
+| Checks | Read-only | Report a failing check onto the issue. |
+| Contents | Read-only | Resolve the branch behind a pull request. |
+
+with `pull_request`, `pull_request_review`, `check_suite` and `issue_comment`
+added to the subscribed events. Still nothing that writes.
+
+## Webhook secret
+
+The webhook secret is set on the App and in the deployment environment as
+`GITHUB_APP_WEBHOOK_SECRET`. Both have to change together: rotate on the App
+first, update the environment, then redeploy, because Vercel does not apply an
+environment change to a deployment that already exists. Between those two steps
+every delivery fails signature verification and GitHub retries, so do it in one
+sitting rather than leaving it half done.


### PR DESCRIPTION
Answers a standing question with evidence rather than guesswork: what can be removed from the App without breaking anything.

## Method

I traced every outbound call in `packages/services/src/github`. There are five, and no others:

```
POST /app/installations/{id}/access_tokens   mint an installation token
GET  /app/installations/{id}                 read the installation back
GET  /installation/repositories              list what was installed on
POST /login/oauth/access_token               exchange the OAuth code
GET  /user/installations                     the installations this user can see
```

The first two authenticate as the App with a JWT and consume no permission grant. The last two are the OAuth leg, running as the signing-in user. **Only `GET /installation/repositories` consumes a permission, and `Metadata: Read-only` covers it.**

There are exactly two `POST` requests in the whole integration and both are token exchanges. Nothing writes to a repository, reads file contents, touches issues or pull requests, or reads members.

## The answer

Repository permissions: **Metadata, Read-only**. Organization permissions: **none**. Account permissions: **none**. Subscribed events: **Repository** (`installation` and `installation_repositories` arrive without subscription and are handled).

Anything else currently granted is more than the code can use.

## Also in here

What pull request tracking will need when it lands, so the grant is widened deliberately at that point rather than pre-emptively now, and the webhook secret rotation order, because Vercel does not apply an environment change to an existing deployment and rotating the App first leaves every delivery failing signature verification until a redeploy.

Nothing in `verify` can catch an over-permissioned App, so this file is the record. It should be updated in the same change that widens the grant.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an operational record for GitHub App permissions, event subscriptions, future pull-request tracking requirements, and webhook-secret rotation. Two parts conflict with the current implementation:
- Existing pull-request, review, and check-suite processing is described as future work and omitted from the current event configuration.
- The rotation instructions use a different environment-variable name from the webhook route.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until the permissions record preserves the event subscriptions required by existing pull-request tracking and names the webhook secret variable consumed by the application.

Following the document literally can disable current pull-request event processing or make every webhook fail signature verification after secret rotation.

**Files Needing Attention:** docs/github-app.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/github-app.md | Adds the GitHub App runbook, but understates subscriptions needed by existing PR tracking and gives the wrong webhook-secret variable name. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant O as Operator
    participant A as GitHub App
    participant W as Orbit webhook route
    participant P as PR tracking
    O->>A: Apply documented permissions and events
    A--xW: PR, review, and check events not delivered
    Note over W,P: Existing tracking receives no updates
    O->>W: Set GITHUB_APP_WEBHOOK_SECRET
    A->>W: Signed webhook delivery
    W-->>A: 401 because code reads GITHUB_WEBHOOK_SECRET
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adocs%2Fgithub-app.md%3A23-26%0A**Current%20webhook%20subscriptions%20omitted**%0A%0AWhen%20an%20operator%20reduces%20the%20App%20configuration%20to%20the%20documented%20%60Repository%60%20subscription%2C%20GitHub%20stops%20delivering%20the%20%60pull_request%60%2C%20%60pull_request_review%60%2C%20and%20%60check_suite%60%20events%20already%20processed%20by%20the%20application%2C%20causing%20linked%20pull%20requests%2C%20issue%20transitions%2C%20and%20review%20or%20check%20notifications%20to%20stop%20updating.%0A%0A%23%23%23%20Issue%202%0Adocs%2Fgithub-app.md%3A70-71%0A**Webhook%20secret%20variable%20mismatched**%0A%0AWhen%20an%20operator%20follows%20this%20rotation%20instruction%2C%20the%20deployment%20sets%20%60GITHUB_APP_WEBHOOK_SECRET%60%2C%20but%20the%20webhook%20route%20reads%20%60GITHUB_WEBHOOK_SECRET%60%3B%20verification%20therefore%20receives%20an%20empty%20secret%20and%20rejects%20every%20GitHub%20delivery%20with%20HTTP%20401.%0A%0A%60%60%60suggestion%0AThe%20webhook%20secret%20is%20set%20on%20the%20App%20and%20in%20the%20deployment%20environment%20as%0A%60GITHUB_WEBHOOK_SECRET%60.%20Both%20have%20to%20change%20together%3A%20rotate%20on%20the%20App%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=noveum%2Forbit&pr=173&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/github-app.md:23-26
**Current webhook subscriptions omitted**

When an operator reduces the App configuration to the documented `Repository` subscription, GitHub stops delivering the `pull_request`, `pull_request_review`, and `check_suite` events already processed by the application, causing linked pull requests, issue transitions, and review or check notifications to stop updating.

### Issue 2
docs/github-app.md:70-71
**Webhook secret variable mismatched**

When an operator follows this rotation instruction, the deployment sets `GITHUB_APP_WEBHOOK_SECRET`, but the webhook route reads `GITHUB_WEBHOOK_SECRET`; verification therefore receives an empty secret and rejects every GitHub delivery with HTTP 401.

```suggestion
The webhook secret is set on the App and in the deployment environment as
`GITHUB_WEBHOOK_SECRET`. Both have to change together: rotate on the App
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(github): record the permissions the..."](https://github.com/noveum/orbit/commit/180caac4a89d77fdac37ce78585ea4b35effd32f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51425153)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->