### PR TITLE
chore(github): add discussion templates and route the issue chooser

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,43 @@
+title: "[idea]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ideas is where a feature starts before anyone agrees on its shape. Nothing here
+        has to be finished. A half formed thought about a workflow that does not work is
+        more useful than a polished specification for the wrong thing.
+
+        Once an idea has a shape people agree on, it becomes an issue. Until then it
+        lives here, where it can change without anyone feeling committed to it.
+
+        Three things are permanently off the table: pricing or billing of any kind,
+        telemetry that phones home, and a second way to do something Orbit already does.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is painful today
+      description: The situation, not the solution. What are you trying to get done, and where does Orbit get in the way?
+    validations:
+      required: true
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: What you do instead
+      description: Including "I keep a spreadsheet" or "I gave up". The workaround tells us what the gap actually costs, which is what moves an idea up.
+    validations:
+      required: true
+
+  - type: textarea
+    id: shape
+    attributes:
+      label: Any thoughts on the shape
+      description: Optional. If you have a sense of how this could work, say so. If you do not, that is fine, and the discussion is for working it out.
+
+  - type: textarea
+    id: prior-art
+    attributes:
+      label: Prior art
+      description: If another tool solves this well, say which and what it gets right. Screenshots help. If another tool solves it badly, that is worth knowing too.

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,57 @@
+title: "[question]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ask anything about running, self-hosting, configuring or building on Orbit.
+
+        Before you post, the answer may already be in
+        [the documentation](https://github.com/Noveum/orbit/tree/main/docs). Setup is in
+        [getting-started.md](https://github.com/Noveum/orbit/blob/main/docs/getting-started.md),
+        environment variables are in
+        [configuration.md](https://github.com/Noveum/orbit/blob/main/docs/configuration.md),
+        and known failures are in
+        [troubleshooting.md](https://github.com/Noveum/orbit/blob/main/docs/troubleshooting.md).
+
+        If the documentation was wrong or missing, say so. That is a bug and we would
+        rather fix it than answer the same question twice.
+
+        Never post an unreported security problem here. Use
+        [SECURITY.md](https://github.com/Noveum/orbit/blob/main/SECURITY.md).
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What you are trying to do
+      description: The goal, not only the step you are stuck on. Knowing where you are heading often changes the answer.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you have tried
+      description: Commands you ran, and what happened. Paste error output in full rather than describing it.
+
+  - type: dropdown
+    id: how
+    attributes:
+      label: How are you running Orbit
+      options:
+        - The hosted instance at orbit.noveum.ai
+        - Self-hosted
+        - Local development from a clone
+        - Not running it yet
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Operating system, Bun version, and how you are deploying if self-hosted. Skip this if you are asking about the hosted instance.
+      placeholder: |
+        OS:
+        Bun:
+        Deployed on:

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -32,7 +32,7 @@ body:
     id: tried
     attributes:
       label: What you have tried
-      description: Commands you ran, and what happened. Paste error output in full rather than describing it.
+      description: Commands you ran, and what happened. Paste error output in full rather than describing it. Redact anything sensitive, including connection strings, API keys and anything out of your .env.
 
   - type: dropdown
     id: how

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,41 @@
+title: "[show and tell]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Show what you built with Orbit, or what you built on top of it. Deployments,
+        integrations, MCP clients, scripts, themes, importers, or the way your team
+        uses it that nobody expected.
+
+        This is also the best place to tell us something is missing without filing
+        anything. If you had to work around Orbit to build your thing, that is worth
+        knowing.
+
+        Do not post screenshots containing anything private. Issue titles and names
+        from a real workspace are easy to forget about.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What you built
+    validations:
+      required: true
+
+  - type: textarea
+    id: how
+    attributes:
+      label: How it works
+      description: Which parts of Orbit it uses. The MCP server, the realtime socket, the importers, the docs product.
+
+  - type: input
+    id: link
+    attributes:
+      label: Link
+      description: Repository, site, or a video. Optional.
+
+  - type: textarea
+    id: friction
+    attributes:
+      label: What got in your way
+      description: Anything you had to work around, or wished existed. This is the part we read most carefully.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,14 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Question or idea
-    url: https://github.com/Noveum/orbit/discussions
-    about: Ask how something works, or float an idea before it becomes a feature request.
+  - name: Where to start contributing
+    url: https://github.com/Noveum/orbit/discussions/231
+    about: Every milestone, what is missing in each, and which issues are small enough for an hour.
+  - name: Ask a question
+    url: https://github.com/Noveum/orbit/discussions/new?category=q-a
+    about: How to run, self-host, configure or build on Orbit.
+  - name: Float an idea
+    url: https://github.com/Noveum/orbit/discussions/new?category=ideas
+    about: Describe a workflow that is painful, before it has a shape. Ideas become issues once we agree what to build.
   - name: Documentation
     url: https://github.com/Noveum/orbit/tree/main/docs
     about: Setup, self-hosting, architecture, keyboard shortcuts and the MCP server.


### PR DESCRIPTION
Discussions has been enabled on this repository with six categories, zero posts and no templates. The issue chooser pointed at the Discussions root, so somebody arriving with a question landed on an empty tab with no prompt to answer.

## What this changes

**Three discussion templates**, in `.github/DISCUSSION_TEMPLATE/`:

- **Ideas** asks what is painful and what you do instead, rather than what widget you want. It states the three permanently off-the-table things up front, matching `feature_request.yml`, so nobody writes a long post about billing.
- **Q&A** points at the documentation first, asks for the goal rather than only the stuck step, and asks for full error output. It also says plainly not to post security problems there.
- **Show and tell** asks what got in the way, which is the part worth reading.

The tone follows the existing issue templates rather than inventing a second voice.

**The issue chooser** now links three specific destinations instead of one generic one: the contribution map, Q&A, and Ideas. The old "Question or idea" link sent both audiences to the same place and neither found what they needed.

## Why now

Part of the Community and repo health milestone, specifically #221.

## Checks

`bun run check-comments` covers YAML and passes. No source files touched, so lint, typecheck and tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds structured GitHub Discussion templates and routes issue-chooser visitors to more specific community destinations.
- Adds Ideas, Q&A, and Show and Tell discussion forms.
- Adds explicit sensitive-output redaction guidance to the Q&A form.
- Replaces the generic Discussions link with contribution, Q&A, and Ideas links.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported disclosure concern is addressed by explicit guidance to redact sensitive output.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/DISCUSSION_TEMPLATE/ideas.yml | Adds a structured form for discussing workflow problems, workarounds, possible solutions, and prior art. |
| .github/DISCUSSION_TEMPLATE/q-a.yml | Adds a Q&A form with documentation and security-reporting directions; the follow-up wording fully addresses the prior sensitive-output disclosure concern. |
| .github/DISCUSSION_TEMPLATE/show-and-tell.yml | Adds a showcase form covering implementation details, links, and encountered friction. |
| .github/ISSUE_TEMPLATE/config.yml | Replaces the generic Discussions destination with direct contribution, Q&A, and Ideas links. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/noveum/orbit/commit/113dc3c6aeb9287948664ae05ada0c1c14b1a8a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51427925)</sub>

<!-- /greptile_comment -->