### PR TITLE
Correct the GitHub App permissions doc before anyone follows it

### DIFF
--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -4,15 +4,15 @@ Orbit talks to GitHub through a GitHub App, not a personal token. A workspace
 owner installs it, picks repositories, and Orbit exchanges the installation for a
 short lived token each time it needs one.
 
-## Permissions the App needs today
+## Permissions the App needs
 
 **Repository permissions**
 
 | Permission | Access | Why |
 | --- | --- | --- |
 | Metadata | Read-only | Mandatory for every GitHub App, and required by `GET /installation/repositories`, which is how the connect flow lists what you may associate. |
-
-That is the whole list. Nothing else is used.
+| Pull requests | Read-only | Required to subscribe to `pull_request` and `pull_request_review`. Those events are what link a pull request to an issue, move the issue as the pull request opens, merges or closes, and raise a review request. |
+| Checks | Read-only | Required to subscribe to `check_suite`, which is what reports a failing run onto the issue. |
 
 **Organization permissions:** none.
 
@@ -20,14 +20,23 @@ That is the whole list. Nothing else is used.
 
 **Subscribe to events**
 
-| Event | Why |
+| Event | What it drives |
 | --- | --- |
-| Repository | A repository being renamed, transferred, archived, made private or public, or deleted has to be reflected against the association Orbit stores, or a project ends up pointing at a repository that no longer answers to that name. |
+| Repository | A rename, transfer, archive, visibility change or delete has to be reflected against the association Orbit stores, or a project ends up pointing at a repository that no longer answers to that name. |
+| Pull request | Linking a pull request to the issues it names, and moving the issue as it opens, merges or closes. |
+| Pull request review | Review requested, and review submitted or approved. |
+| Check suite | A failing suite reported onto the linked issue. |
 
 `installation` and `installation_repositories` are delivered to every App without
-being subscribed to, and Orbit handles both, so they do not appear in that list.
+being subscribed to, and Orbit handles both, so they are not in that list.
 
-## Why nothing else
+Orbit does **not** handle `check_run`, `workflow_run`, `workflow_job`, `status`,
+`push`, `repository_dispatch` or `pull_request_review_comment`. Production has
+received thousands of those and every one was accepted and discarded. Leaving
+them subscribed costs delivery volume and nothing else, but there is no reason
+to subscribe to them.
+
+## Why nothing more than read
 
 Every call the App makes is one of these five, and no other:
 
@@ -41,35 +50,50 @@ GET  /user/installations                     the installations this user can see
 
 The first two authenticate as the App itself with a JWT and need no permission
 grant. The last two are the OAuth leg and run as the signing-in user. Only
-`GET /installation/repositories` consumes a permission, and Metadata covers it.
+`GET /installation/repositories` consumes a permission on the outbound side, and
+Metadata covers it. Pull requests and Checks are needed for the **inbound**
+direction: GitHub will not deliver an event whose permission the App does not
+hold.
 
 There are exactly two `POST` requests in the integration and both are token
 exchanges. Orbit does not write to a repository, does not read file contents,
-does not read or write issues or pull requests, and does not read members. If the
-App is currently granted any of that, it is granting more than the code can use.
+does not create or edit issues or pull requests on GitHub, and does not read
+members. Read-only throughout is enough.
 
-`bun run check-bun-imports` and the rest of `verify` will not catch an
-over-permissioned App, so this file is the record. Keep it level with the code.
+`bun run verify` cannot catch an over-permissioned App, so this file is the
+record. Keep it level with the code: if a new event name appears in
+`packages/services/src/github`, the permission that carries it belongs here.
 
-## What pull request tracking will add
+## How a pull request finds its issue
 
-Tracking pull requests against issues is not built yet. When it lands it will
-need, and this file should be updated at the same time:
+Matching is by issue identifier, and the repository's project association plays
+no part in it. `applyGithubEvent` looks the repository up in the watch list,
+takes the organization from that row, and resolves identifiers against the whole
+workspace. A pull request in any watched repository links to any issue it names.
 
-| Permission | Access | Why |
-| --- | --- | --- |
-| Pull requests | Read-only | Read a pull request's state, reviews and merge status. |
-| Checks | Read-only | Report a failing check onto the issue. |
-| Contents | Read-only | Resolve the branch behind a pull request. |
+Three places are read, and they are not read the same way:
 
-with `pull_request`, `pull_request_review`, `check_suite` and `issue_comment`
-added to the subscribed events. Still nothing that writes.
+- **Branch name** and **title** match a bare identifier, because both are short
+  and written deliberately by the person doing the work. `copy_branch_name`
+  produces `user/eng-3-slug`, which links itself.
+- **Description** needs a linking keyword in front of the identifier: close,
+  closes, closed, fix, fixes, fixed, resolve, resolves, resolved, ref, refs,
+  part of, relates to, related to. Fenced blocks, inline code, HTML comments and
+  quoted lines are stripped before scanning, so a template carrying
+  `<!-- Fixes ENG-123 -->` as its example links nothing.
+
+Associating a repository with a project is organisational. Its load bearing
+effect is that it calls `reconcileWatchedRepositories`, and being in the watch
+list is what lets events through at all. Unlinking the last association stops
+the repository being watched.
 
 ## Webhook secret
 
-The webhook secret is set on the App and in the deployment environment as
-`GITHUB_APP_WEBHOOK_SECRET`. Both have to change together: rotate on the App
-first, update the environment, then redeploy, because Vercel does not apply an
-environment change to a deployment that already exists. Between those two steps
-every delivery fails signature verification and GitHub retries, so do it in one
-sitting rather than leaving it half done.
+The webhook route reads `GITHUB_WEBHOOK_SECRET`. That is the name to set in the
+deployment environment, and it has to match what the App is configured with.
+
+Rotate in this order: change it on the App, update
+`GITHUB_WEBHOOK_SECRET` in the environment, then redeploy. Vercel does not apply
+an environment change to a deployment that already exists, so skipping the
+redeploy leaves every delivery failing signature verification with a `401` while
+GitHub retries. Do it in one sitting.


### PR DESCRIPTION
Fixes two errors I merged in #173. Both would have broken the integration if somebody had acted on them, so this goes in ahead of anything else.

## The permission table was wrong

It listed **Metadata alone**. I derived it by tracing outbound API calls, and missed that a webhook subscription consumes a permission too. GitHub will not deliver `pull_request` or `pull_request_review` without **Pull requests**, or `check_suite` without **Checks**.

Reducing the App to Metadata, which is exactly what the doc told you to do, would have stopped every pull request link, every issue transition driven by a merge, and every check report, with nothing in Orbit to say why. Production is currently taking 568 `pull_request` and 1090 `check_suite` deliveries, so this was live traffic.

Corrected list: Metadata, Pull requests, Checks, all read-only. Subscribed events: Repository, Pull request, Pull request review, Check suite.

## The webhook secret name was wrong

The doc said `GITHUB_APP_WEBHOOK_SECRET`. The route reads `GITHUB_WEBHOOK_SECRET`:

```ts
apps/web/src/app/api/webhooks/github/route.ts:20
const secret = process.env['GITHUB_WEBHOOK_SECRET'] ?? '';
```

Following the rotation instruction would have set a variable nothing reads, verification would have run against an empty secret, and every delivery would have come back `401`.

## Added while correcting it

The events Orbit accepts and then discards, since production has taken thousands of `check_run`, `workflow_job`, `workflow_run`, `status`, `push` and `repository_dispatch` deliveries that reach no handler. They cost delivery volume and nothing else, but there is no reason to subscribe.

And how a pull request finds its issue, because the project association does not drive it and that is the first thing people assume. Branch and title match a bare identifier; the description needs a linking keyword and has code blocks, inline code, HTML comments and quoted lines stripped first.

## On the merge

Greptile raised both of these as P1 and I merged #173 without resolving either. That was my error, not a judgement call, and it is why this is a follow-up rather than a fix in place.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects the GitHub App setup documentation so its permissions, event subscriptions, and webhook-secret variable match the implemented integration.

- Adds the read-only Pull requests and Checks permissions required for subscribed webhook events.
- Distinguishes handled events from deliveries Orbit accepts but discards.
- Documents issue matching and watched-repository behavior.
- Corrects the webhook environment variable and clarifies secret rotation.

<h3>Confidence Score: 5/5</h3>

The documentation-only correction appears safe to merge.

The documented permissions, subscriptions, matching behavior, watched-repository lifecycle, and webhook-secret variable agree with the corresponding implementation and configuration references.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/github-app.md | Corrects permissions and secret configuration while accurately documenting handled events, issue matching, and repository-watch behavior. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Operator
    participant GitHub as GitHub App
    participant Orbit
    Operator->>GitHub: Grant Metadata, Pull requests, and Checks (read-only)
    Operator->>GitHub: Subscribe to repository, pull_request, pull_request_review, check_suite
    GitHub->>Orbit: Deliver subscribed webhook
    Orbit->>Orbit: Verify with GITHUB_WEBHOOK_SECRET
    Orbit->>Orbit: Resolve watched repository and issue identifiers
    Orbit->>Orbit: Link PR, transition issue, or report failed checks
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(github): correct the permissions an..."](https://github.com/noveum/orbit/commit/fd8a9886bcf4a8b2de6fe4da77bfc57e1539540a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51436035)</sub>

<!-- /greptile_comment -->