### PR TITLE
feat(issues): let the properties panel take you to what it names

### DIFF
--- a/apps/web/src/features/issues/issue-properties.tsx
+++ b/apps/web/src/features/issues/issue-properties.tsx
@@ -2,14 +2,15 @@
 
 import { DEFAULT_ESTIMATE_SCALE, PRIORITIES } from '@orbit/shared/constants';
 import { sprintLabel } from '@orbit/shared/utils';
-import { Trash2, X } from 'lucide-react';
+import { ArrowUpRight, Trash2, X } from 'lucide-react';
+import Link from 'next/link';
 import { useState } from 'react';
 import { Avatar } from '@/components/ui/avatar.tsx';
 import { Kbd } from '@/components/ui/kbd.tsx';
 import { cn } from '@/lib/cn.ts';
 import { dangerMenuAction, rowHover } from '@/lib/interaction.ts';
 import { useHotkey } from '@/lib/keyboard/index.ts';
-import type { Issue, Milestone } from '@/lib/query/schemas.ts';
+import type { Cycle, Issue, Milestone, Project } from '@/lib/query/schemas.ts';
 import { useUpdateIssue } from '@/lib/query/use-issues.ts';
 import { useMilestones } from '@/lib/query/use-milestones.ts';
 import { DueDateField } from './due-date-field.tsx';
@@ -60,6 +61,7 @@ export function IssueProperties({ issue, parent = null, onDeleted }: IssueProper
   const teamLabels = workspace.labels.filter(
     (label) => label.teamId === null || label.teamId === issue.teamId,
   );
+  const teamKey = workspace.teams.find((entry) => entry.id === issue.teamId)?.key;
   const parentLabel =
     issue.parentId === null ? 'No parent' : (parent?.identifier ?? 'Parent issue');
 
@@ -241,23 +243,14 @@ export function IssueProperties({ issue, parent = null, onDeleted }: IssueProper
         </PropertyMenu>
       </PropertyRow>
 
-      <PropertyRow label="Project" shortcut="i">
-        <PropertyMenu
-          title="Project"
-          open={openMenu === 'project'}
-          onOpenChange={toggle('project')}
-          options={[
-            { id: 'none', label: 'No project' },
-            ...workspace.projects.map((entry) => ({ id: entry.id, label: entry.name })),
-          ]}
-          selected={issue.projectId === null ? ['none'] : [issue.projectId]}
-          onSelect={(value) => patch({ projectId: value === 'none' ? null : value })}
-        >
-          <button type="button" className={rowClassName} data-testid="property-project">
-            {project?.name ?? 'No project'}
-          </button>
-        </PropertyMenu>
-      </PropertyRow>
+      <ProjectProperty
+        issue={issue}
+        project={project}
+        projects={workspace.projects}
+        open={openMenu === 'project'}
+        onOpenChange={toggle('project')}
+        onSelect={(projectId) => patch({ projectId })}
+      />
 
       <MilestoneProperty
         issue={issue}
@@ -308,29 +301,131 @@ export function IssueProperties({ issue, parent = null, onDeleted }: IssueProper
         </div>
       </PropertyRow>
 
-      <PropertyRow label="Sprint">
+      <SprintProperty
+        cycle={cycle}
+        cycles={cycles}
+        teamKey={teamKey}
+        open={openMenu === 'cycle'}
+        onOpenChange={toggle('cycle')}
+        onSelect={(cycleId) => patch({ cycleId })}
+      />
+
+      <DeleteIssueRow issue={issue} onDeleted={onDeleted} />
+    </aside>
+  );
+}
+
+function ProjectProperty({
+  issue,
+  project,
+  projects,
+  open,
+  onOpenChange,
+  onSelect,
+}: {
+  readonly issue: Issue;
+  readonly project: Project | undefined;
+  readonly projects: readonly Project[];
+  readonly open: boolean;
+  readonly onOpenChange: (next: boolean) => void;
+  readonly onSelect: (projectId: string | null) => void;
+}) {
+  return (
+    <PropertyRow label="Project" shortcut="i">
+      <div className="flex items-center gap-1">
+        <PropertyMenu
+          title="Project"
+          open={open}
+          onOpenChange={onOpenChange}
+          options={[
+            { id: 'none', label: 'No project' },
+            ...projects.map((entry) => ({ id: entry.id, label: entry.name })),
+          ]}
+          selected={issue.projectId === null ? ['none'] : [issue.projectId]}
+          onSelect={(value) => onSelect(value === 'none' ? null : value)}
+        >
+          <button type="button" className={rowClassName} data-testid="property-project">
+            {project?.name ?? 'No project'}
+          </button>
+        </PropertyMenu>
+        {project === undefined || project.slug === '' ? null : (
+          <OpenLink
+            href={`/projects/${project.slug}`}
+            label={`Open ${project.name}`}
+            testId="open-project"
+          />
+        )}
+      </div>
+    </PropertyRow>
+  );
+}
+
+function SprintProperty({
+  cycle,
+  cycles,
+  teamKey,
+  open,
+  onOpenChange,
+  onSelect,
+}: {
+  readonly cycle: Cycle | undefined;
+  readonly cycles: readonly Cycle[];
+  readonly teamKey: string | undefined;
+  readonly open: boolean;
+  readonly onOpenChange: (next: boolean) => void;
+  readonly onSelect: (cycleId: string | null) => void;
+}) {
+  return (
+    <PropertyRow label="Sprint">
+      <div className="flex items-center gap-1">
         <PropertyMenu
           title="Sprint"
-          open={openMenu === 'cycle'}
-          onOpenChange={toggle('cycle')}
+          open={open}
+          onOpenChange={onOpenChange}
           options={[
             { id: 'none', label: 'No sprint' },
-            ...cycles.map((entry) => ({
-              id: entry.id,
-              label: sprintLabel(entry),
-            })),
+            ...cycles.map((entry) => ({ id: entry.id, label: sprintLabel(entry) })),
           ]}
-          selected={issue.cycleId === null ? ['none'] : [issue.cycleId]}
-          onSelect={(value) => patch({ cycleId: value === 'none' ? null : value })}
+          selected={cycle === undefined ? ['none'] : [cycle.id]}
+          onSelect={(value) => onSelect(value === 'none' ? null : value)}
         >
           <button type="button" className={rowClassName} data-testid="property-cycle">
             {cycle === undefined ? 'No sprint' : sprintLabel(cycle)}
           </button>
         </PropertyMenu>
-      </PropertyRow>
+        {cycle === undefined || teamKey === undefined ? null : (
+          <OpenLink
+            href={`/team/${teamKey.toLowerCase()}/sprint/${cycle.number}`}
+            label={`Open ${sprintLabel(cycle)}`}
+            testId="open-sprint"
+          />
+        )}
+      </div>
+    </PropertyRow>
+  );
+}
 
-      <DeleteIssueRow issue={issue} onDeleted={onDeleted} />
-    </aside>
+function OpenLink({
+  href,
+  label,
+  testId,
+}: {
+  readonly href: string;
+  readonly label: string;
+  readonly testId: string;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-label={label}
+      data-testid={testId}
+      className={cn(
+        'flex size-6 shrink-0 items-center justify-center rounded-md text-faint hover:text-text',
+        rowHover,
+      )}
+    >
+      <ArrowUpRight className="size-3.5" aria-hidden="true" />
+    </Link>
   );
 }
 

--- a/apps/web/src/lib/api/bootstrap.ts
+++ b/apps/web/src/lib/api/bootstrap.ts
@@ -126,6 +126,7 @@ export async function bootstrapPayload(principal: Principal, query: BootstrapQue
     })),
     projects: projects.map((project) => ({
       id: project.id,
+      slug: project.slug,
       name: project.name,
       status: project.status,
       color: project.color,

--- a/apps/web/src/lib/query/schemas.ts
+++ b/apps/web/src/lib/query/schemas.ts
@@ -86,6 +86,7 @@ export type Member = z.infer<typeof memberSchema>;
 
 export const projectSchema = z.object({
   id: z.string(),
+  slug: z.string().catch(''),
   name: z.string(),
   status: z.string(),
   color: z.string(),

--- a/apps/web/tests/features/filters/filter-bar.test.tsx
+++ b/apps/web/tests/features/filters/filter-bar.test.tsx
@@ -59,6 +59,7 @@ const workspace: WorkspaceData = {
   projects: [
     {
       id: 'project-1',
+      slug: '1',
       name: 'Atlas',
       status: 'planned',
       color: '#5a63c8',

--- a/apps/web/tests/features/filters/grouping.test.ts
+++ b/apps/web/tests/features/filters/grouping.test.ts
@@ -51,6 +51,7 @@ const context: GroupContext = {
   projects: [
     {
       id: 'project_1',
+      slug: '1',
       name: 'Atlas',
       status: 'planned',
       color: '#5a63c8',

--- a/apps/web/tests/features/issues/issue-properties.test.tsx
+++ b/apps/web/tests/features/issues/issue-properties.test.tsx
@@ -42,6 +42,7 @@ const workspace: WorkspaceData = {
   projects: [
     {
       id: 'project_launch',
+      slug: 'launch',
       name: 'Launch',
       status: 'started',
       color: '#5a63c8',
@@ -49,7 +50,17 @@ const workspace: WorkspaceData = {
       teamIds: ['team_eng'],
     },
   ],
-  cycles: [],
+  cycles: [
+    {
+      id: 'cycle_7',
+      teamId: 'team_eng',
+      number: 7,
+      name: 'Sprint 7',
+      startsAt: '2026-01-01T00:00:00.000Z',
+      endsAt: '2026-01-14T00:00:00.000Z',
+      completedAt: null,
+    },
+  ],
   seedIssues: [],
   stateById: new Map(),
   labelById: new Map(),
@@ -288,5 +299,38 @@ describe('the delete affordance on the properties panel', () => {
 
     expect(screen.queryByTestId('property-delete-issue')).not.toBeInTheDocument();
     Object.assign(workspace, { role: previous });
+  });
+});
+
+describe('reaching what the properties panel names', () => {
+  it('offers a way into the project rather than only a picker', () => {
+    render(
+      <Providers>
+        <IssueProperties issue={issue()} />
+      </Providers>,
+    );
+
+    expect(screen.getByTestId('open-project')).toHaveAttribute('href', '/projects/launch');
+  });
+
+  it('offers a way into the sprint the issue sits in', () => {
+    render(
+      <Providers>
+        <IssueProperties issue={issue({ cycleId: 'cycle_7' })} />
+      </Providers>,
+    );
+
+    expect(screen.getByTestId('open-sprint')).toHaveAttribute('href', '/team/eng/sprint/7');
+  });
+
+  it('offers no link when the issue is on no project and no sprint', () => {
+    render(
+      <Providers>
+        <IssueProperties issue={issue({ projectId: null, cycleId: null })} />
+      </Providers>,
+    );
+
+    expect(screen.queryByTestId('open-project')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('open-sprint')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/tests/features/issues/issue-properties.test.tsx
+++ b/apps/web/tests/features/issues/issue-properties.test.tsx
@@ -323,6 +323,23 @@ describe('reaching what the properties panel names', () => {
     expect(screen.getByTestId('open-sprint')).toHaveAttribute('href', '/team/eng/sprint/7');
   });
 
+  it('hides the project link when the payload carried no slug, rather than linking nowhere', () => {
+    const projects = workspace.projects;
+    Object.assign(workspace, {
+      projects: projects.map((entry) => ({ ...entry, slug: '' })),
+    });
+
+    render(
+      <Providers>
+        <IssueProperties issue={issue()} />
+      </Providers>,
+    );
+
+    expect(screen.getByTestId('property-project')).toHaveTextContent('Launch');
+    expect(screen.queryByTestId('open-project')).not.toBeInTheDocument();
+    Object.assign(workspace, { projects });
+  });
+
   it('offers no link when the issue is on no project and no sprint', () => {
     render(
       <Providers>

--- a/apps/web/tests/features/issues/quick-create.test.tsx
+++ b/apps/web/tests/features/issues/quick-create.test.tsx
@@ -75,6 +75,7 @@ function buildWorkspace(): WorkspaceData {
     projects: [
       {
         id: 'proj_1',
+        slug: 'proj-1',
         name: 'API market',
         status: 'started',
         color: '#00f',
@@ -83,6 +84,7 @@ function buildWorkspace(): WorkspaceData {
       },
       {
         id: 'proj_2',
+        slug: 'proj-2',
         name: 'Brand refresh',
         status: 'started',
         color: '#0f0',

--- a/apps/web/tests/features/views/create-view-dialog.test.tsx
+++ b/apps/web/tests/features/views/create-view-dialog.test.tsx
@@ -63,6 +63,7 @@ function buildWorkspace(): WorkspaceData {
     projects: [
       {
         id: 'project-atlas',
+        slug: 'atlas',
         name: 'Atlas',
         status: 'planned',
         color: '#5a63c8',

--- a/apps/web/tests/features/views/saved-view-page.test.tsx
+++ b/apps/web/tests/features/views/saved-view-page.test.tsx
@@ -66,6 +66,7 @@ function buildWorkspace(): WorkspaceData {
     projects: [
       {
         id: 'project-atlas',
+        slug: 'atlas',
         name: 'Atlas',
         status: 'planned',
         color: '#5a63c8',

--- a/apps/web/tests/features/views/view-href.test.ts
+++ b/apps/web/tests/features/views/view-href.test.ts
@@ -12,6 +12,7 @@ const TEAMS: readonly Team[] = [
 const PROJECTS: readonly Project[] = [
   {
     id: 'project-atlas',
+    slug: 'atlas',
     name: 'Atlas',
     status: 'planned',
     color: '#5a63c8',

--- a/apps/web/tests/features/views/view-scope.test.ts
+++ b/apps/web/tests/features/views/view-scope.test.ts
@@ -12,6 +12,7 @@ const TEAMS: readonly Team[] = [
 const PROJECTS: readonly Project[] = [
   {
     id: 'project-atlas',
+    slug: 'atlas',
     name: 'Atlas',
     status: 'planned',
     color: '#5a63c8',

--- a/apps/web/tests/features/views/views-page.test.tsx
+++ b/apps/web/tests/features/views/views-page.test.tsx
@@ -48,6 +48,7 @@ function buildWorkspace(): WorkspaceData {
     projects: [
       {
         id: 'project-atlas',
+        slug: 'atlas',
         name: 'Atlas',
         status: 'planned',
         color: '#5a63c8',


### PR DESCRIPTION
## What

The issue properties panel named a project and a sprint but gave you no way to reach either. Both rows were pickers only, so opening the project an issue belongs to meant going to the sidebar and finding it by hand.

Both rows now carry an open link, shown only when there is something to open.

| Row | Goes to |
| --- | --- |
| Project | `/projects/<slug>` |
| Sprint | `/team/<key>/sprint/<number>` |

## Why the bootstrap changed

The client had no project slug. `projectSchema` carried `id`, `name`, `status`, `color`, `icon` and `teamIds`, while project pages route on slug, so the href could not be built at all. `bootstrapPayload` now includes it. The Zod field uses `.catch('')` so a client running against an older payload degrades to hiding the link rather than throwing, and the link is suppressed on an empty slug.

The sprint href needed no new data: the team key comes from the workspace and the number is already on the cycle.

## Refactor

Adding two conditionals pushed `IssueProperties` past the complexity cap the linter enforces, so the Project and Sprint rows are now `ProjectProperty` and `SprintProperty`. Same markup, same behaviour, and the panel stops growing.

## Tests

3 new: the project link points at the slug, the sprint link at the team key and number, and neither renders when the issue is on no project and no sprint. Nine existing project fixtures gained the new field.

Verified in a browser on both surfaces, since a link that does not navigate is worse than no link: clicking from the full issue page and from inside the peek both land on `/projects/realtime-sync-engine`.

`bun run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds direct navigation from issue properties to the selected project and sprint, extending bootstrap project data with slugs and preserving compatibility with older payloads.
- Extracts the project and sprint property rows into focused components.
- Adds guarded project and sprint links using their canonical routes.
- Extends project schemas, bootstrap data, fixtures, and navigation tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/issues/issue-properties.tsx | Extracts project and sprint rows and adds guarded links using established project and sprint route contracts. |
| apps/web/src/lib/api/bootstrap.ts | Includes each project's slug in the bootstrap payload so clients can construct project links. |
| apps/web/src/lib/query/schemas.ts | Adds a backward-compatible project slug field that falls back to an empty string for older payloads. |
| apps/web/tests/features/issues/issue-properties.test.tsx | Covers canonical project and sprint hrefs and verifies links are hidden when route data is unavailable. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(issues): cover the project link whe..."](https://github.com/noveum/orbit/commit/ece9f8880e2cf771b96429ffc7a9b5a8d7b76c47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51432197)</sub>

<!-- /greptile_comment -->