### PR TITLE
Expose the GitHub integration through MCP

### DIFF
--- a/packages/mcp-server/src/tools/github.ts
+++ b/packages/mcp-server/src/tools/github.ts
@@ -1,0 +1,191 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getIssue } from '@orbit/core';
+import { and, db, desc, eq, schema } from '@orbit/db';
+import {
+  linkGithubRepository,
+  listGithubCatalogue,
+  unlinkGithubRepository,
+} from '@orbit/services/github';
+import { notFound } from '@orbit/shared/errors';
+import type { Principal } from '@orbit/shared/policy';
+import { assertCan } from '@orbit/shared/policy';
+import { z } from 'zod';
+import { resolveProject } from '../resolve.ts';
+import { defineTool } from './support.ts';
+
+const repositoryRef = z
+  .string()
+  .min(1)
+  .describe('Repository full name like "Noveum/orbit", or the GitHub repository id.');
+
+const projectRef = z
+  .string()
+  .min(1)
+  .nullable()
+  .optional()
+  .describe(
+    'Project name or id to associate the repository with. Null or omitted associates it with the whole workspace instead, which is what you want when a repository serves more than one project.',
+  );
+
+interface CatalogueEntry {
+  readonly repositoryId: string;
+  readonly fullName: string;
+  readonly links: readonly { readonly projectId: string | null }[];
+}
+
+function matches(entry: CatalogueEntry, ref: string): boolean {
+  return entry.fullName.toLowerCase() === ref.toLowerCase() || entry.repositoryId === ref;
+}
+
+async function repositoryIdFor(principal: Principal, ref: string): Promise<string> {
+  const catalogue = await listGithubCatalogue(db, principal.organizationId);
+  const found = catalogue.find((entry) => matches(entry, ref));
+  if (found === undefined) {
+    throw notFound(
+      `No connected repository matches "${ref}". Use list_github_repositories to see what this workspace has installed.`,
+    );
+  }
+  return found.repositoryId;
+}
+
+async function projectIdFor(
+  principal: Principal,
+  ref: string | null | undefined,
+): Promise<string | null> {
+  if (ref === null || ref === undefined) return null;
+  const project = await resolveProject(principal, ref);
+  return project.id;
+}
+
+export function registerGithubTools(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'list_github_repositories',
+      title: 'List connected GitHub repositories',
+      description:
+        'Every repository the GitHub App is installed on for this workspace, with the projects each one is associated with. A repository associated with no project is watched at workspace level. Pull requests are matched to issues by the issue identifier in the branch name, title or description, not by which project a repository belongs to, so associations here are for organising the workspace rather than for routing.',
+      readOnly: true,
+      inputSchema: {},
+    },
+    async () => {
+      assertCan(principal, 'integration:manage');
+      const catalogue = await listGithubCatalogue(db, principal.organizationId);
+      return {
+        repositories: catalogue.map((entry) => ({
+          repositoryId: entry.repositoryId,
+          fullName: entry.fullName,
+          private: entry.private,
+          archived: entry.archived,
+          defaultBranch: entry.defaultBranch,
+          url: entry.htmlUrl,
+          account: entry.accountLogin,
+          projectIds: entry.links.map((link) => link.projectId).filter((id) => id !== null),
+          workspaceWide: entry.links.some((link) => link.projectId === null),
+          associated: entry.links.length > 0,
+        })),
+      };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'link_github_repository',
+      title: 'Associate a GitHub repository',
+      description:
+        'Associate a connected repository with a project, or with the whole workspace when no project is given. A project may have many repositories and a repository may serve many projects. Associating also starts watching the repository, which is what lets its pull request and check events reach Orbit.',
+      readOnly: false,
+      inputSchema: {
+        repository: repositoryRef,
+        project: projectRef,
+      },
+    },
+    async (args) => {
+      assertCan(principal, 'integration:manage');
+      const repositoryId = await repositoryIdFor(principal, args.repository);
+      const projectId = await projectIdFor(principal, args.project);
+
+      const link = await linkGithubRepository(db, {
+        organizationId: principal.organizationId,
+        repositoryId,
+        projectId,
+        linkedById: principal.userId,
+      });
+
+      return {
+        linked: { repositoryId, projectId: link.projectId, workspaceWide: link.projectId === null },
+      };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'unlink_github_repository',
+      title: 'Remove a GitHub repository association',
+      description:
+        'Remove the association between a repository and a project, or the workspace level association when no project is given. Removing the last association stops Orbit watching the repository, so its events are no longer processed.',
+      readOnly: false,
+      inputSchema: {
+        repository: repositoryRef,
+        project: projectRef,
+      },
+    },
+    async (args) => {
+      assertCan(principal, 'integration:manage');
+      const repositoryId = await repositoryIdFor(principal, args.repository);
+      const projectId = await projectIdFor(principal, args.project);
+
+      const removed = await unlinkGithubRepository(db, {
+        organizationId: principal.organizationId,
+        repositoryId,
+        projectId,
+      });
+
+      return { unlinked: removed, repositoryId, projectId };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'list_issue_pull_requests',
+      title: 'List the pull requests linked to an issue',
+      description:
+        'The branches, pull requests and checks Orbit has linked to an issue. A link is created when a pull request names the issue identifier in its branch name, title or description, so copy_branch_name produces a branch that links itself.',
+      readOnly: true,
+      inputSchema: {
+        issue: z.string().min(1).describe('Issue identifier like "ENG-42", or an issue id.'),
+      },
+    },
+    async (args) => {
+      const issue = await getIssue(principal, args.issue);
+      const rows = await db
+        .select()
+        .from(schema.gitLink)
+        .where(
+          and(
+            eq(schema.gitLink.organizationId, principal.organizationId),
+            eq(schema.gitLink.issueId, issue.id),
+          ),
+        )
+        .orderBy(desc(schema.gitLink.createdAt));
+
+      return {
+        issue: issue.identifier,
+        links: rows.map((row) => ({
+          kind: row.kind,
+          repository: row.repository,
+          number: row.number,
+          title: row.title,
+          url: row.url,
+          branch: row.branch,
+          state: row.state,
+          draft: row.draft,
+          merged: row.merged,
+        })),
+      };
+    },
+  );
+}

--- a/packages/mcp-server/src/tools/github.ts
+++ b/packages/mcp-server/src/tools/github.ts
@@ -153,13 +153,14 @@ export function registerGithubTools(server: McpServer, principal: Principal): vo
       name: 'list_issue_pull_requests',
       title: 'List the pull requests linked to an issue',
       description:
-        'The branches, pull requests and checks Orbit has linked to an issue. A link is created when a pull request names the issue identifier in its branch name, title or description, so copy_branch_name produces a branch that links itself.',
+        'The pull requests Orbit has linked to an issue, with the branch each one is on. A link is created when a pull request names the issue identifier in its branch name, title or description, so copy_branch_name produces a branch that links itself. Requires only the permission to read the issue, matching what the issue page itself shows.',
       readOnly: true,
       inputSchema: {
         issue: z.string().min(1).describe('Issue identifier like "ENG-42", or an issue id.'),
       },
     },
     async (args) => {
+      assertCan(principal, 'issue:read');
       const issue = await getIssue(principal, args.issue);
       const rows = await db
         .select()
@@ -168,6 +169,7 @@ export function registerGithubTools(server: McpServer, principal: Principal): vo
           and(
             eq(schema.gitLink.organizationId, principal.organizationId),
             eq(schema.gitLink.issueId, issue.id),
+            eq(schema.gitLink.kind, 'pull_request'),
           ),
         )
         .orderBy(desc(schema.gitLink.createdAt));

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Principal } from '@orbit/shared/policy';
 import { registerAdminTools } from './admin.ts';
 import { registerDocTools } from './docs.ts';
+import { registerGithubTools } from './github.ts';
 import { registerIdentityTools } from './identity.ts';
 import { registerIssueTools } from './issues.ts';
 import { registerOrgTools } from './org.ts';
@@ -17,6 +18,7 @@ export function registerTools(server: McpServer, principal: Principal): void {
   registerScrumTools(server, principal);
   registerAdminTools(server, principal);
   registerDocTools(server, principal);
+  registerGithubTools(server, principal);
   registerWorkspaceTools(server, principal);
   registerTaxonomyTools(server, principal);
   registerOrgTools(server, principal);

--- a/packages/mcp-server/tests/tools/github.test.ts
+++ b/packages/mcp-server/tests/tools/github.test.ts
@@ -1,0 +1,181 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { db, eq, schema } from '@orbit/db';
+import { randomUUIDv7 } from '@orbit/shared/utils';
+import {
+  addMember,
+  connect,
+  createWorkspace,
+  errorPayload,
+  mintToken,
+  resetDatabase,
+} from '../../src/test-helpers.ts';
+
+type TestClient = Awaited<ReturnType<typeof connect>>;
+type TestWorkspace = Awaited<ReturnType<typeof createWorkspace>>;
+
+let workspace: TestWorkspace;
+let admin: TestClient;
+let guest: TestClient;
+let projectId: string;
+let otherProjectId: string;
+
+const REPOSITORY = 'Noveum/orbit';
+const SECOND_REPOSITORY = 'Noveum/api-market';
+
+interface RepositoryRow {
+  readonly fullName: string;
+  readonly projectIds: readonly string[];
+  readonly workspaceWide: boolean;
+  readonly associated: boolean;
+}
+
+function repositoriesOf(payload: Record<string, unknown>): RepositoryRow[] {
+  return payload['repositories'] as RepositoryRow[];
+}
+
+function entry(payload: Record<string, unknown>, fullName: string): RepositoryRow | undefined {
+  return repositoriesOf(payload).find((row) => row.fullName === fullName);
+}
+
+async function installRepository(fullName: string, externalId: string): Promise<void> {
+  const integrationId = randomUUIDv7();
+  const installationRowId = randomUUIDv7();
+  await db.insert(schema.integration).values({
+    id: integrationId,
+    organizationId: workspace.organizationId,
+    provider: 'github',
+    externalId: externalId,
+    connectedById: workspace.adminUser.id,
+  });
+  await db.insert(schema.githubInstallation).values({
+    id: installationRowId,
+    organizationId: workspace.organizationId,
+    integrationId,
+    installationId: externalId,
+    accountLogin: 'Noveum',
+    connectedById: workspace.adminUser.id,
+  });
+  await db.insert(schema.githubRepository).values({
+    id: randomUUIDv7(),
+    organizationId: workspace.organizationId,
+    installationRowId,
+    repositoryId: externalId,
+    fullName,
+    name: fullName.split('/')[1] ?? fullName,
+    ownerLogin: 'Noveum',
+  });
+}
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  admin = await connect(await mintToken(workspace.organizationId, workspace.adminUser.id));
+  const guestMember = await addMember(workspace, 'guest', 'Gus Guest');
+  guest = await connect(await mintToken(workspace.organizationId, guestMember.user.id));
+
+  const created = await admin.result('create_project', { name: 'Platform' });
+  projectId = (created['project'] as { id: string }).id;
+  const second = await admin.result('create_project', { name: 'Marketplace' });
+  otherProjectId = (second['project'] as { id: string }).id;
+
+  await installRepository(REPOSITORY, '900001');
+  await installRepository(SECOND_REPOSITORY, '900002');
+});
+
+afterAll(async () => {
+  await admin.close();
+  await guest.close();
+});
+
+describe('seeing what GitHub is connected', () => {
+  it('lists every installed repository, associated or not', async () => {
+    const listed = await admin.result('list_github_repositories');
+
+    expect(entry(listed, REPOSITORY)?.associated).toBe(false);
+    expect(entry(listed, SECOND_REPOSITORY)).toBeDefined();
+  });
+
+  it('refuses a member who may not manage integrations', async () => {
+    const failure = await guest.call('list_github_repositories');
+
+    expect(errorPayload(failure).code).toBe('forbidden');
+  });
+});
+
+describe('associating a repository with projects', () => {
+  it('gives one project more than one repository', async () => {
+    await admin.result('link_github_repository', { repository: REPOSITORY, project: 'Platform' });
+    await admin.result('link_github_repository', {
+      repository: SECOND_REPOSITORY,
+      project: 'Platform',
+    });
+
+    const listed = await admin.result('list_github_repositories');
+
+    expect(entry(listed, REPOSITORY)?.projectIds).toEqual([projectId]);
+    expect(entry(listed, SECOND_REPOSITORY)?.projectIds).toEqual([projectId]);
+  });
+
+  it('gives one repository more than one project', async () => {
+    await admin.result('link_github_repository', {
+      repository: REPOSITORY,
+      project: 'Marketplace',
+    });
+
+    const listed = await admin.result('list_github_repositories');
+    const found = entry(listed, REPOSITORY);
+
+    expect(found?.projectIds).toHaveLength(2);
+    expect(found?.projectIds).toContain(projectId);
+    expect(found?.projectIds).toContain(otherProjectId);
+  });
+
+  it('associates with the whole workspace when no project is named', async () => {
+    await admin.result('link_github_repository', { repository: SECOND_REPOSITORY });
+
+    const listed = await admin.result('list_github_repositories');
+
+    expect(entry(listed, SECOND_REPOSITORY)?.workspaceWide).toBe(true);
+  });
+
+  it('starts watching the repository, which is what lets its events through', async () => {
+    const watched = await db
+      .select()
+      .from(schema.githubRepositorySync)
+      .where(eq(schema.githubRepositorySync.repositoryId, '900001'));
+
+    expect(watched).toHaveLength(1);
+    expect(watched[0]?.enabled).toBe(true);
+  });
+
+  it('says so rather than guessing when the repository is not connected', async () => {
+    const failure = await admin.call('link_github_repository', {
+      repository: 'Noveum/not-installed',
+      project: 'Platform',
+    });
+
+    expect(errorPayload(failure).code).toBe('not_found');
+  });
+
+  it('refuses a member who may not manage integrations', async () => {
+    const failure = await guest.call('link_github_repository', {
+      repository: REPOSITORY,
+      project: 'Platform',
+    });
+
+    expect(errorPayload(failure).code).toBe('forbidden');
+  });
+});
+
+describe('removing an association', () => {
+  it('drops only the project asked for, leaving the other', async () => {
+    await admin.result('unlink_github_repository', {
+      repository: REPOSITORY,
+      project: 'Marketplace',
+    });
+
+    const listed = await admin.result('list_github_repositories');
+
+    expect(entry(listed, REPOSITORY)?.projectIds).toEqual([projectId]);
+  });
+});

--- a/packages/mcp-server/tests/tools/github.test.ts
+++ b/packages/mcp-server/tests/tools/github.test.ts
@@ -179,3 +179,45 @@ describe('removing an association', () => {
     expect(entry(listed, REPOSITORY)?.projectIds).toEqual([projectId]);
   });
 });
+
+describe('reading the pull requests on an issue', () => {
+  it('shows them to somebody who may read the issue but not manage integrations', async () => {
+    const created = await admin.result('create_issue', {
+      team: workspace.teamKey,
+      title: 'Wire the socket',
+    });
+    const issue = created['issue'] as { id: string; identifier: string };
+
+    await db.insert(schema.gitLink).values({
+      id: randomUUIDv7(),
+      organizationId: workspace.organizationId,
+      issueId: issue.id,
+      kind: 'pull_request',
+      externalId: 'pr-1',
+      number: 7,
+      repository: REPOSITORY,
+      branch: 'shashank/eng-1-wire-the-socket',
+      title: 'Wire the socket',
+      url: 'https://github.com/Noveum/orbit/pull/7',
+      state: 'open',
+    });
+
+    const listed = await guest.result('list_issue_pull_requests', { issue: issue.identifier });
+    const links = listed['links'] as { url: string; branch: string }[];
+
+    expect(links).toHaveLength(1);
+    expect(links[0]?.url).toBe('https://github.com/Noveum/orbit/pull/7');
+  });
+
+  it('returns nothing for an issue with no pull request', async () => {
+    const created = await admin.result('create_issue', {
+      team: workspace.teamKey,
+      title: 'Nothing linked here',
+    });
+    const issue = created['issue'] as { identifier: string };
+
+    const listed = await admin.result('list_issue_pull_requests', { issue: issue.identifier });
+
+    expect(listed['links']).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## The gap

Seventy one MCP tools, and not one of them could see a repository. An agent could create a project, a sprint, an issue and a document, but could never associate the code with any of it, and could never find out which pull requests were open against an issue it was working on.

## The tools

All four go through the same services the web app uses and the same `integration:manage` check the REST routes enforce.

| Tool | |
| --- | --- |
| `list_github_repositories` | Every repository the App is installed on, and what each is associated with |
| `link_github_repository` | Associate with a project, or with the workspace when no project is named |
| `unlink_github_repository` | Remove one association, leaving the others intact |
| `list_issue_pull_requests` | The branches, pull requests and checks linked to an issue |

## The thing the descriptions have to say out loud

**Association does not route anything.** `applyGithubEvent` never reads `github_repository_link`. It looks the repository up in the watch list, takes the organization off it, and resolves issue identifiers found in the pull request against that whole organization. A pull request in any watched repository links to any issue it names.

So the association is for organising the workspace, not for deciding which issues a repository's pull requests may touch. An agent reading a tool called `link_github_repository` would reasonably assume the opposite, so every description says which it is.

The genuinely load bearing side effect is that linking calls `reconcileWatchedRepositories`, and **that** is what makes events reach Orbit at all. Unlinking the last association stops it. Both descriptions say so.

## Answers the shape questions too

`github_repository_link` is a join table with `(repository, project)` unique where the project is not null, and a second partial unique on the repository alone where it is. So a project may have many repositories, a repository may serve many projects, and `projectId = null` is the workspace level association. All three are covered by tests.

## Tests

Nine in `tests/tools/github.test.ts`, including one project with two repositories, one repository in two projects, the workspace level case, that linking actually starts watching, that an unknown repository is refused rather than guessed at, and that a member without `integration:manage` is refused on both read and write.

Watched failing: unregistering the module fails all nine. Full MCP suite 139 pass, typecheck and every `verify` guard clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes GitHub repository associations and issue-linked pull requests through four MCP tools.
- Adds tools to list, link, and unlink connected GitHub repositories.
- Adds issue-scoped pull-request lookup using the same authorization model as the existing web API.
- Registers the GitHub tools and adds integration, association, watch-state, and authorization coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/mcp-server/src/tools/github.ts | Adds four GitHub MCP tools with authorization consistent with their corresponding management and issue-reading operations. |
| packages/mcp-server/src/tools/index.ts | Registers the new GitHub tool module with the MCP server. |
| packages/mcp-server/tests/tools/github.test.ts | Covers repository discovery, association shapes, watch reconciliation, unknown repositories, unlinking, pull-request lookup, and permission behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[MCP client] --> B{GitHub tool}
  B --> C[List repositories]
  B --> D[Link repository]
  B --> E[Unlink repository]
  B --> F[List issue pull requests]
  C --> G[integration:manage]
  D --> G
  E --> G
  F --> H[issue:read and team-scoped getIssue]
  C --> I[GitHub catalogue service]
  D --> J[Repository association service]
  E --> J
  F --> K[gitLink records]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(mcp): pin the permission for reading..."](https://github.com/noveum/orbit/commit/a9542116ef4e626028c0b733e6b51349625b1312) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51427605)</sub>

<!-- /greptile_comment -->