### PR TITLE
Read an issue thread and your inbox over MCP

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -123,6 +123,7 @@ them.
 | `list_labels` | read | Labels |
 | `list_members` | read | Members with their roles |
 | `invite_member` | write | Invite someone |
+| `list_notifications` | read | Your inbox: mentions, assignments, replies and state changes |
 
 ### Issues
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -104,7 +104,7 @@ Point at `http://localhost:3000/mcp` instead. Everything else is the same.
 
 ## What the tools do
 
-Sixty odd tools across seven groups. Read tools need `orbit.read`, write tools
+Seventy odd tools across seven groups. Read tools need `orbit.read`, write tools
 need `orbit.write`.
 
 Most tools take names rather than ids. A team is `"ENG"` or `"Engineering"`, an
@@ -129,6 +129,7 @@ them.
 | Tool | Scope | Does |
 | --- | --- | --- |
 | `get_issue` | read | One issue by identifier |
+| `list_issue_comments` | read | The comment thread on an issue, oldest first |
 | `search_issues` | read | Search and filter |
 | `list_my_issues` | read | Assigned to the caller |
 | `copy_branch_name` | read | The git branch name for an issue |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -124,6 +124,7 @@ them.
 | `list_members` | read | Members with their roles |
 | `invite_member` | write | Invite someone |
 | `list_notifications` | read | Your inbox: mentions, assignments, replies and state changes |
+| `mark_notification_read` | write | Mark your own notifications read |
 
 ### Issues
 

--- a/packages/mcp-server/src/tools/inbox.ts
+++ b/packages/mcp-server/src/tools/inbox.ts
@@ -1,0 +1,107 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { db, eq, inArray, schema } from '@orbit/db';
+import { listInbox } from '@orbit/services/notifications';
+import { NOTIFICATION_TYPES } from '@orbit/shared/constants';
+import type { Principal } from '@orbit/shared/policy';
+import { z } from 'zod';
+import { defineTool } from './support.ts';
+
+interface IssueSummary {
+  readonly identifier: string;
+  readonly title: string;
+  readonly teamKey: string;
+}
+
+async function issueIdsForComments(commentIds: readonly string[]): Promise<Map<string, string>> {
+  if (commentIds.length === 0) return new Map();
+  const rows = await db
+    .select({ id: schema.comment.id, issueId: schema.comment.issueId })
+    .from(schema.comment)
+    .where(inArray(schema.comment.id, [...commentIds]));
+  return new Map(rows.map((row) => [row.id, row.issueId]));
+}
+
+async function issueSummaries(issueIds: readonly string[]): Promise<Map<string, IssueSummary>> {
+  if (issueIds.length === 0) return new Map();
+  const rows = await db
+    .select({
+      id: schema.issue.id,
+      identifier: schema.issue.identifier,
+      title: schema.issue.title,
+      teamKey: schema.team.key,
+    })
+    .from(schema.issue)
+    .innerJoin(schema.team, eq(schema.team.id, schema.issue.teamId))
+    .where(inArray(schema.issue.id, [...issueIds]));
+  return new Map(
+    rows.map((row) => [
+      row.id,
+      { identifier: row.identifier, title: row.title, teamKey: row.teamKey },
+    ]),
+  );
+}
+
+export function registerInboxTools(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'list_notifications',
+      title: 'List your notifications',
+      description:
+        'Your inbox: mentions, assignments, replies and state changes addressed to you. This is how you find work someone has handed you by name. Orbit never notifies you about your own actions, so nothing here was written by you.',
+      readOnly: true,
+      inputSchema: {
+        unreadOnly: z
+          .boolean()
+          .optional()
+          .describe('Only unread notifications. Defaults to false.'),
+        type: z.enum(NOTIFICATION_TYPES).optional().describe('Only this notification type.'),
+        limit: z.number().int().min(1).max(100).optional().describe('Notifications per page.'),
+        cursor: z.string().min(1).optional().describe('Cursor returned by a previous call.'),
+      },
+    },
+    async (args) => {
+      const page = await listInbox(db, {
+        userId: principal.userId,
+        organizationId: principal.organizationId,
+        ...(args.unreadOnly === undefined ? {} : { unreadOnly: args.unreadOnly }),
+        ...(args.type === undefined ? {} : { type: args.type }),
+        ...(args.limit === undefined ? {} : { limit: args.limit }),
+        ...(args.cursor === undefined ? {} : { cursor: args.cursor }),
+      });
+
+      const commentIds = page.items
+        .filter((item) => item.entityType === 'comment')
+        .map((item) => item.entityId);
+      const byComment = await issueIdsForComments(commentIds);
+
+      const issueIds = page.items.flatMap((item) => {
+        if (item.entityType === 'issue') return [item.entityId];
+        const resolved = byComment.get(item.entityId);
+        return resolved === undefined ? [] : [resolved];
+      });
+      const byIssue = await issueSummaries(issueIds);
+
+      return {
+        notifications: page.items.map((item) => {
+          const issueId =
+            item.entityType === 'issue' ? item.entityId : byComment.get(item.entityId);
+          return {
+            id: item.id,
+            type: item.type,
+            reason: item.reason,
+            actorName: item.actorName,
+            title: item.title,
+            body: item.body,
+            url: item.url,
+            createdAt: item.createdAt.toISOString(),
+            read: item.readAt !== null,
+            issue: issueId === undefined ? null : (byIssue.get(issueId) ?? null),
+          };
+        }),
+        nextCursor: page.nextCursor,
+        unreadCount: page.unreadCount,
+      };
+    },
+  );
+}

--- a/packages/mcp-server/src/tools/inbox.ts
+++ b/packages/mcp-server/src/tools/inbox.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { db, eq, inArray, schema } from '@orbit/db';
-import { listInbox } from '@orbit/services/notifications';
+import { listInbox, markRead } from '@orbit/services/notifications';
 import { NOTIFICATION_TYPES } from '@orbit/shared/constants';
 import type { Principal } from '@orbit/shared/policy';
 import { z } from 'zod';
@@ -102,6 +102,33 @@ export function registerInboxTools(server: McpServer, principal: Principal): voi
         nextCursor: page.nextCursor,
         unreadCount: page.unreadCount,
       };
+    },
+  );
+
+  defineTool(
+    server,
+    {
+      name: 'mark_notification_read',
+      title: 'Mark notifications read',
+      description:
+        'Mark your own notifications read once you have acted on them, so they leave your unread queue. Mark a notification read only after the work it describes is done or handed on, never on first sight.',
+      readOnly: false,
+      inputSchema: {
+        ids: z
+          .array(z.string().min(1))
+          .min(1)
+          .max(100)
+          .describe('Notification ids from list_notifications.'),
+      },
+    },
+    async (args) => {
+      const updated = await markRead(db, {
+        userId: principal.userId,
+        organizationId: principal.organizationId,
+        notificationIds: args.ids,
+        read: true,
+      });
+      return { markedIds: updated.map((row) => row.id) };
     },
   );
 }

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -3,6 +3,7 @@ import type { Principal } from '@orbit/shared/policy';
 import { registerAdminTools } from './admin.ts';
 import { registerDocTools } from './docs.ts';
 import { registerIdentityTools } from './identity.ts';
+import { registerInboxTools } from './inbox.ts';
 import { registerIssueTools } from './issues.ts';
 import { registerOrgTools } from './org.ts';
 import { registerPlanningTools } from './planning.ts';
@@ -12,6 +13,7 @@ import { registerWorkspaceTools } from './workspace.ts';
 
 export function registerTools(server: McpServer, principal: Principal): void {
   registerIdentityTools(server, principal);
+  registerInboxTools(server, principal);
   registerIssueTools(server, principal);
   registerPlanningTools(server, principal);
   registerScrumTools(server, principal);

--- a/packages/mcp-server/src/tools/issues.ts
+++ b/packages/mcp-server/src/tools/issues.ts
@@ -4,6 +4,7 @@ import {
   createComment,
   createIssue,
   getIssue,
+  listComments,
   listIssueLabels,
   listIssues,
   listLabels,
@@ -13,7 +14,7 @@ import {
   setRelation,
   updateIssue,
 } from '@orbit/core';
-import { db, eq, schema } from '@orbit/db';
+import { db, eq, inArray, schema } from '@orbit/db';
 import {
   base64LengthFor,
   ISSUE_RELATION_TYPES,
@@ -493,6 +494,54 @@ function registerAddComment(server: McpServer, principal: Principal): void {
   );
 }
 
+async function authorNames(ids: readonly string[]): Promise<Map<string, string>> {
+  const unique = [...new Set(ids)];
+  if (unique.length === 0) return new Map();
+  const rows = await db
+    .select({ id: schema.user.id, name: schema.user.name })
+    .from(schema.user)
+    .where(inArray(schema.user.id, unique));
+  return new Map(rows.map((row) => [row.id, row.name]));
+}
+
+function registerListIssueComments(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'list_issue_comments',
+      title: 'List comments on an issue',
+      description:
+        'Return the comment thread on an issue, oldest first. Read this before replying, so you answer what was actually asked and do not repeat a reply you already posted.',
+      readOnly: true,
+      inputSchema: {
+        issue: z.string().min(1).describe('Issue identifier like "ENG-42", or an issue id.'),
+        limit: z.number().int().min(1).max(200).optional().describe('Comments per page.'),
+        cursor: z.string().min(1).optional().describe('Cursor returned by a previous call.'),
+      },
+    },
+    async (args) => {
+      const issue = await getIssue(principal, args.issue);
+      const page = await listComments(principal, issue.id, {
+        ...(args.limit === undefined ? {} : { limit: args.limit }),
+        ...(args.cursor === undefined ? {} : { cursor: args.cursor }),
+      });
+      const names = await authorNames(page.comments.map((row) => row.comment.authorId));
+      return {
+        comments: page.comments.map(({ comment }) => ({
+          id: comment.id,
+          parentId: comment.parentId,
+          authorId: comment.authorId,
+          authorName: names.get(comment.authorId) ?? 'Unknown',
+          body: comment.body,
+          createdAt: comment.createdAt.toISOString(),
+          updatedAt: comment.updatedAt.toISOString(),
+        })),
+        nextCursor: page.nextCursor,
+      };
+    },
+  );
+}
+
 function registerSetRelation(server: McpServer, principal: Principal): void {
   defineTool(
     server,
@@ -645,6 +694,7 @@ export function registerIssueTools(server: McpServer, principal: Principal): voi
   registerListMyIssues(server, principal);
   registerMoveIssue(server, principal);
   registerAddComment(server, principal);
+  registerListIssueComments(server, principal);
   registerSetRelation(server, principal);
   registerRemoveRelation(server, principal);
   registerAttachFile(server, principal);

--- a/packages/mcp-server/tests/tools/inbox.test.ts
+++ b/packages/mcp-server/tests/tools/inbox.test.ts
@@ -1,0 +1,75 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import {
+  addMember,
+  connect,
+  createWorkspace,
+  mintToken,
+  resetDatabase,
+} from '../../src/test-helpers.ts';
+
+type TestClient = Awaited<ReturnType<typeof connect>>;
+type TestWorkspace = Awaited<ReturnType<typeof createWorkspace>>;
+
+let workspace: TestWorkspace;
+let admin: TestClient;
+let agent: TestClient;
+let agentHandle: string;
+let issueIdentifier: string;
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  admin = await connect(await mintToken(workspace.organizationId, workspace.adminUser.id));
+
+  const member = await addMember(workspace, 'contributor', 'Yodu Desk');
+  agentHandle = member.user.handle;
+  agent = await connect(await mintToken(workspace.organizationId, member.user.id));
+
+  const created = await admin.result('create_issue', {
+    team: workspace.teamKey,
+    title: 'Billing webhook drops retries',
+  });
+  issueIdentifier = (created['issue'] as { identifier: string }).identifier;
+
+  await admin.result('add_comment', {
+    issue: issueIdentifier,
+    body: `@${agentHandle} can you take a look at this?`,
+  });
+});
+
+describe('list_notifications', () => {
+  it('returns the mention with the issue resolved from the comment', async () => {
+    const result = await agent.result('list_notifications', { unreadOnly: true });
+    const rows = result['notifications'] as {
+      type: string;
+      read: boolean;
+      issue: { identifier: string; title: string; teamKey: string } | null;
+    }[];
+
+    const mention = rows.find((row) => row.type === 'mention');
+    expect(mention).toBeDefined();
+    expect(mention?.read).toBe(false);
+    expect(mention?.issue?.identifier).toBe(issueIdentifier);
+    expect(mention?.issue?.title).toBe('Billing webhook drops retries');
+    expect(mention?.issue?.teamKey).toBe(workspace.teamKey);
+  });
+
+  it('never returns a notification the caller authored', async () => {
+    await agent.result('add_comment', { issue: issueIdentifier, body: `Replying to myself.` });
+    const result = await agent.result('list_notifications', {});
+    const rows = result['notifications'] as { title: string }[];
+    expect(rows.every((row) => !row.title.includes('Replying to myself'))).toBe(true);
+  });
+
+  it('filters by type', async () => {
+    const result = await agent.result('list_notifications', { type: 'issue_assigned' });
+    const rows = result['notifications'] as { type: string }[];
+    expect(rows.every((row) => row.type === 'issue_assigned')).toBe(true);
+  });
+
+  it('scopes to the caller, so one user never sees another inbox', async () => {
+    const result = await admin.result('list_notifications', { unreadOnly: true });
+    const rows = result['notifications'] as { type: string }[];
+    expect(rows.some((row) => row.type === 'mention')).toBe(false);
+  });
+});

--- a/packages/mcp-server/tests/tools/inbox.test.ts
+++ b/packages/mcp-server/tests/tools/inbox.test.ts
@@ -73,3 +73,45 @@ describe('list_notifications', () => {
     expect(rows.some((row) => row.type === 'mention')).toBe(false);
   });
 });
+
+describe('mark_notification_read', () => {
+  it('marks a notification read so it leaves the unread queue', async () => {
+    const before = await agent.result('list_notifications', { unreadOnly: true });
+    const rows = before['notifications'] as { id: string }[];
+    const target = rows[0];
+    expect(target).toBeDefined();
+
+    const marked = await agent.result('mark_notification_read', { ids: [target?.id ?? ''] });
+    expect(marked['markedIds']).toEqual([target?.id]);
+
+    const after = await agent.result('list_notifications', { unreadOnly: true });
+    const remaining = after['notifications'] as { id: string }[];
+    expect(remaining.some((row) => row.id === target?.id)).toBe(false);
+  });
+
+  it('cannot mark another user notification read', async () => {
+    const mine = await agent.result('list_notifications', {});
+    const rows = mine['notifications'] as { id: string }[];
+    const target = rows[0];
+    expect(target).toBeDefined();
+
+    const result = await admin.result('mark_notification_read', { ids: [target?.id ?? ''] });
+    expect(result['markedIds']).toEqual([]);
+  });
+
+  it('is withheld from a read-only token', async () => {
+    const readOnly = await connect(
+      await mintToken(
+        workspace.organizationId,
+        workspace.adminUser.id,
+        'Read only client',
+        'openid profile email orbit.read',
+      ),
+    );
+    const listed = await readOnly.client.listTools();
+    const names = listed.tools.map((tool) => tool.name);
+    expect(names).toContain('list_notifications');
+    expect(names).not.toContain('mark_notification_read');
+    await readOnly.close();
+  });
+});

--- a/packages/mcp-server/tests/tools/issue-comments.test.ts
+++ b/packages/mcp-server/tests/tools/issue-comments.test.ts
@@ -1,4 +1,6 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
+import { createComment } from '@orbit/core';
+import { db, eq, schema, sql } from '@orbit/db';
 import {
   addMember,
   connect,
@@ -66,5 +68,42 @@ describe('list_issue_comments', () => {
   it('is available to a contributor token', async () => {
     const result = await contributor.result('list_issue_comments', { issue: issueIdentifier });
     expect((result['comments'] as unknown[]).length).toBe(2);
+  });
+
+  it('returns an empty thread and a null cursor for an issue with no comments', async () => {
+    const created = await admin.result('create_issue', {
+      team: workspace.teamKey,
+      title: 'Nobody has said anything yet',
+    });
+    const quiet = created['issue'] as { identifier: string };
+
+    const result = await admin.result('list_issue_comments', { issue: quiet.identifier });
+
+    expect(result['comments']).toEqual([]);
+    expect(result['nextCursor']).toBeNull();
+  });
+
+  it('falls back to Unknown once the comment author has no user row left', async () => {
+    const created = await admin.result('create_issue', {
+      team: workspace.teamKey,
+      title: 'Its commenter will be removed',
+    });
+    const issue = created['issue'] as { id: string; identifier: string };
+
+    const doomed = await addMember(workspace, 'contributor', 'Gone Already');
+    await createComment(doomed.principal, issue.id, { body: 'I will not be here long.' });
+
+    await db.execute(sql`alter table "user" disable trigger all`);
+    try {
+      await db.delete(schema.user).where(eq(schema.user.id, doomed.user.id));
+    } finally {
+      await db.execute(sql`alter table "user" enable trigger all`);
+    }
+
+    const result = await admin.result('list_issue_comments', { issue: issue.identifier });
+    const comments = result['comments'] as { authorName: string }[];
+
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.authorName).toBe('Unknown');
   });
 });

--- a/packages/mcp-server/tests/tools/issue-comments.test.ts
+++ b/packages/mcp-server/tests/tools/issue-comments.test.ts
@@ -1,0 +1,70 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import {
+  addMember,
+  connect,
+  createWorkspace,
+  mintToken,
+  resetDatabase,
+} from '../../src/test-helpers.ts';
+
+type TestClient = Awaited<ReturnType<typeof connect>>;
+type TestWorkspace = Awaited<ReturnType<typeof createWorkspace>>;
+
+let workspace: TestWorkspace;
+let admin: TestClient;
+let contributor: TestClient;
+let issueIdentifier: string;
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  admin = await connect(await mintToken(workspace.organizationId, workspace.adminUser.id));
+  const member = await addMember(workspace, 'contributor', 'Connie Contributor');
+  contributor = await connect(await mintToken(workspace.organizationId, member.user.id));
+
+  const created = await admin.result('create_issue', {
+    team: workspace.teamKey,
+    title: 'Passkey sign-in fails on Safari',
+  });
+  const issue = created['issue'] as { identifier: string };
+  issueIdentifier = issue.identifier;
+
+  await admin.result('add_comment', { issue: issueIdentifier, body: 'First, from the admin.' });
+  await contributor.result('add_comment', {
+    issue: issueIdentifier,
+    body: 'Second, from the contributor.',
+  });
+});
+
+describe('list_issue_comments', () => {
+  it('returns the thread oldest first with author names', async () => {
+    const result = await admin.result('list_issue_comments', { issue: issueIdentifier });
+    const comments = result['comments'] as { body: string; authorName: string }[];
+
+    expect(comments).toHaveLength(2);
+    expect(comments[0]?.body).toBe('First, from the admin.');
+    expect(comments[0]?.authorName).toBe(workspace.adminUser.name);
+    expect(comments[1]?.body).toBe('Second, from the contributor.');
+    expect(comments[1]?.authorName).toBe('Connie Contributor');
+  });
+
+  it('pages with a cursor', async () => {
+    const first = await admin.result('list_issue_comments', { issue: issueIdentifier, limit: 1 });
+    expect((first['comments'] as unknown[]).length).toBe(1);
+    const cursor = first['nextCursor'] as string;
+    expect(cursor).not.toBeNull();
+
+    const second = await admin.result('list_issue_comments', {
+      issue: issueIdentifier,
+      limit: 1,
+      cursor,
+    });
+    const comments = second['comments'] as { body: string }[];
+    expect(comments[0]?.body).toBe('Second, from the contributor.');
+  });
+
+  it('is available to a contributor token', async () => {
+    const result = await contributor.result('list_issue_comments', { issue: issueIdentifier });
+    expect((result['comments'] as unknown[]).length).toBe(2);
+  });
+});


### PR DESCRIPTION
Three tools so an assistant can work a board rather than only write to it.

- `list_issue_comments`: an assistant could post a comment but never read the
  thread it was replying to. `get_issue` does not return comments and the docs
  equivalent `list_doc_comments` had no issue twin.
- `list_notifications`: mentions already landed in the `notification` table and
  nothing exposed them, so an assistant could be named on an issue and never
  know. Each row resolves its issue, because a mention entity is the comment and
  the identifier was otherwise recoverable only by parsing the url.
- `mark_notification_read`: the cursor. `markRead` already scopes to the caller,
  so one account cannot clear another inbox.

All three are thin wrappers over `listComments`, `listInbox` and `markRead`,
which already existed. No new tables and no schema change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds MCP tools for reading issue discussions, listing the authenticated user's notifications, and marking notifications as read.
- Registers and documents the three new MCP tools.
- Enriches notifications with related issue summaries.
- Resolves comment author names and exposes cursor-based comment pagination.
- Adds integration coverage for pagination, authorization boundaries, filtering, deleted authors, and read-only tokens.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified in the changed paths.

The new tools delegate authorization and mutation to existing scoped services, preserve their pagination contracts, and add focused integration coverage for the exposed behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/mcp-server/src/tools/inbox.ts | Adds caller-scoped notification listing, issue enrichment, and read-state updates without an accepted correctness or authorization defect. |
| packages/mcp-server/src/tools/issues.ts | Adds authorized, paginated issue-comment retrieval with author-name enrichment. |
| packages/mcp-server/src/tools/index.ts | Registers the new inbox tools alongside the existing MCP tool groups. |
| packages/mcp-server/tests/tools/inbox.test.ts | Covers notification enrichment, filtering, caller isolation, read-state updates, and OAuth scope visibility. |
| packages/mcp-server/tests/tools/issue-comments.test.ts | Covers ordering, pagination, contributor access, empty threads, and deleted-author fallback behavior. |
| docs/mcp.md | Documents the three new tools and their required read or write scopes. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[MCP client] --> B{Tool}
  B -->|list_issue_comments| C[Resolve authorized issue]
  C --> D[List paginated comments]
  D --> E[Resolve author names]
  E --> F[Return comment thread]
  B -->|list_notifications| G[List caller-scoped inbox]
  G --> H[Resolve comment-to-issue links]
  H --> I[Load issue summaries]
  I --> J[Return enriched notifications]
  B -->|mark_notification_read| K[Mark caller-owned rows read]
  K --> L[Return marked IDs]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(mcp): mark your notifications read"](https://github.com/noveum/orbit/commit/ab666bfd0e1e477f98c65981378040b3d32f9ae0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51454406)</sub>

<!-- /greptile_comment -->