### PR TITLE
feat(workspace): add permanent workspace deletion

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -24,16 +24,20 @@ export default async function WorkspaceLayout({ children }: { children: ReactNod
   const [onboarding, membership, organizations] = await Promise.all([
     getOnboardingStatus(session.user.id),
     resolveMembership(session.user.id, session.session.activeOrganizationId ?? null),
-    listOrganizationsForUser(session.user.id),
+    listOrganizationsForUser(session.user.id, { includeDeletingForAdmins: true }),
   ]);
 
   if (!onboarding.completed) redirect('/onboarding');
 
+  const workspaceAvailable = membership?.deletionRequestedAt === null;
+
   const [teams, dehydrated] = await Promise.all([
-    membership === null
+    !workspaceAvailable || membership === null
       ? Promise.resolve<ShellTeam[]>([])
       : listTeamsForPrincipal(membership.principal),
-    membership === null ? Promise.resolve(null) : dehydratedWorkspace(membership.principal),
+    !workspaceAvailable || membership === null
+      ? Promise.resolve(null)
+      : dehydratedWorkspace(membership.principal),
   ]);
 
   const workspaces: ShellWorkspace[] = organizations.map((row) => ({
@@ -61,7 +65,7 @@ export default async function WorkspaceLayout({ children }: { children: ReactNod
     </WorkspaceShell>
   );
 
-  if (membership === null || dehydrated === null) return shell;
+  if (!workspaceAvailable || membership === null || dehydrated === null) return shell;
 
   return (
     <HydrationBoundary state={dehydrated}>

--- a/apps/web/src/app/(app)/settings/general/page.tsx
+++ b/apps/web/src/app/(app)/settings/general/page.tsx
@@ -5,8 +5,9 @@ import { WorkspaceDangerZone } from '@/features/settings/workspace-danger-zone.t
 import { pageContext } from '@/lib/api/handler.ts';
 
 export default async function GeneralSettingsPage() {
-  const { principal } = await pageContext();
+  const { principal, deletionRequestedAt } = await pageContext({ allowDeleting: true });
   const organization = await getOrganization(principal.organizationId);
+  const deletionPending = deletionRequestedAt !== null;
 
   return (
     <section className="flex flex-col gap-4">
@@ -15,10 +16,13 @@ export default async function GeneralSettingsPage() {
         name={organization.name}
         logo={organization.logo}
         allowedEmailDomains={organization.allowedEmailDomains}
-        canManage={can(principal, 'org:manage')}
+        canManage={!deletionPending && can(principal, 'org:manage')}
       />
       {can(principal, 'org:delete') ? (
-        <WorkspaceDangerZone organizationName={organization.name} />
+        <WorkspaceDangerZone
+          organizationName={organization.name}
+          deletionRequestedAt={deletionRequestedAt?.toISOString() ?? null}
+        />
       ) : null}
     </section>
   );

--- a/apps/web/src/app/(app)/settings/general/page.tsx
+++ b/apps/web/src/app/(app)/settings/general/page.tsx
@@ -1,6 +1,7 @@
 import { getOrganization } from '@orbit/core';
 import { can } from '@orbit/shared/policy';
 import { GeneralForm } from '@/features/settings/general-form.tsx';
+import { WorkspaceDangerZone } from '@/features/settings/workspace-danger-zone.tsx';
 import { pageContext } from '@/lib/api/handler.ts';
 
 export default async function GeneralSettingsPage() {
@@ -16,6 +17,9 @@ export default async function GeneralSettingsPage() {
         allowedEmailDomains={organization.allowedEmailDomains}
         canManage={can(principal, 'org:manage')}
       />
+      {can(principal, 'org:delete') ? (
+        <WorkspaceDangerZone organizationName={organization.name} />
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/app/api/organizations/current/deletion/route.ts
+++ b/apps/web/src/app/api/organizations/current/deletion/route.ts
@@ -3,6 +3,10 @@ import {
   getOrganizationDeletionSummary,
   publishOrganizationDeleted,
 } from '@orbit/core';
+import {
+  organizationDeletionResponseSchema,
+  organizationDeletionSummaryResponseSchema,
+} from '@orbit/shared/validators';
 import { apiContext, handleRoute, readJson } from '@/lib/api/handler.ts';
 
 const NO_CACHE_HEADERS = { 'cache-control': 'private, no-cache' } as const;
@@ -22,7 +26,9 @@ export async function GET(): Promise<Response> {
   return await handleRoute(async () => {
     const { principal } = await apiContext({ allowDeleting: true });
     const summary = await getOrganizationDeletionSummary(principal);
-    return Response.json({ summary }, { headers: NO_CACHE_HEADERS });
+    return Response.json(organizationDeletionSummaryResponseSchema.parse({ summary }), {
+      headers: NO_CACHE_HEADERS,
+    });
   });
 }
 
@@ -31,9 +37,9 @@ export async function DELETE(request: Request): Promise<Response> {
     const { principal } = await apiContext({ allowDeleting: true });
     const deleted = await deleteOrganization(principal, await readJson(request));
     await publishDeletion(deleted.deletedOrganizationId);
-    return {
+    return organizationDeletionResponseSchema.parse({
       deletedOrganizationId: deleted.deletedOrganizationId,
       nextOrganizationId: deleted.nextOrganizationId,
-    };
+    });
   });
 }

--- a/apps/web/src/app/api/organizations/current/deletion/route.ts
+++ b/apps/web/src/app/api/organizations/current/deletion/route.ts
@@ -20,7 +20,7 @@ async function publishDeletion(organizationId: string): Promise<void> {
 
 export async function GET(): Promise<Response> {
   return await handleRoute(async () => {
-    const { principal } = await apiContext();
+    const { principal } = await apiContext({ allowDeleting: true });
     const summary = await getOrganizationDeletionSummary(principal);
     return Response.json({ summary }, { headers: NO_CACHE_HEADERS });
   });
@@ -28,7 +28,7 @@ export async function GET(): Promise<Response> {
 
 export async function DELETE(request: Request): Promise<Response> {
   return await handleRoute(async () => {
-    const { principal } = await apiContext();
+    const { principal } = await apiContext({ allowDeleting: true });
     const deleted = await deleteOrganization(principal, await readJson(request));
     await publishDeletion(deleted.deletedOrganizationId);
     return {

--- a/apps/web/src/app/api/organizations/current/deletion/route.ts
+++ b/apps/web/src/app/api/organizations/current/deletion/route.ts
@@ -1,0 +1,39 @@
+import {
+  deleteOrganization,
+  getOrganizationDeletionSummary,
+  publishOrganizationDeleted,
+} from '@orbit/core';
+import { apiContext, handleRoute, readJson } from '@/lib/api/handler.ts';
+
+const NO_CACHE_HEADERS = { 'cache-control': 'private, no-cache' } as const;
+
+async function publishDeletion(organizationId: string): Promise<void> {
+  try {
+    await publishOrganizationDeleted(organizationId);
+  } catch (error: unknown) {
+    console.error(
+      'Could not publish the workspace deletion, the write is already committed.',
+      error,
+    );
+  }
+}
+
+export async function GET(): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const summary = await getOrganizationDeletionSummary(principal);
+    return Response.json({ summary }, { headers: NO_CACHE_HEADERS });
+  });
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    const deleted = await deleteOrganization(principal, await readJson(request));
+    await publishDeletion(deleted.deletedOrganizationId);
+    return {
+      deletedOrganizationId: deleted.deletedOrganizationId,
+      nextOrganizationId: deleted.nextOrganizationId,
+    };
+  });
+}

--- a/apps/web/src/app/invite/[token]/page.tsx
+++ b/apps/web/src/app/invite/[token]/page.tsx
@@ -1,4 +1,4 @@
-import { db, eq, schema } from '@orbit/db';
+import { and, db, eq, isNull, schema } from '@orbit/db';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
@@ -29,7 +29,7 @@ async function loadInvite(token: string): Promise<InviteRecord | null> {
     })
     .from(schema.invitation)
     .innerJoin(schema.organization, eq(schema.organization.id, schema.invitation.organizationId))
-    .where(eq(schema.invitation.id, token))
+    .where(and(eq(schema.invitation.id, token), isNull(schema.organization.deletionRequestedAt)))
     .limit(1);
   return row ?? null;
 }

--- a/apps/web/src/features/settings/workspace-danger-zone.tsx
+++ b/apps/web/src/features/settings/workspace-danger-zone.tsx
@@ -255,7 +255,8 @@ export function WorkspaceDangerZone({ organizationName }: { readonly organizatio
 
               {blocked && availableAt !== null ? (
                 <p role="status" className="rounded-md bg-warning/10 p-3 text-warning text-xs">
-                  Deletion becomes available after pending upload links expire at{' '}
+                  Deletion becomes available after pending upload links and their completion window
+                  close at{' '}
                   {new Intl.DateTimeFormat(undefined, {
                     dateStyle: 'medium',
                     timeStyle: 'short',

--- a/apps/web/src/features/settings/workspace-danger-zone.tsx
+++ b/apps/web/src/features/settings/workspace-danger-zone.tsx
@@ -1,8 +1,14 @@
 'use client';
 
 import { formatBytes } from '@orbit/shared/utils';
+import {
+  type OrganizationDeletionResponse,
+  type OrganizationDeletionSummary,
+  organizationDeletionResponseSchema,
+  organizationDeletionSummaryResponseSchema,
+} from '@orbit/shared/validators';
 import { useEffect, useRef, useState } from 'react';
-import { z } from 'zod';
+import { ZodError } from 'zod';
 import { Button } from '@/components/ui/button.tsx';
 import {
   Dialog,
@@ -16,35 +22,6 @@ import { Input } from '@/components/ui/input.tsx';
 import { apiRequest, messageOf } from '@/lib/api/client.ts';
 import { authClient } from '@/lib/auth/client.ts';
 
-const deletionSummarySchema = z
-  .object({
-    organizationName: z.string(),
-    members: z.number().int().nonnegative(),
-    teams: z.number().int().nonnegative(),
-    projects: z.number().int().nonnegative(),
-    issues: z.number().int().nonnegative(),
-    documents: z.number().int().nonnegative(),
-    files: z.number().int().nonnegative(),
-    fileBytes: z.number().int().nonnegative(),
-    fileVersions: z.number().int().nonnegative(),
-    fileVersionBytes: z.number().int().nonnegative(),
-    integrations: z.number().int().nonnegative(),
-    webhooks: z.number().int().nonnegative(),
-    availableAt: z.string().datetime().nullable(),
-    deletionRequestedAt: z.string().datetime().nullable(),
-  })
-  .strict();
-
-const summaryResponseSchema = z.object({ summary: deletionSummarySchema }).strict();
-const deletionResponseSchema = z
-  .object({
-    deletedOrganizationId: z.string(),
-    nextOrganizationId: z.string().nullable(),
-  })
-  .strict();
-
-type DeletionSummary = z.infer<typeof deletionSummarySchema>;
-
 export function formatDeletionBytes(bytes: number): string {
   return formatBytes(bytes);
 }
@@ -54,7 +31,7 @@ function quantity(total: number, singular: string): string {
 }
 
 function payloadError(error: unknown): string {
-  if (error instanceof z.ZodError) return 'The deletion summary could not be read. Try again.';
+  if (error instanceof ZodError) return 'The deletion summary could not be read. Try again.';
   return messageOf(error);
 }
 
@@ -95,7 +72,7 @@ export function WorkspaceDangerZone({
   deletionRequestedAt = null,
 }: WorkspaceDangerZoneProps) {
   const [open, setOpen] = useState(false);
-  const [summary, setSummary] = useState<DeletionSummary | null>(null);
+  const [summary, setSummary] = useState<OrganizationDeletionSummary | null>(null);
   const [confirmation, setConfirmation] = useState('');
   const [loading, setLoading] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -135,7 +112,7 @@ export function WorkspaceDangerZone({
     try {
       const payload = await apiRequest<unknown>('/api/organizations/current/deletion');
       if (requestId.current !== activeRequest) return;
-      const parsed = summaryResponseSchema.parse(payload);
+      const parsed = organizationDeletionSummaryResponseSchema.parse(payload);
       setSummary(parsed.summary);
       setClock(Date.now());
     } catch (caught) {
@@ -167,13 +144,13 @@ export function WorkspaceDangerZone({
     deletingRef.current = true;
     setDeleting(true);
     setError(null);
-    let deleted: z.infer<typeof deletionResponseSchema>;
+    let deleted: OrganizationDeletionResponse;
     try {
       const payload = await apiRequest<unknown>('/api/organizations/current/deletion', {
         method: 'DELETE',
         body: { confirmation },
       });
-      deleted = deletionResponseSchema.parse(payload);
+      deleted = organizationDeletionResponseSchema.parse(payload);
     } catch (caught) {
       const nextError = payloadError(caught);
       deletingRef.current = false;

--- a/apps/web/src/features/settings/workspace-danger-zone.tsx
+++ b/apps/web/src/features/settings/workspace-danger-zone.tsx
@@ -26,6 +26,8 @@ const deletionSummarySchema = z
     documents: z.number().int().nonnegative(),
     files: z.number().int().nonnegative(),
     fileBytes: z.number().int().nonnegative(),
+    fileVersions: z.number().int().nonnegative(),
+    fileVersionBytes: z.number().int().nonnegative(),
     integrations: z.number().int().nonnegative(),
     webhooks: z.number().int().nonnegative(),
     availableAt: z.string().datetime().nullable(),
@@ -227,6 +229,15 @@ export function WorkspaceDangerZone({ organizationName }: { readonly organizatio
                   <span>{quantity(summary.files, 'file')}</span>
                   <span className="text-faint">{formatDeletionBytes(summary.fileBytes)}</span>
                 </li>
+                {summary.fileVersions > summary.files ||
+                summary.fileVersionBytes > summary.fileBytes ? (
+                  <li className="flex flex-wrap gap-1">
+                    <span>{quantity(summary.fileVersions, 'stored file version')}</span>
+                    <span className="text-faint">
+                      {formatDeletionBytes(summary.fileVersionBytes)}
+                    </span>
+                  </li>
+                ) : null}
                 <li>{quantity(summary.integrations, 'integration')}</li>
                 <li>{quantity(summary.webhooks, 'webhook')}</li>
               </ul>
@@ -236,9 +247,9 @@ export function WorkspaceDangerZone({ organizationName }: { readonly organizatio
                   Comments, attachments, activity and settings
                 </summary>
                 <p className="pt-2 text-muted">
-                  Nested comments, issue relations, document history, notifications, saved views,
-                  cycles, labels, workflow states, credentials and other workspace-owned records are
-                  deleted with their parent data.
+                  Nested comments, issue relations, document history, stored file versions,
+                  notifications, saved views, cycles, labels, workflow states, credentials and other
+                  workspace-owned records are deleted with their parent data.
                 </p>
               </details>
 

--- a/apps/web/src/features/settings/workspace-danger-zone.tsx
+++ b/apps/web/src/features/settings/workspace-danger-zone.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import { formatBytes } from '@orbit/shared/utils';
+import { useEffect, useRef, useState } from 'react';
+import { z } from 'zod';
+import { Button } from '@/components/ui/button.tsx';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog.tsx';
+import { Input } from '@/components/ui/input.tsx';
+import { apiRequest, messageOf } from '@/lib/api/client.ts';
+import { authClient } from '@/lib/auth/client.ts';
+
+const deletionSummarySchema = z
+  .object({
+    organizationName: z.string(),
+    members: z.number().int().nonnegative(),
+    teams: z.number().int().nonnegative(),
+    projects: z.number().int().nonnegative(),
+    issues: z.number().int().nonnegative(),
+    documents: z.number().int().nonnegative(),
+    files: z.number().int().nonnegative(),
+    fileBytes: z.number().int().nonnegative(),
+    integrations: z.number().int().nonnegative(),
+    webhooks: z.number().int().nonnegative(),
+    availableAt: z.string().datetime().nullable(),
+  })
+  .strict();
+
+const summaryResponseSchema = z.object({ summary: deletionSummarySchema }).strict();
+const deletionResponseSchema = z
+  .object({
+    deletedOrganizationId: z.string(),
+    nextOrganizationId: z.string().nullable(),
+  })
+  .strict();
+
+type DeletionSummary = z.infer<typeof deletionSummarySchema>;
+
+export function formatDeletionBytes(bytes: number): string {
+  return formatBytes(bytes);
+}
+
+function quantity(total: number, singular: string): string {
+  return `${total} ${total === 1 ? singular : `${singular}s`}`;
+}
+
+function payloadError(error: unknown): string {
+  if (error instanceof z.ZodError) return 'The deletion summary could not be read. Try again.';
+  return messageOf(error);
+}
+
+export function WorkspaceDangerZone({ organizationName }: { readonly organizationName: string }) {
+  const [open, setOpen] = useState(false);
+  const [summary, setSummary] = useState<DeletionSummary | null>(null);
+  const [confirmation, setConfirmation] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [clock, setClock] = useState(() => Date.now());
+  const requestId = useRef(0);
+  const deletingRef = useRef(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const availableAt = summary?.availableAt ?? null;
+  const blocked = availableAt !== null && Date.parse(availableAt) > clock;
+  const currentName = summary?.organizationName ?? organizationName;
+  const canDelete =
+    summary !== null && !loading && !blocked && !deleting && confirmation === currentName;
+
+  useEffect(() => {
+    if (availableAt === null) return;
+    const remaining = Date.parse(availableAt) - Date.now();
+    if (remaining <= 0) {
+      setClock(Date.now());
+      return;
+    }
+    const timer = window.setTimeout(
+      () => setClock(Date.now()),
+      Math.min(remaining + 25, 2_147_483_647),
+    );
+    return () => window.clearTimeout(timer);
+  }, [availableAt]);
+
+  async function loadSummary(): Promise<void> {
+    const activeRequest = requestId.current + 1;
+    requestId.current = activeRequest;
+    setLoading(true);
+    setSummary(null);
+    setError(null);
+    try {
+      const payload = await apiRequest<unknown>('/api/organizations/current/deletion');
+      if (requestId.current !== activeRequest) return;
+      const parsed = summaryResponseSchema.parse(payload);
+      setSummary(parsed.summary);
+      setClock(Date.now());
+    } catch (caught) {
+      if (requestId.current !== activeRequest) return;
+      setError(payloadError(caught));
+    } finally {
+      if (requestId.current === activeRequest) setLoading(false);
+    }
+  }
+
+  function showDialog(): void {
+    setOpen(true);
+    setConfirmation('');
+    setError(null);
+    loadSummary().catch(() => undefined);
+  }
+
+  function closeDialog(): void {
+    if (deletingRef.current) return;
+    requestId.current += 1;
+    setOpen(false);
+    setSummary(null);
+    setConfirmation('');
+    setError(null);
+  }
+
+  async function confirmDeletion(): Promise<void> {
+    if (!canDelete || deletingRef.current) return;
+    deletingRef.current = true;
+    setDeleting(true);
+    setError(null);
+    let deleted: z.infer<typeof deletionResponseSchema>;
+    try {
+      const payload = await apiRequest<unknown>('/api/organizations/current/deletion', {
+        method: 'DELETE',
+        body: { confirmation },
+      });
+      deleted = deletionResponseSchema.parse(payload);
+    } catch (caught) {
+      setError(payloadError(caught));
+      deletingRef.current = false;
+      setDeleting(false);
+      return;
+    }
+    if (deleted.nextOrganizationId === null) {
+      window.location.assign('/workspaces/new');
+      return;
+    }
+    try {
+      const activated = await authClient.organization.setActive({
+        organizationId: deleted.nextOrganizationId,
+      });
+      if (activated.error) {
+        window.location.assign('/workspaces/new');
+        return;
+      }
+      window.location.assign('/my-issues');
+    } catch {
+      window.location.assign('/workspaces/new');
+    }
+  }
+
+  return (
+    <section className="flex flex-col gap-3 rounded-lg border border-danger/40 p-4">
+      <div className="flex flex-col gap-1">
+        <h3 className="font-medium text-danger text-dense">Danger zone</h3>
+        <p className="text-muted text-xs">
+          Permanently delete this workspace and everything stored inside it. This cannot be undone.
+        </p>
+      </div>
+      <div>
+        <Button variant="danger" onClick={showDialog}>
+          Delete workspace
+        </Button>
+      </div>
+
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) closeDialog();
+        }}
+      >
+        <DialogContent
+          ref={dialogRef}
+          tabIndex={-1}
+          showClose={!deleting}
+          className="max-w-md"
+          aria-busy={loading || deleting}
+          onEscapeKeyDown={(event) => {
+            if (deleting) event.preventDefault();
+          }}
+          onPointerDownOutside={(event) => {
+            if (deleting) event.preventDefault();
+          }}
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            queueMicrotask(() => dialogRef.current?.focus());
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle className="font-medium text-base text-text">
+              Delete {currentName}?
+            </DialogTitle>
+            <DialogDescription className="text-muted text-xs">
+              This permanently removes the workspace for every member. Review the impact, then type
+              its exact name to continue.
+            </DialogDescription>
+          </DialogHeader>
+
+          {loading ? (
+            <p role="status" className="text-muted text-xs">
+              Calculating everything that will be deleted...
+            </p>
+          ) : null}
+
+          {summary === null ? null : (
+            <div className="flex flex-col gap-4">
+              <ul
+                aria-label="Workspace contents that will be deleted"
+                className="grid grid-cols-2 gap-x-4 gap-y-2 rounded-md bg-surface-2 p-3 text-dense text-text"
+              >
+                <li>{quantity(summary.members, 'member')}</li>
+                <li>{quantity(summary.teams, 'team')}</li>
+                <li>{quantity(summary.projects, 'project')}</li>
+                <li>{quantity(summary.issues, 'issue')}</li>
+                <li>{quantity(summary.documents, 'document')}</li>
+                <li className="flex flex-wrap gap-1">
+                  <span>{quantity(summary.files, 'file')}</span>
+                  <span className="text-faint">{formatDeletionBytes(summary.fileBytes)}</span>
+                </li>
+                <li>{quantity(summary.integrations, 'integration')}</li>
+                <li>{quantity(summary.webhooks, 'webhook')}</li>
+              </ul>
+
+              <details className="rounded-md border border-border px-3 py-2 text-xs">
+                <summary className="cursor-pointer font-medium text-text">
+                  Comments, attachments, activity and settings
+                </summary>
+                <p className="pt-2 text-muted">
+                  Nested comments, issue relations, document history, notifications, saved views,
+                  cycles, labels, workflow states, credentials and other workspace-owned records are
+                  deleted with their parent data.
+                </p>
+              </details>
+
+              {blocked && availableAt !== null ? (
+                <p role="status" className="rounded-md bg-warning/10 p-3 text-warning text-xs">
+                  Deletion becomes available after pending upload links expire at{' '}
+                  {new Intl.DateTimeFormat(undefined, {
+                    dateStyle: 'medium',
+                    timeStyle: 'short',
+                  }).format(new Date(availableAt))}
+                  .
+                </p>
+              ) : null}
+
+              <div className="flex flex-col gap-1.5">
+                <label
+                  htmlFor="workspace-delete-confirmation"
+                  className="font-medium text-text text-xs"
+                >
+                  Type {currentName} to confirm
+                </label>
+                <Input
+                  id="workspace-delete-confirmation"
+                  value={confirmation}
+                  onChange={(event) => setConfirmation(event.target.value)}
+                  autoComplete="off"
+                  maxLength={80}
+                  disabled={deleting}
+                />
+              </div>
+            </div>
+          )}
+
+          {error === null ? null : (
+            <div role="alert" className="mt-3 rounded-md bg-danger/10 p-3 text-danger text-xs">
+              <p>{error}</p>
+              {summary === null && !loading ? (
+                <Button className="mt-2" size="sm" variant="secondary" onClick={loadSummary}>
+                  Retry
+                </Button>
+              ) : null}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button variant="ghost" disabled={deleting} onClick={closeDialog}>
+              Cancel
+            </Button>
+            <Button variant="danger" disabled={!canDelete} onClick={confirmDeletion}>
+              {deleting ? 'Deleting workspace' : 'Permanently delete workspace'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/apps/web/src/features/settings/workspace-danger-zone.tsx
+++ b/apps/web/src/features/settings/workspace-danger-zone.tsx
@@ -106,9 +106,9 @@ export function WorkspaceDangerZone({
   const dialogRef = useRef<HTMLDivElement>(null);
 
   const availableAt = summary?.availableAt ?? null;
-  const blocked = availableAt !== null && Date.parse(availableAt) > clock;
   const currentName = summary?.organizationName ?? organizationName;
   const pending = (summary?.deletionRequestedAt ?? deletionRequestedAt) !== null;
+  const blocked = pending && availableAt !== null && Date.parse(availableAt) > clock;
   const canDelete =
     summary !== null && !loading && !blocked && !deleting && confirmation === currentName;
 

--- a/apps/web/src/features/settings/workspace-danger-zone.tsx
+++ b/apps/web/src/features/settings/workspace-danger-zone.tsx
@@ -31,6 +31,7 @@ const deletionSummarySchema = z
     integrations: z.number().int().nonnegative(),
     webhooks: z.number().int().nonnegative(),
     availableAt: z.string().datetime().nullable(),
+    deletionRequestedAt: z.string().datetime().nullable(),
   })
   .strict();
 
@@ -57,7 +58,42 @@ function payloadError(error: unknown): string {
   return messageOf(error);
 }
 
-export function WorkspaceDangerZone({ organizationName }: { readonly organizationName: string }) {
+function dangerDescription(pending: boolean): string {
+  if (pending) {
+    return 'Deletion is in progress. Retry the permanent cleanup until every workspace record and file is removed.';
+  }
+  return 'Permanently delete this workspace and everything stored inside it. This cannot be undone.';
+}
+
+function permanentDeletionLabel(pending: boolean, deleting: boolean): string {
+  if (deleting) return 'Deleting workspace';
+  if (pending) return 'Retry permanent deletion';
+  return 'Permanently delete workspace';
+}
+
+function dangerActionLabel(pending: boolean): string {
+  return pending ? 'Retry workspace deletion' : 'Delete workspace';
+}
+
+function PendingDeletionNotice({ pending }: { readonly pending: boolean }) {
+  if (!pending) return null;
+  return (
+    <p role="status" className="rounded-md bg-warning/10 p-3 text-warning text-xs">
+      This workspace is locked for normal use while permanent deletion is pending. A retry safely
+      resumes the idempotent cleanup.
+    </p>
+  );
+}
+
+interface WorkspaceDangerZoneProps {
+  readonly organizationName: string;
+  readonly deletionRequestedAt?: string | null;
+}
+
+export function WorkspaceDangerZone({
+  organizationName,
+  deletionRequestedAt = null,
+}: WorkspaceDangerZoneProps) {
   const [open, setOpen] = useState(false);
   const [summary, setSummary] = useState<DeletionSummary | null>(null);
   const [confirmation, setConfirmation] = useState('');
@@ -72,6 +108,7 @@ export function WorkspaceDangerZone({ organizationName }: { readonly organizatio
   const availableAt = summary?.availableAt ?? null;
   const blocked = availableAt !== null && Date.parse(availableAt) > clock;
   const currentName = summary?.organizationName ?? organizationName;
+  const pending = (summary?.deletionRequestedAt ?? deletionRequestedAt) !== null;
   const canDelete =
     summary !== null && !loading && !blocked && !deleting && confirmation === currentName;
 
@@ -138,9 +175,11 @@ export function WorkspaceDangerZone({ organizationName }: { readonly organizatio
       });
       deleted = deletionResponseSchema.parse(payload);
     } catch (caught) {
-      setError(payloadError(caught));
+      const nextError = payloadError(caught);
       deletingRef.current = false;
       setDeleting(false);
+      await loadSummary();
+      setError(nextError);
       return;
     }
     if (deleted.nextOrganizationId === null) {
@@ -165,13 +204,11 @@ export function WorkspaceDangerZone({ organizationName }: { readonly organizatio
     <section className="flex flex-col gap-3 rounded-lg border border-danger/40 p-4">
       <div className="flex flex-col gap-1">
         <h3 className="font-medium text-danger text-dense">Danger zone</h3>
-        <p className="text-muted text-xs">
-          Permanently delete this workspace and everything stored inside it. This cannot be undone.
-        </p>
+        <p className="text-muted text-xs">{dangerDescription(pending)}</p>
       </div>
       <div>
         <Button variant="danger" onClick={showDialog}>
-          Delete workspace
+          {dangerActionLabel(pending)}
         </Button>
       </div>
 
@@ -216,6 +253,7 @@ export function WorkspaceDangerZone({ organizationName }: { readonly organizatio
 
           {summary === null ? null : (
             <div className="flex flex-col gap-4">
+              <PendingDeletionNotice pending={pending} />
               <ul
                 aria-label="Workspace contents that will be deleted"
                 className="grid grid-cols-2 gap-x-4 gap-y-2 rounded-md bg-surface-2 p-3 text-dense text-text"
@@ -300,7 +338,7 @@ export function WorkspaceDangerZone({ organizationName }: { readonly organizatio
               Cancel
             </Button>
             <Button variant="danger" disabled={!canDelete} onClick={confirmDeletion}>
-              {deleting ? 'Deleting workspace' : 'Permanently delete workspace'}
+              {permanentDeletionLabel(pending, deleting)}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/lib/api/handler.ts
+++ b/apps/web/src/lib/api/handler.ts
@@ -1,5 +1,6 @@
 import { publishDeltas } from '@orbit/core';
 import {
+  conflict,
   internal,
   isDomainError,
   notFound,
@@ -23,6 +24,16 @@ export interface ApiContext extends MembershipContext {
   readonly userEmail: string;
 }
 
+interface ContextOptions {
+  readonly allowDeleting?: boolean;
+}
+
+function assertWorkspaceAvailable(context: ApiContext, options: ContextOptions): void {
+  if (context.deletionRequestedAt !== null && options.allowDeleting !== true) {
+    throw conflict('Workspace deletion is in progress.');
+  }
+}
+
 async function contextFor(session: ActiveSession): Promise<ApiContext | null> {
   const membership = await resolveMembership(
     session.user.id,
@@ -36,18 +47,22 @@ async function contextFor(session: ActiveSession): Promise<ApiContext | null> {
   };
 }
 
-export async function apiContext(): Promise<ApiContext> {
+export async function apiContext(options: ContextOptions = {}): Promise<ApiContext> {
   const session = await getSession();
   if (session === null) throw unauthorized();
   const context = await contextFor(session);
   if (context === null) throw unauthorized('You are not a member of any workspace.');
+  assertWorkspaceAvailable(context, options);
   return context;
 }
 
-export async function pageContext(): Promise<ApiContext> {
+export async function pageContext(options: ContextOptions = {}): Promise<ApiContext> {
   const session = await requireSession();
   const context = await contextFor(session);
   if (context === null) redirect('/login');
+  if (context.deletionRequestedAt !== null && options.allowDeleting !== true) {
+    redirect('/settings/general');
+  }
   return context;
 }
 

--- a/apps/web/src/lib/auth/principal.ts
+++ b/apps/web/src/lib/auth/principal.ts
@@ -13,6 +13,7 @@ export interface MembershipContext {
   readonly memberId: string;
   readonly organizationName: string;
   readonly organizationSlug: string;
+  readonly deletionRequestedAt: Date | null;
 }
 
 export async function resolveMembership(
@@ -27,6 +28,7 @@ export async function resolveMembership(
       organizationId: schema.organization.id,
       organizationName: schema.organization.name,
       organizationSlug: schema.organization.slug,
+      deletionRequestedAt: schema.organization.deletionRequestedAt,
     })
     .from(schema.member)
     .innerJoin(schema.organization, eq(schema.organization.id, schema.member.organizationId))
@@ -47,6 +49,7 @@ export async function resolveMembership(
     memberId: row.memberId,
     organizationName: row.organizationName,
     organizationSlug: row.organizationSlug,
+    deletionRequestedAt: row.deletionRequestedAt,
     principal: {
       userId,
       organizationId: row.organizationId,

--- a/apps/web/src/lib/realtime/provider.tsx
+++ b/apps/web/src/lib/realtime/provider.tsx
@@ -1,10 +1,14 @@
 'use client';
 
 import { RealtimeProvider } from '@orbit/realtime-client/react';
-import { SESSION_REVOKED_CLOSE_CODE } from '@orbit/shared/events';
+import {
+  ORGANIZATION_FORBIDDEN_CLOSE_CODE,
+  SESSION_REVOKED_CLOSE_CODE,
+} from '@orbit/shared/events';
 import type { ReactNode } from 'react';
 import { useCallback } from 'react';
 import { z } from 'zod';
+import { apiRequest } from '@/lib/api/client.ts';
 import { authClient } from '@/lib/auth/client.ts';
 import { ConnectionBanner } from './connection-banner.tsx';
 import { DeltaBridge } from './delta-bridge.tsx';
@@ -19,10 +23,21 @@ export interface SessionGate {
   readonly signOut: () => Promise<unknown>;
 }
 
+export interface WorkspaceRecoveryGate {
+  readonly listOrganizations: () => Promise<unknown>;
+  readonly setActive: (input: { readonly organizationId: string }) => Promise<unknown>;
+}
+
 const noSessionSchema = z.object({
   data: z.null(),
   error: z.null().optional(),
 });
+
+const organizationsSchema = z.object({
+  organizations: z.array(z.object({ id: z.string() })),
+});
+
+const activationSchema = z.object({ error: z.unknown().optional() }).passthrough();
 
 function serverHasNoSession(result: unknown): boolean {
   return noSessionSchema.safeParse(result).success;
@@ -38,9 +53,45 @@ export async function endSessionIfRevoked(gate: SessionGate = authClient): Promi
   return true;
 }
 
-export function handleTerminalClose(code: number, gate: SessionGate = authClient): void {
-  if (code !== SESSION_REVOKED_CLOSE_CODE) return;
-  endSessionIfRevoked(gate).catch(() => undefined);
+function workspaceRecoveryGate(): WorkspaceRecoveryGate {
+  return {
+    listOrganizations: () => apiRequest<unknown>('/api/organizations'),
+    setActive: async (input) => await authClient.organization.setActive(input),
+  };
+}
+
+export async function recoverWorkspaceAfterForbidden(
+  gate: WorkspaceRecoveryGate = workspaceRecoveryGate(),
+): Promise<void> {
+  try {
+    const listed = organizationsSchema.parse(await gate.listOrganizations());
+    const next = listed.organizations[0];
+    if (next === undefined) {
+      window.location.href = '/workspaces/new';
+      return;
+    }
+    const activated = activationSchema.parse(await gate.setActive({ organizationId: next.id }));
+    if (activated.error !== undefined && activated.error !== null) {
+      throw new Error('Could not activate a surviving workspace.');
+    }
+    window.location.href = '/my-issues';
+  } catch {
+    window.location.href = '/workspaces/new';
+  }
+}
+
+export function handleTerminalClose(
+  code: number,
+  sessionGate: SessionGate = authClient,
+  recoveryGate: WorkspaceRecoveryGate = workspaceRecoveryGate(),
+): void {
+  if (code === SESSION_REVOKED_CLOSE_CODE) {
+    endSessionIfRevoked(sessionGate).catch(() => undefined);
+    return;
+  }
+  if (code === ORGANIZATION_FORBIDDEN_CLOSE_CODE) {
+    recoverWorkspaceAfterForbidden(recoveryGate).catch(() => undefined);
+  }
 }
 
 export interface WorkspaceRealtimeProps {

--- a/apps/web/tests-support-issue-routes.ts
+++ b/apps/web/tests-support-issue-routes.ts
@@ -117,6 +117,7 @@ export function signInAs(person: Actor): void {
     memberId: `member_${person.userId}`,
     organizationName: 'Nova',
     organizationSlug: 'nova',
+    deletionRequestedAt: null,
   };
 }
 

--- a/apps/web/tests/app/(app)/layout.test.tsx
+++ b/apps/web/tests/app/(app)/layout.test.tsx
@@ -20,6 +20,7 @@ const membership: MembershipContext = {
   memberId: 'member-1',
   organizationName: 'Noveum',
   organizationSlug: 'noveum',
+  deletionRequestedAt: null,
   principal: {
     userId: 'user-1',
     organizationId: 'org-1',

--- a/apps/web/tests/app/api/docs/duplicate.test.ts
+++ b/apps/web/tests/app/api/docs/duplicate.test.ts
@@ -77,6 +77,7 @@ mockMembership(() => ({
   memberId: 'member_1',
   organizationName: 'Nova',
   organizationSlug: 'nova',
+  deletionRequestedAt: null,
 }));
 
 const { POST } = await import('../../../../src/app/api/docs/[id]/duplicate/route.ts');

--- a/apps/web/tests/app/api/docs/home.test.ts
+++ b/apps/web/tests/app/api/docs/home.test.ts
@@ -94,6 +94,7 @@ mockMembership(() => ({
   memberId: 'member_1',
   organizationName: 'Nova',
   organizationSlug: 'nova',
+  deletionRequestedAt: null,
 }));
 
 const { GET } = await import('../../../../src/app/api/docs/home/route.ts');

--- a/apps/web/tests/app/api/issues/delete-issue.test.ts
+++ b/apps/web/tests/app/api/issues/delete-issue.test.ts
@@ -40,6 +40,7 @@ mockMembership(() => ({
   memberId: 'member_1',
   organizationName: 'Nova',
   organizationSlug: 'nova',
+  deletionRequestedAt: null,
 }));
 
 const { DELETE } = await import('@/app/api/issues/[id]/route.ts');

--- a/apps/web/tests/app/api/organizations/current/deletion/route.test.ts
+++ b/apps/web/tests/app/api/organizations/current/deletion/route.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { OrganizationDeletionResult, OrganizationDeletionSummary } from '@orbit/core';
 import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test-support';
+import { db, eq, schema } from '@orbit/db';
 import { forbidden, internal } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import { z } from 'zod';
@@ -29,6 +30,7 @@ const summary: OrganizationDeletionSummary = {
   integrations: 1,
   webhooks: 2,
   availableAt: null,
+  deletionRequestedAt: null,
 };
 
 const deletion: OrganizationDeletionResult = {
@@ -73,6 +75,7 @@ mockSession(() =>
 const { DELETE, GET } = await import(
   '../../../../../../src/app/api/organizations/current/deletion/route.ts'
 );
+const { apiContext } = await import('../../../../../../src/lib/api/handler.ts');
 
 afterAll(() => {
   mock.module('@orbit/core', () => coreModule);
@@ -128,6 +131,19 @@ describe('GET /api/organizations/current/deletion', () => {
 });
 
 describe('DELETE /api/organizations/current/deletion', () => {
+  it('remains available for a durable deletion retry while normal APIs are locked', async () => {
+    await db
+      .update(schema.organization)
+      .set({ deletionRequestedAt: new Date() })
+      .where(eq(schema.organization.id, workspace.organizationId));
+
+    await expect(apiContext()).rejects.toMatchObject({ code: 'conflict' });
+    const response = await DELETE(request({ confirmation: 'Nova' }));
+
+    expect(response.status).toBe(200);
+    expect(deletions).toHaveLength(1);
+  });
+
   it('deletes the active workspace and publishes its invalidation', async () => {
     const response = await DELETE(request({ confirmation: 'Nova' }));
     const payload = z

--- a/apps/web/tests/app/api/organizations/current/deletion/route.test.ts
+++ b/apps/web/tests/app/api/organizations/current/deletion/route.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { OrganizationDeletionResult, OrganizationDeletionSummary } from '@orbit/core';
+import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test-support';
+import type { Principal } from '@orbit/shared/policy';
+import { z } from 'zod';
+import { mockSession } from '../../../../../../tests-support.ts';
+
+const coreModule = await import('@orbit/core');
+const summaries: Principal[] = [];
+const deletions: { principal: Principal; input: unknown }[] = [];
+const published: string[] = [];
+let publishError: Error | null = null;
+
+const summary: OrganizationDeletionSummary = {
+  organizationName: 'Nova',
+  members: 4,
+  teams: 3,
+  projects: 2,
+  issues: 17,
+  documents: 5,
+  files: 8,
+  fileBytes: 4096,
+  integrations: 1,
+  webhooks: 2,
+  availableAt: null,
+};
+
+const deletion: OrganizationDeletionResult = {
+  deletedOrganizationId: 'org_deleted',
+  deletedOrganizationName: 'Nova',
+  nextOrganizationId: 'org_next',
+};
+
+mock.module('@orbit/core', () => ({
+  ...coreModule,
+  getOrganizationDeletionSummary: (principal: Principal) => {
+    summaries.push(principal);
+    return Promise.resolve(summary);
+  },
+  deleteOrganization: (principal: Principal, input: unknown) => {
+    deletions.push({ principal, input });
+    return Promise.resolve(deletion);
+  },
+  publishOrganizationDeleted: (organizationId: string) => {
+    published.push(organizationId);
+    return publishError === null ? Promise.resolve() : Promise.reject(publishError);
+  },
+}));
+
+mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers()) }));
+
+let workspace: Workspace;
+
+mockSession(() => ({
+  user: {
+    id: workspace.admin.userId,
+    name: 'Workspace Admin',
+    email: 'admin@orbit.test',
+  },
+  session: { activeOrganizationId: workspace.organizationId },
+}));
+
+const { DELETE, GET } = await import(
+  '../../../../../../src/app/api/organizations/current/deletion/route.ts'
+);
+
+afterAll(() => {
+  mock.module('@orbit/core', () => coreModule);
+});
+
+beforeEach(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  summaries.length = 0;
+  deletions.length = 0;
+  published.length = 0;
+  publishError = null;
+});
+
+function request(body: unknown): Request {
+  return new Request('http://localhost:3000/api/organizations/current/deletion', {
+    method: 'DELETE',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('GET /api/organizations/current/deletion', () => {
+  it('returns the current workspace impact with a no-cache policy', async () => {
+    const response = await GET();
+    const payload = z.object({ summary: z.unknown() }).parse(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('private, no-cache');
+    expect(payload.summary).toEqual(summary);
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]?.organizationId).toBe(workspace.organizationId);
+  });
+});
+
+describe('DELETE /api/organizations/current/deletion', () => {
+  it('deletes the active workspace and publishes its invalidation', async () => {
+    const response = await DELETE(request({ confirmation: 'Nova' }));
+    const payload = z
+      .object({
+        deletedOrganizationId: z.string(),
+        nextOrganizationId: z.string().nullable(),
+      })
+      .strict()
+      .parse(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({
+      deletedOrganizationId: deletion.deletedOrganizationId,
+      nextOrganizationId: deletion.nextOrganizationId,
+    });
+    expect(deletions).toHaveLength(1);
+    expect(deletions[0]).toEqual({
+      principal: expect.objectContaining({
+        userId: workspace.admin.userId,
+        organizationId: workspace.organizationId,
+      }),
+      input: { confirmation: 'Nova' },
+    });
+    expect(published).toEqual([deletion.deletedOrganizationId]);
+  });
+
+  it('keeps the committed deletion successful when realtime publishing fails', async () => {
+    publishError = new Error('redis unavailable');
+
+    const response = await DELETE(request({ confirmation: 'Nova' }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      deletedOrganizationId: deletion.deletedOrganizationId,
+      nextOrganizationId: deletion.nextOrganizationId,
+    });
+    expect(published).toEqual([deletion.deletedOrganizationId]);
+  });
+});

--- a/apps/web/tests/app/api/organizations/current/deletion/route.test.ts
+++ b/apps/web/tests/app/api/organizations/current/deletion/route.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { OrganizationDeletionResult, OrganizationDeletionSummary } from '@orbit/core';
 import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test-support';
+import { forbidden, internal } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import { z } from 'zod';
 import { mockSession } from '../../../../../../tests-support.ts';
@@ -10,6 +11,9 @@ const summaries: Principal[] = [];
 const deletions: { principal: Principal; input: unknown }[] = [];
 const published: string[] = [];
 let publishError: Error | null = null;
+let summaryError: Error | null = null;
+let deletionError: Error | null = null;
+let signedIn = true;
 
 const summary: OrganizationDeletionSummary = {
   organizationName: 'Nova',
@@ -20,6 +24,8 @@ const summary: OrganizationDeletionSummary = {
   documents: 5,
   files: 8,
   fileBytes: 4096,
+  fileVersions: 12,
+  fileVersionBytes: 6144,
   integrations: 1,
   webhooks: 2,
   availableAt: null,
@@ -35,11 +41,11 @@ mock.module('@orbit/core', () => ({
   ...coreModule,
   getOrganizationDeletionSummary: (principal: Principal) => {
     summaries.push(principal);
-    return Promise.resolve(summary);
+    return summaryError === null ? Promise.resolve(summary) : Promise.reject(summaryError);
   },
   deleteOrganization: (principal: Principal, input: unknown) => {
     deletions.push({ principal, input });
-    return Promise.resolve(deletion);
+    return deletionError === null ? Promise.resolve(deletion) : Promise.reject(deletionError);
   },
   publishOrganizationDeleted: (organizationId: string) => {
     published.push(organizationId);
@@ -51,14 +57,18 @@ mock.module('next/headers', () => ({ headers: () => Promise.resolve(new Headers(
 
 let workspace: Workspace;
 
-mockSession(() => ({
-  user: {
-    id: workspace.admin.userId,
-    name: 'Workspace Admin',
-    email: 'admin@orbit.test',
-  },
-  session: { activeOrganizationId: workspace.organizationId },
-}));
+mockSession(() =>
+  signedIn
+    ? {
+        user: {
+          id: workspace.admin.userId,
+          name: 'Workspace Admin',
+          email: 'admin@orbit.test',
+        },
+        session: { activeOrganizationId: workspace.organizationId },
+      }
+    : null,
+);
 
 const { DELETE, GET } = await import(
   '../../../../../../src/app/api/organizations/current/deletion/route.ts'
@@ -75,6 +85,9 @@ beforeEach(async () => {
   deletions.length = 0;
   published.length = 0;
   publishError = null;
+  summaryError = null;
+  deletionError = null;
+  signedIn = true;
 });
 
 function request(body: unknown): Request {
@@ -94,6 +107,23 @@ describe('GET /api/organizations/current/deletion', () => {
     expect(payload.summary).toEqual(summary);
     expect(summaries).toHaveLength(1);
     expect(summaries[0]?.organizationId).toBe(workspace.organizationId);
+  });
+
+  it('requires an authenticated session before calculating the impact', async () => {
+    signedIn = false;
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    expect(summaries).toEqual([]);
+  });
+
+  it('preserves authorization failures from the deletion service', async () => {
+    summaryError = forbidden();
+
+    const response = await GET();
+
+    expect(response.status).toBe(403);
   });
 });
 
@@ -135,5 +165,39 @@ describe('DELETE /api/organizations/current/deletion', () => {
       nextOrganizationId: deletion.nextOrganizationId,
     });
     expect(published).toEqual([deletion.deletedOrganizationId]);
+  });
+
+  it('rejects invalid JSON before invoking the deletion service', async () => {
+    const response = await DELETE(
+      new Request('http://localhost:3000/api/organizations/current/deletion', {
+        method: 'DELETE',
+        body: '{',
+      }),
+    );
+
+    expect(response.status).toBe(422);
+    expect(deletions).toEqual([]);
+    expect(published).toEqual([]);
+  });
+
+  it('preserves service authorization failures without publishing', async () => {
+    deletionError = forbidden();
+
+    const response = await DELETE(request({ confirmation: 'Nova' }));
+
+    expect(response.status).toBe(403);
+    expect(published).toEqual([]);
+  });
+
+  it('returns a server failure when storage cleanup cannot complete', async () => {
+    deletionError = internal('storage unavailable');
+
+    const response = await DELETE(request({ confirmation: 'Nova' }));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: { code: 'internal', message: 'storage unavailable' },
+    });
+    expect(published).toEqual([]);
   });
 });

--- a/apps/web/tests/app/settings/general/page.test.tsx
+++ b/apps/web/tests/app/settings/general/page.test.tsx
@@ -1,0 +1,74 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { Principal } from '@orbit/shared/policy';
+import { render, screen } from '@testing-library/react';
+
+const coreModule = await import('@orbit/core');
+const handlerModule = await import('@/lib/api/handler.ts');
+
+let principal: Principal;
+
+mock.module('next/navigation', () => ({
+  useRouter: () => ({ refresh: mock(), push: mock(), back: mock() }),
+}));
+
+mock.module('@/components/ui/toast.tsx', () => ({
+  useToast: () => ({ toast: mock(), dismiss: mock() }),
+}));
+
+mock.module('@orbit/core', () => ({
+  ...coreModule,
+  getOrganization: () =>
+    Promise.resolve({
+      id: 'org_nova',
+      name: 'Nova',
+      logo: null,
+      allowedEmailDomains: [],
+    }),
+}));
+
+mock.module('@/lib/api/handler.ts', () => ({
+  ...handlerModule,
+  pageContext: () =>
+    Promise.resolve({
+      principal,
+      memberId: 'member_1',
+      organizationName: 'Nova',
+      organizationSlug: 'nova',
+      userName: 'Person',
+      userEmail: 'person@orbit.test',
+    }),
+}));
+
+const { default: GeneralSettingsPage } = await import(
+  '../../../../src/app/(app)/settings/general/page.tsx'
+);
+
+afterAll(() => {
+  mock.module('@orbit/core', () => coreModule);
+  mock.module('@/lib/api/handler.ts', () => handlerModule);
+});
+
+beforeEach(() => {
+  principal = {
+    userId: 'user_1',
+    organizationId: 'org_nova',
+    role: 'admin',
+    teamIds: [],
+  };
+});
+
+describe('GeneralSettingsPage workspace deletion permission', () => {
+  it('shows the danger zone to an administrator', async () => {
+    render(await GeneralSettingsPage());
+
+    expect(screen.getByRole('button', { name: 'Delete workspace' })).toBeVisible();
+  });
+
+  it('does not reveal workspace deletion controls to a member', async () => {
+    principal = { ...principal, role: 'member' };
+
+    render(await GeneralSettingsPage());
+
+    expect(screen.queryByRole('button', { name: 'Delete workspace' })).toBeNull();
+  });
+});

--- a/apps/web/tests/app/settings/general/page.test.tsx
+++ b/apps/web/tests/app/settings/general/page.test.tsx
@@ -6,6 +6,7 @@ const coreModule = await import('@orbit/core');
 const handlerModule = await import('@/lib/api/handler.ts');
 
 let principal: Principal;
+let deletionRequestedAt: Date | null;
 
 mock.module('next/navigation', () => ({
   useRouter: () => ({ refresh: mock(), push: mock(), back: mock() }),
@@ -34,6 +35,7 @@ mock.module('@/lib/api/handler.ts', () => ({
       memberId: 'member_1',
       organizationName: 'Nova',
       organizationSlug: 'nova',
+      deletionRequestedAt,
       userName: 'Person',
       userEmail: 'person@orbit.test',
     }),
@@ -49,6 +51,7 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  deletionRequestedAt = null;
   principal = {
     userId: 'user_1',
     organizationId: 'org_nova',
@@ -70,5 +73,14 @@ describe('GeneralSettingsPage workspace deletion permission', () => {
     render(await GeneralSettingsPage());
 
     expect(screen.queryByRole('button', { name: 'Delete workspace' })).toBeNull();
+  });
+
+  it('limits a pending workspace to resuming its deletion', async () => {
+    deletionRequestedAt = new Date('2026-08-08T13:00:00.000Z');
+
+    render(await GeneralSettingsPage());
+
+    expect(screen.getByRole('button', { name: 'Retry workspace deletion' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Save changes' })).toBeDisabled();
   });
 });

--- a/apps/web/tests/features/settings/workspace-danger-zone.test.tsx
+++ b/apps/web/tests/features/settings/workspace-danger-zone.test.tsx
@@ -27,6 +27,8 @@ const summary = {
   documents: 6,
   files: 3,
   fileBytes: 1536,
+  fileVersions: 5,
+  fileVersionBytes: 2560,
   integrations: 1,
   webhooks: 2,
   availableAt: null,
@@ -84,6 +86,8 @@ describe('WorkspaceDangerZone summary and confirmation', () => {
     expect(screen.getByText('6 documents')).toBeVisible();
     expect(screen.getByText('3 files')).toBeVisible();
     expect(screen.getByText('1.5 KB')).toBeVisible();
+    expect(screen.getByText('5 stored file versions')).toBeVisible();
+    expect(screen.getByText('2.5 KB')).toBeVisible();
     expect(screen.getByText('1 integration')).toBeVisible();
     expect(screen.getByText('2 webhooks')).toBeVisible();
     expect(screen.getByText('Comments, attachments, activity and settings')).toBeVisible();

--- a/apps/web/tests/features/settings/workspace-danger-zone.test.tsx
+++ b/apps/web/tests/features/settings/workspace-danger-zone.test.tsx
@@ -114,7 +114,7 @@ describe('WorkspaceDangerZone summary and confirmation', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('keeps deletion blocked until a protected upload completion window closes', async () => {
+  it('allows the first confirmation to lock a workspace with protected upload links', async () => {
     installFetch([
       response({
         summary: { ...summary, availableAt: new Date(Date.now() + 60_000).toISOString() },
@@ -126,8 +126,34 @@ describe('WorkspaceDangerZone summary and confirmation', () => {
     await openDialog(user);
     await user.type(screen.getByLabelText('Type Nova to confirm'), 'Nova');
 
+    expect(screen.queryByText(/pending upload links and their completion window/)).toBeNull();
+    expect(screen.getByRole('button', { name: 'Permanently delete workspace' })).toBeEnabled();
+  });
+
+  it('keeps a pending deletion blocked until every upload capability has drained', async () => {
+    installFetch([
+      response({
+        summary: {
+          ...summary,
+          availableAt: new Date(Date.now() + 60_000).toISOString(),
+          deletionRequestedAt: new Date().toISOString(),
+        },
+      }),
+    ]);
+    const user = userEvent.setup();
+    render(
+      <WorkspaceDangerZone
+        organizationName="Nova"
+        deletionRequestedAt={new Date().toISOString()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Retry workspace deletion' }));
+    await screen.findByText('2 members');
+    await user.type(screen.getByLabelText('Type Nova to confirm'), 'Nova');
+
     expect(screen.getByText(/pending upload links and their completion window/)).toBeVisible();
-    expect(screen.getByRole('button', { name: 'Permanently delete workspace' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Retry permanent deletion' })).toBeDisabled();
   });
 
   it('shows summary failures in an alert and retries in place', async () => {
@@ -249,5 +275,40 @@ describe('WorkspaceDangerZone deletion', () => {
     );
     expect(screen.getByRole('dialog')).toBeVisible();
     expect(assign).not.toHaveBeenCalled();
+  });
+
+  it('refreshes into a locked retry state while upload capabilities drain', async () => {
+    const availableAt = new Date(Date.now() + 60_000).toISOString();
+    const requestedAt = new Date().toISOString();
+    const fetchMock = installFetch([
+      response({ summary }),
+      response(
+        {
+          error: {
+            code: 'conflict',
+            message: 'Workspace deletion is pending while upload links expire.',
+            details: { availableAt },
+          },
+        },
+        409,
+      ),
+      response({
+        summary: { ...summary, availableAt, deletionRequestedAt: requestedAt },
+      }),
+    ]);
+    const user = userEvent.setup();
+    render(<WorkspaceDangerZone organizationName="Nova" />);
+    await openDialog(user);
+    await user.type(screen.getByLabelText('Type Nova to confirm'), 'Nova');
+
+    await user.click(screen.getByRole('button', { name: 'Permanently delete workspace' }));
+
+    expect(await screen.findByText(/locked for normal use/)).toBeVisible();
+    expect(screen.getByText(/pending upload links and their completion window/)).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Retry permanent deletion' })).toBeDisabled();
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Workspace deletion is pending while upload links expire.',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/web/tests/features/settings/workspace-danger-zone.test.tsx
+++ b/apps/web/tests/features/settings/workspace-danger-zone.test.tsx
@@ -113,7 +113,7 @@ describe('WorkspaceDangerZone summary and confirmation', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('keeps deletion blocked until a protected upload target expires', async () => {
+  it('keeps deletion blocked until a protected upload completion window closes', async () => {
     installFetch([
       response({
         summary: { ...summary, availableAt: new Date(Date.now() + 60_000).toISOString() },
@@ -125,7 +125,7 @@ describe('WorkspaceDangerZone summary and confirmation', () => {
     await openDialog(user);
     await user.type(screen.getByLabelText('Type Nova to confirm'), 'Nova');
 
-    expect(screen.getByText(/pending upload links expire/)).toBeVisible();
+    expect(screen.getByText(/pending upload links and their completion window/)).toBeVisible();
     expect(screen.getByRole('button', { name: 'Permanently delete workspace' })).toBeDisabled();
   });
 

--- a/apps/web/tests/features/settings/workspace-danger-zone.test.tsx
+++ b/apps/web/tests/features/settings/workspace-danger-zone.test.tsx
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const setActive = mock();
+const assign = mock();
+
+mock.module('@/lib/auth/client.ts', () => ({
+  authClient: {
+    organization: { setActive: (...args: unknown[]) => setActive(...args) },
+  },
+}));
+
+const { WorkspaceDangerZone, formatDeletionBytes } = await import(
+  '../../../src/features/settings/workspace-danger-zone.tsx'
+);
+
+const realFetch = globalThis.fetch;
+const realLocation = window.location;
+
+const summary = {
+  organizationName: 'Nova',
+  members: 2,
+  teams: 3,
+  projects: 4,
+  issues: 15,
+  documents: 6,
+  files: 3,
+  fileBytes: 1536,
+  integrations: 1,
+  webhooks: 2,
+  availableAt: null,
+};
+
+function response(body: unknown, status = 200): Response {
+  return Response.json(body, { status });
+}
+
+function installFetch(responses: Response[]): ReturnType<typeof mock> {
+  const fetchMock = mock(() => {
+    const next = responses.shift();
+    if (next === undefined) throw new Error('Unexpected request');
+    return Promise.resolve(next);
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+async function openDialog(user = userEvent.setup()): Promise<typeof user> {
+  await user.click(screen.getByRole('button', { name: 'Delete workspace' }));
+  await screen.findByText('2 members');
+  return user;
+}
+
+beforeEach(() => {
+  setActive.mockReset();
+  assign.mockClear();
+  Object.defineProperty(window, 'location', { value: { assign }, writable: true });
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  Object.defineProperty(window, 'location', { value: realLocation, writable: true });
+});
+
+describe('formatDeletionBytes', () => {
+  it('uses readable binary file sizes', () => {
+    expect(formatDeletionBytes(0)).toBe('0 B');
+    expect(formatDeletionBytes(1536)).toBe('1.5 KB');
+  });
+});
+
+describe('WorkspaceDangerZone summary and confirmation', () => {
+  it('shows every deletion category and requires an exact case-sensitive name', async () => {
+    installFetch([response({ summary })]);
+    const user = userEvent.setup();
+    render(<WorkspaceDangerZone organizationName="Nova" />);
+
+    await openDialog(user);
+
+    expect(screen.getByText('3 teams')).toBeVisible();
+    expect(screen.getByText('4 projects')).toBeVisible();
+    expect(screen.getByText('15 issues')).toBeVisible();
+    expect(screen.getByText('6 documents')).toBeVisible();
+    expect(screen.getByText('3 files')).toBeVisible();
+    expect(screen.getByText('1.5 KB')).toBeVisible();
+    expect(screen.getByText('1 integration')).toBeVisible();
+    expect(screen.getByText('2 webhooks')).toBeVisible();
+    expect(screen.getByText('Comments, attachments, activity and settings')).toBeVisible();
+    const confirm = screen.getByRole('button', { name: 'Permanently delete workspace' });
+    expect(confirm).toBeDisabled();
+
+    await user.type(screen.getByLabelText('Type Nova to confirm'), 'nova');
+    expect(confirm).toBeDisabled();
+    await user.clear(screen.getByLabelText('Type Nova to confirm'));
+    await user.type(screen.getByLabelText('Type Nova to confirm'), 'Nova');
+    expect(confirm).toBeEnabled();
+  });
+
+  it('loads a fresh summary each time the dialog opens', async () => {
+    const fetchMock = installFetch([response({ summary }), response({ summary })]);
+    const user = userEvent.setup();
+    render(<WorkspaceDangerZone organizationName="Nova" />);
+
+    await openDialog(user);
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await openDialog(user);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps deletion blocked until a protected upload target expires', async () => {
+    installFetch([
+      response({
+        summary: { ...summary, availableAt: new Date(Date.now() + 60_000).toISOString() },
+      }),
+    ]);
+    const user = userEvent.setup();
+    render(<WorkspaceDangerZone organizationName="Nova" />);
+
+    await openDialog(user);
+    await user.type(screen.getByLabelText('Type Nova to confirm'), 'Nova');
+
+    expect(screen.getByText(/pending upload links expire/)).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Permanently delete workspace' })).toBeDisabled();
+  });
+
+  it('shows summary failures in an alert and retries in place', async () => {
+    const fetchMock = installFetch([
+      response({ error: { code: 'internal', message: 'Storage is unavailable.' } }, 500),
+      response({ summary }),
+    ]);
+    const user = userEvent.setup();
+    render(<WorkspaceDangerZone organizationName="Nova" />);
+
+    await user.click(screen.getByRole('button', { name: 'Delete workspace' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Storage is unavailable.');
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByText('2 members')).toBeVisible();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('WorkspaceDangerZone deletion', () => {
+  it('submits once, activates the next workspace, and leaves the deleted tenant', async () => {
+    let resolveDelete: ((value: Response) => void) | undefined;
+    const deleting = new Promise<Response>((resolve) => {
+      resolveDelete = resolve;
+    });
+    const fetchMock = mock()
+      .mockResolvedValueOnce(response({ summary }))
+      .mockImplementationOnce(() => deleting);
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    setActive.mockResolvedValue({ error: null });
+    const user = userEvent.setup();
+    render(<WorkspaceDangerZone organizationName="Nova" />);
+    await openDialog(user);
+    await user.type(screen.getByLabelText('Type Nova to confirm'), 'Nova');
+
+    const confirm = screen.getByRole('button', { name: 'Permanently delete workspace' });
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    resolveDelete?.(
+      response({ deletedOrganizationId: 'org_deleted', nextOrganizationId: 'org_next' }),
+    );
+
+    await waitFor(() => {
+      expect(setActive).toHaveBeenCalledWith({ organizationId: 'org_next' });
+      expect(assign).toHaveBeenCalledWith('/my-issues');
+    });
+  });
+
+  it('sends a user with no workspace left to workspace creation', async () => {
+    installFetch([
+      response({ summary }),
+      response({ deletedOrganizationId: 'org_deleted', nextOrganizationId: null }),
+    ]);
+    const user = userEvent.setup();
+    render(<WorkspaceDangerZone organizationName="Nova" />);
+    await openDialog(user);
+    await user.type(screen.getByLabelText('Type Nova to confirm'), 'Nova');
+
+    await user.click(screen.getByRole('button', { name: 'Permanently delete workspace' }));
+
+    await waitFor(() => expect(assign).toHaveBeenCalledWith('/workspaces/new'));
+    expect(setActive).not.toHaveBeenCalled();
+  });
+
+  it('leaves deleted workspace state when activating the next workspace fails', async () => {
+    installFetch([
+      response({ summary }),
+      response({ deletedOrganizationId: 'org_deleted', nextOrganizationId: 'org_next' }),
+    ]);
+    setActive.mockRejectedValue(new Error('session update failed'));
+    const user = userEvent.setup();
+    render(<WorkspaceDangerZone organizationName="Nova" />);
+    await openDialog(user);
+    await user.type(screen.getByLabelText('Type Nova to confirm'), 'Nova');
+
+    await user.click(screen.getByRole('button', { name: 'Permanently delete workspace' }));
+
+    await waitFor(() => expect(assign).toHaveBeenCalledWith('/workspaces/new'));
+  });
+
+  it('keeps the dialog open and reports a rejected deletion', async () => {
+    installFetch([
+      response({ summary }),
+      response(
+        {
+          error: {
+            code: 'conflict',
+            message: 'Type the current workspace name exactly to confirm deletion.',
+          },
+        },
+        409,
+      ),
+    ]);
+    const user = userEvent.setup();
+    render(<WorkspaceDangerZone organizationName="Nova" />);
+    await openDialog(user);
+    await user.type(screen.getByLabelText('Type Nova to confirm'), 'Nova');
+
+    await user.click(screen.getByRole('button', { name: 'Permanently delete workspace' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Type the current workspace name exactly to confirm deletion.',
+    );
+    expect(screen.getByRole('dialog')).toBeVisible();
+    expect(assign).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/features/settings/workspace-danger-zone.test.tsx
+++ b/apps/web/tests/features/settings/workspace-danger-zone.test.tsx
@@ -32,6 +32,7 @@ const summary = {
   integrations: 1,
   webhooks: 2,
   availableAt: null,
+  deletionRequestedAt: null,
 };
 
 function response(body: unknown, status = 200): Response {
@@ -144,6 +145,20 @@ describe('WorkspaceDangerZone summary and confirmation', () => {
     expect(await screen.findByText('2 members')).toBeVisible();
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it('explains and resumes a durable deletion attempt', async () => {
+    const requestedAt = '2026-08-08T13:00:00.000Z';
+    installFetch([response({ summary: { ...summary, deletionRequestedAt: requestedAt } })]);
+    const user = userEvent.setup();
+    render(<WorkspaceDangerZone organizationName="Nova" deletionRequestedAt={requestedAt} />);
+
+    expect(screen.getByText(/Deletion is in progress/)).toBeVisible();
+    await user.click(screen.getByRole('button', { name: 'Retry workspace deletion' }));
+    await screen.findByText(/locked for normal use/);
+    await user.type(screen.getByLabelText('Type Nova to confirm'), 'Nova');
+
+    expect(screen.getByRole('button', { name: 'Retry permanent deletion' })).toBeEnabled();
+  });
 });
 
 describe('WorkspaceDangerZone deletion', () => {
@@ -220,6 +235,7 @@ describe('WorkspaceDangerZone deletion', () => {
         },
         409,
       ),
+      response({ summary }),
     ]);
     const user = userEvent.setup();
     render(<WorkspaceDangerZone organizationName="Nova" />);

--- a/apps/web/tests/lib/auth/principal.test.ts
+++ b/apps/web/tests/lib/auth/principal.test.ts
@@ -108,5 +108,23 @@ describe('resolveMembership', () => {
     expect(resolved?.memberId.length ?? 0).toBeGreaterThan(0);
     expect(resolved?.organizationName).toBe('Nova');
     expect(resolved?.organizationSlug.startsWith('nova-')).toBe(true);
+    expect(resolved?.deletionRequestedAt).toBeNull();
+  });
+
+  it('exposes a pending deletion so the app can limit the workspace to retry', async () => {
+    const requestedAt = new Date('2026-08-08T13:00:00.000Z');
+    await db
+      .update(schema.organization)
+      .set({ deletionRequestedAt: requestedAt })
+      .where(eq(schema.organization.id, nova.organizationId));
+    try {
+      const resolved = await resolveMembership(nova.adminUser.id, nova.organizationId);
+      expect(resolved?.deletionRequestedAt).toEqual(requestedAt);
+    } finally {
+      await db
+        .update(schema.organization)
+        .set({ deletionRequestedAt: null })
+        .where(eq(schema.organization.id, nova.organizationId));
+    }
   });
 });

--- a/apps/web/tests/lib/realtime/provider.test.ts
+++ b/apps/web/tests/lib/realtime/provider.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { SESSION_REVOKED_CLOSE_CODE, UNAUTHORIZED_CLOSE_CODE } from '@orbit/shared/events';
-import type { SessionGate } from '../../../src/lib/realtime/provider.tsx';
-import { endSessionIfRevoked, handleTerminalClose } from '../../../src/lib/realtime/provider.tsx';
+import {
+  ORGANIZATION_FORBIDDEN_CLOSE_CODE,
+  SESSION_REVOKED_CLOSE_CODE,
+  UNAUTHORIZED_CLOSE_CODE,
+} from '@orbit/shared/events';
+import type { SessionGate, WorkspaceRecoveryGate } from '../../../src/lib/realtime/provider.tsx';
+import {
+  endSessionIfRevoked,
+  handleTerminalClose,
+  recoverWorkspaceAfterForbidden,
+} from '../../../src/lib/realtime/provider.tsx';
 
 const HERE = 'https://orbit.example/my-issues';
 
@@ -25,6 +33,28 @@ function gateReturning(answer: () => Promise<unknown>): Recorder {
       signOut: () => {
         calls.signOuts += 1;
         return Promise.resolve(undefined);
+      },
+    },
+  };
+}
+
+interface WorkspaceRecorder {
+  readonly gate: WorkspaceRecoveryGate;
+  readonly calls: { lists: number; active: string[] };
+}
+
+function workspaceGateReturning(organizations: unknown): WorkspaceRecorder {
+  const calls = { lists: 0, active: [] as string[] };
+  return {
+    calls,
+    gate: {
+      listOrganizations: () => {
+        calls.lists += 1;
+        return Promise.resolve({ organizations });
+      },
+      setActive: ({ organizationId }) => {
+        calls.active.push(organizationId);
+        return Promise.resolve({ error: null });
       },
     },
   };
@@ -117,5 +147,64 @@ describe('handleTerminalClose', () => {
     expect(calls.sessions).toHaveLength(1);
     expect(calls.signOuts).toBe(0);
     expect(location.href).toBe(HERE);
+  });
+
+  it('starts workspace recovery only for an organization-forbidden close', async () => {
+    const session = gateReturning(async () => ({ data: { session: { id: 'live' } } }));
+    const workspace = workspaceGateReturning([{ id: 'org_2' }]);
+
+    handleTerminalClose(ORGANIZATION_FORBIDDEN_CLOSE_CODE, session.gate, workspace.gate);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(workspace.calls.lists).toBe(1);
+    expect(workspace.calls.active).toEqual(['org_2']);
+    expect(location.href).toBe('/my-issues');
+    expect(session.calls.sessions).toEqual([]);
+  });
+});
+
+describe('recoverWorkspaceAfterForbidden', () => {
+  it('activates the first surviving workspace before leaving the stale tenant', async () => {
+    const { gate, calls } = workspaceGateReturning([{ id: 'org_2' }, { id: 'org_3' }]);
+
+    await recoverWorkspaceAfterForbidden(gate);
+
+    expect(calls.active).toEqual(['org_2']);
+    expect(location.href).toBe('/my-issues');
+  });
+
+  it('opens workspace creation when no membership remains', async () => {
+    const { gate, calls } = workspaceGateReturning([]);
+
+    await recoverWorkspaceAfterForbidden(gate);
+
+    expect(calls.active).toEqual([]);
+    expect(location.href).toBe('/workspaces/new');
+  });
+
+  it('fails closed to workspace creation when recovery throws', async () => {
+    const { gate } = workspaceGateReturning([{ id: 'org_2' }]);
+    const failing: WorkspaceRecoveryGate = {
+      ...gate,
+      setActive: () => Promise.reject(new Error('session update failed')),
+    };
+
+    await recoverWorkspaceAfterForbidden(failing);
+
+    expect(location.href).toBe('/workspaces/new');
+  });
+
+  it('fails closed when the surviving workspace cannot be activated', async () => {
+    const { gate } = workspaceGateReturning([{ id: 'org_2' }]);
+    const rejected: WorkspaceRecoveryGate = {
+      ...gate,
+      setActive: () => Promise.resolve({ error: { message: 'membership changed' } }),
+    };
+
+    await recoverWorkspaceAfterForbidden(rejected);
+
+    expect(location.href).toBe('/workspaces/new');
   });
 });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,10 @@ The bucket needs a CORS policy allowing your origin, otherwise uploads fail in
 the browser while the server logs look healthy. `infra/s3-cors.json` is the
 document, with the origin as a placeholder.
 
+Workspace deletion needs permission to list and delete both current objects and
+object versions. On AWS S3, grant `s3:ListBucket`, `s3:ListBucketVersions`,
+`s3:DeleteObject`, and `s3:DeleteObjectVersion` for the upload bucket.
+
 ## Integrations
 
 | Variable | Notes |

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -58,7 +58,10 @@ continent adds its round trip to every live update anyone sees.
 ### 3. Create the bucket
 
 Cloudflare R2 is the cheapest of these because it does not charge for egress.
-Create a bucket, then create an API token with object read and write on it.
+Create a bucket, then create an API token with object read, write, list, and
+delete permissions. AWS S3 deployments also need `s3:ListBucketVersions` and
+`s3:DeleteObjectVersion` so workspace deletion removes recoverable historical
+versions instead of leaving them behind.
 
 R2 gives you an endpoint like
 `https://<account-id>.r2.cloudflarestorage.com`, and the region is `auto`.

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -121,19 +121,19 @@ Commit: `feat(workspace): define deletion contracts`
 **Interfaces:**
 - Produces: nullable `schema.attachment.uploadExpiresAt: Date | null` mapped to `upload_expires_at`.
 
-- [ ] **Step 1: Write the failing schema assertion**
+- [x] **Step 1: Write the failing schema assertion**
 
 ```ts
 expect(getTableColumns(schema.attachment).uploadExpiresAt?.name).toBe('upload_expires_at');
 ```
 
-- [ ] **Step 2: Run the schema test and confirm it fails**
+- [x] **Step 2: Run the schema test and confirm it fails**
 
 Run: `bun --filter @orbit/db test tests/schema/index.test.ts`
 
 Expected: FAIL because the attachment field does not exist.
 
-- [ ] **Step 3: Add the nullable timestamp and generate the migration**
+- [x] **Step 3: Add the nullable timestamp and generate the migration**
 
 ```ts
 uploadExpiresAt: timestamp('upload_expires_at', { withTimezone: true }),
@@ -148,7 +148,7 @@ UPDATE "attachment"
 SET "upload_expires_at" = "created_at" + interval '900 seconds';
 ```
 
-- [ ] **Step 4: Recreate lane schemas and run the database tests**
+- [x] **Step 4: Recreate lane schemas and run the database tests**
 
 Run: `bun run db:test-setup`
 

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -1,10 +1,8 @@
 # Workspace Deletion Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
-
 **Goal:** Add an administrator-only, permanent workspace deletion flow that previews categorized impact, removes every tenant-owned database row and stored object, and safely recovers every open client.
 
-**Architecture:** A tenant-scoped core service owns preview and deletion. It serializes uploads against deletion with a PostgreSQL organization row lock, commits a durable deletion request that locks normal access, completes every fallible database mutation, and makes exact-prefix object cleanup the final operation before the database commit. A current-workspace API exposes the retryable service, a realtime control event closes affected sockets, and an accessible General settings danger-zone dialog requires the exact workspace name.
+**Architecture:** A tenant-scoped core service owns preview and deletion. It serializes uploads against deletion with a PostgreSQL organization row lock, commits a durable deletion request that locks normal access, performs exact-prefix object cleanup without holding a database transaction open, and finishes with a short cascaded-delete transaction. A current-workspace API exposes the retryable service, a realtime control event closes affected sockets, and an accessible General settings danger-zone dialog requires the exact workspace name.
 
 **Tech Stack:** Bun 1.3+, TypeScript 5.9, Next.js App Router, React 19, Drizzle ORM, PostgreSQL, AWS SDK v3 S3, Redis, Radix Dialog, Zod 4, Testing Library, `bun:test`.
 
@@ -28,7 +26,7 @@
 - `packages/shared/src/events/control.ts`: validate session and organization control messages.
 - `packages/db/src/schema/content.ts`: persist presigned upload expiration.
 - `packages/db/src/schema/org.ts`: persist the durable deletion request timestamp.
-- `packages/db/drizzle/0001_*.sql` and metadata: migrate and conservatively backfill upload expiration.
+- `packages/db/drizzle/0002_glossy_mister_sinister.sql` and metadata: migrate and conservatively backfill upload expiration.
 - `packages/db/tests/schema/index.test.ts`: assert the attachment field at the schema layer.
 - `packages/db/tests/schema/organization-cascade.test.ts`: inspect PostgreSQL foreign keys to prevent non-cascading workspace records.
 - `packages/services/src/storage/types.ts`: expose prefix summary and cleanup contracts.
@@ -114,9 +112,9 @@ Commit: `feat(workspace): define deletion contracts`
 **Files:**
 - Modify: `packages/db/src/schema/content.ts`
 - Modify: `packages/db/tests/schema/index.test.ts`
-- Create: `packages/db/drizzle/0001_*.sql`
+- Create: `packages/db/drizzle/0002_glossy_mister_sinister.sql`
 - Modify: `packages/db/drizzle/meta/_journal.json`
-- Create: `packages/db/drizzle/meta/0001_snapshot.json`
+- Create: `packages/db/drizzle/meta/0002_snapshot.json`
 
 **Interfaces:**
 - Produces: nullable `schema.attachment.uploadExpiresAt: Date | null` mapped to `upload_expires_at`.
@@ -343,7 +341,7 @@ expect(await sessionExists(sessionId)).toBe(true);
 expect(await activeOrganization(sessionId)).toBeNull();
 ```
 
-Cover stale-name refusal, stale-administrator refusal, future upload refusal with `availableAt` details, tracked and untracked capability boundaries, durable retry after storage failure, database failure before storage cleanup, storage prefix selection, neighboring tenant preservation, shared-user preservation, and the null next-workspace result.
+Cover stale-name refusal, stale-administrator refusal, future upload refusal with `availableAt` details, tracked and untracked capability boundaries, durable retry after storage failure, final database statement and commit failures after storage cleanup, storage prefix selection, neighboring tenant preservation, shared-user preservation, and the null next-workspace result.
 
 - [x] **Step 5: Implement durable two-phase cleanup and next-workspace selection**
 
@@ -357,18 +355,25 @@ await db.transaction(async (tx) => {
   }
 });
 
+const organizationId = await db.transaction(async (tx) => {
+  const organization = await validatedDeletionTarget(tx, principal, parsed.confirmation);
+  await assertDeletionReady(tx, organization, now);
+  return organization.id;
+});
+
+await driver.deletePrefix(storagePrefixFor(organizationId));
+
 return await db.transaction(async (tx) => {
   const organization = await validatedDeletionTarget(tx, principal, parsed.confirmation);
   await assertDeletionReady(tx, organization, now);
   await tx.update(schema.session).set({ activeOrganizationId: null })
     .where(eq(schema.session.activeOrganizationId, organization.id));
   await tx.delete(schema.organization).where(eq(schema.organization.id, organization.id));
-  await driver.deletePrefix(storagePrefixFor(organization.id));
   return deletionResult;
 });
 ```
 
-Choose the next membership by organization name and id, excluding the deleting organization and any other pending deletion. The committed timestamp survives a failed second phase, normal access rejects the pending workspace, and an administrator can safely retry idempotent prefix cleanup. The second phase waits one full presigned URL lifetime plus completion grace after the timestamp, in addition to recorded attachment expiration guards. This covers a presigned target whose attachment insert or transaction commit failed. Return only ids and the deleted name.
+Choose the next membership by organization name and id, excluding the deleting organization and any other pending deletion. The committed timestamp survives storage and final-transaction failures, normal access rejects the pending workspace, and an administrator can safely retry idempotent prefix cleanup. The cleanup waits one full presigned URL lifetime plus completion grace after the timestamp, in addition to recorded attachment expiration guards. This covers a presigned target whose attachment insert or transaction commit failed. Return only ids and the deleted name.
 
 - [x] **Step 6: Add the live PostgreSQL cascade regression test**
 

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -452,7 +452,7 @@ Commit: `feat(workspace): expose deletion endpoint`
 - Produces: `WorkspaceDangerZone({ organizationName }: { organizationName: string })`.
 - Produces: `formatDeletionBytes(bytes: number): string` for deterministic file-size rendering.
 
-- [ ] **Step 1: Write failing dialog rendering and confirmation tests**
+- [x] **Step 1: Write failing dialog rendering and confirmation tests**
 
 ```tsx
 render(<WorkspaceDangerZone organizationName="Nova" />);
@@ -464,21 +464,21 @@ await user.type(screen.getByLabelText('Type Nova to confirm'), 'Nova');
 expect(screen.getByRole('button', { name: 'Permanently delete workspace' })).toBeEnabled();
 ```
 
-- [ ] **Step 2: Run the component test and confirm it fails**
+- [x] **Step 2: Run the component test and confirm it fails**
 
 Run: `bun --filter @orbit/web test tests/features/settings/workspace-danger-zone.test.tsx`
 
 Expected: FAIL because the component does not exist.
 
-- [ ] **Step 3: Implement summary loading and accessible destructive state**
+- [x] **Step 3: Implement summary loading and accessible destructive state**
 
 Use the shared `Dialog` primitives with a title, description, labelled input, alert error region, and `danger` button. Load a fresh summary on each open. Render all eight categories and the nested-data disclosure. Disable deletion during loading, before an exact case-sensitive name match, before `availableAt`, and while the DELETE request is pending. Keep the dialog open on an error and allow summary retry.
 
-- [ ] **Step 4: Add request and navigation tests**
+- [x] **Step 4: Add request and navigation tests**
 
 Assert one DELETE request for repeated clicks. Assert `setActive({ organizationId: nextId })` and `/my-issues` for a surviving workspace. Assert `/workspaces/new` without calling `setActive` when `nextOrganizationId` is null. Assert a server conflict appears in the alert region and leaves the dialog open.
 
-- [ ] **Step 5: Render the danger zone only for administrators**
+- [x] **Step 5: Render the danger zone only for administrators**
 
 ```tsx
 {can(principal, 'org:delete') ? (
@@ -486,7 +486,7 @@ Assert one DELETE request for repeated clicks. Assert `setActive({ organizationI
 ) : null}
 ```
 
-- [ ] **Step 6: Run component tests and commit**
+- [x] **Step 6: Run component tests and commit**
 
 Run: `bun --filter @orbit/web test tests/features/settings/workspace-danger-zone.test.tsx`
 

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -235,7 +235,7 @@ Commit: `feat(storage): clean organization prefixes`
 - Produces: `lockOrganization(executor: Transaction, organizationId: string): Promise<OrganizationRow>`.
 - Produces: presigned attachment rows with `uploadExpiresAt`; inline rows keep it null.
 
-- [ ] **Step 1: Write failing upload expiration tests**
+- [x] **Step 1: Write failing upload expiration tests**
 
 ```ts
 expect(registered.attachment.uploadExpiresAt?.toISOString()).toBe(registered.upload.expiresAt);
@@ -244,13 +244,13 @@ expect(attached.attachment.uploadExpiresAt).toBeNull();
 
 Also start a registration transaction behind a held organization row lock and assert the fake storage driver is not called until the lock is released.
 
-- [ ] **Step 2: Run the attachment tests and confirm they fail**
+- [x] **Step 2: Run the attachment tests and confirm they fail**
 
 Run: `bun --filter @orbit/core test tests/content/attachment-service.test.ts`
 
 Expected: FAIL because expiration is not stored and uploads do not lock the organization.
 
-- [ ] **Step 3: Implement one transaction per upload registration**
+- [x] **Step 3: Implement one transaction per upload registration**
 
 ```ts
 return await db.transaction(async (tx) => {
@@ -267,11 +267,11 @@ return await db.transaction(async (tx) => {
 
 Refactor `insertAttachment` to use the caller's transaction. Keep inline storage writes and row insertion under the same organization lock, retaining best-effort cleanup if insertion fails.
 
-- [ ] **Step 4: Run attachment and presign route tests and commit**
+- [x] **Step 4: Run attachment and presign route tests and commit**
 
 Run: `bun --filter @orbit/core test tests/content/attachment-service.test.ts`
 
-Run: `bun --filter @orbit/web test tests/app/api/attachments/presign/route.test.ts`
+Run from `apps/web`: `bun --env-file=../../.env test tests/app/api/attachments/presign/route.test.ts --timeout 20000`
 
 Expected: PASS.
 

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -173,7 +173,7 @@ Commit: `feat(storage): track presigned upload expiry`
 - Produces: `StorageDriver.deletePrefix(prefix: string): Promise<void>`.
 - Produces: `storagePrefixFor(organizationId: string): string` and `assertSafePrefix(prefix: string): string`.
 
-- [ ] **Step 1: Write failing prefix validation and summary tests**
+- [x] **Step 1: Write failing prefix validation and summary tests**
 
 ```ts
 expect(storagePrefixFor('org_1')).toBe('org_1/');
@@ -184,13 +184,13 @@ expect(await driver.summarizePrefix('org_1/')).toEqual({ objects: 3, bytes: 60 }
 
 The controlled S3 client must return two `ListObjectsV2Command` pages so the test asserts the second request uses the first continuation token.
 
-- [ ] **Step 2: Run the prefix tests and confirm they fail**
+- [x] **Step 2: Run the prefix tests and confirm they fail**
 
 Run: `bun --filter @orbit/services test tests/storage/storage-prefix.test.ts`
 
 Expected: FAIL because prefix operations do not exist.
 
-- [ ] **Step 3: Implement validated pagination and batching**
+- [x] **Step 3: Implement validated pagination and batching**
 
 ```ts
 export interface StoragePrefixSummary {
@@ -204,7 +204,7 @@ async deletePrefix(prefix: string): Promise<void>
 
 Use `ListObjectsV2Command` with `Prefix` and `ContinuationToken`. Sum each returned object's `Size`. Send `DeleteObjectsCommand` requests of no more than 1,000 exact returned keys, reject any response containing `Errors`, and repeat listing until an empty page proves the prefix is empty.
 
-- [ ] **Step 4: Add deletion tests for all safety boundaries**
+- [x] **Step 4: Add deletion tests for all safety boundaries**
 
 ```ts
 await driver.deletePrefix('org_1/');
@@ -215,7 +215,7 @@ await expect(partialFailure()).rejects.toMatchObject({ code: 'internal' });
 
 Cover empty prefixes, more than one list page, more than one delete batch, missing keys, malformed prefixes, and a per-object S3 error.
 
-- [ ] **Step 5: Run service tests and commit**
+- [x] **Step 5: Run service tests and commit**
 
 Run: `bun --filter @orbit/services test tests/storage/storage-prefix.test.ts tests/storage/storage.test.ts`
 

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -90,7 +90,7 @@ Expected: FAIL because `org:delete`, `organizationDeleteSchema`, and the organiz
 
 ```ts
 export const organizationDeleteSchema = z.object({
-  confirmation: z.string().trim().min(1).max(80),
+  confirmation: z.string().min(1).max(80).refine((value) => value === value.trim()),
 });
 
 export const controlMessageSchema = z.discriminatedUnion('type', [
@@ -211,7 +211,7 @@ async summarizePrefix(prefix: string): Promise<StoragePrefixSummary>
 async deletePrefix(prefix: string): Promise<void>
 ```
 
-Use `ListObjectsV2Command` with `Prefix` and `ContinuationToken`. Sum each returned object's `Size`. Use `ListObjectVersionsCommand` to count and permanently remove historical versions and delete markers. Send `DeleteObjectsCommand` requests of no more than 1,000 exact returned keys and version ids, reject any response containing `Errors`, and repeat listing until empty pages prove the prefix and its version history are empty. Treat only a provider's explicit `NotImplemented` response as a versionless fallback.
+Use `ListObjectsV2Command` with `Prefix` and `ContinuationToken`. Sum each returned object's `Size`. Use `ListObjectVersionsCommand` to count and permanently remove historical versions and delete markers. Require both continuation markers from every truncated version page. Send `DeleteObjectsCommand` requests of no more than 1,000 exact returned keys and version ids, reject any response containing `Errors`, and repeat listing until empty pages prove the prefix and its version history are empty. Treat only a provider's explicit `NotImplemented` response as a versionless fallback.
 
 - [x] **Step 4: Add deletion tests for all safety boundaries**
 
@@ -327,7 +327,7 @@ Expected: FAIL because the service does not exist.
 
 - [x] **Step 3: Implement bounded aggregate summary queries**
 
-Use one `count()` query per category with `eq(table.organizationId, principal.organizationId)`, a future `max(attachment.uploadExpiresAt)` query, and `driver.summarizePrefix(storagePrefixFor(principal.organizationId))`. Call `assertCan(principal, 'org:delete')` before database or storage access.
+Use one `count()` query per category with `eq(table.organizationId, principal.organizationId)`, a latest protected-upload query that adds the exported completion grace, and `driver.summarizePrefix(storagePrefixFor(principal.organizationId))`. Call `assertCan(principal, 'org:delete')` before database or storage access. Lock and recheck the current membership role inside the deletion transaction before touching storage.
 
 - [x] **Step 4: Write failing destructive service tests**
 
@@ -343,7 +343,7 @@ expect(await sessionExists(sessionId)).toBe(true);
 expect(await activeOrganization(sessionId)).toBeNull();
 ```
 
-Cover stale-name refusal, future upload refusal with `availableAt` details, exact expiry boundary, storage failure rollback, storage prefix selection, neighboring tenant preservation, shared-user preservation, and the null next-workspace result.
+Cover stale-name refusal, stale-administrator refusal, future upload refusal with `availableAt` details, exact completion-grace boundary, storage failure rollback, storage prefix selection, neighboring tenant preservation, shared-user preservation, and the null next-workspace result.
 
 - [x] **Step 5: Implement locked cleanup and next-workspace selection**
 

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -66,7 +66,7 @@
 **Interfaces:**
 - Produces: `organizationDeleteSchema`, `OrganizationDeleteInput`, and `ControlMessage` variants `{ type: 'session_revoked'; userId: string } | { type: 'organization_deleted'; organizationId: string }`.
 
-- [ ] **Step 1: Write failing shared contract tests**
+- [x] **Step 1: Write failing shared contract tests**
 
 ```ts
 expect(can(principal('admin'), 'org:delete')).toBe(true);
@@ -80,13 +80,13 @@ expect(controlMessageSchema.parse({
 })).toEqual({ type: 'organization_deleted', organizationId: 'org_1' });
 ```
 
-- [ ] **Step 2: Run the tests and confirm the new contracts fail**
+- [x] **Step 2: Run the tests and confirm the new contracts fail**
 
 Run: `bun --filter @orbit/shared test tests/policy/policy.test.ts tests/validators/organization.test.ts tests/events/control.test.ts`
 
 Expected: FAIL because `org:delete`, `organizationDeleteSchema`, and the organization control variant do not exist.
 
-- [ ] **Step 3: Implement the shared contracts**
+- [x] **Step 3: Implement the shared contracts**
 
 ```ts
 export const organizationDeleteSchema = z.object({
@@ -101,7 +101,7 @@ export const controlMessageSchema = z.discriminatedUnion('type', [
 
 Add `org:delete` to the permission tuple and the administrator permission set only.
 
-- [ ] **Step 4: Run the focused tests and commit**
+- [x] **Step 4: Run the focused tests and commit**
 
 Run: `bun --filter @orbit/shared test tests/policy/policy.test.ts tests/validators/organization.test.ts tests/events/control.test.ts`
 

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add an administrator-only, permanent workspace deletion flow that previews categorized impact, removes every tenant-owned database row and stored object, and safely recovers every open client.
 
-**Architecture:** A tenant-scoped core service owns preview and deletion. It serializes uploads against deletion with a PostgreSQL organization row lock, removes the exact `<organizationId>/` object-storage prefix, clears stale session pointers, then relies on verified cascading foreign keys for database cleanup. A current-workspace API exposes the service, a realtime control event closes affected sockets, and an accessible General settings danger-zone dialog requires the exact workspace name.
+**Architecture:** A tenant-scoped core service owns preview and deletion. It serializes uploads against deletion with a PostgreSQL organization row lock, commits a durable deletion request that locks normal access, completes every fallible database mutation, and makes exact-prefix object cleanup the final operation before the database commit. A current-workspace API exposes the retryable service, a realtime control event closes affected sockets, and an accessible General settings danger-zone dialog requires the exact workspace name.
 
 **Tech Stack:** Bun 1.3+, TypeScript 5.9, Next.js App Router, React 19, Drizzle ORM, PostgreSQL, AWS SDK v3 S3, Redis, Radix Dialog, Zod 4, Testing Library, `bun:test`.
 
@@ -13,7 +13,6 @@
 - Run every package command through Bun. Do not use npm, pnpm, yarn, or turbo.
 - Shipped server code runs on Node and must not import Bun built-ins.
 - Add no code comments and no em dash characters.
-- Add no AI attribution to branches, commits, code, documentation, or pull requests.
 - Keep strict TypeScript compatibility with `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`.
 - Parse external input with a shared Zod validator.
 - Put tests in each package's `tests/` tree and import from `bun:test`.
@@ -28,6 +27,7 @@
 - `packages/shared/src/validators/organization.ts`: parse exact-name deletion confirmation.
 - `packages/shared/src/events/control.ts`: validate session and organization control messages.
 - `packages/db/src/schema/content.ts`: persist presigned upload expiration.
+- `packages/db/src/schema/org.ts`: persist the durable deletion request timestamp.
 - `packages/db/drizzle/0001_*.sql` and metadata: migrate and conservatively backfill upload expiration.
 - `packages/db/tests/schema/index.test.ts`: assert the attachment field at the schema layer.
 - `packages/db/tests/schema/organization-cascade.test.ts`: inspect PostgreSQL foreign keys to prevent non-cascading workspace records.
@@ -286,7 +286,7 @@ Expected: PASS.
 
 Commit: `fix(storage): serialize workspace uploads`
 
-### Task 5: Tenant-scoped deletion summary and transaction
+### Task 5: Tenant-scoped deletion summary and retryable cleanup
 
 **Files:**
 - Create: `packages/core/src/org/organization-deletion-service.ts`
@@ -296,7 +296,7 @@ Commit: `fix(storage): serialize workspace uploads`
 
 **Interfaces:**
 - Consumes: `StorageDriver.summarizePrefix`, `StorageDriver.deletePrefix`, `storagePrefixFor`, `organizationDeleteSchema`, and `lockOrganization`.
-- Produces: `OrganizationDeletionSummary` with `organizationName`, `members`, `teams`, `projects`, `issues`, `documents`, `files`, `fileBytes`, `integrations`, `webhooks`, and `availableAt`.
+- Produces: `OrganizationDeletionSummary` with `organizationName`, `members`, `teams`, `projects`, `issues`, `documents`, `files`, `fileBytes`, version totals, `integrations`, `webhooks`, `availableAt`, and `deletionRequestedAt`.
 - Produces: `getOrganizationDeletionSummary(principal, driver?)` and `deleteOrganization(principal, input, driver?)`.
 
 - [x] **Step 1: Write failing summary and policy tests**
@@ -343,28 +343,36 @@ expect(await sessionExists(sessionId)).toBe(true);
 expect(await activeOrganization(sessionId)).toBeNull();
 ```
 
-Cover stale-name refusal, stale-administrator refusal, future upload refusal with `availableAt` details, exact completion-grace boundary, storage failure rollback, storage prefix selection, neighboring tenant preservation, shared-user preservation, and the null next-workspace result.
+Cover stale-name refusal, stale-administrator refusal, future upload refusal with `availableAt` details, exact completion-grace boundary, durable retry after storage failure, database failure before storage cleanup, storage prefix selection, neighboring tenant preservation, shared-user preservation, and the null next-workspace result.
 
-- [x] **Step 5: Implement locked cleanup and next-workspace selection**
+- [x] **Step 5: Implement durable two-phase cleanup and next-workspace selection**
 
 ```ts
-return await db.transaction(async (tx) => {
+await db.transaction(async (tx) => {
   const organization = await lockOrganization(tx, principal.organizationId);
   if (parsed.confirmation !== organization.name) throw conflict(nameMessage);
   await assertNoLiveUploadTargets(tx, organization.id, now);
-  await driver.deletePrefix(storagePrefixFor(organization.id));
+  if (organization.deletionRequestedAt === null) {
+    await tx.update(schema.organization).set({ deletionRequestedAt: now })
+      .where(eq(schema.organization.id, organization.id));
+  }
+});
+
+return await db.transaction(async (tx) => {
+  const organization = await validatedDeletionTarget(tx, principal, parsed.confirmation, now);
   await tx.update(schema.session).set({ activeOrganizationId: null })
     .where(eq(schema.session.activeOrganizationId, organization.id));
   await tx.delete(schema.organization).where(eq(schema.organization.id, organization.id));
+  await driver.deletePrefix(storagePrefixFor(organization.id));
   return deletionResult;
 });
 ```
 
-Choose the next membership by organization name and id, excluding the deleting organization. Return only ids and the deleted name.
+Choose the next membership by organization name and id, excluding the deleting organization and any other pending deletion. The committed timestamp survives a failed second phase, normal access rejects the pending workspace, and an administrator can safely retry idempotent prefix cleanup. Return only ids and the deleted name.
 
 - [x] **Step 6: Add the live PostgreSQL cascade regression test**
 
-Query `pg_constraint`, `pg_class`, and `pg_attribute` for every foreign key whose referenced table is `organization`. Assert at least one result and assert every `confdeltype` is `c`. This automatically catches any future direct workspace foreign key that is not `ON DELETE CASCADE`.
+Query `pg_constraint`, `pg_class`, and `pg_attribute` for every public table carrying `organization_id`. Assert the inventory stays substantial and every column references `organization` with `confdeltype` equal to `c`. This automatically catches any future direct workspace column that lacks an `ON DELETE CASCADE` foreign key.
 
 - [x] **Step 7: Run core and database tests and commit**
 
@@ -580,11 +588,11 @@ Run: `rg -n "\\x{2014}|\\x{2013}|T.DO|F.XME|generated by|co-authored-by"` over c
 
 Check authorization order, tenant predicates, row-lock order, S3 prefix validation, failure atomicity, accessible dialog behavior, and test strength. Commit any correction with a specific conventional subject.
 
-- [ ] **Step 4: Push and open a ready pull request**
+- [x] **Step 4: Push and open a ready pull request**
 
 Push `codex/feat-workspace-deletion`. Create a ready PR against `main` with the problem, safety model, deletion inventory, test evidence, migration behavior, storage failure behavior, and explicit note that third-party provider installations are not removed.
 
-- [ ] **Step 5: Complete review loop one and update the PR**
+- [x] **Step 5: Complete review loop one and update the PR**
 
 Read the entire GitHub PR diff and all CI output. Make a written problem list ordered by severity. Fix every confirmed problem one by one with tests, run affected package tests plus `bun run verify`, commit, push, and confirm the PR shows the new head.
 

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -504,7 +504,7 @@ Commit: `feat(settings): add workspace danger zone`
 - Consumes: `ORGANIZATION_FORBIDDEN_CLOSE_CODE`, `GET /api/organizations`, and `authClient.organization.setActive`.
 - Produces: `recoverWorkspaceAfterForbidden(gate?)` and an updated `handleTerminalClose`.
 
-- [ ] **Step 1: Write failing terminal recovery tests**
+- [x] **Step 1: Write failing terminal recovery tests**
 
 ```ts
 await recoverWorkspaceAfterForbidden(gateWith([{ id: 'org_2' }]));
@@ -518,17 +518,17 @@ expect(location.href).toBe('/workspaces/new');
 
 Also assert ordinary transport closes and unauthorized closes do not start recovery, while session-revoked behavior stays unchanged.
 
-- [ ] **Step 2: Run provider tests and confirm they fail**
+- [x] **Step 2: Run provider tests and confirm they fail**
 
 Run: `bun --filter @orbit/web test tests/lib/realtime/provider.test.ts`
 
 Expected: FAIL because organization-forbidden recovery does not exist.
 
-- [ ] **Step 3: Implement fail-closed workspace recovery**
+- [x] **Step 3: Implement fail-closed workspace recovery**
 
 List workspaces through `apiRequest('/api/organizations')`. If a workspace exists, call `setActive` with the first returned id before full navigation to `/my-issues`. If the list is empty, navigate to `/workspaces/new`. If recovery itself fails, navigate to `/workspaces/new` so a deleted tenant cannot remain rendered.
 
-- [ ] **Step 4: Run provider tests and commit**
+- [x] **Step 4: Run provider tests and commit**
 
 Run: `bun --filter @orbit/web test tests/lib/realtime/provider.test.ts`
 

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -90,7 +90,7 @@ Expected: FAIL because `org:delete`, `organizationDeleteSchema`, and the organiz
 
 ```ts
 export const organizationDeleteSchema = z.object({
-  confirmation: z.string().trim().min(1).max(64),
+  confirmation: z.string().trim().min(1).max(80),
 });
 
 export const controlMessageSchema = z.discriminatedUnion('type', [
@@ -136,12 +136,14 @@ Expected: FAIL because the attachment field does not exist.
 - [x] **Step 3: Add the nullable timestamp and generate the migration**
 
 ```ts
-uploadExpiresAt: timestamp('upload_expires_at', { withTimezone: true }),
+uploadExpiresAt: timestamp('upload_expires_at', { withTimezone: true }).default(
+  sql`now() + interval '900 seconds'`,
+),
 ```
 
 Run: `bun run db:generate`
 
-Append a conservative backfill to the generated SQL:
+Give the column the same 900-second database default to protect inserts from older instances during a rolling release, then append a conservative backfill to the generated SQL:
 
 ```sql
 UPDATE "attachment"
@@ -290,7 +292,7 @@ Commit: `fix(storage): serialize workspace uploads`
 - Produces: `OrganizationDeletionSummary` with `organizationName`, `members`, `teams`, `projects`, `issues`, `documents`, `files`, `fileBytes`, `integrations`, `webhooks`, and `availableAt`.
 - Produces: `getOrganizationDeletionSummary(principal, driver?)` and `deleteOrganization(principal, input, driver?)`.
 
-- [ ] **Step 1: Write failing summary and policy tests**
+- [x] **Step 1: Write failing summary and policy tests**
 
 ```ts
 expect(summary).toMatchObject({
@@ -310,17 +312,17 @@ await expect(getOrganizationDeletionSummary(member, storage)).rejects.toMatchObj
 
 Seed a neighboring workspace and make its larger counts distinguishable, proving every query uses `principal.organizationId`.
 
-- [ ] **Step 2: Run the deletion service test and confirm it fails**
+- [x] **Step 2: Run the deletion service test and confirm it fails**
 
 Run: `bun --filter @orbit/core test tests/org/organization-deletion-service.test.ts`
 
 Expected: FAIL because the service does not exist.
 
-- [ ] **Step 3: Implement bounded aggregate summary queries**
+- [x] **Step 3: Implement bounded aggregate summary queries**
 
 Use one `count()` query per category with `eq(table.organizationId, principal.organizationId)`, a future `max(attachment.uploadExpiresAt)` query, and `driver.summarizePrefix(storagePrefixFor(principal.organizationId))`. Call `assertCan(principal, 'org:delete')` before database or storage access.
 
-- [ ] **Step 4: Write failing destructive service tests**
+- [x] **Step 4: Write failing destructive service tests**
 
 ```ts
 await expect(deleteOrganization(admin, { confirmation: 'nova' }, storage)).rejects.toMatchObject({
@@ -336,7 +338,7 @@ expect(await activeOrganization(sessionId)).toBeNull();
 
 Cover stale-name refusal, future upload refusal with `availableAt` details, exact expiry boundary, storage failure rollback, storage prefix selection, neighboring tenant preservation, shared-user preservation, and the null next-workspace result.
 
-- [ ] **Step 5: Implement locked cleanup and next-workspace selection**
+- [x] **Step 5: Implement locked cleanup and next-workspace selection**
 
 ```ts
 return await db.transaction(async (tx) => {
@@ -353,11 +355,11 @@ return await db.transaction(async (tx) => {
 
 Choose the next membership by organization name and id, excluding the deleting organization. Return only ids and the deleted name.
 
-- [ ] **Step 6: Add the live PostgreSQL cascade regression test**
+- [x] **Step 6: Add the live PostgreSQL cascade regression test**
 
 Query `pg_constraint`, `pg_class`, and `pg_attribute` for every foreign key whose referenced table is `organization`. Assert at least one result and assert every `confdeltype` is `c`. This automatically catches any future direct workspace foreign key that is not `ON DELETE CASCADE`.
 
-- [ ] **Step 7: Run core and database tests and commit**
+- [x] **Step 7: Run core and database tests and commit**
 
 Run: `bun --filter @orbit/core test tests/org/organization-deletion-service.test.ts tests/content/attachment-service.test.ts`
 

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -327,7 +327,7 @@ Expected: FAIL because the service does not exist.
 
 - [x] **Step 3: Implement bounded aggregate summary queries**
 
-Use one `count()` query per category with `eq(table.organizationId, principal.organizationId)`, a latest protected-upload query that adds the exported completion grace, and `driver.summarizePrefix(storagePrefixFor(principal.organizationId))`. Call `assertCan(principal, 'org:delete')` before database or storage access. Lock and recheck the current membership role inside the deletion transaction before touching storage.
+Use one `count()` query per category with `eq(table.organizationId, principal.organizationId)`, a latest protected-upload query that adds the exported completion grace, a deletion-request drain that adds the URL lifetime and completion grace, and `driver.summarizePrefix(storagePrefixFor(principal.organizationId))`. Call `assertCan(principal, 'org:delete')` before database or storage access. Lock and recheck the current membership role inside the deletion transaction before touching storage.
 
 - [x] **Step 4: Write failing destructive service tests**
 
@@ -343,7 +343,7 @@ expect(await sessionExists(sessionId)).toBe(true);
 expect(await activeOrganization(sessionId)).toBeNull();
 ```
 
-Cover stale-name refusal, stale-administrator refusal, future upload refusal with `availableAt` details, exact completion-grace boundary, durable retry after storage failure, database failure before storage cleanup, storage prefix selection, neighboring tenant preservation, shared-user preservation, and the null next-workspace result.
+Cover stale-name refusal, stale-administrator refusal, future upload refusal with `availableAt` details, tracked and untracked capability boundaries, durable retry after storage failure, database failure before storage cleanup, storage prefix selection, neighboring tenant preservation, shared-user preservation, and the null next-workspace result.
 
 - [x] **Step 5: Implement durable two-phase cleanup and next-workspace selection**
 
@@ -351,7 +351,6 @@ Cover stale-name refusal, stale-administrator refusal, future upload refusal wit
 await db.transaction(async (tx) => {
   const organization = await lockOrganization(tx, principal.organizationId);
   if (parsed.confirmation !== organization.name) throw conflict(nameMessage);
-  await assertNoLiveUploadTargets(tx, organization.id, now);
   if (organization.deletionRequestedAt === null) {
     await tx.update(schema.organization).set({ deletionRequestedAt: now })
       .where(eq(schema.organization.id, organization.id));
@@ -359,7 +358,8 @@ await db.transaction(async (tx) => {
 });
 
 return await db.transaction(async (tx) => {
-  const organization = await validatedDeletionTarget(tx, principal, parsed.confirmation, now);
+  const organization = await validatedDeletionTarget(tx, principal, parsed.confirmation);
+  await assertDeletionReady(tx, organization, now);
   await tx.update(schema.session).set({ activeOrganizationId: null })
     .where(eq(schema.session.activeOrganizationId, organization.id));
   await tx.delete(schema.organization).where(eq(schema.organization.id, organization.id));
@@ -368,7 +368,7 @@ return await db.transaction(async (tx) => {
 });
 ```
 
-Choose the next membership by organization name and id, excluding the deleting organization and any other pending deletion. The committed timestamp survives a failed second phase, normal access rejects the pending workspace, and an administrator can safely retry idempotent prefix cleanup. Return only ids and the deleted name.
+Choose the next membership by organization name and id, excluding the deleting organization and any other pending deletion. The committed timestamp survives a failed second phase, normal access rejects the pending workspace, and an administrator can safely retry idempotent prefix cleanup. The second phase waits one full presigned URL lifetime plus completion grace after the timestamp, in addition to recorded attachment expiration guards. This covers a presigned target whose attachment insert or transaction commit failed. Return only ids and the deleted name.
 
 - [x] **Step 6: Add the live PostgreSQL cascade regression test**
 
@@ -487,7 +487,7 @@ Expected: FAIL because the component does not exist.
 
 - [x] **Step 3: Implement summary loading and accessible destructive state**
 
-Use the shared `Dialog` primitives with a title, description, labelled input, alert error region, and `danger` button. Load a fresh summary on each open. Render all eight categories and the nested-data disclosure. Disable deletion during loading, before an exact case-sensitive name match, before `availableAt`, and while the DELETE request is pending. Keep the dialog open on an error and allow summary retry.
+Use the shared `Dialog` primitives with a title, description, labelled input, alert error region, and `danger` button. Load a fresh summary on each open. Render all eight categories and the nested-data disclosure. Disable deletion during loading, before an exact case-sensitive name match, before `availableAt` on a pending deletion, and while the DELETE request is pending. The initial confirmation remains available so it can lock the workspace before upload capabilities drain. Keep the dialog open on an error and allow summary retry.
 
 - [x] **Step 4: Add request and navigation tests**
 

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -170,7 +170,7 @@ Commit: `feat(storage): track presigned upload expiry`
 - Create: `packages/services/tests/storage/storage-prefix.test.ts`
 
 **Interfaces:**
-- Produces: `StoragePrefixSummary { objects: number; bytes: number }`.
+- Produces: `StoragePrefixSummary { objects: number; bytes: number; versions: number; versionBytes: number }`.
 - Produces: `StorageDriver.summarizePrefix(prefix: string): Promise<StoragePrefixSummary>`.
 - Produces: `StorageDriver.deletePrefix(prefix: string): Promise<void>`.
 - Produces: `storagePrefixFor(organizationId: string): string` and `assertSafePrefix(prefix: string): string`.
@@ -181,7 +181,12 @@ Commit: `feat(storage): track presigned upload expiry`
 expect(storagePrefixFor('org_1')).toBe('org_1/');
 expect(() => assertSafePrefix('')).toThrow(DomainError);
 expect(() => assertSafePrefix('../')).toThrow(DomainError);
-expect(await driver.summarizePrefix('org_1/')).toEqual({ objects: 3, bytes: 60 });
+expect(await driver.summarizePrefix('org_1/')).toEqual({
+  objects: 3,
+  bytes: 60,
+  versions: 5,
+  versionBytes: 90,
+});
 ```
 
 The controlled S3 client must return two `ListObjectsV2Command` pages so the test asserts the second request uses the first continuation token.
@@ -198,13 +203,15 @@ Expected: FAIL because prefix operations do not exist.
 export interface StoragePrefixSummary {
   readonly objects: number;
   readonly bytes: number;
+  readonly versions: number;
+  readonly versionBytes: number;
 }
 
 async summarizePrefix(prefix: string): Promise<StoragePrefixSummary>
 async deletePrefix(prefix: string): Promise<void>
 ```
 
-Use `ListObjectsV2Command` with `Prefix` and `ContinuationToken`. Sum each returned object's `Size`. Send `DeleteObjectsCommand` requests of no more than 1,000 exact returned keys, reject any response containing `Errors`, and repeat listing until an empty page proves the prefix is empty.
+Use `ListObjectsV2Command` with `Prefix` and `ContinuationToken`. Sum each returned object's `Size`. Use `ListObjectVersionsCommand` to count and permanently remove historical versions and delete markers. Send `DeleteObjectsCommand` requests of no more than 1,000 exact returned keys and version ids, reject any response containing `Errors`, and repeat listing until empty pages prove the prefix and its version history are empty. Treat only a provider's explicit `NotImplemented` response as a versionless fallback.
 
 - [x] **Step 4: Add deletion tests for all safety boundaries**
 
@@ -215,7 +222,7 @@ expect(deleteBatchSizes).toEqual([1000, 1]);
 await expect(partialFailure()).rejects.toMatchObject({ code: 'internal' });
 ```
 
-Cover empty prefixes, more than one list page, more than one delete batch, missing keys, malformed prefixes, and a per-object S3 error.
+Cover empty prefixes, more than one list page, more than one delete batch, missing keys, malformed prefixes, historical versions, delete markers, a provider without the version API, and a per-object S3 error.
 
 - [x] **Step 5: Run service tests and commit**
 
@@ -565,7 +572,7 @@ Run: `ORBIT_TEST_LANE=workspace-deletion bun run verify`
 
 Expected: lint, comment policy, byte limits, Bun import policy, dependency checks, types, and all tests pass.
 
-- [ ] **Step 3: Inspect the complete diff and commit the verification corrections**
+- [x] **Step 3: Inspect the complete diff and commit the verification corrections**
 
 Run: `git diff --check origin/main...HEAD`
 

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -1,0 +1,588 @@
+# Workspace Deletion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an administrator-only, permanent workspace deletion flow that previews categorized impact, removes every tenant-owned database row and stored object, and safely recovers every open client.
+
+**Architecture:** A tenant-scoped core service owns preview and deletion. It serializes uploads against deletion with a PostgreSQL organization row lock, removes the exact `<organizationId>/` object-storage prefix, clears stale session pointers, then relies on verified cascading foreign keys for database cleanup. A current-workspace API exposes the service, a realtime control event closes affected sockets, and an accessible General settings danger-zone dialog requires the exact workspace name.
+
+**Tech Stack:** Bun 1.3+, TypeScript 5.9, Next.js App Router, React 19, Drizzle ORM, PostgreSQL, AWS SDK v3 S3, Redis, Radix Dialog, Zod 4, Testing Library, `bun:test`.
+
+## Global Constraints
+
+- Run every package command through Bun. Do not use npm, pnpm, yarn, or turbo.
+- Shipped server code runs on Node and must not import Bun built-ins.
+- Add no code comments and no em dash characters.
+- Add no AI attribution to branches, commits, code, documentation, or pull requests.
+- Keep strict TypeScript compatibility with `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`.
+- Parse external input with a shared Zod validator.
+- Put tests in each package's `tests/` tree and import from `bun:test`.
+- Enforce `org:delete` through `packages/shared/src/policy` and again inside the core service.
+- Never accept an organization id, slug, or storage prefix from the deletion API caller.
+- A successful deletion must leave the exact organization storage prefix empty and every direct organization foreign key must cascade.
+- Do not delete user, account, passkey, avatar, or data in another workspace.
+
+## File Structure
+
+- `packages/shared/src/policy/index.ts`: define administrator-only `org:delete` authorization.
+- `packages/shared/src/validators/organization.ts`: parse exact-name deletion confirmation.
+- `packages/shared/src/events/control.ts`: validate session and organization control messages.
+- `packages/db/src/schema/content.ts`: persist presigned upload expiration.
+- `packages/db/drizzle/0001_*.sql` and metadata: migrate and conservatively backfill upload expiration.
+- `packages/db/tests/schema/index.test.ts`: assert the attachment field at the schema layer.
+- `packages/db/tests/schema/organization-cascade.test.ts`: inspect PostgreSQL foreign keys to prevent non-cascading workspace records.
+- `packages/services/src/storage/types.ts`: expose prefix summary and cleanup contracts.
+- `packages/services/src/storage/key.ts`: derive and validate an exact organization prefix.
+- `packages/services/src/storage/s3.ts`: paginate prefix summaries and batch deletion.
+- `packages/services/tests/storage/storage-prefix.test.ts`: exercise pagination, batching, validation, and per-object failures with a controlled S3 client.
+- `packages/core/src/org/organization-lock.ts`: centralize organization row locking for upload and deletion transactions.
+- `packages/core/src/content/attachment-service.ts`: serialize presigned and inline upload registration, storing explicit expiration only for presigned targets.
+- `packages/core/src/org/organization-deletion-service.ts`: calculate impact and perform storage plus database deletion.
+- `packages/core/tests/content/attachment-service.test.ts`: prove upload expiration and locking behavior.
+- `packages/core/tests/org/organization-deletion-service.test.ts`: prove tenant isolation, cleanup, rollback, upload guard, and next-workspace selection.
+- `packages/core/src/realtime/publisher.ts`: publish organization deletion controls.
+- `packages/realtime-server/src/hub.ts`: close only sockets connected to the deleted organization.
+- `packages/realtime-server/tests/hub.test.ts`: verify organization control delivery.
+- `apps/web/src/app/api/organizations/current/deletion/route.ts`: expose private no-cache preview and destructive delete endpoints.
+- `apps/web/tests/app/api/organizations/current/deletion/route.test.ts`: verify endpoint behavior and post-commit publication.
+- `apps/web/src/features/settings/workspace-danger-zone.tsx`: render the preview and exact-name confirmation dialog.
+- `apps/web/src/app/(app)/settings/general/page.tsx`: render the danger zone only for authorized administrators.
+- `apps/web/tests/features/settings/workspace-danger-zone.test.tsx`: verify dialog behavior, accessibility, errors, and navigation.
+- `apps/web/src/lib/realtime/provider.tsx`: recover other tabs after the workspace-forbidden close code.
+- `apps/web/tests/lib/realtime/provider.test.ts`: verify surviving-workspace and no-workspace recovery.
+
+---
+
+### Task 1: Shared authorization, validation, and control contracts
+
+**Files:**
+- Modify: `packages/shared/src/policy/index.ts`
+- Modify: `packages/shared/src/validators/organization.ts`
+- Modify: `packages/shared/src/events/control.ts`
+- Modify: `packages/shared/tests/policy/policy.test.ts`
+- Create: `packages/shared/tests/validators/organization.test.ts`
+- Modify: `packages/shared/tests/events/control.test.ts`
+
+**Interfaces:**
+- Produces: `organizationDeleteSchema`, `OrganizationDeleteInput`, and `ControlMessage` variants `{ type: 'session_revoked'; userId: string } | { type: 'organization_deleted'; organizationId: string }`.
+
+- [ ] **Step 1: Write failing shared contract tests**
+
+```ts
+expect(can(principal('admin'), 'org:delete')).toBe(true);
+expect(can(principal('member'), 'org:delete')).toBe(false);
+expect(organizationDeleteSchema.parse({ confirmation: '  Nova  ' })).toEqual({
+  confirmation: 'Nova',
+});
+expect(controlMessageSchema.parse({
+  type: 'organization_deleted',
+  organizationId: 'org_1',
+})).toEqual({ type: 'organization_deleted', organizationId: 'org_1' });
+```
+
+- [ ] **Step 2: Run the tests and confirm the new contracts fail**
+
+Run: `bun --filter @orbit/shared test tests/policy/policy.test.ts tests/validators/organization.test.ts tests/events/control.test.ts`
+
+Expected: FAIL because `org:delete`, `organizationDeleteSchema`, and the organization control variant do not exist.
+
+- [ ] **Step 3: Implement the shared contracts**
+
+```ts
+export const organizationDeleteSchema = z.object({
+  confirmation: z.string().trim().min(1).max(64),
+});
+
+export const controlMessageSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('session_revoked'), userId: z.string().min(1) }),
+  z.object({ type: z.literal('organization_deleted'), organizationId: z.string().min(1) }),
+]);
+```
+
+Add `org:delete` to the permission tuple and the administrator permission set only.
+
+- [ ] **Step 4: Run the focused tests and commit**
+
+Run: `bun --filter @orbit/shared test tests/policy/policy.test.ts tests/validators/organization.test.ts tests/events/control.test.ts`
+
+Expected: PASS.
+
+Commit: `feat(workspace): define deletion contracts`
+
+### Task 2: Upload expiration schema and migration
+
+**Files:**
+- Modify: `packages/db/src/schema/content.ts`
+- Modify: `packages/db/tests/schema/index.test.ts`
+- Create: `packages/db/drizzle/0001_*.sql`
+- Modify: `packages/db/drizzle/meta/_journal.json`
+- Create: `packages/db/drizzle/meta/0001_snapshot.json`
+
+**Interfaces:**
+- Produces: nullable `schema.attachment.uploadExpiresAt: Date | null` mapped to `upload_expires_at`.
+
+- [ ] **Step 1: Write the failing schema assertion**
+
+```ts
+expect(getTableColumns(schema.attachment).uploadExpiresAt?.name).toBe('upload_expires_at');
+```
+
+- [ ] **Step 2: Run the schema test and confirm it fails**
+
+Run: `bun --filter @orbit/db test tests/schema/index.test.ts`
+
+Expected: FAIL because the attachment field does not exist.
+
+- [ ] **Step 3: Add the nullable timestamp and generate the migration**
+
+```ts
+uploadExpiresAt: timestamp('upload_expires_at', { withTimezone: true }),
+```
+
+Run: `bun run db:generate`
+
+Append a conservative backfill to the generated SQL:
+
+```sql
+UPDATE "attachment"
+SET "upload_expires_at" = "created_at" + interval '900 seconds';
+```
+
+- [ ] **Step 4: Recreate lane schemas and run the database tests**
+
+Run: `bun run db:test-setup`
+
+Run: `bun --filter @orbit/db test tests/schema/index.test.ts`
+
+Expected: PASS.
+
+Commit: `feat(storage): track presigned upload expiry`
+
+### Task 3: Exact storage-prefix summary and cleanup
+
+**Files:**
+- Modify: `packages/services/src/storage/types.ts`
+- Modify: `packages/services/src/storage/key.ts`
+- Modify: `packages/services/src/storage/index.ts`
+- Modify: `packages/services/src/storage/s3.ts`
+- Create: `packages/services/tests/storage/storage-prefix.test.ts`
+
+**Interfaces:**
+- Produces: `StoragePrefixSummary { objects: number; bytes: number }`.
+- Produces: `StorageDriver.summarizePrefix(prefix: string): Promise<StoragePrefixSummary>`.
+- Produces: `StorageDriver.deletePrefix(prefix: string): Promise<void>`.
+- Produces: `storagePrefixFor(organizationId: string): string` and `assertSafePrefix(prefix: string): string`.
+
+- [ ] **Step 1: Write failing prefix validation and summary tests**
+
+```ts
+expect(storagePrefixFor('org_1')).toBe('org_1/');
+expect(() => assertSafePrefix('')).toThrow(DomainError);
+expect(() => assertSafePrefix('../')).toThrow(DomainError);
+expect(await driver.summarizePrefix('org_1/')).toEqual({ objects: 3, bytes: 60 });
+```
+
+The controlled S3 client must return two `ListObjectsV2Command` pages so the test asserts the second request uses the first continuation token.
+
+- [ ] **Step 2: Run the prefix tests and confirm they fail**
+
+Run: `bun --filter @orbit/services test tests/storage/storage-prefix.test.ts`
+
+Expected: FAIL because prefix operations do not exist.
+
+- [ ] **Step 3: Implement validated pagination and batching**
+
+```ts
+export interface StoragePrefixSummary {
+  readonly objects: number;
+  readonly bytes: number;
+}
+
+async summarizePrefix(prefix: string): Promise<StoragePrefixSummary>
+async deletePrefix(prefix: string): Promise<void>
+```
+
+Use `ListObjectsV2Command` with `Prefix` and `ContinuationToken`. Sum each returned object's `Size`. Send `DeleteObjectsCommand` requests of no more than 1,000 exact returned keys, reject any response containing `Errors`, and repeat listing until an empty page proves the prefix is empty.
+
+- [ ] **Step 4: Add deletion tests for all safety boundaries**
+
+```ts
+await driver.deletePrefix('org_1/');
+expect(deletedKeys).toEqual(expectedKeys);
+expect(deleteBatchSizes).toEqual([1000, 1]);
+await expect(partialFailure()).rejects.toMatchObject({ code: 'internal' });
+```
+
+Cover empty prefixes, more than one list page, more than one delete batch, missing keys, malformed prefixes, and a per-object S3 error.
+
+- [ ] **Step 5: Run service tests and commit**
+
+Run: `bun --filter @orbit/services test tests/storage/storage-prefix.test.ts tests/storage/storage.test.ts`
+
+Expected: PASS.
+
+Commit: `feat(storage): clean organization prefixes`
+
+### Task 4: Serialize upload creation with workspace deletion
+
+**Files:**
+- Create: `packages/core/src/org/organization-lock.ts`
+- Modify: `packages/core/src/content/attachment-service.ts`
+- Modify: `packages/core/tests/content/attachment-service.test.ts`
+
+**Interfaces:**
+- Consumes: `schema.attachment.uploadExpiresAt` and `UploadTarget.expiresAt`.
+- Produces: `lockOrganization(executor: Transaction, organizationId: string): Promise<OrganizationRow>`.
+- Produces: presigned attachment rows with `uploadExpiresAt`; inline rows keep it null.
+
+- [ ] **Step 1: Write failing upload expiration tests**
+
+```ts
+expect(registered.attachment.uploadExpiresAt?.toISOString()).toBe(registered.upload.expiresAt);
+expect(attached.attachment.uploadExpiresAt).toBeNull();
+```
+
+Also start a registration transaction behind a held organization row lock and assert the fake storage driver is not called until the lock is released.
+
+- [ ] **Step 2: Run the attachment tests and confirm they fail**
+
+Run: `bun --filter @orbit/core test tests/content/attachment-service.test.ts`
+
+Expected: FAIL because expiration is not stored and uploads do not lock the organization.
+
+- [ ] **Step 3: Implement one transaction per upload registration**
+
+```ts
+return await db.transaction(async (tx) => {
+  await lockOrganization(tx, principal.organizationId);
+  await assertUploadParent(tx, principal, parsed.parentType, parsed.parentId);
+  const target = await store.createUploadTarget(key, upload.contentType, upload.size);
+  const registered = await insertAttachment(tx, principal, {
+    ...draft,
+    uploadExpiresAt: new Date(target.expiresAt),
+  });
+  return { ...registered, upload: target };
+});
+```
+
+Refactor `insertAttachment` to use the caller's transaction. Keep inline storage writes and row insertion under the same organization lock, retaining best-effort cleanup if insertion fails.
+
+- [ ] **Step 4: Run attachment and presign route tests and commit**
+
+Run: `bun --filter @orbit/core test tests/content/attachment-service.test.ts`
+
+Run: `bun --filter @orbit/web test tests/app/api/attachments/presign/route.test.ts`
+
+Expected: PASS.
+
+Commit: `fix(storage): serialize workspace uploads`
+
+### Task 5: Tenant-scoped deletion summary and transaction
+
+**Files:**
+- Create: `packages/core/src/org/organization-deletion-service.ts`
+- Modify: `packages/core/src/index.ts`
+- Create: `packages/core/tests/org/organization-deletion-service.test.ts`
+- Create: `packages/db/tests/schema/organization-cascade.test.ts`
+
+**Interfaces:**
+- Consumes: `StorageDriver.summarizePrefix`, `StorageDriver.deletePrefix`, `storagePrefixFor`, `organizationDeleteSchema`, and `lockOrganization`.
+- Produces: `OrganizationDeletionSummary` with `organizationName`, `members`, `teams`, `projects`, `issues`, `documents`, `files`, `fileBytes`, `integrations`, `webhooks`, and `availableAt`.
+- Produces: `getOrganizationDeletionSummary(principal, driver?)` and `deleteOrganization(principal, input, driver?)`.
+
+- [ ] **Step 1: Write failing summary and policy tests**
+
+```ts
+expect(summary).toMatchObject({
+  organizationName: 'Nova',
+  members: 2,
+  teams: 1,
+  projects: 1,
+  issues: 2,
+  documents: 1,
+  files: 2,
+  fileBytes: 3072,
+});
+await expect(getOrganizationDeletionSummary(member, storage)).rejects.toMatchObject({
+  code: 'forbidden',
+});
+```
+
+Seed a neighboring workspace and make its larger counts distinguishable, proving every query uses `principal.organizationId`.
+
+- [ ] **Step 2: Run the deletion service test and confirm it fails**
+
+Run: `bun --filter @orbit/core test tests/org/organization-deletion-service.test.ts`
+
+Expected: FAIL because the service does not exist.
+
+- [ ] **Step 3: Implement bounded aggregate summary queries**
+
+Use one `count()` query per category with `eq(table.organizationId, principal.organizationId)`, a future `max(attachment.uploadExpiresAt)` query, and `driver.summarizePrefix(storagePrefixFor(principal.organizationId))`. Call `assertCan(principal, 'org:delete')` before database or storage access.
+
+- [ ] **Step 4: Write failing destructive service tests**
+
+```ts
+await expect(deleteOrganization(admin, { confirmation: 'nova' }, storage)).rejects.toMatchObject({
+  code: 'conflict',
+});
+const result = await deleteOrganization(admin, { confirmation: 'Nova' }, storage);
+expect(result.nextOrganizationId).toBe(neighbor.organizationId);
+expect(await organizationExists(workspace.organizationId)).toBe(false);
+expect(await organizationExists(neighbor.organizationId)).toBe(true);
+expect(await sessionExists(sessionId)).toBe(true);
+expect(await activeOrganization(sessionId)).toBeNull();
+```
+
+Cover stale-name refusal, future upload refusal with `availableAt` details, exact expiry boundary, storage failure rollback, storage prefix selection, neighboring tenant preservation, shared-user preservation, and the null next-workspace result.
+
+- [ ] **Step 5: Implement locked cleanup and next-workspace selection**
+
+```ts
+return await db.transaction(async (tx) => {
+  const organization = await lockOrganization(tx, principal.organizationId);
+  if (parsed.confirmation !== organization.name) throw conflict(nameMessage);
+  await assertNoLiveUploadTargets(tx, organization.id, now);
+  await driver.deletePrefix(storagePrefixFor(organization.id));
+  await tx.update(schema.session).set({ activeOrganizationId: null })
+    .where(eq(schema.session.activeOrganizationId, organization.id));
+  await tx.delete(schema.organization).where(eq(schema.organization.id, organization.id));
+  return deletionResult;
+});
+```
+
+Choose the next membership by organization name and id, excluding the deleting organization. Return only ids and the deleted name.
+
+- [ ] **Step 6: Add the live PostgreSQL cascade regression test**
+
+Query `pg_constraint`, `pg_class`, and `pg_attribute` for every foreign key whose referenced table is `organization`. Assert at least one result and assert every `confdeltype` is `c`. This automatically catches any future direct workspace foreign key that is not `ON DELETE CASCADE`.
+
+- [ ] **Step 7: Run core and database tests and commit**
+
+Run: `bun --filter @orbit/core test tests/org/organization-deletion-service.test.ts tests/content/attachment-service.test.ts`
+
+Run: `bun --filter @orbit/db test tests/schema/index.test.ts tests/schema/organization-cascade.test.ts`
+
+Expected: PASS.
+
+Commit: `feat(workspace): delete tenant data safely`
+
+### Task 6: API endpoint and realtime invalidation
+
+**Files:**
+- Modify: `packages/core/src/realtime/publisher.ts`
+- Modify: `packages/core/tests/realtime/publisher.test.ts`
+- Modify: `packages/realtime-server/src/hub.ts`
+- Modify: `packages/realtime-server/tests/hub.test.ts`
+- Create: `apps/web/src/app/api/organizations/current/deletion/route.ts`
+- Create: `apps/web/tests/app/api/organizations/current/deletion/route.test.ts`
+
+**Interfaces:**
+- Consumes: core deletion functions and the `organization_deleted` control message.
+- Produces: `publishOrganizationDeleted(organizationId: string): Promise<void>`.
+- Produces: `GET` response `{ summary }` with `cache-control: private, no-cache`.
+- Produces: `DELETE` response `{ deletedOrganizationId, nextOrganizationId }`.
+
+- [ ] **Step 1: Write failing publisher and hub tests**
+
+```ts
+await publishOrganizationDeleted(deletedId);
+expect(deletedSocket.closures[0]).toEqual({
+  code: ORGANIZATION_FORBIDDEN_CLOSE_CODE,
+  reason: 'organization_deleted',
+});
+expect(otherSocket.closures).toHaveLength(0);
+```
+
+- [ ] **Step 2: Run realtime tests and confirm they fail**
+
+Run: `bun --filter @orbit/core test tests/realtime/publisher.test.ts`
+
+Run: `bun --filter @orbit/realtime-server test tests/hub.test.ts`
+
+Expected: FAIL because organization deletion controls are not published or delivered.
+
+- [ ] **Step 3: Implement control publication and targeted socket closure**
+
+Branch `deliverControl` on the discriminated `type`. Keep session revalidation unchanged. For `organization_deleted`, remove and close every connection whose `organizationId` matches, using code `ORGANIZATION_FORBIDDEN_CLOSE_CODE` and reason `organization_deleted`.
+
+- [ ] **Step 4: Write failing route tests**
+
+Test GET authentication, administrator authorization, summary payload, and private no-cache header. Test DELETE body validation, exact service result, successful post-commit publication, and successful response when publication rejects after the service has committed.
+
+- [ ] **Step 5: Implement the current-workspace deletion route**
+
+```ts
+export async function GET(): Promise<Response> {
+  return await handleRoute(async () => {
+    const { principal } = await apiContext();
+    return Response.json(
+      { summary: await getOrganizationDeletionSummary(principal) },
+      { headers: { 'cache-control': 'private, no-cache' } },
+    );
+  });
+}
+```
+
+The DELETE handler reads only `{ confirmation }`, calls the core deletion service, catches only the post-commit publication failure for logging, and returns the two organization ids.
+
+- [ ] **Step 6: Run route and realtime tests and commit**
+
+Run: `bun --filter @orbit/core test tests/realtime/publisher.test.ts`
+
+Run: `bun --filter @orbit/realtime-server test tests/hub.test.ts`
+
+Run: `bun --filter @orbit/web test tests/app/api/organizations/current/deletion/route.test.ts`
+
+Expected: PASS.
+
+Commit: `feat(workspace): expose deletion endpoint`
+
+### Task 7: Accessible deletion dialog and calling-tab navigation
+
+**Files:**
+- Create: `apps/web/src/features/settings/workspace-danger-zone.tsx`
+- Modify: `apps/web/src/app/(app)/settings/general/page.tsx`
+- Create: `apps/web/tests/features/settings/workspace-danger-zone.test.tsx`
+
+**Interfaces:**
+- Consumes: API responses from Task 6 and `authClient.organization.setActive`.
+- Produces: `WorkspaceDangerZone({ organizationName }: { organizationName: string })`.
+- Produces: `formatDeletionBytes(bytes: number): string` for deterministic file-size rendering.
+
+- [ ] **Step 1: Write failing dialog rendering and confirmation tests**
+
+```tsx
+render(<WorkspaceDangerZone organizationName="Nova" />);
+await user.click(screen.getByRole('button', { name: 'Delete workspace' }));
+expect(await screen.findByText('2 members')).toBeVisible();
+expect(screen.getByText('3 files')).toBeVisible();
+expect(screen.getByRole('button', { name: 'Permanently delete workspace' })).toBeDisabled();
+await user.type(screen.getByLabelText('Type Nova to confirm'), 'Nova');
+expect(screen.getByRole('button', { name: 'Permanently delete workspace' })).toBeEnabled();
+```
+
+- [ ] **Step 2: Run the component test and confirm it fails**
+
+Run: `bun --filter @orbit/web test tests/features/settings/workspace-danger-zone.test.tsx`
+
+Expected: FAIL because the component does not exist.
+
+- [ ] **Step 3: Implement summary loading and accessible destructive state**
+
+Use the shared `Dialog` primitives with a title, description, labelled input, alert error region, and `danger` button. Load a fresh summary on each open. Render all eight categories and the nested-data disclosure. Disable deletion during loading, before an exact case-sensitive name match, before `availableAt`, and while the DELETE request is pending. Keep the dialog open on an error and allow summary retry.
+
+- [ ] **Step 4: Add request and navigation tests**
+
+Assert one DELETE request for repeated clicks. Assert `setActive({ organizationId: nextId })` and `/my-issues` for a surviving workspace. Assert `/workspaces/new` without calling `setActive` when `nextOrganizationId` is null. Assert a server conflict appears in the alert region and leaves the dialog open.
+
+- [ ] **Step 5: Render the danger zone only for administrators**
+
+```tsx
+{can(principal, 'org:delete') ? (
+  <WorkspaceDangerZone organizationName={organization.name} />
+) : null}
+```
+
+- [ ] **Step 6: Run component tests and commit**
+
+Run: `bun --filter @orbit/web test tests/features/settings/workspace-danger-zone.test.tsx`
+
+Expected: PASS.
+
+Commit: `feat(settings): add workspace danger zone`
+
+### Task 8: Other-tab workspace recovery
+
+**Files:**
+- Modify: `apps/web/src/lib/realtime/provider.tsx`
+- Modify: `apps/web/tests/lib/realtime/provider.test.ts`
+
+**Interfaces:**
+- Consumes: `ORGANIZATION_FORBIDDEN_CLOSE_CODE`, `GET /api/organizations`, and `authClient.organization.setActive`.
+- Produces: `recoverWorkspaceAfterForbidden(gate?)` and an updated `handleTerminalClose`.
+
+- [ ] **Step 1: Write failing terminal recovery tests**
+
+```ts
+await recoverWorkspaceAfterForbidden(gateWith([{ id: 'org_2' }]));
+expect(calls.active).toEqual(['org_2']);
+expect(location.href).toBe('/my-issues');
+
+await recoverWorkspaceAfterForbidden(gateWith([]));
+expect(calls.active).toEqual([]);
+expect(location.href).toBe('/workspaces/new');
+```
+
+Also assert ordinary transport closes and unauthorized closes do not start recovery, while session-revoked behavior stays unchanged.
+
+- [ ] **Step 2: Run provider tests and confirm they fail**
+
+Run: `bun --filter @orbit/web test tests/lib/realtime/provider.test.ts`
+
+Expected: FAIL because organization-forbidden recovery does not exist.
+
+- [ ] **Step 3: Implement fail-closed workspace recovery**
+
+List workspaces through `apiRequest('/api/organizations')`. If a workspace exists, call `setActive` with the first returned id before full navigation to `/my-issues`. If the list is empty, navigate to `/workspaces/new`. If recovery itself fails, navigate to `/workspaces/new` so a deleted tenant cannot remain rendered.
+
+- [ ] **Step 4: Run provider tests and commit**
+
+Run: `bun --filter @orbit/web test tests/lib/realtime/provider.test.ts`
+
+Expected: PASS.
+
+Commit: `fix(realtime): recover deleted workspaces`
+
+### Task 9: Verification, pull request, two review loops, and merge
+
+**Files:**
+- Review: every file changed from `origin/main`.
+- Update: pull request description and screenshots when practical.
+
+**Interfaces:**
+- Produces: a ready GitHub pull request whose CI is green and whose complete diff has passed two separate review-and-fix loops.
+
+- [ ] **Step 1: Run focused cross-package verification**
+
+Run: `bun run lint`
+
+Run: `bun run check-comments`
+
+Run: `bun run check-bytes`
+
+Run: `bun run typecheck`
+
+Run each focused test command from Tasks 1 through 8.
+
+Expected: every command exits zero.
+
+- [ ] **Step 2: Run the full repository verification**
+
+Run: `ORBIT_TEST_LANE=workspace-deletion bun run verify`
+
+Expected: lint, comment policy, byte limits, Bun import policy, dependency checks, types, and all tests pass.
+
+- [ ] **Step 3: Inspect the complete diff and commit the verification corrections**
+
+Run: `git diff --check origin/main...HEAD`
+
+Run: `rg -n "\\x{2014}|\\x{2013}|T.DO|F.XME|generated by|co-authored-by"` over changed text files.
+
+Check authorization order, tenant predicates, row-lock order, S3 prefix validation, failure atomicity, accessible dialog behavior, and test strength. Commit any correction with a specific conventional subject.
+
+- [ ] **Step 4: Push and open a ready pull request**
+
+Push `codex/feat-workspace-deletion`. Create a ready PR against `main` with the problem, safety model, deletion inventory, test evidence, migration behavior, storage failure behavior, and explicit note that third-party provider installations are not removed.
+
+- [ ] **Step 5: Complete review loop one and update the PR**
+
+Read the entire GitHub PR diff and all CI output. Make a written problem list ordered by severity. Fix every confirmed problem one by one with tests, run affected package tests plus `bun run verify`, commit, push, and confirm the PR shows the new head.
+
+- [ ] **Step 6: Complete review loop two independently and update the PR**
+
+Re-read the entire updated PR from the base commit without relying on loop one's notes. Recheck security, data completeness, races, idempotency, errors, UX, accessibility, migration safety, types, and test blind spots. Make a second written problem list, fix every confirmed issue, run affected tests plus `bun run verify`, commit, and push.
+
+- [ ] **Step 7: Confirm merge readiness and merge**
+
+Wait for required GitHub checks and reviews. Confirm the PR is mergeable, the final head matches the locally verified commit, both review loops have no unresolved findings, and no review thread is unresolved. Merge using the repository's accepted method, then report the PR URL, merge commit, tests, review-loop findings and fixes, and confirmation that no production workspace was deleted by this work.

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -545,7 +545,7 @@ Commit: `fix(realtime): recover deleted workspaces`
 **Interfaces:**
 - Produces: a ready GitHub pull request whose CI is green and whose complete diff has passed two separate review-and-fix loops.
 
-- [ ] **Step 1: Run focused cross-package verification**
+- [x] **Step 1: Run focused cross-package verification**
 
 Run: `bun run lint`
 
@@ -559,7 +559,7 @@ Run each focused test command from Tasks 1 through 8.
 
 Expected: every command exits zero.
 
-- [ ] **Step 2: Run the full repository verification**
+- [x] **Step 2: Run the full repository verification**
 
 Run: `ORBIT_TEST_LANE=workspace-deletion bun run verify`
 

--- a/docs/superpowers/plans/2026-08-08-workspace-deletion.md
+++ b/docs/superpowers/plans/2026-08-08-workspace-deletion.md
@@ -385,7 +385,7 @@ Commit: `feat(workspace): delete tenant data safely`
 - Produces: `GET` response `{ summary }` with `cache-control: private, no-cache`.
 - Produces: `DELETE` response `{ deletedOrganizationId, nextOrganizationId }`.
 
-- [ ] **Step 1: Write failing publisher and hub tests**
+- [x] **Step 1: Write failing publisher and hub tests**
 
 ```ts
 await publishOrganizationDeleted(deletedId);
@@ -396,7 +396,7 @@ expect(deletedSocket.closures[0]).toEqual({
 expect(otherSocket.closures).toHaveLength(0);
 ```
 
-- [ ] **Step 2: Run realtime tests and confirm they fail**
+- [x] **Step 2: Run realtime tests and confirm they fail**
 
 Run: `bun --filter @orbit/core test tests/realtime/publisher.test.ts`
 
@@ -404,15 +404,15 @@ Run: `bun --filter @orbit/realtime-server test tests/hub.test.ts`
 
 Expected: FAIL because organization deletion controls are not published or delivered.
 
-- [ ] **Step 3: Implement control publication and targeted socket closure**
+- [x] **Step 3: Implement control publication and targeted socket closure**
 
 Branch `deliverControl` on the discriminated `type`. Keep session revalidation unchanged. For `organization_deleted`, remove and close every connection whose `organizationId` matches, using code `ORGANIZATION_FORBIDDEN_CLOSE_CODE` and reason `organization_deleted`.
 
-- [ ] **Step 4: Write failing route tests**
+- [x] **Step 4: Write failing route tests**
 
 Test GET authentication, administrator authorization, summary payload, and private no-cache header. Test DELETE body validation, exact service result, successful post-commit publication, and successful response when publication rejects after the service has committed.
 
-- [ ] **Step 5: Implement the current-workspace deletion route**
+- [x] **Step 5: Implement the current-workspace deletion route**
 
 ```ts
 export async function GET(): Promise<Response> {
@@ -428,7 +428,7 @@ export async function GET(): Promise<Response> {
 
 The DELETE handler reads only `{ confirmation }`, calls the core deletion service, catches only the post-commit publication failure for logging, and returns the two organization ids.
 
-- [ ] **Step 6: Run route and realtime tests and commit**
+- [x] **Step 6: Run route and realtime tests and commit**
 
 Run: `bun --filter @orbit/core test tests/realtime/publisher.test.ts`
 

--- a/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
+++ b/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
@@ -21,7 +21,7 @@ The dialog shows counts for:
 
 It also states that comments, cycles, milestones, modules, labels, saved views, notifications, activity, invitations, OAuth grants, API keys, repository links, automations, and workspace settings are included. User accounts and their data in other workspaces are not deleted.
 
-The administrator must type the exact workspace name. The destructive button remains disabled while the summary is loading, the typed name differs, or a recent upload is still protected. A pending deletion changes the danger zone into a retry flow and keeps the exact-name requirement. The dialog explains that deletion is permanent.
+The administrator must type the exact workspace name. The destructive button remains disabled while the summary is loading or the typed name differs. The first confirmation locks the workspace even when a recent upload is still protected. A pending deletion changes the danger zone into a retry flow, keeps the exact-name requirement, and disables the retry until every upload capability has drained. The dialog explains that deletion is permanent.
 
 If the deleted workspace is not the user's only workspace, the client activates another membership and performs a full navigation to `/my-issues`. If no membership remains, it navigates to `/workspaces/new`.
 
@@ -37,20 +37,20 @@ The confirmation is preserved exactly and compared case-sensitively with the cur
 
 `getOrganizationDeletionSummary` returns the organization name, categorized counts, actual stored object bytes, stored object-version bytes, an optional `availableAt` timestamp, and an optional `deletionRequestedAt` timestamp. Database counts come from bounded aggregate queries over direct organization columns. File counts and bytes come from `StorageDriver.summarizePrefix`, so pending uploads, orphaned objects, and recoverable historical versions under the organization prefix are visible even when they do not have an attachment row. The summary does not fetch row bodies or enumerate names.
 
-`availableAt` protects outstanding presigned uploads. A nullable `attachment.uploadExpiresAt` records the expiration of each presigned target and remains null for inline uploads. The summary uses the latest expiration plus a 15-minute upload-completion grace. If present, the dialog names when deletion becomes available and the server refuses an early delete even if a client bypasses the UI.
+`availableAt` protects outstanding presigned uploads. A nullable `attachment.uploadExpiresAt` records the expiration of each committed presigned target and remains null for inline uploads. The summary uses the later of the latest recorded expiration plus a 15-minute upload-completion grace and the deletion request plus the 15-minute URL lifetime and 15-minute completion grace. Once deletion is pending, the dialog names when a retry becomes available and the server refuses an early cleanup even if a client bypasses the UI.
 
 ## Upload and deletion serialization
 
 Storage keys already begin with `<organizationId>/`. Deleting the whole prefix removes tracked attachments, pending uploads, and orphaned objects.
 
-S3 checks a presigned URL when the HTTP request begins, so a request started before expiration can finish afterward. A prefix that was empty at deletion time could otherwise receive a late upload. The upload registration and deletion paths therefore serialize on the organization row, and deletion waits through a completion grace after the last URL expires:
+S3 checks a presigned URL when the HTTP request begins, so a request started before expiration can finish afterward. A prefix that was empty at deletion time could otherwise receive a late upload. Creating a presigned target is also external work: the target can remain valid if its database transaction later fails and no attachment guard row is committed. The upload registration and deletion paths therefore serialize on the organization row, and every confirmed deletion drains both recorded and potentially unrecorded capabilities:
 
 1. Upload registration locks the organization row before it creates a target and attachment record.
 2. The target expiration is stored on the attachment, and the transaction commits before the target is returned to the browser.
-3. Workspace deletion obtains the same lock.
-4. Deletion refuses while any attachment can still have an unexpired upload target or a started upload inside the completion grace.
-5. After the last completion grace closes, deletion commits `organization.deletionRequestedAt` before storage work begins.
-6. Upload registration and inline storage reject a workspace carrying that timestamp, so a retry cannot recreate the prefix.
+3. Workspace deletion obtains the same lock and commits `organization.deletionRequestedAt` before storage work begins.
+4. Upload registration and inline storage reject a workspace carrying that timestamp, so no new capability or object can be created.
+5. Final cleanup waits until both every recorded target expiration plus completion grace and the deletion timestamp plus one full URL lifetime and completion grace have passed.
+6. The timestamp-based drain covers a target issued immediately before deletion whose attachment insert or transaction commit failed.
 
 Inline uploads use the same organization lock around storage and attachment registration. A deletion that wins the lock removes the organization before a waiting upload can proceed. The waiting upload then fails closed instead of recreating the prefix.
 
@@ -74,9 +74,9 @@ The implementation sends exact keys and version ids returned by S3 and never bro
 
 PostgreSQL and object storage cannot share one atomic transaction. The deletion service therefore uses a durable two-phase retry state.
 
-The first transaction locks the active organization, locks and rechecks the caller's current membership role, rechecks the confirmation and upload guard, and commits `organization.deletionRequestedAt`. A demoted or removed administrator cannot start or resume deletion using a stale principal. Once this state is present, normal API and page access is redirected or rejected, uploads cannot create new objects, ordinary organization lists omit the workspace, MCP and realtime authentication fail closed, and public docs and attachments stop resolving. The deletion summary and delete endpoint remain available. The app switcher includes pending workspaces only for their administrators, so an authorized retry remains discoverable after a sign-out or workspace switch.
+The first transaction locks the active organization, locks and rechecks the caller's current membership role, rechecks the confirmation, and commits `organization.deletionRequestedAt`. A demoted or removed administrator cannot start or resume deletion using a stale principal. Once this state is present, normal API and page access is redirected or rejected, uploads cannot create new objects, ordinary organization lists omit the workspace, MCP and realtime authentication fail closed, and public docs and attachments stop resolving. The deletion summary and delete endpoint remain available. The app switcher includes pending workspaces only for their administrators, so an authorized retry remains discoverable after a sign-out or workspace switch.
 
-The second transaction repeats the lock, role, confirmation, and upload checks. It clears `session.active_organization_id`, chooses a next organization that is not itself pending deletion, and executes the organization delete before it calls object storage. This means a failing database statement cannot run after irreversible storage work. Existing foreign keys cascade through workspace-owned rows. User, account, passkey, and avatar records remain because they belong to the person rather than a workspace.
+The second transaction repeats the lock, role, and confirmation checks, then calculates the later of the tracked-upload guard and deletion-request drain. An early retry returns that exact timestamp without touching storage. A ready retry clears `session.active_organization_id`, chooses a next organization that is not itself pending deletion, and executes the organization delete before it calls object storage. This means a failing database statement cannot run after irreversible storage work. Existing foreign keys cascade through workspace-owned rows. User, account, passkey, and avatar records remain because they belong to the person rather than a workspace.
 
 Storage prefix deletion is the last operation inside the second transaction. If storage fails, the database mutations roll back but the deletion timestamp from the first transaction remains committed. If the final database commit fails after storage cleanup, that durable timestamp also remains. The dialog can retry the same endpoint, and prefix deletion is idempotent even after partial or complete cleanup. A successful commit removes the organization and its deletion state together.
 
@@ -135,7 +135,7 @@ Core integration tests cover:
 - preservation of the neighboring workspace and shared users
 - deletion of every direct organization table through cascades
 - clearing active session references without deleting user sessions
-- presigned expiration storage, conservative migration backfill, completion-grace blocking, and the grace boundary
+- presigned expiration storage, conservative migration backfill, tracked completion-grace blocking, untracked capability draining, and both exact boundaries
 - stale administrator role refusal inside the deletion transaction
 - durable retry state and database rollback when storage cleanup fails
 - database failures before storage cleanup

--- a/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
+++ b/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
@@ -15,7 +15,7 @@ The dialog shows counts for:
 - projects
 - issues
 - documents
-- files and total file size
+- files, total file size, and stored version history when present
 - integrations
 - webhooks
 
@@ -35,7 +35,7 @@ The confirmation is trimmed and compared case-sensitively with the current datab
 
 ## Deletion summary
 
-`getOrganizationDeletionSummary` returns the organization name, categorized counts, actual stored object bytes, and an optional `availableAt` timestamp. Database counts come from bounded aggregate queries over direct organization columns. File count and bytes come from `StorageDriver.summarizePrefix`, so pending uploads and orphaned objects under the organization prefix are visible even when they do not have an attachment row. The summary does not fetch row bodies or enumerate names.
+`getOrganizationDeletionSummary` returns the organization name, categorized counts, actual stored object bytes, stored object-version bytes, and an optional `availableAt` timestamp. Database counts come from bounded aggregate queries over direct organization columns. File counts and bytes come from `StorageDriver.summarizePrefix`, so pending uploads, orphaned objects, and recoverable historical versions under the organization prefix are visible even when they do not have an attachment row. The summary does not fetch row bodies or enumerate names.
 
 `availableAt` protects outstanding presigned uploads. A nullable `attachment.uploadExpiresAt` records the expiration of each presigned target and remains null for inline uploads. The summary uses the latest future value. If present, the dialog names when deletion becomes available and the server refuses an early delete even if a client bypasses the UI.
 
@@ -60,13 +60,14 @@ The upload URL lifetime is exported from the storage package so the registration
 `StorageDriver` gains `summarizePrefix(prefix)` and `deletePrefix(prefix)`. Both operations use the same strict prefix validation. The summary walks every page and totals the exact objects and bytes reported by S3. The deletion implementation:
 
 1. validates a non-empty safe prefix ending in `/`
-2. lists all objects under the prefix with pagination
+2. lists all current objects under the prefix with pagination
 3. deletes listed keys in S3 batch limits
-4. treats an empty prefix as success
-5. reports any per-object deletion error as an internal domain error
-6. lists again until the prefix is empty
+4. lists object versions and delete markers and permanently deletes each version id
+5. treats an empty prefix as success
+6. reports any per-object deletion error as an internal domain error
+7. lists again until the prefix and its version history are empty
 
-The implementation sends exact keys returned by S3 and never broadens the requested prefix. Tests cover pagination, more than one deletion batch, empty prefixes, malformed prefixes, and partial S3 errors.
+The implementation sends exact keys and version ids returned by S3 and never broadens the requested prefix. Providers such as Cloudflare R2 that return `501 Not Implemented` for the version-listing API fall back to current-object cleanup because they do not expose S3 object versioning. Permission or partial-delete errors continue to fail closed. AWS S3 policies used by Orbit need `s3:ListBucketVersions` and `s3:DeleteObjectVersion` in addition to current-object list and delete permissions. Tests cover pagination, more than one deletion batch, version history, delete markers, unsupported version APIs, empty prefixes, malformed prefixes, and partial S3 errors.
 
 ## Database cleanup
 
@@ -113,7 +114,7 @@ The dialog uses the shared Radix-based dialog, an explicit title and description
 
 Shared tests cover the validator and `org:delete` permission matrix.
 
-Storage tests cover safe prefix validation, summary pagination and byte totals, deletion pagination, batch deletion, idempotent empty cleanup, and partial errors.
+Storage tests cover safe prefix validation, current and version summary pagination, byte totals, deletion pagination, batch deletion, historical versions, delete markers, providers without a version API, idempotent empty cleanup, and partial errors.
 
 Core integration tests cover:
 
@@ -134,7 +135,7 @@ Realtime contract and hub tests cover closing only connections for the deleted o
 
 Web route tests cover authentication, authorization, validation, summary headers, successful deletion, publish behavior, and storage failure responses. Component tests cover summary loading, categorized counts, byte formatting, exact confirmation, recent-upload messaging, error retry, single submission, and both navigation outcomes.
 
-The completed branch must pass focused package tests and `ORBIT_TEST_LANE=workspace-deletion bun run verify`. The pull request includes a screenshot of the dialog in both themes when practical.
+The completed branch must pass focused package tests and `ORBIT_TEST_LANE=workspace_deletion bun run verify`. The pull request includes a screenshot of the dialog in both themes when practical.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
+++ b/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
@@ -1,0 +1,143 @@
+# Workspace deletion design
+
+## Goal
+
+Add a permanent workspace deletion flow to General settings. An administrator can inspect a categorized inventory, confirm the exact active workspace name, and delete that workspace together with its database records and object storage. The operation must remain tenant scoped and must not accept a caller supplied organization id.
+
+## Product behavior
+
+General settings ends with an administrator-only danger zone. Selecting `Delete workspace` opens a dialog that loads a fresh deletion summary for the active workspace.
+
+The dialog shows counts for:
+
+- members
+- teams
+- projects
+- issues
+- documents
+- files and total file size
+- integrations
+- webhooks
+
+It also states that comments, cycles, milestones, modules, labels, saved views, notifications, activity, invitations, OAuth grants, API keys, repository links, automations, and workspace settings are included. User accounts and their data in other workspaces are not deleted.
+
+The administrator must type the exact workspace name. The destructive button remains disabled while the summary is loading, the typed name differs, a recent upload is still protected, or a deletion is pending. The dialog explains that deletion is permanent.
+
+If the deleted workspace is not the user's only workspace, the client activates another membership and performs a full navigation to `/my-issues`. If no membership remains, it navigates to `/workspaces/new`.
+
+## Authorization and tenant isolation
+
+The shared policy adds `org:delete`, granted only to the administrator role. The summary and deletion services both call `assertCan` on the server.
+
+The API is rooted at `/api/organizations/current/deletion`. It never accepts an organization id, slug, or storage prefix. Both `GET` and `DELETE` resolve the workspace from the authenticated principal. The delete body contains only the workspace-name confirmation. This makes a cross-workspace request impossible even when the caller administers more than one workspace.
+
+The confirmation is trimmed and compared case-sensitively with the current database value while the organization row is locked. A stale dialog cannot delete a workspace after another administrator renames it.
+
+## Deletion summary
+
+`getOrganizationDeletionSummary` returns the organization name, categorized counts, actual stored object bytes, and an optional `availableAt` timestamp. Database counts come from bounded aggregate queries over direct organization columns. File count and bytes come from `StorageDriver.summarizePrefix`, so pending uploads and orphaned objects under the organization prefix are visible even when they do not have an attachment row. The summary does not fetch row bodies or enumerate names.
+
+`availableAt` protects outstanding presigned uploads. A nullable `attachment.uploadExpiresAt` records the expiration of each presigned target and remains null for inline uploads. The summary uses the latest future value. If present, the dialog names when deletion becomes available and the server refuses an early delete even if a client bypasses the UI.
+
+## Upload and deletion serialization
+
+Storage keys already begin with `<organizationId>/`. Deleting the whole prefix removes tracked attachments, pending uploads, and orphaned objects.
+
+An S3 upload URL remains writable until it expires. A prefix that was empty at deletion time could otherwise receive a late upload. The upload registration and deletion paths therefore serialize on the organization row:
+
+1. Upload registration locks the organization row before it creates a target and attachment record.
+2. The target expiration is stored on the attachment, and the transaction commits before the target is returned to the browser.
+3. Workspace deletion obtains the same lock.
+4. Deletion refuses while any attachment can still have an unexpired upload target.
+5. After the last target expires, no application path can mint another target while deletion holds the lock.
+
+Inline uploads use the same organization lock around storage and attachment registration. A deletion that wins the lock removes the organization before a waiting upload can proceed. The waiting upload then fails closed instead of recreating the prefix.
+
+The upload URL lifetime is exported from the storage package so the registration, migration backfill, summary, deletion, and tests use one value. The migration conservatively gives every recently created existing attachment an expiration based on its creation time, closing the rollout window for targets minted by the previous application version.
+
+## Storage cleanup
+
+`StorageDriver` gains `summarizePrefix(prefix)` and `deletePrefix(prefix)`. Both operations use the same strict prefix validation. The summary walks every page and totals the exact objects and bytes reported by S3. The deletion implementation:
+
+1. validates a non-empty safe prefix ending in `/`
+2. lists all objects under the prefix with pagination
+3. deletes listed keys in S3 batch limits
+4. treats an empty prefix as success
+5. reports any per-object deletion error as an internal domain error
+6. lists again until the prefix is empty
+
+The implementation sends exact keys returned by S3 and never broadens the requested prefix. Tests cover pagination, more than one deletion batch, empty prefixes, malformed prefixes, and partial S3 errors.
+
+## Database cleanup
+
+The deletion service starts a database transaction, locks the active organization, rechecks the confirmation and recent-upload guard, and deletes the storage prefix while new uploads are excluded. If storage cleanup fails, the transaction rolls back and the endpoint returns an error. Retrying is safe because prefix deletion is idempotent.
+
+After storage is empty, the same transaction clears `session.active_organization_id` wherever it names the workspace and deletes the organization row. Existing foreign keys cascade through workspace-owned rows. User, account, passkey, and avatar records remain because they belong to the person rather than a workspace. The schema migration adds `attachment.upload_expires_at` and the conservative backfill used by the upload guard.
+
+A database schema regression test queries PostgreSQL metadata and requires every direct foreign key to `organization.id` to use `ON DELETE CASCADE`. The session field is the intentional non-foreign-key exception and is covered by service tests. This prevents a future workspace table from silently surviving deletion or blocking it.
+
+The transaction returns the deleting user's next organization id, if one exists, plus the deleted organization id and name.
+
+## Realtime behavior
+
+The shared control protocol adds an `organization_deleted` message carrying the organization id. After the database commit, the route publishes this control message. The realtime hub closes every connection authenticated for that organization with the existing organization-forbidden close code and an `organization_deleted` reason.
+
+The calling tab navigates immediately from the delete response. The web realtime provider gains recovery for the organization-forbidden close code. It lists the signed-in user's remaining organizations through the existing API, activates the first result, and performs a full navigation to `/my-issues`, or navigates to `/workspaces/new` when the list is empty. This also repairs tabs affected by a membership removal. No deleted organization data remains subscribed in memory.
+
+Publishing is best effort after commit, matching existing delta behavior. A missed control message cannot restore access because membership validation fails on the next request, subscription, or connection.
+
+## API responses and errors
+
+`GET /api/organizations/current/deletion` returns `{ summary }` with private no-cache headers.
+
+`DELETE /api/organizations/current/deletion` parses `{ confirmation }` through the shared validator and returns `{ deletedOrganizationId, nextOrganizationId }`.
+
+Expected failures are:
+
+- `401` when signed out
+- `403` when the role lacks `org:delete`
+- `409` when the confirmation does not match or an upload URL can still be used
+- `500` when object storage cannot be fully cleaned
+
+The UI keeps the dialog open and displays the server message. It does not remove the workspace locally until the delete response succeeds.
+
+## UI structure and accessibility
+
+The existing General form remains focused on editable workspace fields. A separate `WorkspaceDangerZone` client component owns summary loading, confirmation state, deletion, errors, and navigation.
+
+The server page passes only the active organization name and `can(principal, 'org:delete')`. Non-admin users do not receive the destructive control.
+
+The dialog uses the shared Radix-based dialog, an explicit title and description, a labelled confirmation input, an alert region for errors, and a danger button. Focus starts on the dialog content rather than the delete button. Closing is disabled only during the final request. All colors and transitions use existing tokens.
+
+## Testing
+
+Shared tests cover the validator and `org:delete` permission matrix.
+
+Storage tests cover safe prefix validation, summary pagination and byte totals, deletion pagination, batch deletion, idempotent empty cleanup, and partial errors.
+
+Core integration tests cover:
+
+- summary counts and file bytes
+- administrator-only access
+- exact-name confirmation
+- stale-name refusal after rename
+- active-workspace scoping when one administrator belongs to two workspaces
+- preservation of the neighboring workspace and shared users
+- deletion of every direct organization table through cascades
+- clearing active session references without deleting user sessions
+- presigned expiration storage, conservative migration backfill, recent-upload blocking, and the expiry boundary
+- rollback when storage cleanup fails
+- upload and deletion lock ordering
+- selection of the next surviving workspace
+
+Realtime contract and hub tests cover closing only connections for the deleted organization. Web realtime tests cover selecting another organization and the no-membership workspace-creation fallback after a terminal organization close.
+
+Web route tests cover authentication, authorization, validation, summary headers, successful deletion, publish behavior, and storage failure responses. Component tests cover summary loading, categorized counts, byte formatting, exact confirmation, recent-upload messaging, error retry, single submission, and both navigation outcomes.
+
+The completed branch must pass focused package tests and `ORBIT_TEST_LANE=workspace-deletion bun run verify`. The pull request includes a screenshot of the dialog in both themes when practical.
+
+## Out of scope
+
+This change does not delete a user's account, data in another workspace, or third-party accounts. Removing an Orbit integration deletes its stored credentials, grants, repository associations, channel associations, and webhook configuration. It does not uninstall an app from the administrator's GitHub, Slack, or other provider account.
+
+This change does not add soft deletion, restoration, data export, scheduled deletion, or a second workspace selection control inside the dialog.

--- a/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
+++ b/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
@@ -53,7 +53,7 @@ An S3 upload URL remains writable until it expires. A prefix that was empty at d
 
 Inline uploads use the same organization lock around storage and attachment registration. A deletion that wins the lock removes the organization before a waiting upload can proceed. The waiting upload then fails closed instead of recreating the prefix.
 
-The upload URL lifetime is exported from the storage package so the registration, migration backfill, summary, deletion, and tests use one value. The migration conservatively gives every recently created existing attachment an expiration based on its creation time, closing the rollout window for targets minted by the previous application version.
+The upload URL lifetime is exported from the storage package so the registration, migration backfill, summary, deletion, and tests use one value. The migration conservatively gives every recently created existing attachment an expiration based on its creation time. The nullable column also has a 15-minute database default, so an older application instance that omits it during a rolling release remains protected. The new inline-upload path explicitly stores null.
 
 ## Storage cleanup
 

--- a/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
+++ b/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
@@ -76,9 +76,11 @@ PostgreSQL and object storage cannot share one atomic transaction. The deletion 
 
 The first transaction locks the active organization, locks and rechecks the caller's current membership role, rechecks the confirmation, and commits `organization.deletionRequestedAt`. A demoted or removed administrator cannot start or resume deletion using a stale principal. Once this state is present, normal API and page access is redirected or rejected, uploads cannot create new objects, ordinary organization lists omit the workspace, MCP and realtime authentication fail closed, and public docs and attachments stop resolving. The deletion summary and delete endpoint remain available. The app switcher includes pending workspaces only for their administrators, so an authorized retry remains discoverable after a sign-out or workspace switch.
 
-The second transaction repeats the lock, role, and confirmation checks, then calculates the later of the tracked-upload guard and deletion-request drain. An early retry returns that exact timestamp without touching storage. A ready retry clears `session.active_organization_id`, chooses a next organization that is not itself pending deletion, and executes the organization delete before it calls object storage. This means a failing database statement cannot run after irreversible storage work. Existing foreign keys cascade through workspace-owned rows. User, account, passkey, and avatar records remain because they belong to the person rather than a workspace.
+The readiness transaction repeats the lock, role, and confirmation checks, then calculates the later of the tracked-upload guard and deletion-request drain. An early retry returns that exact timestamp without touching storage. A ready retry releases the transaction before it deletes the exact storage prefix. Because the durable marker blocks uploads and every normal ingress, the prefix remains quiescent while paginated cleanup runs.
 
-Storage prefix deletion is the last operation inside the second transaction. If storage fails, the database mutations roll back but the deletion timestamp from the first transaction remains committed. If the final database commit fails after storage cleanup, that durable timestamp also remains. The dialog can retry the same endpoint, and prefix deletion is idempotent even after partial or complete cleanup. A successful commit removes the organization and its deletion state together.
+After storage cleanup, a short final transaction repeats the lock, role, confirmation, and readiness checks. It clears `session.active_organization_id`, chooses a next organization that is not itself pending deletion, and deletes the organization so existing foreign keys cascade through workspace-owned rows. User, account, passkey, and avatar records remain because they belong to the person rather than a workspace.
+
+If storage fails, the database graph remains intact and the deletion timestamp from the first transaction stays committed. If a final database statement or commit fails after storage cleanup, the graph and durable timestamp also remain. The dialog can retry the same endpoint, and prefix deletion is idempotent even after partial or complete cleanup. A successful final commit removes the organization and its deletion state together.
 
 The schema migration adds `attachment.upload_expires_at`, its conservative backfill, and `organization.deletion_requested_at`.
 
@@ -136,9 +138,9 @@ Core integration tests cover:
 - deletion of every direct organization table through cascades
 - clearing active session references without deleting user sessions
 - presigned expiration storage, conservative migration backfill, tracked completion-grace blocking, untracked capability draining, and both exact boundaries
-- stale administrator role refusal inside the deletion transaction
-- durable retry state and database rollback when storage cleanup fails
-- database failures before storage cleanup
+- stale administrator role refusal inside readiness and final transactions
+- durable retry state with no database transaction held during storage cleanup
+- final database statement and commit failures after storage cleanup
 - pending-deletion access locks for APIs, uploads, public docs, public attachments, MCP principals, and realtime principals
 - upload and deletion lock ordering
 - selection of the next surviving workspace

--- a/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
+++ b/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
@@ -31,29 +31,29 @@ The shared policy adds `org:delete`, granted only to the administrator role. The
 
 The API is rooted at `/api/organizations/current/deletion`. It never accepts an organization id, slug, or storage prefix. Both `GET` and `DELETE` resolve the workspace from the authenticated principal. The delete body contains only the workspace-name confirmation. This makes a cross-workspace request impossible even when the caller administers more than one workspace.
 
-The confirmation is trimmed and compared case-sensitively with the current database value while the organization row is locked. A stale dialog cannot delete a workspace after another administrator renames it.
+The confirmation is preserved exactly and compared case-sensitively with the current database value while the organization row is locked. Surrounding spaces are rejected instead of silently changed. A stale dialog cannot delete a workspace after another administrator renames it.
 
 ## Deletion summary
 
 `getOrganizationDeletionSummary` returns the organization name, categorized counts, actual stored object bytes, stored object-version bytes, and an optional `availableAt` timestamp. Database counts come from bounded aggregate queries over direct organization columns. File counts and bytes come from `StorageDriver.summarizePrefix`, so pending uploads, orphaned objects, and recoverable historical versions under the organization prefix are visible even when they do not have an attachment row. The summary does not fetch row bodies or enumerate names.
 
-`availableAt` protects outstanding presigned uploads. A nullable `attachment.uploadExpiresAt` records the expiration of each presigned target and remains null for inline uploads. The summary uses the latest future value. If present, the dialog names when deletion becomes available and the server refuses an early delete even if a client bypasses the UI.
+`availableAt` protects outstanding presigned uploads. A nullable `attachment.uploadExpiresAt` records the expiration of each presigned target and remains null for inline uploads. The summary uses the latest expiration plus a 15-minute upload-completion grace. If present, the dialog names when deletion becomes available and the server refuses an early delete even if a client bypasses the UI.
 
 ## Upload and deletion serialization
 
 Storage keys already begin with `<organizationId>/`. Deleting the whole prefix removes tracked attachments, pending uploads, and orphaned objects.
 
-An S3 upload URL remains writable until it expires. A prefix that was empty at deletion time could otherwise receive a late upload. The upload registration and deletion paths therefore serialize on the organization row:
+S3 checks a presigned URL when the HTTP request begins, so a request started before expiration can finish afterward. A prefix that was empty at deletion time could otherwise receive a late upload. The upload registration and deletion paths therefore serialize on the organization row, and deletion waits through a completion grace after the last URL expires:
 
 1. Upload registration locks the organization row before it creates a target and attachment record.
 2. The target expiration is stored on the attachment, and the transaction commits before the target is returned to the browser.
 3. Workspace deletion obtains the same lock.
-4. Deletion refuses while any attachment can still have an unexpired upload target.
-5. After the last target expires, no application path can mint another target while deletion holds the lock.
+4. Deletion refuses while any attachment can still have an unexpired upload target or a started upload inside the completion grace.
+5. After the last completion grace closes, no application path can mint another target while deletion holds the lock.
 
 Inline uploads use the same organization lock around storage and attachment registration. A deletion that wins the lock removes the organization before a waiting upload can proceed. The waiting upload then fails closed instead of recreating the prefix.
 
-The upload URL lifetime is exported from the storage package so the registration, migration backfill, summary, deletion, and tests use one value. The migration conservatively gives every recently created existing attachment an expiration based on its creation time. The nullable column also has a 15-minute database default, so an older application instance that omits it during a rolling release remains protected. The new inline-upload path explicitly stores null.
+The upload URL lifetime and completion grace are exported from the storage package so registration, migration backfill, summary, deletion, and tests use the same values. The migration conservatively gives every recently created existing attachment an expiration based on its creation time. The nullable column also has a 15-minute database default, so an older application instance that omits it during a rolling release remains protected. The new inline-upload path explicitly stores null.
 
 ## Storage cleanup
 
@@ -67,11 +67,11 @@ The upload URL lifetime is exported from the storage package so the registration
 6. reports any per-object deletion error as an internal domain error
 7. lists again until the prefix and its version history are empty
 
-The implementation sends exact keys and version ids returned by S3 and never broadens the requested prefix. Providers such as Cloudflare R2 that return `501 Not Implemented` for the version-listing API fall back to current-object cleanup because they do not expose S3 object versioning. Permission or partial-delete errors continue to fail closed. AWS S3 policies used by Orbit need `s3:ListBucketVersions` and `s3:DeleteObjectVersion` in addition to current-object list and delete permissions. Tests cover pagination, more than one deletion batch, version history, delete markers, unsupported version APIs, empty prefixes, malformed prefixes, and partial S3 errors.
+The implementation sends exact keys and version ids returned by S3 and never broadens the requested prefix. Truncated version pages must include both continuation markers required by S3 or cleanup fails closed. Providers such as Cloudflare R2 that return `501 Not Implemented` for the version-listing API fall back to current-object cleanup because they do not expose S3 object versioning. Permission or partial-delete errors continue to fail closed. AWS S3 policies used by Orbit need `s3:ListBucketVersions` and `s3:DeleteObjectVersion` in addition to current-object list and delete permissions. Tests cover pagination, more than one deletion batch, version history, delete markers, unsupported version APIs, empty prefixes, malformed prefixes, and partial S3 errors.
 
 ## Database cleanup
 
-The deletion service starts a database transaction, locks the active organization, rechecks the confirmation and recent-upload guard, and deletes the storage prefix while new uploads are excluded. If storage cleanup fails, the transaction rolls back and the endpoint returns an error. Retrying is safe because prefix deletion is idempotent.
+The deletion service starts a database transaction, locks the active organization, locks and rechecks the caller's current membership role, rechecks the confirmation and upload guard, and deletes the storage prefix while new uploads are excluded. A demoted or removed administrator cannot complete a request using a stale principal. If storage cleanup fails, the transaction rolls back and the endpoint returns an error. Retrying is safe because prefix deletion is idempotent.
 
 After storage is empty, the same transaction clears `session.active_organization_id` wherever it names the workspace and deletes the organization row. Existing foreign keys cascade through workspace-owned rows. User, account, passkey, and avatar records remain because they belong to the person rather than a workspace. The schema migration adds `attachment.upload_expires_at` and the conservative backfill used by the upload guard.
 
@@ -97,7 +97,7 @@ Expected failures are:
 
 - `401` when signed out
 - `403` when the role lacks `org:delete`
-- `409` when the confirmation does not match or an upload URL can still be used
+- `409` when the confirmation does not match or an upload URL or started upload remains protected
 - `500` when object storage cannot be fully cleaned
 
 The UI keeps the dialog open and displays the server message. It does not remove the workspace locally until the delete response succeeds.
@@ -126,7 +126,8 @@ Core integration tests cover:
 - preservation of the neighboring workspace and shared users
 - deletion of every direct organization table through cascades
 - clearing active session references without deleting user sessions
-- presigned expiration storage, conservative migration backfill, recent-upload blocking, and the expiry boundary
+- presigned expiration storage, conservative migration backfill, completion-grace blocking, and the grace boundary
+- stale administrator role refusal inside the deletion transaction
 - rollback when storage cleanup fails
 - upload and deletion lock ordering
 - selection of the next surviving workspace

--- a/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
+++ b/docs/superpowers/specs/2026-08-08-workspace-deletion-design.md
@@ -21,7 +21,7 @@ The dialog shows counts for:
 
 It also states that comments, cycles, milestones, modules, labels, saved views, notifications, activity, invitations, OAuth grants, API keys, repository links, automations, and workspace settings are included. User accounts and their data in other workspaces are not deleted.
 
-The administrator must type the exact workspace name. The destructive button remains disabled while the summary is loading, the typed name differs, a recent upload is still protected, or a deletion is pending. The dialog explains that deletion is permanent.
+The administrator must type the exact workspace name. The destructive button remains disabled while the summary is loading, the typed name differs, or a recent upload is still protected. A pending deletion changes the danger zone into a retry flow and keeps the exact-name requirement. The dialog explains that deletion is permanent.
 
 If the deleted workspace is not the user's only workspace, the client activates another membership and performs a full navigation to `/my-issues`. If no membership remains, it navigates to `/workspaces/new`.
 
@@ -35,7 +35,7 @@ The confirmation is preserved exactly and compared case-sensitively with the cur
 
 ## Deletion summary
 
-`getOrganizationDeletionSummary` returns the organization name, categorized counts, actual stored object bytes, stored object-version bytes, and an optional `availableAt` timestamp. Database counts come from bounded aggregate queries over direct organization columns. File counts and bytes come from `StorageDriver.summarizePrefix`, so pending uploads, orphaned objects, and recoverable historical versions under the organization prefix are visible even when they do not have an attachment row. The summary does not fetch row bodies or enumerate names.
+`getOrganizationDeletionSummary` returns the organization name, categorized counts, actual stored object bytes, stored object-version bytes, an optional `availableAt` timestamp, and an optional `deletionRequestedAt` timestamp. Database counts come from bounded aggregate queries over direct organization columns. File counts and bytes come from `StorageDriver.summarizePrefix`, so pending uploads, orphaned objects, and recoverable historical versions under the organization prefix are visible even when they do not have an attachment row. The summary does not fetch row bodies or enumerate names.
 
 `availableAt` protects outstanding presigned uploads. A nullable `attachment.uploadExpiresAt` records the expiration of each presigned target and remains null for inline uploads. The summary uses the latest expiration plus a 15-minute upload-completion grace. If present, the dialog names when deletion becomes available and the server refuses an early delete even if a client bypasses the UI.
 
@@ -49,7 +49,8 @@ S3 checks a presigned URL when the HTTP request begins, so a request started bef
 2. The target expiration is stored on the attachment, and the transaction commits before the target is returned to the browser.
 3. Workspace deletion obtains the same lock.
 4. Deletion refuses while any attachment can still have an unexpired upload target or a started upload inside the completion grace.
-5. After the last completion grace closes, no application path can mint another target while deletion holds the lock.
+5. After the last completion grace closes, deletion commits `organization.deletionRequestedAt` before storage work begins.
+6. Upload registration and inline storage reject a workspace carrying that timestamp, so a retry cannot recreate the prefix.
 
 Inline uploads use the same organization lock around storage and attachment registration. A deletion that wins the lock removes the organization before a waiting upload can proceed. The waiting upload then fails closed instead of recreating the prefix.
 
@@ -71,9 +72,15 @@ The implementation sends exact keys and version ids returned by S3 and never bro
 
 ## Database cleanup
 
-The deletion service starts a database transaction, locks the active organization, locks and rechecks the caller's current membership role, rechecks the confirmation and upload guard, and deletes the storage prefix while new uploads are excluded. A demoted or removed administrator cannot complete a request using a stale principal. If storage cleanup fails, the transaction rolls back and the endpoint returns an error. Retrying is safe because prefix deletion is idempotent.
+PostgreSQL and object storage cannot share one atomic transaction. The deletion service therefore uses a durable two-phase retry state.
 
-After storage is empty, the same transaction clears `session.active_organization_id` wherever it names the workspace and deletes the organization row. Existing foreign keys cascade through workspace-owned rows. User, account, passkey, and avatar records remain because they belong to the person rather than a workspace. The schema migration adds `attachment.upload_expires_at` and the conservative backfill used by the upload guard.
+The first transaction locks the active organization, locks and rechecks the caller's current membership role, rechecks the confirmation and upload guard, and commits `organization.deletionRequestedAt`. A demoted or removed administrator cannot start or resume deletion using a stale principal. Once this state is present, normal API and page access is redirected or rejected, uploads cannot create new objects, ordinary organization lists omit the workspace, MCP and realtime authentication fail closed, and public docs and attachments stop resolving. The deletion summary and delete endpoint remain available. The app switcher includes pending workspaces only for their administrators, so an authorized retry remains discoverable after a sign-out or workspace switch.
+
+The second transaction repeats the lock, role, confirmation, and upload checks. It clears `session.active_organization_id`, chooses a next organization that is not itself pending deletion, and executes the organization delete before it calls object storage. This means a failing database statement cannot run after irreversible storage work. Existing foreign keys cascade through workspace-owned rows. User, account, passkey, and avatar records remain because they belong to the person rather than a workspace.
+
+Storage prefix deletion is the last operation inside the second transaction. If storage fails, the database mutations roll back but the deletion timestamp from the first transaction remains committed. If the final database commit fails after storage cleanup, that durable timestamp also remains. The dialog can retry the same endpoint, and prefix deletion is idempotent even after partial or complete cleanup. A successful commit removes the organization and its deletion state together.
+
+The schema migration adds `attachment.upload_expires_at`, its conservative backfill, and `organization.deletion_requested_at`.
 
 A database schema regression test queries PostgreSQL metadata and requires every direct foreign key to `organization.id` to use `ON DELETE CASCADE`. The session field is the intentional non-foreign-key exception and is covered by service tests. This prevents a future workspace table from silently surviving deletion or blocking it.
 
@@ -86,6 +93,8 @@ The shared control protocol adds an `organization_deleted` message carrying the 
 The calling tab navigates immediately from the delete response. The web realtime provider gains recovery for the organization-forbidden close code. It lists the signed-in user's remaining organizations through the existing API, activates the first result, and performs a full navigation to `/my-issues`, or navigates to `/workspaces/new` when the list is empty. This also repairs tabs affected by a membership removal. No deleted organization data remains subscribed in memory.
 
 Publishing is best effort after commit, matching existing delta behavior. A missed control message cannot restore access because membership validation fails on the next request, subscription, or connection.
+
+While deletion is pending, new realtime tickets are refused and periodic membership validation closes existing connections. The app layout does not mount a realtime client for the pending workspace.
 
 ## API responses and errors
 
@@ -106,7 +115,7 @@ The UI keeps the dialog open and displays the server message. It does not remove
 
 The existing General form remains focused on editable workspace fields. A separate `WorkspaceDangerZone` client component owns summary loading, confirmation state, deletion, errors, and navigation.
 
-The server page passes only the active organization name and `can(principal, 'org:delete')`. Non-admin users do not receive the destructive control.
+The server page passes the active organization name, deletion timestamp, and `can(principal, 'org:delete')`. Non-admin users do not receive the destructive control. A pending workspace disables ordinary settings writes and labels the action as a retry.
 
 The dialog uses the shared Radix-based dialog, an explicit title and description, a labelled confirmation input, an alert region for errors, and a danger button. Focus starts on the dialog content rather than the delete button. Closing is disabled only during the final request. All colors and transitions use existing tokens.
 
@@ -128,7 +137,9 @@ Core integration tests cover:
 - clearing active session references without deleting user sessions
 - presigned expiration storage, conservative migration backfill, completion-grace blocking, and the grace boundary
 - stale administrator role refusal inside the deletion transaction
-- rollback when storage cleanup fails
+- durable retry state and database rollback when storage cleanup fails
+- database failures before storage cleanup
+- pending-deletion access locks for APIs, uploads, public docs, public attachments, MCP principals, and realtime principals
 - upload and deletion lock ordering
 - selection of the next surviving workspace
 

--- a/packages/core/src/content/attachment-service.ts
+++ b/packages/core/src/content/attachment-service.ts
@@ -177,12 +177,12 @@ export async function registerUpload(
 ): Promise<RegisteredUpload> {
   const upload = validateUpload(input);
   const parsed = uploadRequestSchema.parse(input);
-  const store = driver ?? storageDriver();
   const key = storageKeyFor(principal.organizationId, upload.safeName);
   return await db.transaction(async (tx) => {
     const organization = await lockOrganization(tx, principal.organizationId);
     assertOrganizationAcceptsFiles(organization);
     await assertUploadParent(tx, principal, parsed.parentType, parsed.parentId);
+    const store = driver ?? storageDriver();
     const target = await store.createUploadTarget(key, upload.contentType, upload.size);
     const registered = await insertAttachment(tx, principal, {
       parentType: parsed.parentType,
@@ -231,14 +231,15 @@ export async function attachFile(
     contentType: parsed.contentType,
     size: bytes.byteLength,
   });
-  const store = driver ?? storageDriver();
   const key = storageKeyFor(principal.organizationId, upload.safeName);
+  let store: StorageDriver | null = driver ?? null;
   let objectStored = false;
   try {
     return await db.transaction(async (tx) => {
       const organization = await lockOrganization(tx, principal.organizationId);
       assertOrganizationAcceptsFiles(organization);
       await assertUploadParent(tx, principal, parsed.parentType, parsed.parentId);
+      store ??= storageDriver();
       await store.put(key, bytes, upload.contentType);
       objectStored = true;
       const stored = await insertAttachment(tx, principal, {
@@ -254,7 +255,7 @@ export async function attachFile(
       return { ...stored, url: fileUrlFor(key) };
     });
   } catch (error: unknown) {
-    if (objectStored) await store.delete(key).catch(() => undefined);
+    if (objectStored && store !== null) await store.delete(key).catch(() => undefined);
     throw error;
   }
 }

--- a/packages/core/src/content/attachment-service.ts
+++ b/packages/core/src/content/attachment-service.ts
@@ -1,4 +1,4 @@
-import { and, db, eq, schema } from '@orbit/db';
+import { and, db, eq, schema, type Transaction } from '@orbit/db';
 import {
   assertUploadParent,
   fileUrlFor,
@@ -15,6 +15,7 @@ import type { Principal } from '@orbit/shared/policy';
 import { inlineUploadSchema, uploadRequestSchema } from '@orbit/shared/validators';
 import { principalActor } from '../activity/activity-service.ts';
 import { type Executor, newId, requireRow } from '../internal.ts';
+import { lockOrganization } from '../org/organization-lock.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
 
@@ -111,49 +112,50 @@ interface AttachmentDraft {
   readonly size: number;
   readonly storageKey: string;
   readonly status: 'pending' | 'ready';
+  readonly uploadExpiresAt: Date | null;
 }
 
 async function insertAttachment(
+  tx: Transaction,
   principal: Principal,
   draft: AttachmentDraft,
 ): Promise<CompletedAttachment> {
-  return await db.transaction(async (tx) => {
-    const syncId = await nextSyncId(tx);
-    const [created] = await tx
-      .insert(schema.attachment)
-      .values({
-        id: newId(),
-        organizationId: principal.organizationId,
-        parentType: draft.parentType,
-        parentId: draft.parentId,
-        fileName: draft.fileName,
-        contentType: draft.contentType,
-        size: draft.size,
-        storageKey: draft.storageKey,
-        status: draft.status,
-        uploadedById: principal.userId,
-        syncId,
-      })
-      .returning();
-    const attachment = requireRow(created, 'That upload could not be registered.');
-    const actor = await principalActor(tx, principal);
+  const syncId = await nextSyncId(tx);
+  const [created] = await tx
+    .insert(schema.attachment)
+    .values({
+      id: newId(),
+      organizationId: principal.organizationId,
+      parentType: draft.parentType,
+      parentId: draft.parentId,
+      fileName: draft.fileName,
+      contentType: draft.contentType,
+      size: draft.size,
+      storageKey: draft.storageKey,
+      status: draft.status,
+      uploadExpiresAt: draft.uploadExpiresAt,
+      uploadedById: principal.userId,
+      syncId,
+    })
+    .returning();
+  const attachment = requireRow(created, 'That upload could not be registered.');
+  const actor = await principalActor(tx, principal);
 
-    return {
-      attachment,
-      actions: [
-        buildSyncAction({
-          syncId,
-          organizationId: attachment.organizationId,
-          scopes: await resolveAttachmentScopes(tx, attachment, attachment.organizationId),
-          action: 'insert',
-          model: 'attachment',
-          modelId: attachment.id,
-          data: attachment,
-          actor,
-        }),
-      ],
-    };
-  });
+  return {
+    attachment,
+    actions: [
+      buildSyncAction({
+        syncId,
+        organizationId: attachment.organizationId,
+        scopes: await resolveAttachmentScopes(tx, attachment, attachment.organizationId),
+        action: 'insert',
+        model: 'attachment',
+        modelId: attachment.id,
+        data: attachment,
+        actor,
+      }),
+    ],
+  };
 }
 
 export interface RegisteredUpload extends CompletedAttachment {
@@ -167,22 +169,24 @@ export async function registerUpload(
 ): Promise<RegisteredUpload> {
   const upload = validateUpload(input);
   const parsed = uploadRequestSchema.parse(input);
-  await assertUploadParent(db, principal, parsed.parentType, parsed.parentId);
-
   const store = driver ?? storageDriver();
   const key = storageKeyFor(principal.organizationId, upload.safeName);
-  const target = await store.createUploadTarget(key, upload.contentType, upload.size);
-  const registered = await insertAttachment(principal, {
-    parentType: parsed.parentType,
-    parentId: parsed.parentId,
-    fileName: upload.fileName,
-    contentType: upload.contentType,
-    size: upload.size,
-    storageKey: target.key,
-    status: 'pending',
+  return await db.transaction(async (tx) => {
+    await lockOrganization(tx, principal.organizationId);
+    await assertUploadParent(tx, principal, parsed.parentType, parsed.parentId);
+    const target = await store.createUploadTarget(key, upload.contentType, upload.size);
+    const registered = await insertAttachment(tx, principal, {
+      parentType: parsed.parentType,
+      parentId: parsed.parentId,
+      fileName: upload.fileName,
+      contentType: upload.contentType,
+      size: upload.size,
+      storageKey: target.key,
+      status: 'pending',
+      uploadExpiresAt: new Date(target.expiresAt),
+    });
+    return { ...registered, upload: target };
   });
-
-  return { ...registered, upload: target };
 }
 
 export async function finishUpload(
@@ -218,24 +222,29 @@ export async function attachFile(
     contentType: parsed.contentType,
     size: bytes.byteLength,
   });
-  await assertUploadParent(db, principal, parsed.parentType, parsed.parentId);
-
   const store = driver ?? storageDriver();
   const key = storageKeyFor(principal.organizationId, upload.safeName);
-  await store.put(key, bytes, upload.contentType);
+  let objectStored = false;
   try {
-    const stored = await insertAttachment(principal, {
-      parentType: parsed.parentType,
-      parentId: parsed.parentId,
-      fileName: upload.fileName,
-      contentType: upload.contentType,
-      size: upload.size,
-      storageKey: key,
-      status: 'ready',
+    return await db.transaction(async (tx) => {
+      await lockOrganization(tx, principal.organizationId);
+      await assertUploadParent(tx, principal, parsed.parentType, parsed.parentId);
+      await store.put(key, bytes, upload.contentType);
+      objectStored = true;
+      const stored = await insertAttachment(tx, principal, {
+        parentType: parsed.parentType,
+        parentId: parsed.parentId,
+        fileName: upload.fileName,
+        contentType: upload.contentType,
+        size: upload.size,
+        storageKey: key,
+        status: 'ready',
+        uploadExpiresAt: null,
+      });
+      return { ...stored, url: fileUrlFor(key) };
     });
-    return { ...stored, url: fileUrlFor(key) };
   } catch (error: unknown) {
-    await store.delete(key).catch(() => undefined);
+    if (objectStored) await store.delete(key).catch(() => undefined);
     throw error;
   }
 }

--- a/packages/core/src/content/attachment-service.ts
+++ b/packages/core/src/content/attachment-service.ts
@@ -8,7 +8,7 @@ import {
   type UploadTarget,
   validateUpload,
 } from '@orbit/services/storage';
-import { notFound, validationFailed } from '@orbit/shared/errors';
+import { conflict, notFound, validationFailed } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
@@ -162,6 +162,14 @@ export interface RegisteredUpload extends CompletedAttachment {
   readonly upload: UploadTarget;
 }
 
+function assertOrganizationAcceptsFiles(
+  organization: typeof schema.organization.$inferSelect,
+): void {
+  if (organization.deletionRequestedAt !== null) {
+    throw conflict('Workspace deletion is in progress.');
+  }
+}
+
 export async function registerUpload(
   principal: Principal,
   input: unknown,
@@ -172,7 +180,8 @@ export async function registerUpload(
   const store = driver ?? storageDriver();
   const key = storageKeyFor(principal.organizationId, upload.safeName);
   return await db.transaction(async (tx) => {
-    await lockOrganization(tx, principal.organizationId);
+    const organization = await lockOrganization(tx, principal.organizationId);
+    assertOrganizationAcceptsFiles(organization);
     await assertUploadParent(tx, principal, parsed.parentType, parsed.parentId);
     const target = await store.createUploadTarget(key, upload.contentType, upload.size);
     const registered = await insertAttachment(tx, principal, {
@@ -227,7 +236,8 @@ export async function attachFile(
   let objectStored = false;
   try {
     return await db.transaction(async (tx) => {
-      await lockOrganization(tx, principal.organizationId);
+      const organization = await lockOrganization(tx, principal.organizationId);
+      assertOrganizationAcceptsFiles(organization);
       await assertUploadParent(tx, principal, parsed.parentType, parsed.parentId);
       await store.put(key, bytes, upload.contentType);
       objectStored = true;

--- a/packages/core/src/content/doc-service.ts
+++ b/packages/core/src/content/doc-service.ts
@@ -936,7 +936,14 @@ export async function getPublishedDoc(pathSegment: string): Promise<DocDetail | 
   const [doc] = await db
     .select(DOC_COLUMNS)
     .from(schema.doc)
-    .where(and(eq(schema.doc.publishToken, token), isNull(schema.doc.archivedAt)))
+    .innerJoin(schema.organization, eq(schema.organization.id, schema.doc.organizationId))
+    .where(
+      and(
+        eq(schema.doc.publishToken, token),
+        isNull(schema.doc.archivedAt),
+        isNull(schema.organization.deletionRequestedAt),
+      ),
+    )
     .limit(1);
   if (doc === undefined) return null;
   if (!isExternallyShared(doc.visibility)) return null;
@@ -947,11 +954,13 @@ export async function listPublicDocs(): Promise<DocRow[]> {
   return await db
     .select(DOC_COLUMNS)
     .from(schema.doc)
+    .innerJoin(schema.organization, eq(schema.organization.id, schema.doc.organizationId))
     .where(
       and(
         eq(schema.doc.visibility, 'public'),
         isNull(schema.doc.archivedAt),
         ne(schema.doc.publishToken, ''),
+        isNull(schema.organization.deletionRequestedAt),
       ),
     )
     .orderBy(desc(schema.doc.updatedAt))
@@ -962,7 +971,8 @@ export async function isPublishedDoc(docId: string): Promise<boolean> {
   const [row] = await db
     .select({ visibility: schema.doc.visibility, archivedAt: schema.doc.archivedAt })
     .from(schema.doc)
-    .where(eq(schema.doc.id, docId))
+    .innerJoin(schema.organization, eq(schema.organization.id, schema.doc.organizationId))
+    .where(and(eq(schema.doc.id, docId), isNull(schema.organization.deletionRequestedAt)))
     .limit(1);
   return row !== undefined && row.archivedAt === null && isExternallyShared(row.visibility);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './org/avatar-service.ts';
 export * from './org/invite-service.ts';
 export * from './org/member-service.ts';
 export * from './org/onboarding-service.ts';
+export * from './org/organization-deletion-service.ts';
 export * from './org/organization-service.ts';
 export * from './org/profile-service.ts';
 export * from './org/starter-content.ts';

--- a/packages/core/src/org/invite-service.ts
+++ b/packages/core/src/org/invite-service.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { and, asc, db, eq, gt, inArray, schema, sql } from '@orbit/db';
+import { and, asc, db, eq, gt, inArray, isNull, schema, sql } from '@orbit/db';
 import { ORG_ROLES, type OrgRole } from '@orbit/shared/constants';
 import { conflict, forbidden, notFound } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
@@ -11,6 +11,7 @@ import { principalActor } from '../activity/activity-service.ts';
 import { addUtcDays, type Executor, newId, newToken, requireRow } from '../internal.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
+import { lockOrganization } from './organization-lock.ts';
 import { assertEmailDomainAllowed, type MemberRow } from './organization-service.ts';
 
 export type InvitationRow = typeof schema.invitation.$inferSelect;
@@ -208,6 +209,7 @@ export async function pendingInvitesForEmail(email: string): Promise<PendingInvi
         eq(sql`lower(${schema.invitation.email})`, email.toLowerCase()),
         eq(schema.invitation.status, 'pending'),
         gt(schema.invitation.expiresAt, new Date()),
+        isNull(schema.organization.deletionRequestedAt),
       ),
     )
     .orderBy(asc(schema.invitation.createdAt));
@@ -299,6 +301,10 @@ export async function acceptInvite(token: string, userId: string): Promise<Accep
       .where(eq(schema.invitation.id, token))
       .limit(1);
     const invitation = requireRow(found, 'That invite is not valid.');
+    const organization = await lockOrganization(tx, invitation.organizationId);
+    if (organization.deletionRequestedAt !== null) {
+      throw conflict('That workspace is being permanently deleted.');
+    }
 
     const [existingMember] = await tx
       .select()

--- a/packages/core/src/org/member-service.ts
+++ b/packages/core/src/org/member-service.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, db, eq, inArray, ne, schema } from '@orbit/db';
+import { and, asc, count, db, eq, inArray, isNull, ne, schema } from '@orbit/db';
 import { OPEN_STATE_CATEGORIES, type OrgRole } from '@orbit/shared/constants';
 import { conflict, forbidden } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
@@ -31,9 +31,16 @@ export async function resolvePrincipal(
   executor: Executor = db,
 ): Promise<Principal> {
   const [membership] = await executor
-    .select()
+    .select({ role: schema.member.role })
     .from(schema.member)
-    .where(and(eq(schema.member.organizationId, organizationId), eq(schema.member.userId, userId)))
+    .innerJoin(schema.organization, eq(schema.organization.id, schema.member.organizationId))
+    .where(
+      and(
+        eq(schema.member.organizationId, organizationId),
+        eq(schema.member.userId, userId),
+        isNull(schema.organization.deletionRequestedAt),
+      ),
+    )
     .limit(1);
   if (membership === undefined) throw forbidden('You are not a member of this workspace.');
 

--- a/packages/core/src/org/organization-deletion-service.ts
+++ b/packages/core/src/org/organization-deletion-service.ts
@@ -1,0 +1,156 @@
+import { and, asc, count, db, desc, eq, gt, ne, schema } from '@orbit/db';
+import { type StorageDriver, storageDriver, storagePrefixFor } from '@orbit/services/storage';
+import { conflict } from '@orbit/shared/errors';
+import type { Principal } from '@orbit/shared/policy';
+import { assertCan } from '@orbit/shared/policy';
+import { organizationDeleteSchema } from '@orbit/shared/validators';
+import { type Executor, requireRow } from '../internal.ts';
+import { lockOrganization } from './organization-lock.ts';
+
+export interface OrganizationDeletionSummary {
+  readonly organizationName: string;
+  readonly members: number;
+  readonly teams: number;
+  readonly projects: number;
+  readonly issues: number;
+  readonly documents: number;
+  readonly files: number;
+  readonly fileBytes: number;
+  readonly integrations: number;
+  readonly webhooks: number;
+  readonly availableAt: string | null;
+}
+
+export interface OrganizationDeletionResult {
+  readonly deletedOrganizationId: string;
+  readonly deletedOrganizationName: string;
+  readonly nextOrganizationId: string | null;
+}
+
+function totalOf(rows: readonly { readonly total: number }[]): number {
+  return rows[0]?.total ?? 0;
+}
+
+async function latestLiveUploadExpiration(
+  executor: Executor,
+  organizationId: string,
+  now: Date,
+): Promise<Date | null> {
+  const [row] = await executor
+    .select({ uploadExpiresAt: schema.attachment.uploadExpiresAt })
+    .from(schema.attachment)
+    .where(
+      and(
+        eq(schema.attachment.organizationId, organizationId),
+        gt(schema.attachment.uploadExpiresAt, now),
+      ),
+    )
+    .orderBy(desc(schema.attachment.uploadExpiresAt))
+    .limit(1);
+  return row?.uploadExpiresAt ?? null;
+}
+
+export async function getOrganizationDeletionSummary(
+  principal: Principal,
+  driver: StorageDriver = storageDriver(),
+  now: Date = new Date(),
+): Promise<OrganizationDeletionSummary> {
+  assertCan(principal, 'org:delete');
+  const [organization] = await db
+    .select({ name: schema.organization.name })
+    .from(schema.organization)
+    .where(eq(schema.organization.id, principal.organizationId))
+    .limit(1);
+  const current = requireRow(organization, 'That workspace does not exist.');
+  const [members, teams, projects, issues, documents, integrations, webhooks, availableAt, stored] =
+    await Promise.all([
+      db
+        .select({ total: count() })
+        .from(schema.member)
+        .where(eq(schema.member.organizationId, principal.organizationId)),
+      db
+        .select({ total: count() })
+        .from(schema.team)
+        .where(eq(schema.team.organizationId, principal.organizationId)),
+      db
+        .select({ total: count() })
+        .from(schema.project)
+        .where(eq(schema.project.organizationId, principal.organizationId)),
+      db
+        .select({ total: count() })
+        .from(schema.issue)
+        .where(eq(schema.issue.organizationId, principal.organizationId)),
+      db
+        .select({ total: count() })
+        .from(schema.doc)
+        .where(eq(schema.doc.organizationId, principal.organizationId)),
+      db
+        .select({ total: count() })
+        .from(schema.integration)
+        .where(eq(schema.integration.organizationId, principal.organizationId)),
+      db
+        .select({ total: count() })
+        .from(schema.webhook)
+        .where(eq(schema.webhook.organizationId, principal.organizationId)),
+      latestLiveUploadExpiration(db, principal.organizationId, now),
+      driver.summarizePrefix(storagePrefixFor(principal.organizationId)),
+    ]);
+  return {
+    organizationName: current.name,
+    members: totalOf(members),
+    teams: totalOf(teams),
+    projects: totalOf(projects),
+    issues: totalOf(issues),
+    documents: totalOf(documents),
+    files: stored.objects,
+    fileBytes: stored.bytes,
+    integrations: totalOf(integrations),
+    webhooks: totalOf(webhooks),
+    availableAt: availableAt?.toISOString() ?? null,
+  };
+}
+
+export async function deleteOrganization(
+  principal: Principal,
+  input: unknown,
+  driver: StorageDriver = storageDriver(),
+  now: Date = new Date(),
+): Promise<OrganizationDeletionResult> {
+  assertCan(principal, 'org:delete');
+  const parsed = organizationDeleteSchema.parse(input);
+  return await db.transaction(async (tx) => {
+    const organization = await lockOrganization(tx, principal.organizationId);
+    if (parsed.confirmation !== organization.name) {
+      throw conflict('Type the current workspace name exactly to confirm deletion.');
+    }
+    const availableAt = await latestLiveUploadExpiration(tx, organization.id, now);
+    if (availableAt !== null) {
+      throw conflict('Wait for pending upload links to expire before deleting this workspace.', {
+        details: { availableAt: availableAt.toISOString() },
+      });
+    }
+    await driver.deletePrefix(storagePrefixFor(organization.id));
+    await tx
+      .update(schema.session)
+      .set({ activeOrganizationId: null })
+      .where(eq(schema.session.activeOrganizationId, organization.id));
+    const [next] = await tx
+      .select({ organizationId: schema.organization.id })
+      .from(schema.member)
+      .innerJoin(schema.organization, eq(schema.organization.id, schema.member.organizationId))
+      .where(
+        and(
+          eq(schema.member.userId, principal.userId),
+          ne(schema.member.organizationId, organization.id),
+        ),
+      )
+      .orderBy(asc(schema.organization.name), asc(schema.organization.id))
+      .limit(1);
+    await tx.delete(schema.organization).where(eq(schema.organization.id, organization.id));
+    return {
+      deletedOrganizationId: organization.id,
+      deletedOrganizationName: organization.name,
+      nextOrganizationId: next?.organizationId ?? null,
+    };
+  });
+}

--- a/packages/core/src/org/organization-deletion-service.ts
+++ b/packages/core/src/org/organization-deletion-service.ts
@@ -10,26 +10,14 @@ import { ORG_ROLES, type OrgRole } from '@orbit/shared/constants';
 import { conflict } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan } from '@orbit/shared/policy';
-import { organizationDeleteSchema } from '@orbit/shared/validators';
+import {
+  type OrganizationDeletionSummary,
+  organizationDeleteSchema,
+} from '@orbit/shared/validators';
 import { type Executor, requireRow } from '../internal.ts';
 import { lockOrganization } from './organization-lock.ts';
 
-export interface OrganizationDeletionSummary {
-  readonly organizationName: string;
-  readonly members: number;
-  readonly teams: number;
-  readonly projects: number;
-  readonly issues: number;
-  readonly documents: number;
-  readonly files: number;
-  readonly fileBytes: number;
-  readonly fileVersions: number;
-  readonly fileVersionBytes: number;
-  readonly integrations: number;
-  readonly webhooks: number;
-  readonly availableAt: string | null;
-  readonly deletionRequestedAt: string | null;
-}
+export type { OrganizationDeletionSummary } from '@orbit/shared/validators';
 
 export interface OrganizationDeletionResult {
   readonly deletedOrganizationId: string;
@@ -226,6 +214,12 @@ export async function deleteOrganization(
       .set({ deletionRequestedAt: now })
       .where(eq(schema.organization.id, organization.id));
   });
+  const organizationId = await db.transaction(async (tx) => {
+    const organization = await validatedDeletionTarget(tx, principal, parsed.confirmation);
+    await assertDeletionReady(tx, organization, now);
+    return organization.id;
+  });
+  await driver.deletePrefix(storagePrefixFor(organizationId));
   return await db.transaction(async (tx) => {
     const organization = await validatedDeletionTarget(tx, principal, parsed.confirmation);
     await assertDeletionReady(tx, organization, now);
@@ -247,7 +241,6 @@ export async function deleteOrganization(
       .orderBy(asc(schema.organization.name), asc(schema.organization.id))
       .limit(1);
     await tx.delete(schema.organization).where(eq(schema.organization.id, organization.id));
-    await driver.deletePrefix(storagePrefixFor(organization.id));
     return {
       deletedOrganizationId: organization.id,
       deletedOrganizationName: organization.name,

--- a/packages/core/src/org/organization-deletion-service.ts
+++ b/packages/core/src/org/organization-deletion-service.ts
@@ -1,5 +1,11 @@
-import { and, asc, count, db, desc, eq, gt, ne, schema } from '@orbit/db';
-import { type StorageDriver, storageDriver, storagePrefixFor } from '@orbit/services/storage';
+import { and, asc, count, db, desc, eq, gt, ne, schema, type Transaction } from '@orbit/db';
+import {
+  type StorageDriver,
+  storageDriver,
+  storagePrefixFor,
+  UPLOAD_COMPLETION_GRACE_SECONDS,
+} from '@orbit/services/storage';
+import { ORG_ROLES, type OrgRole } from '@orbit/shared/constants';
 import { conflict } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan } from '@orbit/shared/policy';
@@ -33,23 +39,49 @@ function totalOf(rows: readonly { readonly total: number }[]): number {
   return rows[0]?.total ?? 0;
 }
 
-async function latestLiveUploadExpiration(
+function organizationRole(value: string | undefined): OrgRole {
+  return ORG_ROLES.find((role) => role === value) ?? 'guest';
+}
+
+async function assertCurrentDeletionPermission(
+  tx: Transaction,
+  principal: Principal,
+): Promise<void> {
+  const [membership] = await tx
+    .select({ role: schema.member.role })
+    .from(schema.member)
+    .where(
+      and(
+        eq(schema.member.organizationId, principal.organizationId),
+        eq(schema.member.userId, principal.userId),
+      ),
+    )
+    .limit(1)
+    .for('update');
+  assertCan({ ...principal, role: organizationRole(membership?.role) }, 'org:delete');
+}
+
+async function latestUploadProtectionEnd(
   executor: Executor,
   organizationId: string,
   now: Date,
 ): Promise<Date | null> {
+  const graceMs = UPLOAD_COMPLETION_GRACE_SECONDS * 1000;
+  const protectedAfter = new Date(now.getTime() - graceMs);
   const [row] = await executor
     .select({ uploadExpiresAt: schema.attachment.uploadExpiresAt })
     .from(schema.attachment)
     .where(
       and(
         eq(schema.attachment.organizationId, organizationId),
-        gt(schema.attachment.uploadExpiresAt, now),
+        gt(schema.attachment.uploadExpiresAt, protectedAfter),
       ),
     )
     .orderBy(desc(schema.attachment.uploadExpiresAt))
     .limit(1);
-  return row?.uploadExpiresAt ?? null;
+  const expiration = row?.uploadExpiresAt;
+  if (expiration === undefined || expiration === null) return null;
+  return new Date(expiration.getTime() + graceMs);
 }
 
 export async function getOrganizationDeletionSummary(
@@ -94,7 +126,7 @@ export async function getOrganizationDeletionSummary(
         .select({ total: count() })
         .from(schema.webhook)
         .where(eq(schema.webhook.organizationId, principal.organizationId)),
-      latestLiveUploadExpiration(db, principal.organizationId, now),
+      latestUploadProtectionEnd(db, principal.organizationId, now),
       driver.summarizePrefix(storagePrefixFor(principal.organizationId)),
     ]);
   return {
@@ -124,10 +156,11 @@ export async function deleteOrganization(
   const parsed = organizationDeleteSchema.parse(input);
   return await db.transaction(async (tx) => {
     const organization = await lockOrganization(tx, principal.organizationId);
+    await assertCurrentDeletionPermission(tx, principal);
     if (parsed.confirmation !== organization.name) {
       throw conflict('Type the current workspace name exactly to confirm deletion.');
     }
-    const availableAt = await latestLiveUploadExpiration(tx, organization.id, now);
+    const availableAt = await latestUploadProtectionEnd(tx, organization.id, now);
     if (availableAt !== null) {
       throw conflict('Wait for pending upload links to expire before deleting this workspace.', {
         details: { availableAt: availableAt.toISOString() },

--- a/packages/core/src/org/organization-deletion-service.ts
+++ b/packages/core/src/org/organization-deletion-service.ts
@@ -4,6 +4,7 @@ import {
   storageDriver,
   storagePrefixFor,
   UPLOAD_COMPLETION_GRACE_SECONDS,
+  UPLOAD_URL_TTL_SECONDS,
 } from '@orbit/services/storage';
 import { ORG_ROLES, type OrgRole } from '@orbit/shared/constants';
 import { conflict } from '@orbit/shared/errors';
@@ -34,6 +35,11 @@ export interface OrganizationDeletionResult {
   readonly deletedOrganizationId: string;
   readonly deletedOrganizationName: string;
   readonly nextOrganizationId: string | null;
+}
+
+interface DeletionProtectionTarget {
+  readonly id: string;
+  readonly deletionRequestedAt: Date | null;
 }
 
 function totalOf(rows: readonly { readonly total: number }[]): number {
@@ -85,6 +91,30 @@ async function latestUploadProtectionEnd(
   return new Date(expiration.getTime() + graceMs);
 }
 
+function deletionRequestProtectionEnd(deletionRequestedAt: Date | null): Date | null {
+  if (deletionRequestedAt === null) return null;
+  const protectionMs = (UPLOAD_URL_TTL_SECONDS + UPLOAD_COMPLETION_GRACE_SECONDS) * 1000;
+  return new Date(deletionRequestedAt.getTime() + protectionMs);
+}
+
+function laterDate(first: Date | null, second: Date | null): Date | null {
+  if (first === null) return second;
+  if (second === null) return first;
+  return first.getTime() >= second.getTime() ? first : second;
+}
+
+async function deletionAvailableAt(
+  executor: Executor,
+  organization: DeletionProtectionTarget,
+  now: Date,
+): Promise<Date | null> {
+  const trackedUploadEnd = await latestUploadProtectionEnd(executor, organization.id, now);
+  const untrackedUploadEnd = deletionRequestProtectionEnd(organization.deletionRequestedAt);
+  const availableAt = laterDate(trackedUploadEnd, untrackedUploadEnd);
+  if (availableAt === null || availableAt.getTime() <= now.getTime()) return null;
+  return availableAt;
+}
+
 export async function getOrganizationDeletionSummary(
   principal: Principal,
   driver: StorageDriver = storageDriver(),
@@ -93,6 +123,7 @@ export async function getOrganizationDeletionSummary(
   assertCan(principal, 'org:delete');
   const [organization] = await db
     .select({
+      id: schema.organization.id,
       name: schema.organization.name,
       deletionRequestedAt: schema.organization.deletionRequestedAt,
     })
@@ -130,7 +161,7 @@ export async function getOrganizationDeletionSummary(
         .select({ total: count() })
         .from(schema.webhook)
         .where(eq(schema.webhook.organizationId, principal.organizationId)),
-      latestUploadProtectionEnd(db, principal.organizationId, now),
+      deletionAvailableAt(db, current, now),
       driver.summarizePrefix(storagePrefixFor(principal.organizationId)),
     ]);
   return {
@@ -155,20 +186,28 @@ async function validatedDeletionTarget(
   tx: Transaction,
   principal: Principal,
   confirmation: string,
-  now: Date,
 ): Promise<typeof schema.organization.$inferSelect> {
   const organization = await lockOrganization(tx, principal.organizationId);
   await assertCurrentDeletionPermission(tx, principal);
   if (confirmation !== organization.name) {
     throw conflict('Type the current workspace name exactly to confirm deletion.');
   }
-  const availableAt = await latestUploadProtectionEnd(tx, organization.id, now);
-  if (availableAt !== null) {
-    throw conflict('Wait for pending upload links to expire before deleting this workspace.', {
-      details: { availableAt: availableAt.toISOString() },
-    });
-  }
   return organization;
+}
+
+async function assertDeletionReady(
+  tx: Transaction,
+  organization: typeof schema.organization.$inferSelect,
+  now: Date,
+): Promise<void> {
+  const availableAt = await deletionAvailableAt(tx, organization, now);
+  if (availableAt === null) return;
+  throw conflict(
+    'Workspace deletion is pending while upload links expire. Retry after this time.',
+    {
+      details: { availableAt: availableAt.toISOString() },
+    },
+  );
 }
 
 export async function deleteOrganization(
@@ -180,7 +219,7 @@ export async function deleteOrganization(
   assertCan(principal, 'org:delete');
   const parsed = organizationDeleteSchema.parse(input);
   await db.transaction(async (tx) => {
-    const organization = await validatedDeletionTarget(tx, principal, parsed.confirmation, now);
+    const organization = await validatedDeletionTarget(tx, principal, parsed.confirmation);
     if (organization.deletionRequestedAt !== null) return;
     await tx
       .update(schema.organization)
@@ -188,7 +227,8 @@ export async function deleteOrganization(
       .where(eq(schema.organization.id, organization.id));
   });
   return await db.transaction(async (tx) => {
-    const organization = await validatedDeletionTarget(tx, principal, parsed.confirmation, now);
+    const organization = await validatedDeletionTarget(tx, principal, parsed.confirmation);
+    await assertDeletionReady(tx, organization, now);
     await tx
       .update(schema.session)
       .set({ activeOrganizationId: null })

--- a/packages/core/src/org/organization-deletion-service.ts
+++ b/packages/core/src/org/organization-deletion-service.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, db, desc, eq, gt, ne, schema, type Transaction } from '@orbit/db';
+import { and, asc, count, db, desc, eq, gt, isNull, ne, schema, type Transaction } from '@orbit/db';
 import {
   type StorageDriver,
   storageDriver,
@@ -27,6 +27,7 @@ export interface OrganizationDeletionSummary {
   readonly integrations: number;
   readonly webhooks: number;
   readonly availableAt: string | null;
+  readonly deletionRequestedAt: string | null;
 }
 
 export interface OrganizationDeletionResult {
@@ -91,7 +92,10 @@ export async function getOrganizationDeletionSummary(
 ): Promise<OrganizationDeletionSummary> {
   assertCan(principal, 'org:delete');
   const [organization] = await db
-    .select({ name: schema.organization.name })
+    .select({
+      name: schema.organization.name,
+      deletionRequestedAt: schema.organization.deletionRequestedAt,
+    })
     .from(schema.organization)
     .where(eq(schema.organization.id, principal.organizationId))
     .limit(1);
@@ -143,7 +147,28 @@ export async function getOrganizationDeletionSummary(
     integrations: totalOf(integrations),
     webhooks: totalOf(webhooks),
     availableAt: availableAt?.toISOString() ?? null,
+    deletionRequestedAt: current.deletionRequestedAt?.toISOString() ?? null,
   };
+}
+
+async function validatedDeletionTarget(
+  tx: Transaction,
+  principal: Principal,
+  confirmation: string,
+  now: Date,
+): Promise<typeof schema.organization.$inferSelect> {
+  const organization = await lockOrganization(tx, principal.organizationId);
+  await assertCurrentDeletionPermission(tx, principal);
+  if (confirmation !== organization.name) {
+    throw conflict('Type the current workspace name exactly to confirm deletion.');
+  }
+  const availableAt = await latestUploadProtectionEnd(tx, organization.id, now);
+  if (availableAt !== null) {
+    throw conflict('Wait for pending upload links to expire before deleting this workspace.', {
+      details: { availableAt: availableAt.toISOString() },
+    });
+  }
+  return organization;
 }
 
 export async function deleteOrganization(
@@ -154,19 +179,16 @@ export async function deleteOrganization(
 ): Promise<OrganizationDeletionResult> {
   assertCan(principal, 'org:delete');
   const parsed = organizationDeleteSchema.parse(input);
+  await db.transaction(async (tx) => {
+    const organization = await validatedDeletionTarget(tx, principal, parsed.confirmation, now);
+    if (organization.deletionRequestedAt !== null) return;
+    await tx
+      .update(schema.organization)
+      .set({ deletionRequestedAt: now })
+      .where(eq(schema.organization.id, organization.id));
+  });
   return await db.transaction(async (tx) => {
-    const organization = await lockOrganization(tx, principal.organizationId);
-    await assertCurrentDeletionPermission(tx, principal);
-    if (parsed.confirmation !== organization.name) {
-      throw conflict('Type the current workspace name exactly to confirm deletion.');
-    }
-    const availableAt = await latestUploadProtectionEnd(tx, organization.id, now);
-    if (availableAt !== null) {
-      throw conflict('Wait for pending upload links to expire before deleting this workspace.', {
-        details: { availableAt: availableAt.toISOString() },
-      });
-    }
-    await driver.deletePrefix(storagePrefixFor(organization.id));
+    const organization = await validatedDeletionTarget(tx, principal, parsed.confirmation, now);
     await tx
       .update(schema.session)
       .set({ activeOrganizationId: null })
@@ -179,11 +201,13 @@ export async function deleteOrganization(
         and(
           eq(schema.member.userId, principal.userId),
           ne(schema.member.organizationId, organization.id),
+          isNull(schema.organization.deletionRequestedAt),
         ),
       )
       .orderBy(asc(schema.organization.name), asc(schema.organization.id))
       .limit(1);
     await tx.delete(schema.organization).where(eq(schema.organization.id, organization.id));
+    await driver.deletePrefix(storagePrefixFor(organization.id));
     return {
       deletedOrganizationId: organization.id,
       deletedOrganizationName: organization.name,

--- a/packages/core/src/org/organization-deletion-service.ts
+++ b/packages/core/src/org/organization-deletion-service.ts
@@ -16,6 +16,8 @@ export interface OrganizationDeletionSummary {
   readonly documents: number;
   readonly files: number;
   readonly fileBytes: number;
+  readonly fileVersions: number;
+  readonly fileVersionBytes: number;
   readonly integrations: number;
   readonly webhooks: number;
   readonly availableAt: string | null;
@@ -104,6 +106,8 @@ export async function getOrganizationDeletionSummary(
     documents: totalOf(documents),
     files: stored.objects,
     fileBytes: stored.bytes,
+    fileVersions: stored.versions,
+    fileVersionBytes: stored.versionBytes,
     integrations: totalOf(integrations),
     webhooks: totalOf(webhooks),
     availableAt: availableAt?.toISOString() ?? null,

--- a/packages/core/src/org/organization-lock.ts
+++ b/packages/core/src/org/organization-lock.ts
@@ -1,0 +1,15 @@
+import { eq, schema, type Transaction } from '@orbit/db';
+import { requireRow } from '../internal.ts';
+
+export async function lockOrganization(
+  executor: Transaction,
+  organizationId: string,
+): Promise<typeof schema.organization.$inferSelect> {
+  const [organization] = await executor
+    .select()
+    .from(schema.organization)
+    .where(eq(schema.organization.id, organizationId))
+    .limit(1)
+    .for('update');
+  return requireRow(organization, 'That workspace does not exist.');
+}

--- a/packages/core/src/org/organization-service.ts
+++ b/packages/core/src/org/organization-service.ts
@@ -1,4 +1,4 @@
-import { and, asc, db, eq, schema } from '@orbit/db';
+import { and, asc, db, eq, isNull, or, schema } from '@orbit/db';
 import { conflict, forbidden } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
@@ -199,12 +199,17 @@ export async function getOrganization(organizationId: string): Promise<Organizat
 
 export async function listOrganizationsForUser(
   userId: string,
+  options: { readonly includeDeletingForAdmins?: boolean } = {},
 ): Promise<{ organization: OrganizationRow; role: string }[]> {
+  const visibleOrganization =
+    options.includeDeletingForAdmins === true
+      ? or(isNull(schema.organization.deletionRequestedAt), eq(schema.member.role, 'admin'))
+      : isNull(schema.organization.deletionRequestedAt);
   const rows = await db
     .select({ organization: schema.organization, role: schema.member.role })
     .from(schema.member)
     .innerJoin(schema.organization, eq(schema.organization.id, schema.member.organizationId))
-    .where(eq(schema.member.userId, userId))
+    .where(and(eq(schema.member.userId, userId), visibleOrganization))
     .orderBy(asc(schema.organization.name));
   return rows;
 }

--- a/packages/core/src/realtime/publisher.ts
+++ b/packages/core/src/realtime/publisher.ts
@@ -66,6 +66,13 @@ export async function publishSessionRevoked(userId: string): Promise<void> {
   await redis.publish(REDIS_CONTROL_CHANNEL, JSON.stringify(message));
 }
 
+export async function publishOrganizationDeleted(organizationId: string): Promise<void> {
+  const redis = connection();
+  if (redis === null) return;
+  const message: ControlMessage = { type: 'organization_deleted', organizationId };
+  await redis.publish(REDIS_CONTROL_CHANNEL, JSON.stringify(message));
+}
+
 export function closeRealtime(): Promise<void> {
   const open = client;
   client = null;

--- a/packages/core/tests/content/attachment-service.test.ts
+++ b/packages/core/tests/content/attachment-service.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 import { db, eq, schema } from '@orbit/db';
 import type { StorageDriver, StoredObject } from '@orbit/services/storage';
 import type { Principal } from '@orbit/shared/policy';
+import postgres from 'postgres';
 import {
   type AttachmentRecord,
   attachFile,
@@ -35,21 +36,25 @@ interface FakeStorage {
   readonly deletes: string[];
 }
 
-function fakeStorage(): FakeStorage {
+function fakeStorage(
+  options: { readonly expiresAt?: string; readonly onCreateTarget?: () => void } = {},
+): FakeStorage {
   const puts: { key: string; bytes: number; contentType: string }[] = [];
   const deletes: string[] = [];
   const objects = new Map<string, StoredObject>();
   const driver = {
     name: 's3',
-    createUploadTarget: (key: string, contentType: string, contentLength: number) =>
-      Promise.resolve({
+    createUploadTarget: (key: string, contentType: string, contentLength: number) => {
+      options.onCreateTarget?.();
+      return Promise.resolve({
         key,
         url: `https://storage.test/${key}`,
         method: 'PUT',
         headers: { 'content-type': contentType },
         maxBytes: contentLength,
-        expiresAt: new Date(Date.now() + 60_000).toISOString(),
-      }),
+        expiresAt: options.expiresAt ?? new Date(Date.now() + 60_000).toISOString(),
+      });
+    },
     put: (key: string, body: Uint8Array, contentType: string) => {
       puts.push({ key, bytes: body.byteLength, contentType });
       objects.set(key, { key, size: body.byteLength, contentType, updatedAt: new Date() });
@@ -64,6 +69,34 @@ function fakeStorage(): FakeStorage {
     stat: (key: string) => Promise.resolve(objects.get(key) ?? null),
   } as unknown as StorageDriver;
   return { driver, puts, deletes };
+}
+
+function databaseUrl(): string {
+  const url = process.env['DATABASE_URL'];
+  if (url === undefined || url.length === 0) throw new Error('DATABASE_URL is required.');
+  return url;
+}
+
+function pause(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function waitForDatabaseLock(client: ReturnType<typeof postgres>): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = await client<{ waiting: number }[]>`
+      select count(*)::int as waiting
+      from pg_stat_activity
+      where datname = current_database()
+        and pid <> pg_backend_pid()
+        and wait_event_type = 'Lock'
+    `;
+    if ((rows[0]?.waiting ?? 0) > 0) return;
+    await pause(10);
+  }
+  throw new Error('The upload did not wait for the organization row lock.');
 }
 
 beforeEach(async () => {
@@ -234,6 +267,7 @@ describe('registerUpload', () => {
     expect(registered.attachment.parentType).toBe('comment');
     expect(registered.attachment.parentId).toBe(commentId);
     expect(registered.attachment.status).toBe('pending');
+    expect(registered.attachment.uploadExpiresAt?.toISOString()).toBe(registered.upload.expiresAt);
     expect(registered.upload.method).toBe('PUT');
     expect(registered.actions[0]?.scopes).toEqual([`issue:${issueId}`]);
   });
@@ -266,6 +300,41 @@ describe('registerUpload', () => {
         ),
       ),
     ).toEqual({ code: 'not_found', status: 404 });
+  });
+
+  it('waits for the organization lock before creating an upload target', async () => {
+    const client = postgres(databaseUrl(), { max: 1, idle_timeout: 5, onnotice: () => undefined });
+    let announceTarget: (() => void) | undefined;
+    const targetCreated = new Promise<void>((resolve) => {
+      announceTarget = resolve;
+    });
+    const storage = fakeStorage({ onCreateTarget: () => announceTarget?.() });
+    await client.unsafe('begin');
+    await client`select id from organization where id = ${nova.organizationId} for update`;
+    const registration = registerUpload(
+      nova.admin,
+      {
+        fileName: 'trace.log',
+        contentType: 'text/plain',
+        size: 12,
+        parentType: 'comment',
+        parentId: commentId,
+      },
+      storage.driver,
+    );
+    try {
+      const first = await Promise.race([
+        targetCreated.then(() => 'target' as const),
+        waitForDatabaseLock(client).then(() => 'lock' as const),
+      ]);
+      expect(first).toBe('lock');
+      await client.unsafe('commit');
+      expect((await registration).attachment.status).toBe('pending');
+    } finally {
+      await client.unsafe('rollback').catch(() => undefined);
+      await registration.catch(() => undefined);
+      await client.end();
+    }
   });
 });
 
@@ -333,6 +402,7 @@ describe('attachFile', () => {
     expect(storage.puts[0]?.bytes).toBe(11);
     expect(stored.attachment.size).toBe(11);
     expect(stored.attachment.status).toBe('ready');
+    expect(stored.attachment.uploadExpiresAt).toBeNull();
     expect(stored.url).toBe(`/api/files/${stored.attachment.storageKey}`);
     expect(stored.actions[0]?.scopes).toEqual([`issue:${issueId}`]);
   });

--- a/packages/core/tests/content/attachment-service.test.ts
+++ b/packages/core/tests/content/attachment-service.test.ts
@@ -249,6 +249,30 @@ describe('markAttachmentReady', () => {
 });
 
 describe('registerUpload', () => {
+  it('does not mint a storage target after workspace deletion enters its retry state', async () => {
+    await db
+      .update(schema.organization)
+      .set({ deletionRequestedAt: new Date() })
+      .where(eq(schema.organization.id, nova.organizationId));
+    let targetCreated = false;
+    const storage = fakeStorage({ onCreateTarget: () => (targetCreated = true) });
+
+    await expect(
+      registerUpload(
+        nova.admin,
+        {
+          fileName: 'trace.log',
+          contentType: 'text/plain',
+          size: 12,
+          parentType: 'comment',
+          parentId: commentId,
+        },
+        storage.driver,
+      ),
+    ).rejects.toMatchObject({ code: 'conflict' });
+    expect(targetCreated).toBe(false);
+  });
+
   it('registers a comment upload and publishes it on the issue of that comment', async () => {
     const storage = fakeStorage();
 
@@ -383,6 +407,29 @@ describe('finishUpload', () => {
 });
 
 describe('attachFile', () => {
+  it('does not store inline bytes after workspace deletion enters its retry state', async () => {
+    await db
+      .update(schema.organization)
+      .set({ deletionRequestedAt: new Date() })
+      .where(eq(schema.organization.id, nova.organizationId));
+    const storage = fakeStorage();
+
+    await expect(
+      attachFile(
+        nova.admin,
+        {
+          parentType: 'comment',
+          parentId: commentId,
+          fileName: 'notes.txt',
+          contentType: 'text/plain',
+          content: Buffer.from('hello orbit').toString('base64'),
+        },
+        storage.driver,
+      ),
+    ).rejects.toMatchObject({ code: 'conflict' });
+    expect(storage.puts).toHaveLength(0);
+  });
+
   it('stores the decoded bytes and returns a url that serves them back', async () => {
     const storage = fakeStorage();
 

--- a/packages/core/tests/content/doc-service.test.ts
+++ b/packages/core/tests/content/doc-service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
+import { db, eq, schema } from '@orbit/db';
 import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
 import { DOC_CONTENT_LIMIT, DOC_TITLE_LIMIT } from '@orbit/shared/validators';
@@ -293,6 +294,20 @@ describe('published doc urls', () => {
 });
 
 describe('visibility modes', () => {
+  it('hides public pages and sitemap entries while workspace deletion is pending', async () => {
+    const open = await newDoc('Open notes');
+    const published = await shareDoc(workspace.admin, open.id, { visibility: 'public' });
+    const token = published.publishToken;
+    if (token === null) throw new Error('expected a token');
+    await db
+      .update(schema.organization)
+      .set({ deletionRequestedAt: new Date() })
+      .where(eq(schema.organization.id, workspace.organizationId));
+
+    expect(await getPublishedDoc(token)).toBeNull();
+    expect((await listPublicDocs()).some((row) => row.id === open.id)).toBe(false);
+  });
+
   it('lists a public doc in the sitemap feed and never an unlisted one', async () => {
     const open = await newDoc('Open notes');
     const unlisted = await newDoc('Quiet notes');

--- a/packages/core/tests/org/invite-service.test.ts
+++ b/packages/core/tests/org/invite-service.test.ts
@@ -7,6 +7,7 @@ import {
   createInvites,
   listPendingInvites,
   matchAllowedDomain,
+  pendingInvitesForEmail,
   resendInvite,
   revokeInvite,
 } from '../../src/org/invite-service.ts';
@@ -87,6 +88,23 @@ describe('acceptInvite', () => {
       .from(schema.invitation)
       .where(eq(schema.invitation.id, token));
     expect(invitation?.status).toBe('accepted');
+  });
+
+  it('rejects acceptance and hides pending invites while deletion is pending', async () => {
+    const invited = await createUser('Ivy Invitee');
+    const { token } = await createInvite(workspace.admin, { email: invited.email });
+    await db
+      .update(schema.organization)
+      .set({ deletionRequestedAt: new Date() })
+      .where(eq(schema.organization.id, workspace.organizationId));
+
+    expect(await pendingInvitesForEmail(invited.email)).toEqual([]);
+    await expect(acceptInvite(token, invited.id)).rejects.toMatchObject({ code: 'conflict' });
+    const memberships = await db
+      .select()
+      .from(schema.member)
+      .where(eq(schema.member.userId, invited.id));
+    expect(memberships).toEqual([]);
   });
 
   it('is idempotent when the token is used twice', async () => {

--- a/packages/core/tests/org/member-service.test.ts
+++ b/packages/core/tests/org/member-service.test.ts
@@ -47,6 +47,17 @@ describe('resolvePrincipal', () => {
       resolvePrincipal(outsider.user.id, workspace.organizationId),
     ).rejects.toMatchObject({ code: 'forbidden' });
   });
+
+  it('refuses normal access while workspace deletion is pending', async () => {
+    await db
+      .update(schema.organization)
+      .set({ deletionRequestedAt: new Date() })
+      .where(eq(schema.organization.id, workspace.organizationId));
+
+    await expect(
+      resolvePrincipal(workspace.admin.userId, workspace.organizationId),
+    ).rejects.toMatchObject({ code: 'forbidden' });
+  });
 });
 
 describe('listMembers', () => {

--- a/packages/core/tests/org/organization-deletion-service.test.ts
+++ b/packages/core/tests/org/organization-deletion-service.test.ts
@@ -1,0 +1,475 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { and, count, db, eq, schema } from '@orbit/db';
+import type { StorageDriver, StoragePrefixSummary } from '@orbit/services/storage';
+import { internal } from '@orbit/shared/errors';
+import type { Principal } from '@orbit/shared/policy';
+import postgres from 'postgres';
+import { registerUpload } from '../../src/content/attachment-service.ts';
+import { createDoc } from '../../src/content/doc-service.ts';
+import * as core from '../../src/index.ts';
+import { newId } from '../../src/internal.ts';
+import {
+  addMember,
+  createWorkspace,
+  resetDatabase,
+  type Workspace,
+} from '../../src/test-support.ts';
+import { createIssue } from '../../src/work/issue-service.ts';
+import { createProject } from '../../src/work/project-service.ts';
+
+interface DeletionSummary {
+  readonly organizationName: string;
+  readonly members: number;
+  readonly teams: number;
+  readonly projects: number;
+  readonly issues: number;
+  readonly documents: number;
+  readonly files: number;
+  readonly fileBytes: number;
+  readonly integrations: number;
+  readonly webhooks: number;
+  readonly availableAt: string | null;
+}
+
+interface DeletionResult {
+  readonly deletedOrganizationId: string;
+  readonly deletedOrganizationName: string;
+  readonly nextOrganizationId: string | null;
+}
+
+const expectedCore = core as typeof core & {
+  readonly getOrganizationDeletionSummary: (
+    principal: Principal,
+    driver: StorageDriver,
+    now?: Date,
+  ) => Promise<DeletionSummary>;
+  readonly deleteOrganization: (
+    principal: Principal,
+    input: unknown,
+    driver: StorageDriver,
+    now?: Date,
+  ) => Promise<DeletionResult>;
+};
+const { deleteOrganization, getOrganizationDeletionSummary } = expectedCore;
+
+interface FakeStorage {
+  readonly driver: StorageDriver;
+  readonly summarized: string[];
+  readonly deleted: string[];
+}
+
+function fakeStorage(
+  summary: StoragePrefixSummary = { objects: 0, bytes: 0 },
+  deleteError: Error | null = null,
+): FakeStorage {
+  const summarized: string[] = [];
+  const deleted: string[] = [];
+  const driver = {
+    name: 's3',
+    createUploadTarget: () => Promise.reject(new Error('unused')),
+    put: () => Promise.reject(new Error('unused')),
+    getUrl: () => Promise.reject(new Error('unused')),
+    delete: () => Promise.reject(new Error('unused')),
+    stat: () => Promise.reject(new Error('unused')),
+    summarizePrefix: (prefix: string) => {
+      summarized.push(prefix);
+      return Promise.resolve(summary);
+    },
+    deletePrefix: (prefix: string) => {
+      deleted.push(prefix);
+      return deleteError === null ? Promise.resolve() : Promise.reject(deleteError);
+    },
+  } as unknown as StorageDriver;
+  return { driver, summarized, deleted };
+}
+
+let nova: Workspace;
+let orion: Workspace;
+
+beforeEach(async () => {
+  await resetDatabase();
+  nova = await createWorkspace('Nova');
+  orion = await createWorkspace('Orion');
+});
+
+async function seedDeletionInventory(): Promise<void> {
+  await addMember(nova, 'member', { name: 'Mira Member' });
+  await createProject(nova.admin, { name: 'Roadmap', teamIds: [nova.teamId] });
+  await createIssue(nova.admin, { teamId: nova.teamId, title: 'First issue' });
+  await createIssue(nova.admin, { teamId: nova.teamId, title: 'Second issue' });
+  await createDoc(nova.admin, { title: 'Workspace handbook' });
+  await db.insert(schema.integration).values({
+    id: newId(),
+    organizationId: nova.organizationId,
+    provider: 'slack',
+    externalId: 'team_nova',
+    connectedById: nova.adminUser.id,
+  });
+  await db.insert(schema.webhook).values({
+    id: newId(),
+    organizationId: nova.organizationId,
+    url: 'https://hooks.example/nova',
+    secret: 'secret',
+    createdById: nova.adminUser.id,
+  });
+  await createIssue(orion.admin, { teamId: orion.teamId, title: 'Neighbor issue' });
+  await createIssue(orion.admin, { teamId: orion.teamId, title: 'Neighbor issue two' });
+  await createIssue(orion.admin, { teamId: orion.teamId, title: 'Neighbor issue three' });
+}
+
+async function organizationCount(organizationId: string): Promise<number> {
+  const [row] = await db
+    .select({ total: count() })
+    .from(schema.organization)
+    .where(eq(schema.organization.id, organizationId));
+  return row?.total ?? 0;
+}
+
+function databaseUrl(): string {
+  const url = process.env['DATABASE_URL'];
+  if (url === undefined || url.length === 0) throw new Error('DATABASE_URL is required.');
+  return url;
+}
+
+function pause(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function waitForDatabaseLock(client: ReturnType<typeof postgres>): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = await client<{ waiting: number }[]>`
+      select count(*)::int as waiting
+      from pg_stat_activity
+      where datname = current_database()
+        and pid <> pg_backend_pid()
+        and wait_event_type = 'Lock'
+    `;
+    if ((rows[0]?.waiting ?? 0) > 0) return;
+    await pause(10);
+  }
+  throw new Error('The upload did not wait for workspace deletion.');
+}
+
+describe('getOrganizationDeletionSummary', () => {
+  it('reports categorized tenant counts and the actual storage prefix inventory', async () => {
+    await seedDeletionInventory();
+    const storage = fakeStorage({ objects: 3, bytes: 3_072 });
+
+    const summary = await getOrganizationDeletionSummary(nova.admin, storage.driver);
+
+    expect(summary).toEqual({
+      organizationName: 'Nova',
+      members: 2,
+      teams: 1,
+      projects: 1,
+      issues: 2,
+      documents: 1,
+      files: 3,
+      fileBytes: 3_072,
+      integrations: 1,
+      webhooks: 1,
+      availableAt: null,
+    });
+    expect(storage.summarized).toEqual([`${nova.organizationId}/`]);
+  });
+
+  it('refuses non-administrators before reading storage', async () => {
+    const member = await addMember(nova, 'member');
+    const storage = fakeStorage({ objects: 9, bytes: 99 });
+
+    await expect(
+      getOrganizationDeletionSummary(member.principal, storage.driver),
+    ).rejects.toMatchObject({ code: 'forbidden' });
+    expect(storage.summarized).toEqual([]);
+  });
+
+  it('reports the latest live presigned upload expiration', async () => {
+    const earlier = new Date('2026-08-08T12:10:00.000Z');
+    const later = new Date('2026-08-08T12:12:00.000Z');
+    await db.insert(schema.attachment).values([
+      {
+        id: newId(),
+        organizationId: nova.organizationId,
+        parentType: 'issue',
+        parentId: 'issue_1',
+        fileName: 'one.txt',
+        contentType: 'text/plain',
+        size: 1,
+        storageKey: `${nova.organizationId}/one.txt`,
+        status: 'pending',
+        uploadedById: nova.adminUser.id,
+        uploadExpiresAt: earlier,
+      },
+      {
+        id: newId(),
+        organizationId: nova.organizationId,
+        parentType: 'issue',
+        parentId: 'issue_2',
+        fileName: 'two.txt',
+        contentType: 'text/plain',
+        size: 1,
+        storageKey: `${nova.organizationId}/two.txt`,
+        status: 'pending',
+        uploadedById: nova.adminUser.id,
+        uploadExpiresAt: later,
+      },
+    ]);
+
+    const summary = await getOrganizationDeletionSummary(
+      nova.admin,
+      fakeStorage().driver,
+      new Date('2026-08-08T12:00:00.000Z'),
+    );
+
+    expect(summary.availableAt).toBe(later.toISOString());
+  });
+});
+
+describe('deleteOrganization', () => {
+  it('requires the current case-sensitive workspace name', async () => {
+    const storage = fakeStorage();
+
+    await expect(
+      deleteOrganization(nova.admin, { confirmation: 'nova' }, storage.driver),
+    ).rejects.toMatchObject({ code: 'conflict' });
+    expect(await organizationCount(nova.organizationId)).toBe(1);
+    expect(storage.deleted).toEqual([]);
+  });
+
+  it('refuses a confirmation captured before another administrator renamed the workspace', async () => {
+    await db
+      .update(schema.organization)
+      .set({ name: 'Nova Renamed' })
+      .where(eq(schema.organization.id, nova.organizationId));
+    const storage = fakeStorage();
+
+    await expect(
+      deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver),
+    ).rejects.toMatchObject({ code: 'conflict' });
+    expect(await organizationCount(nova.organizationId)).toBe(1);
+    expect(storage.deleted).toEqual([]);
+  });
+
+  it('blocks while a presigned target can still recreate the prefix', async () => {
+    const now = new Date('2026-08-08T12:00:00.000Z');
+    const availableAt = new Date('2026-08-08T12:01:00.000Z');
+    await db.insert(schema.attachment).values({
+      id: newId(),
+      organizationId: nova.organizationId,
+      parentType: 'issue',
+      parentId: 'issue_1',
+      fileName: 'pending.txt',
+      contentType: 'text/plain',
+      size: 1,
+      storageKey: `${nova.organizationId}/pending.txt`,
+      status: 'pending',
+      uploadedById: nova.adminUser.id,
+      uploadExpiresAt: availableAt,
+    });
+    const storage = fakeStorage();
+
+    await expect(
+      deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver, now),
+    ).rejects.toMatchObject({
+      code: 'conflict',
+      details: { availableAt: availableAt.toISOString() },
+    });
+    expect(storage.deleted).toEqual([]);
+  });
+
+  it('deletes the exact prefix and tenant rows while preserving shared people and sessions', async () => {
+    await seedDeletionInventory();
+    await db.insert(schema.member).values({
+      id: newId(),
+      organizationId: orion.organizationId,
+      userId: nova.adminUser.id,
+      role: 'member',
+    });
+    const sessionId = newId();
+    await db.insert(schema.session).values({
+      id: sessionId,
+      token: newId(),
+      userId: nova.adminUser.id,
+      activeOrganizationId: nova.organizationId,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const storage = fakeStorage({ objects: 4, bytes: 4_096 });
+
+    const result = await deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver);
+
+    expect(result).toEqual({
+      deletedOrganizationId: nova.organizationId,
+      deletedOrganizationName: 'Nova',
+      nextOrganizationId: orion.organizationId,
+    });
+    expect(storage.deleted).toEqual([`${nova.organizationId}/`]);
+    expect(await organizationCount(nova.organizationId)).toBe(0);
+    expect(await organizationCount(orion.organizationId)).toBe(1);
+    const [session] = await db
+      .select()
+      .from(schema.session)
+      .where(eq(schema.session.id, sessionId));
+    expect(session?.activeOrganizationId).toBeNull();
+    const [user] = await db
+      .select({ id: schema.user.id })
+      .from(schema.user)
+      .where(eq(schema.user.id, nova.adminUser.id));
+    expect(user?.id).toBe(nova.adminUser.id);
+    const [neighborIssues] = await db
+      .select({ total: count() })
+      .from(schema.issue)
+      .where(eq(schema.issue.organizationId, orion.organizationId));
+    expect(neighborIssues?.total).toBe(3);
+  });
+
+  it('rolls the database transaction back when storage cleanup fails', async () => {
+    const sessionId = newId();
+    await db.insert(schema.session).values({
+      id: sessionId,
+      token: newId(),
+      userId: nova.adminUser.id,
+      activeOrganizationId: nova.organizationId,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const storage = fakeStorage({ objects: 1, bytes: 12 }, internal('storage unavailable'));
+
+    await expect(
+      deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver),
+    ).rejects.toMatchObject({ code: 'internal' });
+
+    expect(await organizationCount(nova.organizationId)).toBe(1);
+    const [session] = await db
+      .select({ activeOrganizationId: schema.session.activeOrganizationId })
+      .from(schema.session)
+      .where(eq(schema.session.id, sessionId));
+    expect(session?.activeOrganizationId).toBe(nova.organizationId);
+  });
+
+  it('allows deletion at the exact upload-expiry boundary and returns no fallback', async () => {
+    const now = new Date('2026-08-08T12:00:00.000Z');
+    await db.insert(schema.attachment).values({
+      id: newId(),
+      organizationId: nova.organizationId,
+      parentType: 'issue',
+      parentId: 'issue_1',
+      fileName: 'expired.txt',
+      contentType: 'text/plain',
+      size: 1,
+      storageKey: `${nova.organizationId}/expired.txt`,
+      status: 'pending',
+      uploadedById: nova.adminUser.id,
+      uploadExpiresAt: now,
+    });
+
+    const result = await deleteOrganization(
+      nova.admin,
+      { confirmation: 'Nova' },
+      fakeStorage().driver,
+      now,
+    );
+
+    expect(result.nextOrganizationId).toBeNull();
+    expect(await organizationCount(nova.organizationId)).toBe(0);
+    const [attachment] = await db
+      .select({ id: schema.attachment.id })
+      .from(schema.attachment)
+      .where(
+        and(
+          eq(schema.attachment.organizationId, nova.organizationId),
+          eq(schema.attachment.fileName, 'expired.txt'),
+        ),
+      );
+    expect(attachment).toBeUndefined();
+  });
+
+  it('prevents a waiting upload from minting a target after deletion starts', async () => {
+    const { issue } = await createIssue(nova.admin, {
+      teamId: nova.teamId,
+      title: 'Upload race',
+    });
+    let announceDeletion: (() => void) | undefined;
+    let releaseDeletion: (() => void) | undefined;
+    const deletionStarted = new Promise<void>((resolve) => {
+      announceDeletion = resolve;
+    });
+    const deletionReleased = new Promise<void>((resolve) => {
+      releaseDeletion = resolve;
+    });
+    const deletionStorage = fakeStorage();
+    const blockingDeletionDriver = {
+      ...deletionStorage.driver,
+      deletePrefix: (prefix: string) => {
+        deletionStorage.deleted.push(prefix);
+        announceDeletion?.();
+        return deletionReleased;
+      },
+    } as StorageDriver;
+    let targetCreated = false;
+    const uploadDriver = {
+      ...fakeStorage().driver,
+      createUploadTarget: (key: string, contentType: string, contentLength: number) => {
+        targetCreated = true;
+        return Promise.resolve({
+          key,
+          url: `https://storage.example/${key}`,
+          method: 'PUT' as const,
+          headers: { 'content-type': contentType },
+          maxBytes: contentLength,
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        });
+      },
+    } as StorageDriver;
+    const challenger = postgres(databaseUrl(), {
+      max: 1,
+      idle_timeout: 5,
+      onnotice: () => undefined,
+    });
+    const monitor = postgres(databaseUrl(), {
+      max: 1,
+      idle_timeout: 5,
+      onnotice: () => undefined,
+    });
+    const deleting = deleteOrganization(
+      nova.admin,
+      { confirmation: 'Nova' },
+      blockingDeletionDriver,
+    );
+    await deletionStarted;
+    const competingLock = challenger`
+      select id from organization where id = ${nova.organizationId} for update
+    `;
+    const uploading = registerUpload(
+      nova.admin,
+      {
+        fileName: 'race.txt',
+        contentType: 'text/plain',
+        size: 4,
+        parentType: 'issue',
+        parentId: issue.id,
+      },
+      uploadDriver,
+    );
+    try {
+      const first = await Promise.race([
+        competingLock.then(() => 'acquired' as const),
+        waitForDatabaseLock(monitor).then(() => 'lock' as const),
+      ]);
+      expect(first).toBe('lock');
+      releaseDeletion?.();
+      await deleting;
+      await competingLock;
+      await expect(uploading).rejects.toMatchObject({ code: 'not_found' });
+      expect(targetCreated).toBe(false);
+    } finally {
+      releaseDeletion?.();
+      await deleting.catch(() => undefined);
+      await uploading.catch(() => undefined);
+      await competingLock.catch(() => undefined);
+      await challenger.end();
+      await monitor.end();
+    }
+  });
+});

--- a/packages/core/tests/org/organization-deletion-service.test.ts
+++ b/packages/core/tests/org/organization-deletion-service.test.ts
@@ -26,6 +26,8 @@ interface DeletionSummary {
   readonly documents: number;
   readonly files: number;
   readonly fileBytes: number;
+  readonly fileVersions: number;
+  readonly fileVersionBytes: number;
   readonly integrations: number;
   readonly webhooks: number;
   readonly availableAt: string | null;
@@ -59,7 +61,7 @@ interface FakeStorage {
 }
 
 function fakeStorage(
-  summary: StoragePrefixSummary = { objects: 0, bytes: 0 },
+  summary: StoragePrefixSummary = { objects: 0, bytes: 0, versions: 0, versionBytes: 0 },
   deleteError: Error | null = null,
 ): FakeStorage {
   const summarized: string[] = [];
@@ -156,7 +158,7 @@ async function waitForDatabaseLock(client: ReturnType<typeof postgres>): Promise
 describe('getOrganizationDeletionSummary', () => {
   it('reports categorized tenant counts and the actual storage prefix inventory', async () => {
     await seedDeletionInventory();
-    const storage = fakeStorage({ objects: 3, bytes: 3_072 });
+    const storage = fakeStorage({ objects: 3, bytes: 3_072, versions: 5, versionBytes: 4_096 });
 
     const summary = await getOrganizationDeletionSummary(nova.admin, storage.driver);
 
@@ -169,6 +171,8 @@ describe('getOrganizationDeletionSummary', () => {
       documents: 1,
       files: 3,
       fileBytes: 3_072,
+      fileVersions: 5,
+      fileVersionBytes: 4_096,
       integrations: 1,
       webhooks: 1,
       availableAt: null,
@@ -178,7 +182,7 @@ describe('getOrganizationDeletionSummary', () => {
 
   it('refuses non-administrators before reading storage', async () => {
     const member = await addMember(nova, 'member');
-    const storage = fakeStorage({ objects: 9, bytes: 99 });
+    const storage = fakeStorage({ objects: 9, bytes: 99, versions: 9, versionBytes: 99 });
 
     await expect(
       getOrganizationDeletionSummary(member.principal, storage.driver),
@@ -296,7 +300,12 @@ describe('deleteOrganization', () => {
       activeOrganizationId: nova.organizationId,
       expiresAt: new Date(Date.now() + 60_000),
     });
-    const storage = fakeStorage({ objects: 4, bytes: 4_096 });
+    const storage = fakeStorage({
+      objects: 4,
+      bytes: 4_096,
+      versions: 4,
+      versionBytes: 4_096,
+    });
 
     const result = await deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver);
 
@@ -334,7 +343,10 @@ describe('deleteOrganization', () => {
       activeOrganizationId: nova.organizationId,
       expiresAt: new Date(Date.now() + 60_000),
     });
-    const storage = fakeStorage({ objects: 1, bytes: 12 }, internal('storage unavailable'));
+    const storage = fakeStorage(
+      { objects: 1, bytes: 12, versions: 1, versionBytes: 12 },
+      internal('storage unavailable'),
+    );
 
     await expect(
       deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver),

--- a/packages/core/tests/org/organization-deletion-service.test.ts
+++ b/packages/core/tests/org/organization-deletion-service.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { and, count, db, eq, schema } from '@orbit/db';
-import type { StorageDriver, StoragePrefixSummary } from '@orbit/services/storage';
+import {
+  type StorageDriver,
+  type StoragePrefixSummary,
+  UPLOAD_COMPLETION_GRACE_SECONDS,
+} from '@orbit/services/storage';
 import { internal } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import postgres from 'postgres';
@@ -190,7 +194,7 @@ describe('getOrganizationDeletionSummary', () => {
     expect(storage.summarized).toEqual([]);
   });
 
-  it('reports the latest live presigned upload expiration', async () => {
+  it('reports the latest upload expiration plus its completion grace', async () => {
     const earlier = new Date('2026-08-08T12:10:00.000Z');
     const later = new Date('2026-08-08T12:12:00.000Z');
     await db.insert(schema.attachment).values([
@@ -228,7 +232,9 @@ describe('getOrganizationDeletionSummary', () => {
       new Date('2026-08-08T12:00:00.000Z'),
     );
 
-    expect(summary.availableAt).toBe(later.toISOString());
+    expect(summary.availableAt).toBe(
+      new Date(later.getTime() + UPLOAD_COMPLETION_GRACE_SECONDS * 1000).toISOString(),
+    );
   });
 });
 
@@ -257,9 +263,31 @@ describe('deleteOrganization', () => {
     expect(storage.deleted).toEqual([]);
   });
 
+  it('refuses a stale administrator principal after the member was demoted', async () => {
+    await db
+      .update(schema.member)
+      .set({ role: 'member' })
+      .where(
+        and(
+          eq(schema.member.organizationId, nova.organizationId),
+          eq(schema.member.userId, nova.admin.userId),
+        ),
+      );
+    const storage = fakeStorage();
+
+    await expect(
+      deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver),
+    ).rejects.toMatchObject({ code: 'forbidden' });
+    expect(await organizationCount(nova.organizationId)).toBe(1);
+    expect(storage.deleted).toEqual([]);
+  });
+
   it('blocks while a presigned target can still recreate the prefix', async () => {
     const now = new Date('2026-08-08T12:00:00.000Z');
-    const availableAt = new Date('2026-08-08T12:01:00.000Z');
+    const uploadExpiresAt = new Date('2026-08-08T12:01:00.000Z');
+    const availableAt = new Date(
+      uploadExpiresAt.getTime() + UPLOAD_COMPLETION_GRACE_SECONDS * 1000,
+    );
     await db.insert(schema.attachment).values({
       id: newId(),
       organizationId: nova.organizationId,
@@ -271,7 +299,7 @@ describe('deleteOrganization', () => {
       storageKey: `${nova.organizationId}/pending.txt`,
       status: 'pending',
       uploadedById: nova.adminUser.id,
-      uploadExpiresAt: availableAt,
+      uploadExpiresAt,
     });
     const storage = fakeStorage();
 
@@ -360,7 +388,7 @@ describe('deleteOrganization', () => {
     expect(session?.activeOrganizationId).toBe(nova.organizationId);
   });
 
-  it('allows deletion at the exact upload-expiry boundary and returns no fallback', async () => {
+  it('blocks at URL expiry while an upload may still be finishing', async () => {
     const now = new Date('2026-08-08T12:00:00.000Z');
     await db.insert(schema.attachment).values({
       id: newId(),
@@ -374,6 +402,34 @@ describe('deleteOrganization', () => {
       status: 'pending',
       uploadedById: nova.adminUser.id,
       uploadExpiresAt: now,
+    });
+
+    await expect(
+      deleteOrganization(nova.admin, { confirmation: 'Nova' }, fakeStorage().driver, now),
+    ).rejects.toMatchObject({
+      code: 'conflict',
+      details: {
+        availableAt: new Date(now.getTime() + UPLOAD_COMPLETION_GRACE_SECONDS * 1000).toISOString(),
+      },
+    });
+    expect(await organizationCount(nova.organizationId)).toBe(1);
+  });
+
+  it('allows deletion at the exact upload-completion boundary and returns no fallback', async () => {
+    const now = new Date('2026-08-08T12:15:00.000Z');
+    const uploadExpiresAt = new Date(now.getTime() - UPLOAD_COMPLETION_GRACE_SECONDS * 1000);
+    await db.insert(schema.attachment).values({
+      id: newId(),
+      organizationId: nova.organizationId,
+      parentType: 'issue',
+      parentId: 'issue_1',
+      fileName: 'expired.txt',
+      contentType: 'text/plain',
+      size: 1,
+      storageKey: `${nova.organizationId}/expired.txt`,
+      status: 'pending',
+      uploadedById: nova.adminUser.id,
+      uploadExpiresAt,
     });
 
     const result = await deleteOrganization(

--- a/packages/core/tests/org/organization-deletion-service.test.ts
+++ b/packages/core/tests/org/organization-deletion-service.test.ts
@@ -4,6 +4,7 @@ import {
   type StorageDriver,
   type StoragePrefixSummary,
   UPLOAD_COMPLETION_GRACE_SECONDS,
+  UPLOAD_URL_TTL_SECONDS,
 } from '@orbit/services/storage';
 import { internal } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
@@ -58,6 +59,7 @@ const expectedCore = core as typeof core & {
   ) => Promise<DeletionResult>;
 };
 const { deleteOrganization, getOrganizationDeletionSummary } = expectedCore;
+const deletionDrainMilliseconds = (UPLOAD_URL_TTL_SECONDS + UPLOAD_COMPLETION_GRACE_SECONDS) * 1000;
 
 interface FakeStorage {
   readonly driver: StorageDriver;
@@ -130,6 +132,13 @@ async function organizationCount(organizationId: string): Promise<number> {
     .from(schema.organization)
     .where(eq(schema.organization.id, organizationId));
   return row?.total ?? 0;
+}
+
+async function makeDeletionReady(organizationId: string, now: Date): Promise<void> {
+  await db
+    .update(schema.organization)
+    .set({ deletionRequestedAt: new Date(now.getTime() - deletionDrainMilliseconds) })
+    .where(eq(schema.organization.id, organizationId));
 }
 
 function databaseUrl(): string {
@@ -238,6 +247,24 @@ describe('getOrganizationDeletionSummary', () => {
       new Date(later.getTime() + UPLOAD_COMPLETION_GRACE_SECONDS * 1000).toISOString(),
     );
   });
+
+  it('reports the deletion request drain when it ends after tracked uploads', async () => {
+    const requestedAt = new Date('2026-08-08T12:00:00.000Z');
+    await db
+      .update(schema.organization)
+      .set({ deletionRequestedAt: requestedAt })
+      .where(eq(schema.organization.id, nova.organizationId));
+
+    const summary = await getOrganizationDeletionSummary(
+      nova.admin,
+      fakeStorage().driver,
+      requestedAt,
+    );
+
+    expect(summary.availableAt).toBe(
+      new Date(requestedAt.getTime() + deletionDrainMilliseconds).toISOString(),
+    );
+  });
 });
 
 describe('deleteOrganization', () => {
@@ -286,6 +313,7 @@ describe('deleteOrganization', () => {
 
   it('blocks while a presigned target can still recreate the prefix', async () => {
     const now = new Date('2026-08-08T12:00:00.000Z');
+    await makeDeletionReady(nova.organizationId, now);
     const uploadExpiresAt = new Date('2026-08-08T12:01:00.000Z');
     const availableAt = new Date(
       uploadExpiresAt.getTime() + UPLOAD_COMPLETION_GRACE_SECONDS * 1000,
@@ -314,6 +342,92 @@ describe('deleteOrganization', () => {
     expect(storage.deleted).toEqual([]);
   });
 
+  it('drains a presigned target whose attachment transaction failed', async () => {
+    const requestedAt = new Date('2026-08-08T12:00:00.000Z');
+    const availableAt = new Date(requestedAt.getTime() + deletionDrainMilliseconds);
+    const { issue } = await createIssue(nova.admin, {
+      teamId: nova.teamId,
+      title: 'Failed upload registration',
+    });
+    let targetCreated = false;
+    const uploadDriver = {
+      ...fakeStorage().driver,
+      createUploadTarget: (key: string, contentType: string, contentLength: number) => {
+        targetCreated = true;
+        return Promise.resolve({
+          key,
+          url: `https://storage.example/${key}`,
+          method: 'PUT' as const,
+          headers: { 'content-type': contentType },
+          maxBytes: contentLength,
+          expiresAt: new Date(requestedAt.getTime() + UPLOAD_URL_TTL_SECONDS * 1000).toISOString(),
+        });
+      },
+    } as StorageDriver;
+    await db.execute(sql`drop trigger if exists reject_attachment_registration on attachment`);
+    await db.execute(sql`
+      create or replace function reject_attachment_registration() returns trigger as $$
+      begin
+        raise exception 'attachment registration failed';
+      end;
+      $$ language plpgsql
+    `);
+    await db.execute(sql`
+      create trigger reject_attachment_registration
+      before insert on attachment
+      for each row execute function reject_attachment_registration()
+    `);
+    try {
+      await expect(
+        registerUpload(
+          nova.admin,
+          {
+            fileName: 'untracked.txt',
+            contentType: 'text/plain',
+            size: 4,
+            parentType: 'issue',
+            parentId: issue.id,
+          },
+          uploadDriver,
+        ),
+      ).rejects.toBeDefined();
+    } finally {
+      await db.execute(sql`drop trigger if exists reject_attachment_registration on attachment`);
+      await db.execute(sql`drop function if exists reject_attachment_registration()`);
+    }
+    const [untracked] = await db
+      .select({ total: count() })
+      .from(schema.attachment)
+      .where(eq(schema.attachment.organizationId, nova.organizationId));
+    expect(targetCreated).toBe(true);
+    expect(untracked?.total).toBe(0);
+    const storage = fakeStorage();
+
+    await expect(
+      deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver, requestedAt),
+    ).rejects.toMatchObject({
+      code: 'conflict',
+      details: { availableAt: availableAt.toISOString() },
+    });
+
+    const [pending] = await db
+      .select({ deletionRequestedAt: schema.organization.deletionRequestedAt })
+      .from(schema.organization)
+      .where(eq(schema.organization.id, nova.organizationId));
+    expect(pending?.deletionRequestedAt).toEqual(requestedAt);
+    expect(storage.deleted).toEqual([]);
+
+    const result = await deleteOrganization(
+      nova.admin,
+      { confirmation: 'Nova' },
+      storage.driver,
+      availableAt,
+    );
+
+    expect(result.deletedOrganizationId).toBe(nova.organizationId);
+    expect(storage.deleted).toEqual([`${nova.organizationId}/`]);
+  });
+
   it('deletes the exact prefix and tenant rows while preserving shared people and sessions', async () => {
     await seedDeletionInventory();
     await db.insert(schema.member).values({
@@ -336,8 +450,15 @@ describe('deleteOrganization', () => {
       versions: 4,
       versionBytes: 4_096,
     });
+    const now = new Date('2026-08-08T14:00:00.000Z');
+    await makeDeletionReady(nova.organizationId, now);
 
-    const result = await deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver);
+    const result = await deleteOrganization(
+      nova.admin,
+      { confirmation: 'Nova' },
+      storage.driver,
+      now,
+    );
 
     expect(result).toEqual({
       deletedOrganizationId: nova.organizationId,
@@ -366,6 +487,7 @@ describe('deleteOrganization', () => {
 
   it('keeps a durable retry state when storage cleanup fails', async () => {
     const now = new Date('2026-08-08T13:00:00.000Z');
+    const availableAt = new Date(now.getTime() + deletionDrainMilliseconds);
     const sessionId = newId();
     await db.insert(schema.session).values({
       id: sessionId,
@@ -381,6 +503,12 @@ describe('deleteOrganization', () => {
 
     await expect(
       deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver, now),
+    ).rejects.toMatchObject({
+      code: 'conflict',
+      details: { availableAt: availableAt.toISOString() },
+    });
+    await expect(
+      deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver, availableAt),
     ).rejects.toMatchObject({ code: 'internal' });
 
     expect(await organizationCount(nova.organizationId)).toBe(1);
@@ -400,7 +528,7 @@ describe('deleteOrganization', () => {
       nova.admin,
       { confirmation: 'Nova' },
       retryStorage.driver,
-      now,
+      availableAt,
     );
     expect(retried.deletedOrganizationId).toBe(nova.organizationId);
     expect(retryStorage.deleted).toEqual([`${nova.organizationId}/`]);
@@ -408,6 +536,8 @@ describe('deleteOrganization', () => {
   });
 
   it('finishes every fallible database mutation before deleting storage', async () => {
+    const now = new Date('2026-08-08T14:00:00.000Z');
+    await makeDeletionReady(nova.organizationId, now);
     await db.execute(sql`
       create table organization_deletion_test_blocker (
         organization_id text primary key references organization(id)
@@ -421,7 +551,7 @@ describe('deleteOrganization', () => {
       const storage = fakeStorage();
 
       await expect(
-        deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver),
+        deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver, now),
       ).rejects.toBeDefined();
 
       expect(storage.deleted).toEqual([]);
@@ -438,6 +568,7 @@ describe('deleteOrganization', () => {
 
   it('blocks at URL expiry while an upload may still be finishing', async () => {
     const now = new Date('2026-08-08T12:00:00.000Z');
+    await makeDeletionReady(nova.organizationId, now);
     await db.insert(schema.attachment).values({
       id: newId(),
       organizationId: nova.organizationId,
@@ -465,6 +596,7 @@ describe('deleteOrganization', () => {
 
   it('allows deletion at the exact upload-completion boundary and returns no fallback', async () => {
     const now = new Date('2026-08-08T12:15:00.000Z');
+    await makeDeletionReady(nova.organizationId, now);
     const uploadExpiresAt = new Date(now.getTime() - UPLOAD_COMPLETION_GRACE_SECONDS * 1000);
     await db.insert(schema.attachment).values({
       id: newId(),
@@ -502,6 +634,8 @@ describe('deleteOrganization', () => {
   });
 
   it('prevents a waiting upload from minting a target after deletion starts', async () => {
+    const now = new Date();
+    await makeDeletionReady(nova.organizationId, now);
     const { issue } = await createIssue(nova.admin, {
       teamId: nova.teamId,
       title: 'Upload race',
@@ -552,6 +686,7 @@ describe('deleteOrganization', () => {
       nova.admin,
       { confirmation: 'Nova' },
       blockingDeletionDriver,
+      now,
     );
     await deletionStarted;
     const competingLock = challenger`

--- a/packages/core/tests/org/organization-deletion-service.test.ts
+++ b/packages/core/tests/org/organization-deletion-service.test.ts
@@ -566,6 +566,53 @@ describe('deleteOrganization', () => {
     }
   });
 
+  it('keeps a retry state when the final database commit fails after storage cleanup', async () => {
+    const now = new Date('2026-08-08T15:00:00.000Z');
+    await makeDeletionReady(nova.organizationId, now);
+    await db.execute(sql`
+      create table organization_deletion_commit_blocker (
+        organization_id text primary key references organization(id)
+          deferrable initially deferred
+      )
+    `);
+    try {
+      await db.execute(sql`
+        insert into organization_deletion_commit_blocker (organization_id)
+        values (${nova.organizationId})
+      `);
+      const storage = fakeStorage();
+
+      await expect(
+        deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver, now),
+      ).rejects.toBeDefined();
+
+      expect(storage.deleted).toEqual([`${nova.organizationId}/`]);
+      expect(await organizationCount(nova.organizationId)).toBe(1);
+      const [organization] = await db
+        .select({ deletionRequestedAt: schema.organization.deletionRequestedAt })
+        .from(schema.organization)
+        .where(eq(schema.organization.id, nova.organizationId));
+      expect(organization?.deletionRequestedAt).toBeInstanceOf(Date);
+
+      await db.execute(sql`
+        delete from organization_deletion_commit_blocker
+        where organization_id = ${nova.organizationId}
+      `);
+
+      const retried = await deleteOrganization(
+        nova.admin,
+        { confirmation: 'Nova' },
+        storage.driver,
+        now,
+      );
+      expect(retried.deletedOrganizationId).toBe(nova.organizationId);
+      expect(storage.deleted).toEqual([`${nova.organizationId}/`, `${nova.organizationId}/`]);
+      expect(await organizationCount(nova.organizationId)).toBe(0);
+    } finally {
+      await db.execute(sql`drop table organization_deletion_commit_blocker`);
+    }
+  });
+
   it('blocks at URL expiry while an upload may still be finishing', async () => {
     const now = new Date('2026-08-08T12:00:00.000Z');
     await makeDeletionReady(nova.organizationId, now);

--- a/packages/core/tests/org/organization-deletion-service.test.ts
+++ b/packages/core/tests/org/organization-deletion-service.test.ts
@@ -153,22 +153,6 @@ function pause(ms: number): Promise<void> {
   });
 }
 
-async function waitForDatabaseLock(client: ReturnType<typeof postgres>): Promise<void> {
-  const deadline = Date.now() + 5_000;
-  while (Date.now() < deadline) {
-    const rows = await client<{ waiting: number }[]>`
-      select count(*)::int as waiting
-      from pg_stat_activity
-      where datname = current_database()
-        and pid <> pg_backend_pid()
-        and wait_event_type = 'Lock'
-    `;
-    if ((rows[0]?.waiting ?? 0) > 0) return;
-    await pause(10);
-  }
-  throw new Error('The upload did not wait for workspace deletion.');
-}
-
 describe('getOrganizationDeletionSummary', () => {
   it('reports categorized tenant counts and the actual storage prefix inventory', async () => {
     await seedDeletionInventory();
@@ -535,7 +519,7 @@ describe('deleteOrganization', () => {
     expect(await organizationCount(nova.organizationId)).toBe(0);
   });
 
-  it('finishes every fallible database mutation before deleting storage', async () => {
+  it('keeps a retry state when a final database statement fails after storage cleanup', async () => {
     const now = new Date('2026-08-08T14:00:00.000Z');
     await makeDeletionReady(nova.organizationId, now);
     await db.execute(sql`
@@ -554,13 +538,28 @@ describe('deleteOrganization', () => {
         deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver, now),
       ).rejects.toBeDefined();
 
-      expect(storage.deleted).toEqual([]);
+      expect(storage.deleted).toEqual([`${nova.organizationId}/`]);
       expect(await organizationCount(nova.organizationId)).toBe(1);
       const [organization] = await db
         .select({ deletionRequestedAt: schema.organization.deletionRequestedAt })
         .from(schema.organization)
         .where(eq(schema.organization.id, nova.organizationId));
       expect(organization?.deletionRequestedAt).toBeInstanceOf(Date);
+
+      await db.execute(sql`
+        delete from organization_deletion_test_blocker
+        where organization_id = ${nova.organizationId}
+      `);
+
+      const retried = await deleteOrganization(
+        nova.admin,
+        { confirmation: 'Nova' },
+        storage.driver,
+        now,
+      );
+      expect(retried.deletedOrganizationId).toBe(nova.organizationId);
+      expect(storage.deleted).toEqual([`${nova.organizationId}/`, `${nova.organizationId}/`]);
+      expect(await organizationCount(nova.organizationId)).toBe(0);
     } finally {
       await db.execute(sql`drop table organization_deletion_test_blocker`);
     }
@@ -724,11 +723,6 @@ describe('deleteOrganization', () => {
       idle_timeout: 5,
       onnotice: () => undefined,
     });
-    const monitor = postgres(databaseUrl(), {
-      max: 1,
-      idle_timeout: 5,
-      onnotice: () => undefined,
-    });
     const deleting = deleteOrganization(
       nova.admin,
       { confirmation: 'Nova' },
@@ -749,17 +743,23 @@ describe('deleteOrganization', () => {
         parentId: issue.id,
       },
       uploadDriver,
+    ).then(
+      () => ({ status: 'fulfilled' as const }),
+      (error: unknown) => ({ error, status: 'rejected' as const }),
     );
     try {
       const first = await Promise.race([
         competingLock.then(() => 'acquired' as const),
-        waitForDatabaseLock(monitor).then(() => 'lock' as const),
+        pause(1_000).then(() => 'timeout' as const),
       ]);
-      expect(first).toBe('lock');
+      expect(first).toBe('acquired');
       releaseDeletion?.();
       await deleting;
       await competingLock;
-      await expect(uploading).rejects.toMatchObject({ code: 'not_found' });
+      expect(await uploading).toMatchObject({
+        error: { code: 'conflict' },
+        status: 'rejected',
+      });
       expect(targetCreated).toBe(false);
     } finally {
       releaseDeletion?.();
@@ -767,7 +767,6 @@ describe('deleteOrganization', () => {
       await uploading.catch(() => undefined);
       await competingLock.catch(() => undefined);
       await challenger.end();
-      await monitor.end();
     }
   });
 });

--- a/packages/core/tests/org/organization-deletion-service.test.ts
+++ b/packages/core/tests/org/organization-deletion-service.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import { and, count, db, eq, schema } from '@orbit/db';
+import { and, count, db, eq, schema, sql } from '@orbit/db';
 import {
   type StorageDriver,
   type StoragePrefixSummary,
@@ -35,6 +35,7 @@ interface DeletionSummary {
   readonly integrations: number;
   readonly webhooks: number;
   readonly availableAt: string | null;
+  readonly deletionRequestedAt: string | null;
 }
 
 interface DeletionResult {
@@ -180,6 +181,7 @@ describe('getOrganizationDeletionSummary', () => {
       integrations: 1,
       webhooks: 1,
       availableAt: null,
+      deletionRequestedAt: null,
     });
     expect(storage.summarized).toEqual([`${nova.organizationId}/`]);
   });
@@ -362,7 +364,8 @@ describe('deleteOrganization', () => {
     expect(neighborIssues?.total).toBe(3);
   });
 
-  it('rolls the database transaction back when storage cleanup fails', async () => {
+  it('keeps a durable retry state when storage cleanup fails', async () => {
+    const now = new Date('2026-08-08T13:00:00.000Z');
     const sessionId = newId();
     await db.insert(schema.session).values({
       id: sessionId,
@@ -377,7 +380,7 @@ describe('deleteOrganization', () => {
     );
 
     await expect(
-      deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver),
+      deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver, now),
     ).rejects.toMatchObject({ code: 'internal' });
 
     expect(await organizationCount(nova.organizationId)).toBe(1);
@@ -386,6 +389,51 @@ describe('deleteOrganization', () => {
       .from(schema.session)
       .where(eq(schema.session.id, sessionId));
     expect(session?.activeOrganizationId).toBe(nova.organizationId);
+    const [organization] = await db
+      .select({ deletionRequestedAt: schema.organization.deletionRequestedAt })
+      .from(schema.organization)
+      .where(eq(schema.organization.id, nova.organizationId));
+    expect(organization?.deletionRequestedAt).toEqual(now);
+
+    const retryStorage = fakeStorage();
+    const retried = await deleteOrganization(
+      nova.admin,
+      { confirmation: 'Nova' },
+      retryStorage.driver,
+      now,
+    );
+    expect(retried.deletedOrganizationId).toBe(nova.organizationId);
+    expect(retryStorage.deleted).toEqual([`${nova.organizationId}/`]);
+    expect(await organizationCount(nova.organizationId)).toBe(0);
+  });
+
+  it('finishes every fallible database mutation before deleting storage', async () => {
+    await db.execute(sql`
+      create table organization_deletion_test_blocker (
+        organization_id text primary key references organization(id)
+      )
+    `);
+    try {
+      await db.execute(sql`
+        insert into organization_deletion_test_blocker (organization_id)
+        values (${nova.organizationId})
+      `);
+      const storage = fakeStorage();
+
+      await expect(
+        deleteOrganization(nova.admin, { confirmation: 'Nova' }, storage.driver),
+      ).rejects.toBeDefined();
+
+      expect(storage.deleted).toEqual([]);
+      expect(await organizationCount(nova.organizationId)).toBe(1);
+      const [organization] = await db
+        .select({ deletionRequestedAt: schema.organization.deletionRequestedAt })
+        .from(schema.organization)
+        .where(eq(schema.organization.id, nova.organizationId));
+      expect(organization?.deletionRequestedAt).toBeInstanceOf(Date);
+    } finally {
+      await db.execute(sql`drop table organization_deletion_test_blocker`);
+    }
   });
 
   it('blocks at URL expiry while an upload may still be finishing', async () => {

--- a/packages/core/tests/org/organization-service.test.ts
+++ b/packages/core/tests/org/organization-service.test.ts
@@ -107,6 +107,37 @@ describe('listOrganizationsForUser', () => {
     const theirs = await listOrganizationsForUser(stranger.id);
     expect(theirs.map((row) => row.organization.slug)).toEqual(['quasar']);
   });
+
+  it('hides a pending deletion except from an administrator retry listing', async () => {
+    const user = await createUser('Nia New');
+    const active = await createOrganization(user.id, { name: 'Comet', slug: 'comet' });
+    const deleting = await createOrganization(user.id, { name: 'Nebula', slug: 'nebula' });
+    const member = await createUser('Mira Member');
+    await db.insert(schema.member).values({
+      id: 'member_pending_workspace',
+      organizationId: deleting.organization.id,
+      userId: member.id,
+      role: 'member',
+    });
+    await db
+      .update(schema.organization)
+      .set({ deletionRequestedAt: new Date() })
+      .where(eq(schema.organization.id, deleting.organization.id));
+
+    const mine = await listOrganizationsForUser(user.id);
+    const retryable = await listOrganizationsForUser(user.id, {
+      includeDeletingForAdmins: true,
+    });
+    const memberRetryable = await listOrganizationsForUser(member.id, {
+      includeDeletingForAdmins: true,
+    });
+
+    expect(mine.map((row) => row.organization.id)).toEqual([active.organization.id]);
+    expect(retryable.map((row) => row.organization.id).sort()).toEqual(
+      [active.organization.id, deleting.organization.id].sort(),
+    );
+    expect(memberRetryable).toEqual([]);
+  });
 });
 
 describe('teams', () => {

--- a/packages/core/tests/realtime/publisher.test.ts
+++ b/packages/core/tests/realtime/publisher.test.ts
@@ -1,6 +1,41 @@
-import { describe, expect, it } from 'bun:test';
-import { scopes, syncActionSchema } from '@orbit/shared/events';
-import { buildSyncAction, publishDeltas } from '../../src/realtime/publisher.ts';
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { REDIS_CONTROL_CHANNEL, scopes, syncActionSchema } from '@orbit/shared/events';
+
+class FakeRedis {
+  static readonly published: { channel: string; message: string }[] = [];
+
+  on(): this {
+    return this;
+  }
+
+  publish(channel: string, message: string): Promise<number> {
+    FakeRedis.published.push({ channel, message });
+    return Promise.resolve(1);
+  }
+
+  disconnect(): void {
+    FakeRedis.published.splice(0);
+  }
+}
+
+const previousRedisUrl = process.env['REDIS_URL'];
+process.env['REDIS_URL'] = 'redis://fake:6379';
+mock.module('ioredis', () => ({ Redis: FakeRedis }));
+
+const { buildSyncAction, closeRealtime, publishDeltas, publishOrganizationDeleted } = await import(
+  '../../src/realtime/publisher.ts'
+);
+
+beforeEach(async () => {
+  await closeRealtime();
+  FakeRedis.published.length = 0;
+});
+
+afterAll(async () => {
+  await closeRealtime();
+  if (previousRedisUrl === undefined) delete process.env['REDIS_URL'];
+  else process.env['REDIS_URL'] = previousRedisUrl;
+});
 
 describe('buildSyncAction', () => {
   it('stamps an ISO timestamp, dedupes scopes, and matches the shared contract', () => {
@@ -54,8 +89,34 @@ describe('buildSyncAction', () => {
 });
 
 describe('publishDeltas', () => {
-  it('is a no op when there is nothing to publish or no redis configured', async () => {
+  it('is a no op when there is nothing to publish', async () => {
     await expect(publishDeltas([])).resolves.toBeUndefined();
+    expect(FakeRedis.published).toHaveLength(0);
+  });
+
+  it('is a no op when redis is not configured', async () => {
+    await closeRealtime();
+    delete process.env['REDIS_URL'];
+    try {
+      await publishDeltas([
+        buildSyncAction({
+          syncId: 1,
+          organizationId: 'org_1',
+          scopes: [scopes.organization('org_1')],
+          action: 'insert',
+          model: 'issue',
+          modelId: 'issue_1',
+          data: {},
+          actor: { type: 'system', id: 'system' },
+        }),
+      ]);
+      expect(FakeRedis.published).toHaveLength(0);
+    } finally {
+      process.env['REDIS_URL'] = 'redis://fake:6379';
+    }
+  });
+
+  it('publishes actions when redis is configured', async () => {
     await expect(
       publishDeltas([
         buildSyncAction({
@@ -70,5 +131,22 @@ describe('publishDeltas', () => {
         }),
       ]),
     ).resolves.toBeUndefined();
+    expect(FakeRedis.published).toHaveLength(1);
+  });
+});
+
+describe('publishOrganizationDeleted', () => {
+  it('publishes a validated organization deletion control message', async () => {
+    await publishOrganizationDeleted('org_deleted');
+
+    expect(FakeRedis.published).toEqual([
+      {
+        channel: REDIS_CONTROL_CHANNEL,
+        message: JSON.stringify({
+          type: 'organization_deleted',
+          organizationId: 'org_deleted',
+        }),
+      },
+    ]);
   });
 });

--- a/packages/core/tests/realtime/publisher.test.ts
+++ b/packages/core/tests/realtime/publisher.test.ts
@@ -19,6 +19,7 @@ class FakeRedis {
 }
 
 const previousRedisUrl = process.env['REDIS_URL'];
+const redisModule = await import('ioredis');
 process.env['REDIS_URL'] = 'redis://fake:6379';
 mock.module('ioredis', () => ({ Redis: FakeRedis }));
 
@@ -35,6 +36,7 @@ afterAll(async () => {
   await closeRealtime();
   if (previousRedisUrl === undefined) delete process.env['REDIS_URL'];
   else process.env['REDIS_URL'] = previousRedisUrl;
+  mock.module('ioredis', () => redisModule);
 });
 
 describe('buildSyncAction', () => {

--- a/packages/db/drizzle/0002_glossy_mister_sinister.sql
+++ b/packages/db/drizzle/0002_glossy_mister_sinister.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "attachment" ADD COLUMN "upload_expires_at" timestamp with time zone;
+--> statement-breakpoint
+UPDATE "attachment"
+SET "upload_expires_at" = "created_at" + interval '900 seconds';

--- a/packages/db/drizzle/0002_glossy_mister_sinister.sql
+++ b/packages/db/drizzle/0002_glossy_mister_sinister.sql
@@ -1,4 +1,4 @@
-ALTER TABLE "attachment" ADD COLUMN "upload_expires_at" timestamp with time zone;
+ALTER TABLE "attachment" ADD COLUMN "upload_expires_at" timestamp with time zone DEFAULT (now() + interval '900 seconds');
 --> statement-breakpoint
 UPDATE "attachment"
 SET "upload_expires_at" = "created_at" + interval '900 seconds';

--- a/packages/db/drizzle/0002_glossy_mister_sinister.sql
+++ b/packages/db/drizzle/0002_glossy_mister_sinister.sql
@@ -2,3 +2,5 @@ ALTER TABLE "attachment" ADD COLUMN "upload_expires_at" timestamp with time zone
 --> statement-breakpoint
 UPDATE "attachment"
 SET "upload_expires_at" = "created_at" + interval '900 seconds';
+--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN "deletion_requested_at" timestamp with time zone;

--- a/packages/db/drizzle/meta/0001_snapshot.json
+++ b/packages/db/drizzle/meta/0001_snapshot.json
@@ -6676,12 +6676,6 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
-        },
-        "deletion_requested_at": {
-          "name": "deletion_requested_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
         }
       },
       "indexes": {},

--- a/packages/db/drizzle/meta/0001_snapshot.json
+++ b/packages/db/drizzle/meta/0001_snapshot.json
@@ -6676,6 +6676,12 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
+        },
+        "deletion_requested_at": {
+          "name": "deletion_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {},

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -6683,6 +6683,12 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
+        },
+        "deletion_requested_at": {
+          "name": "deletion_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {},

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -3805,7 +3805,8 @@
           "name": "upload_expires_at",
           "type": "timestamp with time zone",
           "primaryKey": false,
-          "notNull": false
+          "notNull": false,
+          "default": "now() + interval '900 seconds'"
         },
         "uploaded_by_id": {
           "name": "uploaded_by_id",

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,11019 @@
+{
+  "id": "b61bb92f-189c-458b-b951-9bae6cc70498",
+  "prevId": "54b93c00-3e53-4506-9898-ad562d469860",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_unique": {
+          "name": "account_provider_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_i_d": {
+          "name": "credential_i_d",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_user_idx": {
+          "name": "passkey_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "onboarding_step": {
+          "name": "onboarding_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace'"
+        },
+        "onboarding_state": {
+          "name": "onboarding_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_handle_idx": {
+          "name": "user_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_handle_unique": {
+          "name": "user_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_org_idx": {
+          "name": "api_key_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_organization_id_organization_id_fk": {
+          "name": "api_key_organization_id_organization_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_user_id_user_id_fk": {
+          "name": "api_key_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_hashed_key_unique": {
+          "name": "api_key_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_org_idx": {
+          "name": "audit_log_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_organization_id_organization_id_fk": {
+          "name": "audit_log_organization_id_organization_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_rule": {
+      "name": "automation_rule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_state_id": {
+          "name": "target_state_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_rule_unique": {
+          "name": "automation_rule_unique",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_rule_organization_id_organization_id_fk": {
+          "name": "automation_rule_organization_id_organization_id_fk",
+          "tableFrom": "automation_rule",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automation_rule_team_id_team_id_fk": {
+          "name": "automation_rule_team_id_team_id_fk",
+          "tableFrom": "automation_rule",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_delivery": {
+      "name": "email_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_email": {
+          "name": "to_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_delivery_status_idx": {
+          "name": "email_delivery_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_delivery_idempotency_key_unique": {
+          "name": "email_delivery_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_link": {
+      "name": "git_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merged": {
+          "name": "merged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "git_link_unique": {
+          "name": "git_link_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "git_link_issue_idx": {
+          "name": "git_link_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "git_link_organization_id_organization_id_fk": {
+          "name": "git_link_organization_id_organization_id_fk",
+          "tableFrom": "git_link",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_link_issue_id_issue_id_fk": {
+          "name": "git_link_issue_id_issue_id_fk",
+          "tableFrom": "git_link",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_comment_sync": {
+      "name": "github_comment_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_sync_id": {
+          "name": "repository_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_comment_sync_unique": {
+          "name": "github_comment_sync_unique",
+          "columns": [
+            {
+              "expression": "repository_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_comment_sync_comment_idx": {
+          "name": "github_comment_sync_comment_idx",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_comment_sync_organization_id_organization_id_fk": {
+          "name": "github_comment_sync_organization_id_organization_id_fk",
+          "tableFrom": "github_comment_sync",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_comment_sync_comment_id_comment_id_fk": {
+          "name": "github_comment_sync_comment_id_comment_id_fk",
+          "tableFrom": "github_comment_sync",
+          "tableTo": "comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_comment_sync_repository_sync_fk": {
+          "name": "github_comment_sync_repository_sync_fk",
+          "tableFrom": "github_comment_sync",
+          "tableTo": "github_repository_sync",
+          "columnsFrom": [
+            "repository_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installation": {
+      "name": "github_installation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Organization'"
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'selected'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "connected_by_id": {
+          "name": "connected_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repositories_synced_at": {
+          "name": "repositories_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installation_installation_unique": {
+          "name": "github_installation_installation_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installation_org_idx": {
+          "name": "github_installation_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installation_organization_id_organization_id_fk": {
+          "name": "github_installation_organization_id_organization_id_fk",
+          "tableFrom": "github_installation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installation_integration_id_integration_id_fk": {
+          "name": "github_installation_integration_id_integration_id_fk",
+          "tableFrom": "github_installation",
+          "tableTo": "integration",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installation_connected_by_id_user_id_fk": {
+          "name": "github_installation_connected_by_id_user_id_fk",
+          "tableFrom": "github_installation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "connected_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sync": {
+      "name": "github_issue_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_sync_id": {
+          "name": "repository_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_number": {
+          "name": "external_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_issue_sync_unique": {
+          "name": "github_issue_sync_unique",
+          "columns": [
+            {
+              "expression": "repository_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issue_sync_issue_idx": {
+          "name": "github_issue_sync_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sync_organization_id_organization_id_fk": {
+          "name": "github_issue_sync_organization_id_organization_id_fk",
+          "tableFrom": "github_issue_sync",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sync_issue_id_issue_id_fk": {
+          "name": "github_issue_sync_issue_id_issue_id_fk",
+          "tableFrom": "github_issue_sync",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sync_repository_sync_fk": {
+          "name": "github_issue_sync_repository_sync_fk",
+          "tableFrom": "github_issue_sync",
+          "tableTo": "github_repository_sync",
+          "columnsFrom": [
+            "repository_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_pr_state_mapping": {
+      "name": "github_pr_state_mapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_sync_id": {
+          "name": "repository_sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_state": {
+          "name": "pull_request_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_id": {
+          "name": "state_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_pr_state_mapping_unique": {
+          "name": "github_pr_state_mapping_unique",
+          "columns": [
+            {
+              "expression": "repository_sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pull_request_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_pr_state_mapping_organization_id_organization_id_fk": {
+          "name": "github_pr_state_mapping_organization_id_organization_id_fk",
+          "tableFrom": "github_pr_state_mapping",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_pr_state_mapping_state_id_workflow_state_id_fk": {
+          "name": "github_pr_state_mapping_state_id_workflow_state_id_fk",
+          "tableFrom": "github_pr_state_mapping",
+          "tableTo": "workflow_state",
+          "columnsFrom": [
+            "state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_pr_state_mapping_repository_sync_fk": {
+          "name": "github_pr_state_mapping_repository_sync_fk",
+          "tableFrom": "github_pr_state_mapping",
+          "tableTo": "github_repository_sync",
+          "columnsFrom": [
+            "repository_sync_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository": {
+      "name": "github_repository",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "owner_login": {
+          "name": "owner_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repository_unique": {
+          "name": "github_repository_unique",
+          "columns": [
+            {
+              "expression": "installation_row_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_org_idx": {
+          "name": "github_repository_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_organization_id_organization_id_fk": {
+          "name": "github_repository_organization_id_organization_id_fk",
+          "tableFrom": "github_repository",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_installation_row_id_github_installation_id_fk": {
+          "name": "github_repository_installation_row_id_github_installation_id_fk",
+          "tableFrom": "github_repository",
+          "tableTo": "github_installation",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_link": {
+      "name": "github_repository_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_row_id": {
+          "name": "repository_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_by_id": {
+          "name": "linked_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repository_link_project_unique": {
+          "name": "github_repository_link_project_unique",
+          "columns": [
+            {
+              "expression": "repository_row_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_repository_link\".\"project_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_link_workspace_unique": {
+          "name": "github_repository_link_workspace_unique",
+          "columns": [
+            {
+              "expression": "repository_row_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_repository_link\".\"project_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_link_project_idx": {
+          "name": "github_repository_link_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_link_org_idx": {
+          "name": "github_repository_link_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_link_organization_id_organization_id_fk": {
+          "name": "github_repository_link_organization_id_organization_id_fk",
+          "tableFrom": "github_repository_link",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_link_repository_row_id_github_repository_id_fk": {
+          "name": "github_repository_link_repository_row_id_github_repository_id_fk",
+          "tableFrom": "github_repository_link",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_link_project_id_project_id_fk": {
+          "name": "github_repository_link_project_id_project_id_fk",
+          "tableFrom": "github_repository_link",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_link_linked_by_id_user_id_fk": {
+          "name": "github_repository_link_linked_by_id_user_id_fk",
+          "tableFrom": "github_repository_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "linked_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_sync": {
+      "name": "github_repository_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name": {
+          "name": "repository_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repository_sync_unique": {
+          "name": "github_repository_sync_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_sync_team_idx": {
+          "name": "github_repository_sync_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_sync_organization_id_organization_id_fk": {
+          "name": "github_repository_sync_organization_id_organization_id_fk",
+          "tableFrom": "github_repository_sync",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_sync_integration_id_integration_id_fk": {
+          "name": "github_repository_sync_integration_id_integration_id_fk",
+          "tableFrom": "github_repository_sync",
+          "tableTo": "integration",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_sync_team_id_team_id_fk": {
+          "name": "github_repository_sync_team_id_team_id_fk",
+          "tableFrom": "github_repository_sync",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration": {
+      "name": "integration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "connected_by_id": {
+          "name": "connected_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_org_provider_unique": {
+          "name": "integration_org_provider_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_organization_id_organization_id_fk": {
+          "name": "integration_organization_id_organization_id_fk",
+          "tableFrom": "integration",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connected_by_id_user_id_fk": {
+          "name": "integration_connected_by_id_user_id_fk",
+          "tableFrom": "integration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "connected_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_channel": {
+      "name": "integration_channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_channel_unique": {
+          "name": "integration_channel_unique",
+          "columns": [
+            {
+              "expression": "integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_channel_integration_id_integration_id_fk": {
+          "name": "integration_channel_integration_id_integration_id_fk",
+          "tableFrom": "integration_channel",
+          "tableTo": "integration",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_oauth_state": {
+      "name": "integration_oauth_state",
+      "schema": "",
+      "columns": {
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_oauth_state_expires_idx": {
+          "name": "integration_oauth_state_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_oauth_state_organization_id_organization_id_fk": {
+          "name": "integration_oauth_state_organization_id_organization_id_fk",
+          "tableFrom": "integration_oauth_state",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_oauth_state_user_id_user_id_fk": {
+          "name": "integration_oauth_state_user_id_user_id_fk",
+          "tableFrom": "integration_oauth_state",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "notification_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_channels": {
+          "name": "delivered_channels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_idx": {
+          "name": "notification_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_unread_idx": {
+          "name": "notification_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_organization_id_organization_id_fk": {
+          "name": "notification_organization_id_organization_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preference": {
+      "name": "notification_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "notification_preference_unique": {
+          "name": "notification_preference_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_preference_user_id_user_id_fk": {
+          "name": "notification_preference_user_id_user_id_fk",
+          "tableFrom": "notification_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_setting": {
+      "name": "notification_setting",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quiet_hours_enabled": {
+          "name": "quiet_hours_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'18:00'"
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'09:00'"
+        },
+        "urgent_bypass_enabled": {
+          "name": "urgent_bypass_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "digest_enabled": {
+          "name": "digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_setting_user_id_user_id_fk": {
+          "name": "notification_setting_user_id_user_id_fk",
+          "tableFrom": "notification_setting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_channel_sync": {
+      "name": "slack_channel_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_channel_sync_unique": {
+          "name": "slack_channel_sync_unique",
+          "columns": [
+            {
+              "expression": "integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_channel_sync_team_idx": {
+          "name": "slack_channel_sync_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_channel_sync_organization_id_organization_id_fk": {
+          "name": "slack_channel_sync_organization_id_organization_id_fk",
+          "tableFrom": "slack_channel_sync",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_channel_sync_integration_id_integration_id_fk": {
+          "name": "slack_channel_sync_integration_id_integration_id_fk",
+          "tableFrom": "slack_channel_sync",
+          "tableTo": "integration",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_channel_sync_team_id_team_id_fk": {
+          "name": "slack_channel_sync_team_id_team_id_fk",
+          "tableFrom": "slack_channel_sync",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.web_vital": {
+      "name": "web_vital",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navigation_type": {
+          "name": "navigation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "interaction_type": {
+          "name": "interaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "web_vital_org_metric_idx": {
+          "name": "web_vital_org_metric_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_vital_route_idx": {
+          "name": "web_vital_route_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "route",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "web_vital_organization_id_organization_id_fk": {
+          "name": "web_vital_organization_id_organization_id_fk",
+          "tableFrom": "web_vital",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "web_vital_user_id_user_id_fk": {
+          "name": "web_vital_user_id_user_id_fk",
+          "tableFrom": "web_vital",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_org_idx": {
+          "name": "webhook_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_organization_id_organization_id_fk": {
+          "name": "webhook_organization_id_organization_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_created_by_id_user_id_fk": {
+          "name": "webhook_created_by_id_user_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_delivery": {
+      "name": "webhook_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_delivery_unique": {
+          "name": "webhook_delivery_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_log": {
+      "name": "webhook_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_log_webhook_idx": {
+          "name": "webhook_log_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_log_organization_id_organization_id_fk": {
+          "name": "webhook_log_organization_id_organization_id_fk",
+          "tableFrom": "webhook_log",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_log_webhook_id_webhook_id_fk": {
+          "name": "webhook_log_webhook_id_webhook_id_fk",
+          "tableFrom": "webhook_log",
+          "tableTo": "webhook",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment": {
+      "name": "attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_type": {
+          "name": "parent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "width": {
+          "name": "width",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_expires_at": {
+          "name": "upload_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachment_parent_idx": {
+          "name": "attachment_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_organization_id_organization_id_fk": {
+          "name": "attachment_organization_id_organization_id_fk",
+          "tableFrom": "attachment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attachment_uploaded_by_id_user_id_fk": {
+          "name": "attachment_uploaded_by_id_user_id_fk",
+          "tableFrom": "attachment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attachment_storage_key_unique": {
+          "name": "attachment_storage_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comment_issue_idx": {
+          "name": "comment_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_parent_idx": {
+          "name": "comment_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_organization_id_organization_id_fk": {
+          "name": "comment_organization_id_organization_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_issue_id_issue_id_fk": {
+          "name": "comment_issue_id_issue_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_author_id_user_id_fk": {
+          "name": "comment_author_id_user_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc": {
+      "name": "doc",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', left(coalesce(content, ''), 200000)), 'B')",
+            "type": "stored"
+          }
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace'"
+        },
+        "publish_token": {
+          "name": "publish_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_binding": {
+          "name": "repo_binding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "doc_org_idx": {
+          "name": "doc_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_project_idx": {
+          "name": "doc_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_parent_idx": {
+          "name": "doc_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_collection_order_idx": {
+          "name": "doc_collection_order_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_title_trgm_idx": {
+          "name": "doc_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "doc_content_trgm_idx": {
+          "name": "doc_content_trgm_idx",
+          "columns": [
+            {
+              "expression": "content",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "doc_search_idx": {
+          "name": "doc_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_organization_id_organization_id_fk": {
+          "name": "doc_organization_id_organization_id_fk",
+          "tableFrom": "doc",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_collection_id_doc_collection_id_fk": {
+          "name": "doc_collection_id_doc_collection_id_fk",
+          "tableFrom": "doc",
+          "tableTo": "doc_collection",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "doc_parent_id_doc_id_fk": {
+          "name": "doc_parent_id_doc_id_fk",
+          "tableFrom": "doc",
+          "tableTo": "doc",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "doc_project_id_project_id_fk": {
+          "name": "doc_project_id_project_id_fk",
+          "tableFrom": "doc",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_author_id_user_id_fk": {
+          "name": "doc_author_id_user_id_fk",
+          "tableFrom": "doc",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "doc_publish_token_unique": {
+          "name": "doc_publish_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publish_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_access": {
+      "name": "doc_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_access_unique": {
+          "name": "doc_access_unique",
+          "columns": [
+            {
+              "expression": "doc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_access_subject_idx": {
+          "name": "doc_access_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_access_organization_id_organization_id_fk": {
+          "name": "doc_access_organization_id_organization_id_fk",
+          "tableFrom": "doc_access",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_access_doc_id_doc_id_fk": {
+          "name": "doc_access_doc_id_doc_id_fk",
+          "tableFrom": "doc_access",
+          "tableTo": "doc",
+          "columnsFrom": [
+            "doc_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_access_granted_by_id_user_id_fk": {
+          "name": "doc_access_granted_by_id_user_id_fk",
+          "tableFrom": "doc_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_access_request": {
+      "name": "doc_access_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "decided_by_id": {
+          "name": "decided_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_access_request_pending_unique": {
+          "name": "doc_access_request_pending_unique",
+          "columns": [
+            {
+              "expression": "doc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_access_request_doc_idx": {
+          "name": "doc_access_request_doc_idx",
+          "columns": [
+            {
+              "expression": "doc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_access_request_requester_idx": {
+          "name": "doc_access_request_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_access_request_organization_id_organization_id_fk": {
+          "name": "doc_access_request_organization_id_organization_id_fk",
+          "tableFrom": "doc_access_request",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_access_request_doc_id_doc_id_fk": {
+          "name": "doc_access_request_doc_id_doc_id_fk",
+          "tableFrom": "doc_access_request",
+          "tableTo": "doc",
+          "columnsFrom": [
+            "doc_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_access_request_requester_id_user_id_fk": {
+          "name": "doc_access_request_requester_id_user_id_fk",
+          "tableFrom": "doc_access_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_access_request_decided_by_id_user_id_fk": {
+          "name": "doc_access_request_decided_by_id_user_id_fk",
+          "tableFrom": "doc_access_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_collection": {
+      "name": "doc_collection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'book'"
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_collection_org_idx": {
+          "name": "doc_collection_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_collection_organization_id_organization_id_fk": {
+          "name": "doc_collection_organization_id_organization_id_fk",
+          "tableFrom": "doc_collection",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_comment": {
+      "name": "doc_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "doc_comment_doc_idx": {
+          "name": "doc_comment_doc_idx",
+          "columns": [
+            {
+              "expression": "doc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_comment_parent_idx": {
+          "name": "doc_comment_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_comment_organization_id_organization_id_fk": {
+          "name": "doc_comment_organization_id_organization_id_fk",
+          "tableFrom": "doc_comment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_comment_doc_id_doc_id_fk": {
+          "name": "doc_comment_doc_id_doc_id_fk",
+          "tableFrom": "doc_comment",
+          "tableTo": "doc",
+          "columnsFrom": [
+            "doc_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_comment_author_id_user_id_fk": {
+          "name": "doc_comment_author_id_user_id_fk",
+          "tableFrom": "doc_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "doc_comment_parent_id_doc_comment_id_fk": {
+          "name": "doc_comment_parent_id_doc_comment_id_fk",
+          "tableFrom": "doc_comment",
+          "tableTo": "doc_comment",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_subscription": {
+      "name": "doc_subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "doc_subscription_unique": {
+          "name": "doc_subscription_unique",
+          "columns": [
+            {
+              "expression": "doc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_subscription_doc_id_doc_id_fk": {
+          "name": "doc_subscription_doc_id_doc_id_fk",
+          "tableFrom": "doc_subscription",
+          "tableTo": "doc",
+          "columnsFrom": [
+            "doc_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_subscription_user_id_user_id_fk": {
+          "name": "doc_subscription_user_id_user_id_fk",
+          "tableFrom": "doc_subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_version": {
+      "name": "doc_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owned_by_id": {
+          "name": "owned_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_id": {
+          "name": "restored_from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_saved_at": {
+          "name": "last_saved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_version_doc_idx": {
+          "name": "doc_version_doc_idx",
+          "columns": [
+            {
+              "expression": "doc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_saved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_version_doc_id_doc_id_fk": {
+          "name": "doc_version_doc_id_doc_id_fk",
+          "tableFrom": "doc_version",
+          "tableTo": "doc",
+          "columnsFrom": [
+            "doc_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_version_organization_id_organization_id_fk": {
+          "name": "doc_version_organization_id_organization_id_fk",
+          "tableFrom": "doc_version",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_version_owned_by_id_user_id_fk": {
+          "name": "doc_version_owned_by_id_user_id_fk",
+          "tableFrom": "doc_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owned_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorite": {
+      "name": "favorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1024
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "favorite_unique": {
+          "name": "favorite_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorite_user_idx": {
+          "name": "favorite_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorite_organization_id_organization_id_fk": {
+          "name": "favorite_organization_id_organization_id_fk",
+          "tableFrom": "favorite",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorite_user_id_user_id_fk": {
+          "name": "favorite_user_id_user_id_fk",
+          "tableFrom": "favorite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.home_widget_preference": {
+      "name": "home_widget_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "widget": {
+          "name": "widget",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "home_widget_preference_unique": {
+          "name": "home_widget_preference_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "widget",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "home_widget_preference_organization_id_organization_id_fk": {
+          "name": "home_widget_preference_organization_id_organization_id_fk",
+          "tableFrom": "home_widget_preference",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "home_widget_preference_user_id_user_id_fk": {
+          "name": "home_widget_preference_user_id_user_id_fk",
+          "tableFrom": "home_widget_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reaction": {
+      "name": "reaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reaction_comment_unique": {
+          "name": "reaction_comment_unique",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_comment_idx": {
+          "name": "reaction_comment_idx",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_issue_idx": {
+          "name": "reaction_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reaction_organization_id_organization_id_fk": {
+          "name": "reaction_organization_id_organization_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reaction_comment_id_comment_id_fk": {
+          "name": "reaction_comment_id_comment_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reaction_issue_id_issue_id_fk": {
+          "name": "reaction_issue_id_issue_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reaction_user_id_user_id_fk": {
+          "name": "reaction_user_id_user_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recent_visit": {
+      "name": "recent_visit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visited_at": {
+          "name": "visited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recent_visit_unique": {
+          "name": "recent_visit_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recent_visit_user_idx": {
+          "name": "recent_visit_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visited_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recent_visit_organization_id_organization_id_fk": {
+          "name": "recent_visit_organization_id_organization_id_fk",
+          "tableFrom": "recent_visit",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recent_visit_user_id_user_id_fk": {
+          "name": "recent_visit_user_id_user_id_fk",
+          "tableFrom": "recent_visit",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_grant": {
+      "name": "mcp_grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_grant_client_user_unique": {
+          "name": "mcp_grant_client_user_unique",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_grant_user_idx": {
+          "name": "mcp_grant_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_grant_client_id_oauth_application_client_id_fk": {
+          "name": "mcp_grant_client_id_oauth_application_client_id_fk",
+          "tableFrom": "mcp_grant",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_grant_user_id_user_id_fk": {
+          "name": "mcp_grant_user_id_user_id_fk",
+          "tableFrom": "mcp_grant",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_grant_organization_id_organization_id_fk": {
+          "name": "mcp_grant_organization_id_organization_id_fk",
+          "tableFrom": "mcp_grant",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_idx": {
+          "name": "oauth_access_token_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_idx": {
+          "name": "oauth_access_token_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_application_user_idx": {
+          "name": "oauth_application_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_user_id_user_id_fk": {
+          "name": "oauth_application_user_id_user_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_idx": {
+          "name": "oauth_consent_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_idx": {
+          "name": "oauth_consent_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_ids": {
+          "name": "team_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_org_idx": {
+          "name": "invitation_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_org_email_pending_unique": {
+          "name": "invitation_org_email_pending_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invitation\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_org_user_unique": {
+          "name": "member_org_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_org_idx": {
+          "name": "member_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_idx": {
+          "name": "member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'circle'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#5A63C8'"
+        },
+        "issue_counter": {
+          "name": "issue_counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "team_org_key_active_unique": {
+          "name": "team_org_key_active_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"team\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_org_idx": {
+          "name": "team_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_organization_id_organization_id_fk": {
+          "name": "team_organization_id_organization_id_fk",
+          "tableFrom": "team",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_member": {
+      "name": "team_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_member_unique": {
+          "name": "team_member_unique",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_member_user_idx": {
+          "name": "team_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_member_team_id_team_id_fk": {
+          "name": "team_member_team_id_team_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_member_user_id_user_id_fk": {
+          "name": "team_member_user_id_user_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cycle": {
+      "name": "cycle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cycle_team_number_unique": {
+          "name": "cycle_team_number_unique",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cycle_team_dates_idx": {
+          "name": "cycle_team_dates_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cycle_organization_id_organization_id_fk": {
+          "name": "cycle_organization_id_organization_id_fk",
+          "tableFrom": "cycle",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cycle_team_id_team_id_fk": {
+          "name": "cycle_team_id_team_id_fk",
+          "tableFrom": "cycle",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cycle_progress_snapshot": {
+      "name": "cycle_progress_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cycle_id": {
+          "name": "cycle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_on": {
+          "name": "captured_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_issues": {
+          "name": "total_issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlog_issues": {
+          "name": "backlog_issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unstarted_issues": {
+          "name": "unstarted_issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_issues": {
+          "name": "started_issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_issues": {
+          "name": "completed_issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "canceled_issues": {
+          "name": "canceled_issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_estimate": {
+          "name": "total_estimate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_estimate": {
+          "name": "completed_estimate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown": {
+          "name": "breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cycle_progress_snapshot_unique": {
+          "name": "cycle_progress_snapshot_unique",
+          "columns": [
+            {
+              "expression": "cycle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cycle_progress_snapshot_organization_id_organization_id_fk": {
+          "name": "cycle_progress_snapshot_organization_id_organization_id_fk",
+          "tableFrom": "cycle_progress_snapshot",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cycle_progress_snapshot_cycle_id_cycle_id_fk": {
+          "name": "cycle_progress_snapshot_cycle_id_cycle_id_fk",
+          "tableFrom": "cycle_progress_snapshot",
+          "tableTo": "cycle",
+          "columnsFrom": [
+            "cycle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.estimate_point": {
+      "name": "estimate_point",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scale_id": {
+          "name": "scale_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "estimate_point_scale_key_unique": {
+          "name": "estimate_point_scale_key_unique",
+          "columns": [
+            {
+              "expression": "scale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "estimate_point_scale_idx": {
+          "name": "estimate_point_scale_idx",
+          "columns": [
+            {
+              "expression": "scale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "estimate_point_organization_id_organization_id_fk": {
+          "name": "estimate_point_organization_id_organization_id_fk",
+          "tableFrom": "estimate_point",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "estimate_point_scale_id_estimate_scale_id_fk": {
+          "name": "estimate_point_scale_id_estimate_scale_id_fk",
+          "tableFrom": "estimate_point",
+          "tableTo": "estimate_scale",
+          "columnsFrom": [
+            "scale_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.estimate_scale": {
+      "name": "estimate_scale",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'points'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "estimate_scale_org_idx": {
+          "name": "estimate_scale_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "estimate_scale_org_name_active_unique": {
+          "name": "estimate_scale_org_name_active_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"estimate_scale\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "estimate_scale_organization_id_organization_id_fk": {
+          "name": "estimate_scale_organization_id_organization_id_fk",
+          "tableFrom": "estimate_scale",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intake": {
+      "name": "intake",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Intake'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intake_team_unique": {
+          "name": "intake_team_unique",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "intake_anchor_unique": {
+          "name": "intake_anchor_unique",
+          "columns": [
+            {
+              "expression": "anchor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intake_organization_id_organization_id_fk": {
+          "name": "intake_organization_id_organization_id_fk",
+          "tableFrom": "intake",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intake_team_id_team_id_fk": {
+          "name": "intake_team_id_team_id_fk",
+          "tableFrom": "intake",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intake_issue": {
+      "name": "intake_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intake_id": {
+          "name": "intake_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "source_email": {
+          "name": "source_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_of_id": {
+          "name": "duplicate_of_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_by_id": {
+          "name": "triaged_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intake_issue_unique": {
+          "name": "intake_issue_unique",
+          "columns": [
+            {
+              "expression": "intake_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "intake_issue_status_idx": {
+          "name": "intake_issue_status_idx",
+          "columns": [
+            {
+              "expression": "intake_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intake_issue_organization_id_organization_id_fk": {
+          "name": "intake_issue_organization_id_organization_id_fk",
+          "tableFrom": "intake_issue",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intake_issue_intake_id_intake_id_fk": {
+          "name": "intake_issue_intake_id_intake_id_fk",
+          "tableFrom": "intake_issue",
+          "tableTo": "intake",
+          "columnsFrom": [
+            "intake_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intake_issue_issue_id_issue_id_fk": {
+          "name": "intake_issue_issue_id_issue_id_fk",
+          "tableFrom": "intake_issue",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "intake_issue_duplicate_of_id_issue_id_fk": {
+          "name": "intake_issue_duplicate_of_id_issue_id_fk",
+          "tableFrom": "intake_issue",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "duplicate_of_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "intake_issue_triaged_by_id_user_id_fk": {
+          "name": "intake_issue_triaged_by_id_user_id_fk",
+          "tableFrom": "intake_issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triaged_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue": {
+      "name": "issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state_id": {
+          "name": "state_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cycle_id": {
+          "name": "cycle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_point_id": {
+          "name": "estimate_point_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1024
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_entered_at": {
+          "name": "state_entered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_team_number_unique": {
+          "name": "issue_team_number_unique",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_org_identifier_unique": {
+          "name": "issue_org_identifier_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_board_idx": {
+          "name": "issue_board_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_assignee_idx": {
+          "name": "issue_assignee_idx",
+          "columns": [
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_project_idx": {
+          "name": "issue_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_cycle_idx": {
+          "name": "issue_cycle_idx",
+          "columns": [
+            {
+              "expression": "cycle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_parent_idx": {
+          "name": "issue_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_sync_idx": {
+          "name": "issue_sync_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_org_active_idx": {
+          "name": "issue_org_active_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_team_order_idx": {
+          "name": "issue_team_order_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_team_updated_idx": {
+          "name": "issue_team_updated_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_team_created_idx": {
+          "name": "issue_team_created_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_milestone_idx": {
+          "name": "issue_milestone_idx",
+          "columns": [
+            {
+              "expression": "milestone_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_title_trgm_idx": {
+          "name": "issue_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "issue_description_trgm_idx": {
+          "name": "issue_description_trgm_idx",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_organization_id_organization_id_fk": {
+          "name": "issue_organization_id_organization_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_team_id_team_id_fk": {
+          "name": "issue_team_id_team_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_state_id_workflow_state_id_fk": {
+          "name": "issue_state_id_workflow_state_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "workflow_state",
+          "columnsFrom": [
+            "state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "issue_creator_id_user_id_fk": {
+          "name": "issue_creator_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "issue_assignee_id_user_id_fk": {
+          "name": "issue_assignee_id_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_project_id_project_id_fk": {
+          "name": "issue_project_id_project_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_milestone_id_milestone_id_fk": {
+          "name": "issue_milestone_id_milestone_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "milestone",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_cycle_id_cycle_id_fk": {
+          "name": "issue_cycle_id_cycle_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "cycle",
+          "columnsFrom": [
+            "cycle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_parent_id_issue_id_fk": {
+          "name": "issue_parent_id_issue_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_estimate_point_id_estimate_point_id_fk": {
+          "name": "issue_estimate_point_id_estimate_point_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "estimate_point",
+          "columnsFrom": [
+            "estimate_point_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_activity": {
+      "name": "issue_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_value": {
+          "name": "from_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_value": {
+          "name": "to_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_activity_issue_idx": {
+          "name": "issue_activity_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_activity_cycle_moves_idx": {
+          "name": "issue_activity_cycle_moves_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue_activity\".\"field\" = 'cycleId'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_activity_organization_id_organization_id_fk": {
+          "name": "issue_activity_organization_id_organization_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_activity_issue_id_issue_id_fk": {
+          "name": "issue_activity_issue_id_issue_id_fk",
+          "tableFrom": "issue_activity",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_identifier_alias": {
+      "name": "issue_identifier_alias",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_identifier_alias_unique": {
+          "name": "issue_identifier_alias_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_identifier_alias_issue_idx": {
+          "name": "issue_identifier_alias_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_identifier_alias_organization_id_organization_id_fk": {
+          "name": "issue_identifier_alias_organization_id_organization_id_fk",
+          "tableFrom": "issue_identifier_alias",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_identifier_alias_issue_id_issue_id_fk": {
+          "name": "issue_identifier_alias_issue_id_issue_id_fk",
+          "tableFrom": "issue_identifier_alias",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_label": {
+      "name": "issue_label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "issue_label_unique": {
+          "name": "issue_label_unique",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_label_label_idx": {
+          "name": "issue_label_label_idx",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_label_issue_id_issue_id_fk": {
+          "name": "issue_label_issue_id_issue_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_label_label_id_label_id_fk": {
+          "name": "issue_label_label_id_label_id_fk",
+          "tableFrom": "issue_label",
+          "tableTo": "label",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_relation": {
+      "name": "issue_relation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_issue_id": {
+          "name": "related_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_relation_unique": {
+          "name": "issue_relation_unique",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_relation_issue_idx": {
+          "name": "issue_relation_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_relation_organization_id_organization_id_fk": {
+          "name": "issue_relation_organization_id_organization_id_fk",
+          "tableFrom": "issue_relation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_relation_issue_id_issue_id_fk": {
+          "name": "issue_relation_issue_id_issue_id_fk",
+          "tableFrom": "issue_relation",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_relation_related_issue_id_issue_id_fk": {
+          "name": "issue_relation_related_issue_id_issue_id_fk",
+          "tableFrom": "issue_relation",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "related_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_subscription": {
+      "name": "issue_subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_subscription_unique": {
+          "name": "issue_subscription_unique",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_subscription_issue_id_issue_id_fk": {
+          "name": "issue_subscription_issue_id_issue_id_fk",
+          "tableFrom": "issue_subscription",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_subscription_user_id_user_id_fk": {
+          "name": "issue_subscription_user_id_user_id_fk",
+          "tableFrom": "issue_subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label": {
+      "name": "label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "label_org_idx": {
+          "name": "label_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_team_name_unique": {
+          "name": "label_team_name_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"label\".\"team_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_org_name_unique": {
+          "name": "label_org_name_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"label\".\"team_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "label_organization_id_organization_id_fk": {
+          "name": "label_organization_id_organization_id_fk",
+          "tableFrom": "label",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_team_id_team_id_fk": {
+          "name": "label_team_id_team_id_fk",
+          "tableFrom": "label",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone": {
+      "name": "milestone",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1024
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "milestone_project_idx": {
+          "name": "milestone_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "milestone_organization_id_organization_id_fk": {
+          "name": "milestone_organization_id_organization_id_fk",
+          "tableFrom": "milestone",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_project_id_project_id_fk": {
+          "name": "milestone_project_id_project_id_fk",
+          "tableFrom": "milestone",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module": {
+      "name": "module",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'backlog'"
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1024
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "module_team_idx": {
+          "name": "module_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "module_project_idx": {
+          "name": "module_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "module_team_name_active_unique": {
+          "name": "module_team_name_active_unique",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"module\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "module_organization_id_organization_id_fk": {
+          "name": "module_organization_id_organization_id_fk",
+          "tableFrom": "module",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "module_team_id_team_id_fk": {
+          "name": "module_team_id_team_id_fk",
+          "tableFrom": "module",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "module_project_id_project_id_fk": {
+          "name": "module_project_id_project_id_fk",
+          "tableFrom": "module",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "module_lead_id_user_id_fk": {
+          "name": "module_lead_id_user_id_fk",
+          "tableFrom": "module",
+          "tableTo": "user",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module_issue": {
+      "name": "module_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "module_issue_unique": {
+          "name": "module_issue_unique",
+          "columns": [
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "module_issue_issue_idx": {
+          "name": "module_issue_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "module_issue_module_id_module_id_fk": {
+          "name": "module_issue_module_id_module_id_fk",
+          "tableFrom": "module_issue",
+          "tableTo": "module",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "module_issue_issue_id_issue_id_fk": {
+          "name": "module_issue_issue_id_issue_id_fk",
+          "tableFrom": "module_issue",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module_link": {
+      "name": "module_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "module_link_module_idx": {
+          "name": "module_link_module_idx",
+          "columns": [
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "module_link_organization_id_organization_id_fk": {
+          "name": "module_link_organization_id_organization_id_fk",
+          "tableFrom": "module_link",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "module_link_module_id_module_id_fk": {
+          "name": "module_link_module_id_module_id_fk",
+          "tableFrom": "module_link",
+          "tableTo": "module",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "module_link_created_by_id_user_id_fk": {
+          "name": "module_link_created_by_id_user_id_fk",
+          "tableFrom": "module_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module_member": {
+      "name": "module_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "module_member_unique": {
+          "name": "module_member_unique",
+          "columns": [
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "module_member_user_idx": {
+          "name": "module_member_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "module_member_module_id_module_id_fk": {
+          "name": "module_member_module_id_module_id_fk",
+          "tableFrom": "module_member",
+          "tableTo": "module",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "module_member_user_id_user_id_fk": {
+          "name": "module_member_user_id_user_id_fk",
+          "tableFrom": "module_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'backlog'"
+        },
+        "health": {
+          "name": "health",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_update'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'box'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#5A63C8'"
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_scale_id": {
+          "name": "estimate_scale_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1024
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_org_slug_active_unique": {
+          "name": "project_org_slug_active_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_org_idx": {
+          "name": "project_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_lead_id_user_id_fk": {
+          "name": "project_lead_id_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_estimate_scale_id_estimate_scale_id_fk": {
+          "name": "project_estimate_scale_id_estimate_scale_id_fk",
+          "tableFrom": "project",
+          "tableTo": "estimate_scale",
+          "columnsFrom": [
+            "estimate_scale_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_team": {
+      "name": "project_team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_team_unique": {
+          "name": "project_team_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_team_team_idx": {
+          "name": "project_team_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_team_project_id_project_id_fk": {
+          "name": "project_team_project_id_project_id_fk",
+          "tableFrom": "project_team",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_team_team_id_team_id_fk": {
+          "name": "project_team_team_id_team_id_fk",
+          "tableFrom": "project_team",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_update": {
+      "name": "project_update",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "health": {
+          "name": "health",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_update_project_idx": {
+          "name": "project_update_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_update_organization_id_organization_id_fk": {
+          "name": "project_update_organization_id_organization_id_fk",
+          "tableFrom": "project_update",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_update_project_id_project_id_fk": {
+          "name": "project_update_project_id_project_id_fk",
+          "tableFrom": "project_update",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_update_author_id_user_id_fk": {
+          "name": "project_update_author_id_user_id_fk",
+          "tableFrom": "project_update",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_analytics_view": {
+      "name": "saved_analytics_view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "shared": {
+          "name": "shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "saved_analytics_view_org_idx": {
+          "name": "saved_analytics_view_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_analytics_view_owner_idx": {
+          "name": "saved_analytics_view_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_analytics_view_organization_id_organization_id_fk": {
+          "name": "saved_analytics_view_organization_id_organization_id_fk",
+          "tableFrom": "saved_analytics_view",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_analytics_view_owner_id_user_id_fk": {
+          "name": "saved_analytics_view_owner_id_user_id_fk",
+          "tableFrom": "saved_analytics_view",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.view": {
+      "name": "view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'list'"
+        },
+        "group_by": {
+          "name": "group_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'state'"
+        },
+        "shared": {
+          "name": "shared",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "view_org_idx": {
+          "name": "view_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "view_team_idx": {
+          "name": "view_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "view_organization_id_organization_id_fk": {
+          "name": "view_organization_id_organization_id_fk",
+          "tableFrom": "view",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "view_owner_id_user_id_fk": {
+          "name": "view_owner_id_user_id_fk",
+          "tableFrom": "view",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "view_team_id_team_id_fk": {
+          "name": "view_team_id_team_id_fk",
+          "tableFrom": "view",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.view_preference": {
+      "name": "view_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page": {
+          "name": "page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'list'"
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "view_preference_unique": {
+          "name": "view_preference_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "view_preference_organization_id_organization_id_fk": {
+          "name": "view_preference_organization_id_organization_id_fk",
+          "tableFrom": "view_preference",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "view_preference_user_id_user_id_fk": {
+          "name": "view_preference_user_id_user_id_fk",
+          "tableFrom": "view_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_state": {
+      "name": "workflow_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_state_team_idx": {
+          "name": "workflow_state_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_state_team_name_unique": {
+          "name": "workflow_state_team_name_unique",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_state_organization_id_organization_id_fk": {
+          "name": "workflow_state_organization_id_organization_id_fk",
+          "tableFrom": "workflow_state",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_state_team_id_team_id_fk": {
+          "name": "workflow_state_team_id_team_id_fk",
+          "tableFrom": "workflow_state",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.notification_reason": {
+      "name": "notification_reason",
+      "schema": "public",
+      "values": [
+        "assigned",
+        "mentioned",
+        "subscribed",
+        "commented",
+        "state_changed",
+        "review_requested",
+        "review_approved",
+        "pull_request_merged",
+        "due_soon",
+        "access_requested",
+        "access_granted",
+        "manual"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {
+    "public.sync_id_seq": {
+      "name": "sync_id_seq",
+      "schema": "public",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1786216640676,
       "tag": "0001_lean_satana",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1786217938315,
+      "tag": "0002_glossy_mister_sinister",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/content.ts
+++ b/packages/db/src/schema/content.ts
@@ -252,7 +252,9 @@ export const attachment = pgTable(
     width: bigint('width', { mode: 'number' }),
     height: bigint('height', { mode: 'number' }),
     durationSeconds: bigint('duration_seconds', { mode: 'number' }),
-    uploadExpiresAt: timestamp('upload_expires_at', { withTimezone: true }),
+    uploadExpiresAt: timestamp('upload_expires_at', { withTimezone: true }).default(
+      sql`now() + interval '900 seconds'`,
+    ),
     uploadedById: text('uploaded_by_id')
       .notNull()
       .references(() => user.id, { onDelete: 'restrict' }),

--- a/packages/db/src/schema/content.ts
+++ b/packages/db/src/schema/content.ts
@@ -252,6 +252,7 @@ export const attachment = pgTable(
     width: bigint('width', { mode: 'number' }),
     height: bigint('height', { mode: 'number' }),
     durationSeconds: bigint('duration_seconds', { mode: 'number' }),
+    uploadExpiresAt: timestamp('upload_expires_at', { withTimezone: true }),
     uploadedById: text('uploaded_by_id')
       .notNull()
       .references(() => user.id, { onDelete: 'restrict' }),

--- a/packages/db/src/schema/org.ts
+++ b/packages/db/src/schema/org.ts
@@ -24,6 +24,7 @@ export const organization = pgTable('organization', {
   allowedEmailDomains: jsonb('allowed_email_domains').$type<string[]>().notNull().default([]),
   syncId: bigint('sync_id', { mode: 'number' }).notNull().default(0),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  deletionRequestedAt: timestamp('deletion_requested_at', { withTimezone: true }),
 });
 
 export const member = pgTable(

--- a/packages/db/tests/apply-catchup.test.ts
+++ b/packages/db/tests/apply-catchup.test.ts
@@ -52,7 +52,7 @@ async function run<T>(url: string, work: (sql: postgres.Sql) => Promise<T>): Pro
   try {
     return await work(sql);
   } finally {
-    await sql.end({ timeout: 5 });
+    await sql.end();
   }
 }
 

--- a/packages/db/tests/schema/index.test.ts
+++ b/packages/db/tests/schema/index.test.ts
@@ -137,6 +137,10 @@ describe('list and search indexes', () => {
 });
 
 describe('domain invariants', () => {
+  it('tracks the expiration of presigned attachment targets', () => {
+    expect(getTableColumns(schema.attachment).uploadExpiresAt?.name).toBe('upload_expires_at');
+  });
+
   it('keeps authored rows when their author is deleted', () => {
     expect(deleteActionOf(schema.issue, 'creator_id')).toBe('restrict');
     expect(deleteActionOf(schema.comment, 'author_id')).toBe('restrict');

--- a/packages/db/tests/schema/index.test.ts
+++ b/packages/db/tests/schema/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { readFile } from 'node:fs/promises';
 import { SYNC_MODELS } from '@orbit/shared/events';
-import { getTableColumns, type Table } from 'drizzle-orm';
+import { getTableColumns, type SQL, type Table } from 'drizzle-orm';
 import { getTableConfig, PgDialect, type PgTable } from 'drizzle-orm/pg-core';
 import * as schema from '../../src/schema/index.ts';
 
@@ -138,7 +138,12 @@ describe('list and search indexes', () => {
 
 describe('domain invariants', () => {
   it('tracks the expiration of presigned attachment targets', () => {
-    expect(getTableColumns(schema.attachment).uploadExpiresAt?.name).toBe('upload_expires_at');
+    const uploadExpiresAt = getTableColumns(schema.attachment).uploadExpiresAt;
+    expect(uploadExpiresAt?.name).toBe('upload_expires_at');
+    expect(uploadExpiresAt?.default).toBeDefined();
+    expect(new PgDialect().sqlToQuery(uploadExpiresAt?.default as SQL).sql).toBe(
+      "now() + interval '900 seconds'",
+    );
   });
 
   it('keeps authored rows when their author is deleted', () => {

--- a/packages/db/tests/schema/index.test.ts
+++ b/packages/db/tests/schema/index.test.ts
@@ -137,6 +137,12 @@ describe('list and search indexes', () => {
 });
 
 describe('domain invariants', () => {
+  it('records a durable workspace deletion request', () => {
+    const deletionRequestedAt = getTableColumns(schema.organization).deletionRequestedAt;
+    expect(deletionRequestedAt?.name).toBe('deletion_requested_at');
+    expect(deletionRequestedAt?.notNull).toBe(false);
+  });
+
   it('tracks the expiration of presigned attachment targets', () => {
     const uploadExpiresAt = getTableColumns(schema.attachment).uploadExpiresAt;
     expect(uploadExpiresAt?.name).toBe('upload_expires_at');

--- a/packages/db/tests/schema/organization-cascade.test.ts
+++ b/packages/db/tests/schema/organization-cascade.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test';
+import { db, sql } from '../../src/index.ts';
+
+interface OrganizationForeignKey extends Record<string, unknown> {
+  readonly tableName: string;
+  readonly referencedTable: string | null;
+  readonly deleteAction: string | null;
+}
+
+describe('organization deletion schema', () => {
+  it('cascades every organization_id column from the organization table', async () => {
+    const rows = await db.execute<OrganizationForeignKey>(sql`
+      select
+        child.relname as "tableName",
+        parent.relname as "referencedTable",
+        foreign_key.confdeltype::text as "deleteAction"
+      from pg_class child
+      inner join pg_namespace namespace on namespace.oid = child.relnamespace
+      inner join pg_attribute organization_column
+        on organization_column.attrelid = child.oid
+        and organization_column.attname = 'organization_id'
+        and not organization_column.attisdropped
+      left join pg_constraint foreign_key
+        on foreign_key.conrelid = child.oid
+        and foreign_key.contype = 'f'
+        and organization_column.attnum = any(foreign_key.conkey)
+      left join pg_class parent on parent.oid = foreign_key.confrelid
+      where namespace.nspname = 'public'
+        and child.relkind = 'r'
+      order by child.relname
+    `);
+
+    expect(rows.length).toBeGreaterThan(30);
+    expect(
+      rows.filter((row) => row.referencedTable !== 'organization' || row.deleteAction !== 'c'),
+    ).toEqual([]);
+  });
+});

--- a/packages/mcp-server/tests/auth.test.ts
+++ b/packages/mcp-server/tests/auth.test.ts
@@ -85,6 +85,22 @@ describe('access token verification', () => {
     await expect(verifyMcpAccessToken(token)).rejects.toMatchObject({ code: 'unauthorized' });
   });
 
+  it('rejects a token while workspace deletion is pending', async () => {
+    const token = await mintToken(workspace.organizationId, workspace.adminUser.id);
+    await db
+      .update(schema.organization)
+      .set({ deletionRequestedAt: new Date() })
+      .where(eq(schema.organization.id, workspace.organizationId));
+    try {
+      await expect(verifyMcpAccessToken(token)).rejects.toMatchObject({ code: 'forbidden' });
+    } finally {
+      await db
+        .update(schema.organization)
+        .set({ deletionRequestedAt: null })
+        .where(eq(schema.organization.id, workspace.organizationId));
+    }
+  });
+
   it('rejects an unknown token', async () => {
     await expect(verifyMcpAccessToken('at_notarealtoken')).rejects.toMatchObject({
       code: 'unauthorized',

--- a/packages/realtime-server/src/auth.ts
+++ b/packages/realtime-server/src/auth.ts
@@ -1,4 +1,4 @@
-import { and, db, eq, gt, inArray, or, schema, sql } from '@orbit/db';
+import { and, db, eq, gt, inArray, isNull, or, schema, sql } from '@orbit/db';
 import { ORG_ROLES, type OrgRole } from '@orbit/shared/constants';
 import { authMessageSchema } from '@orbit/shared/events';
 import { type RealtimeTicketPayload, verifyRealtimeTicket } from '@orbit/shared/events/ticket';
@@ -108,10 +108,12 @@ export async function authenticateTicket(
   const memberships = await db
     .select({ role: schema.member.role })
     .from(schema.member)
+    .innerJoin(schema.organization, eq(schema.organization.id, schema.member.organizationId))
     .where(
       and(
         eq(schema.member.userId, found.userId),
         eq(schema.member.organizationId, payload.organizationId),
+        isNull(schema.organization.deletionRequestedAt),
       ),
     )
     .limit(1);
@@ -154,10 +156,12 @@ export async function membershipStillValid(principal: ConnectionPrincipal): Prom
   const rows = await db
     .select({ id: schema.member.id })
     .from(schema.member)
+    .innerJoin(schema.organization, eq(schema.organization.id, schema.member.organizationId))
     .where(
       and(
         eq(schema.member.organizationId, principal.organizationId),
         eq(schema.member.userId, principal.userId),
+        isNull(schema.organization.deletionRequestedAt),
       ),
     )
     .limit(1);
@@ -170,10 +174,12 @@ export async function refreshedPrincipal(
   const rows = await db
     .select({ role: schema.member.role })
     .from(schema.member)
+    .innerJoin(schema.organization, eq(schema.organization.id, schema.member.organizationId))
     .where(
       and(
         eq(schema.member.organizationId, principal.organizationId),
         eq(schema.member.userId, principal.userId),
+        isNull(schema.organization.deletionRequestedAt),
       ),
     )
     .limit(1);

--- a/packages/realtime-server/src/hub.ts
+++ b/packages/realtime-server/src/hub.ts
@@ -192,13 +192,25 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
     }
   }
 
+  function closeOrganizationConnections(organizationId: string): void {
+    for (const connection of connections.values()) {
+      if (connection.organizationId !== organizationId) continue;
+      connections.delete(connection.id);
+      connection.close(ORGANIZATION_FORBIDDEN_CLOSE_CODE, 'organization_deleted');
+    }
+  }
+
   function deliverControl(payload: string): void {
     const parsed = controlMessageSchema.safeParse(parseJson(payload));
     if (!parsed.success) {
       logger.warn('discarded malformed control message', { channel: REDIS_CONTROL_CHANNEL });
       return;
     }
-    revalidateSessionsFor(parsed.data.userId);
+    if (parsed.data.type === 'session_revoked') {
+      revalidateSessionsFor(parsed.data.userId);
+      return;
+    }
+    closeOrganizationConnections(parsed.data.organizationId);
   }
 
   function revalidateDocScopes(action: SyncAction): void {

--- a/packages/realtime-server/tests/auth/authorize-scope.test.ts
+++ b/packages/realtime-server/tests/auth/authorize-scope.test.ts
@@ -319,6 +319,28 @@ describe('authenticateTicket', () => {
     expect(result).toEqual({ ok: false, reason: 'organization_forbidden' });
   });
 
+  it('rejects a new connection while workspace deletion is pending', async () => {
+    const { sessionId } = await insertSession(home.readerUserId, new Date(Date.now() + 60_000));
+    await db
+      .update(schema.organization)
+      .set({ deletionRequestedAt: new Date() })
+      .where(eq(schema.organization.id, home.organizationId));
+    try {
+      const result = await authenticateTicket({
+        userId: home.readerUserId,
+        organizationId: home.organizationId,
+        sessionId,
+        exp: Date.now() + 60_000,
+      });
+      expect(result).toEqual({ ok: false, reason: 'organization_forbidden' });
+    } finally {
+      await db
+        .update(schema.organization)
+        .set({ deletionRequestedAt: null })
+        .where(eq(schema.organization.id, home.organizationId));
+    }
+  });
+
   it('falls back to guest for a role nobody recognises', async () => {
     await db
       .update(schema.member)
@@ -362,6 +384,22 @@ describe('sessionStillValid and membershipStillValid', () => {
         reader({ userId: home.strangerUserId, organizationId: away.organizationId }),
       ),
     ).toBe(false);
+  });
+
+  it('reports a pending workspace deletion as terminal membership loss', async () => {
+    await db
+      .update(schema.organization)
+      .set({ deletionRequestedAt: new Date() })
+      .where(eq(schema.organization.id, home.organizationId));
+    try {
+      expect(await membershipStillValid(reader())).toBe(false);
+      expect(await refreshedPrincipal(reader())).toBeNull();
+    } finally {
+      await db
+        .update(schema.organization)
+        .set({ deletionRequestedAt: null })
+        .where(eq(schema.organization.id, home.organizationId));
+    }
   });
 });
 

--- a/packages/realtime-server/tests/hub.test.ts
+++ b/packages/realtime-server/tests/hub.test.ts
@@ -420,6 +420,41 @@ describe('membership and session revocation', () => {
       await hub.close();
     }
   });
+
+  it('closes only connections attached to a deleted workspace', async () => {
+    const hub = await newHub();
+    try {
+      const deletedAdmin = await connect(hub, home.adminUserId, home.organizationId);
+      const deletedReader = await connect(hub, home.readerUserId, home.organizationId);
+      const retained = await connect(hub, away.adminUserId, away.organizationId);
+
+      await driver().publish(
+        REDIS_CONTROL_CHANNEL,
+        JSON.stringify({
+          type: 'organization_deleted',
+          organizationId: home.organizationId,
+        }),
+      );
+      await waitFor(
+        () => deletedAdmin.socket.closures.length > 0 && deletedReader.socket.closures.length > 0,
+        'the deleted workspace connections to be closed',
+      );
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(deletedAdmin.socket.closures[0]).toEqual({
+        code: ORGANIZATION_FORBIDDEN_CLOSE_CODE,
+        reason: 'organization_deleted',
+      });
+      expect(deletedReader.socket.closures[0]).toEqual({
+        code: ORGANIZATION_FORBIDDEN_CLOSE_CODE,
+        reason: 'organization_deleted',
+      });
+      expect(retained.socket.closures).toHaveLength(0);
+      expect(hub.stats().connections).toBe(1);
+    } finally {
+      await hub.close();
+    }
+  });
 });
 
 describe('the periodic session sweep closes what no control message ever announced', () => {

--- a/packages/services/src/storage/index.ts
+++ b/packages/services/src/storage/index.ts
@@ -2,7 +2,13 @@ import { validationFailed } from '@orbit/shared';
 import { S3StorageDriver } from './s3.ts';
 import type { StorageDriver } from './types.ts';
 
-export { assertSafeKey, FILE_ROUTE, fileUrlFor } from './key.ts';
+export {
+  assertSafeKey,
+  assertSafePrefix,
+  FILE_ROUTE,
+  fileUrlFor,
+  storagePrefixFor,
+} from './key.ts';
 export {
   type AttachmentOwner,
   type AttachmentParentType,
@@ -11,11 +17,17 @@ export {
   isPubliclyReadable,
   type StorageExecutor,
 } from './parent.ts';
-export { type S3Config, S3StorageDriver, s3ConfigSchema } from './s3.ts';
+export {
+  type S3Config,
+  S3StorageDriver,
+  s3ConfigSchema,
+  UPLOAD_URL_TTL_SECONDS,
+} from './s3.ts';
 export {
   STORAGE_KINDS,
   type StorageDriver,
   type StorageKind,
+  type StoragePrefixSummary,
   type StoredObject,
   type UploadTarget,
 } from './types.ts';

--- a/packages/services/src/storage/index.ts
+++ b/packages/services/src/storage/index.ts
@@ -21,6 +21,7 @@ export {
   type S3Config,
   S3StorageDriver,
   s3ConfigSchema,
+  UPLOAD_COMPLETION_GRACE_SECONDS,
   UPLOAD_URL_TTL_SECONDS,
 } from './s3.ts';
 export {

--- a/packages/services/src/storage/key.ts
+++ b/packages/services/src/storage/key.ts
@@ -24,3 +24,24 @@ export function assertSafeKey(key: string): string {
   }
   return normalized;
 }
+
+export function assertSafePrefix(prefix: string): string {
+  if (!prefix.endsWith('/') || prefix.length < 2) {
+    throw validationFailed('That storage prefix is not allowed.', { details: { prefix } });
+  }
+  const marker = `${prefix}sentinel`;
+  if (assertSafeKey(marker) !== marker) {
+    throw validationFailed('That storage prefix is not allowed.', { details: { prefix } });
+  }
+  return prefix;
+}
+
+export function storagePrefixFor(organizationId: string): string {
+  const valid = /^[A-Za-z0-9_-]+$/.test(organizationId);
+  if (!valid) {
+    throw validationFailed('That organization cannot own stored files.', {
+      details: { organizationId },
+    });
+  }
+  return assertSafePrefix(`${organizationId}/`);
+}

--- a/packages/services/src/storage/parent.ts
+++ b/packages/services/src/storage/parent.ts
@@ -1,4 +1,14 @@
-import { and, type Database, eq, inArray, or, schema, sql, type Transaction } from '@orbit/db';
+import {
+  and,
+  type Database,
+  eq,
+  inArray,
+  isNull,
+  or,
+  schema,
+  sql,
+  type Transaction,
+} from '@orbit/db';
 import { isExternallyShared, isRestricted } from '@orbit/shared/constants';
 import { notFound } from '@orbit/shared/errors';
 import { assertCan, isInTeam, type Principal } from '@orbit/shared/policy';
@@ -27,7 +37,14 @@ async function docFor(
   const [row] = await executor
     .select({ visibility: schema.doc.visibility, archivedAt: schema.doc.archivedAt })
     .from(schema.doc)
-    .where(and(eq(schema.doc.id, docId), eq(schema.doc.organizationId, organizationId)))
+    .innerJoin(schema.organization, eq(schema.organization.id, schema.doc.organizationId))
+    .where(
+      and(
+        eq(schema.doc.id, docId),
+        eq(schema.doc.organizationId, organizationId),
+        isNull(schema.organization.deletionRequestedAt),
+      ),
+    )
     .limit(1);
   return row;
 }

--- a/packages/services/src/storage/s3.ts
+++ b/packages/services/src/storage/s3.ts
@@ -161,7 +161,7 @@ async function currentPrefixInventory(
       throw internal('The workspace file inventory is too large to summarize safely.');
     }
     if (page.IsTruncated !== true) return { objects, bytes };
-    if (page.NextContinuationToken === undefined) {
+    if (page.NextContinuationToken === undefined || page.NextContinuationToken.length === 0) {
       throw internal('Object storage returned an incomplete workspace file listing.');
     }
     continuationToken = page.NextContinuationToken;
@@ -222,7 +222,12 @@ async function versionPrefixInventory(
       throw internal('The workspace file-version inventory is too large to summarize safely.');
     }
     if (page.IsTruncated !== true) return { objects, bytes };
-    if (page.NextKeyMarker === undefined || page.NextVersionIdMarker === undefined) {
+    if (
+      page.NextKeyMarker === undefined ||
+      page.NextKeyMarker.length === 0 ||
+      page.NextVersionIdMarker === undefined ||
+      page.NextVersionIdMarker.length === 0
+    ) {
       throw internal('Object storage returned an incomplete workspace file-version listing.');
     }
     keyMarker = page.NextKeyMarker;

--- a/packages/services/src/storage/s3.ts
+++ b/packages/services/src/storage/s3.ts
@@ -42,6 +42,7 @@ export const s3ConfigSchema = z.object({
 export type S3Config = z.input<typeof s3ConfigSchema>;
 
 export const UPLOAD_URL_TTL_SECONDS = 900;
+export const UPLOAD_COMPLETION_GRACE_SECONDS = UPLOAD_URL_TTL_SECONDS;
 const DEFAULT_CONTENT_TYPE = 'application/octet-stream';
 const MAX_DELETE_OBJECTS = 1000;
 
@@ -221,7 +222,7 @@ async function versionPrefixInventory(
       throw internal('The workspace file-version inventory is too large to summarize safely.');
     }
     if (page.IsTruncated !== true) return { objects, bytes };
-    if (page.NextKeyMarker === undefined) {
+    if (page.NextKeyMarker === undefined || page.NextVersionIdMarker === undefined) {
       throw internal('Object storage returned an incomplete workspace file-version listing.');
     }
     keyMarker = page.NextKeyMarker;

--- a/packages/services/src/storage/s3.ts
+++ b/packages/services/src/storage/s3.ts
@@ -4,6 +4,8 @@ import {
   GetObjectCommand,
   HeadObjectCommand,
   ListObjectsV2Command,
+  ListObjectVersionsCommand,
+  type ListObjectVersionsCommandOutput,
   PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
@@ -48,6 +50,16 @@ interface ListedObject {
   readonly size: number;
 }
 
+interface ListedVersion {
+  readonly Key: string;
+  readonly VersionId: string;
+}
+
+interface DeletionTarget {
+  readonly Key: string;
+  readonly VersionId?: string;
+}
+
 function listedObjects(
   contents: readonly {
     readonly Key?: string | undefined;
@@ -65,6 +77,44 @@ function listedObjects(
   });
 }
 
+function listedVersions(
+  entries: readonly {
+    readonly Key?: string | undefined;
+    readonly VersionId?: string | undefined;
+  }[],
+  prefix: string,
+): ListedVersion[] {
+  return entries.map((entry) => {
+    const key = entry.Key;
+    const versionId = entry.VersionId;
+    if (
+      key === undefined ||
+      !key.startsWith(prefix) ||
+      versionId === undefined ||
+      versionId.length === 0
+    ) {
+      throw internal('Object storage returned an invalid workspace file-version listing.');
+    }
+    return { Key: key, VersionId: versionId };
+  });
+}
+
+function versionListingUnavailable(error: unknown): boolean {
+  if (error === null || typeof error !== 'object') return false;
+  const candidate = error as {
+    readonly name?: unknown;
+    readonly Code?: unknown;
+    readonly $metadata?: { readonly httpStatusCode?: unknown };
+  };
+  return (
+    candidate.$metadata?.httpStatusCode === 501 ||
+    candidate.name === 'NotImplemented' ||
+    candidate.name === 'NotSupported' ||
+    candidate.Code === 'NotImplemented' ||
+    candidate.Code === 'NotSupported'
+  );
+}
+
 function throwStorageError(message: string, error: unknown): never {
   if (isDomainError(error)) throw error;
   throw internal(message, error);
@@ -78,6 +128,177 @@ function assertSignableLength(contentLength: number): void {
     throw payloadTooLarge(`Files must be ${formatBytes(MAX_UPLOAD_BYTES)} or smaller.`, {
       details: { size: contentLength, maxBytes: MAX_UPLOAD_BYTES },
     });
+  }
+}
+
+interface PrefixInventory {
+  readonly objects: number;
+  readonly bytes: number;
+}
+
+async function currentPrefixInventory(
+  client: S3Client,
+  bucket: string,
+  prefix: string,
+): Promise<PrefixInventory> {
+  let continuationToken: string | undefined;
+  let objects = 0;
+  let bytes = 0;
+  do {
+    const page = await client.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        MaxKeys: MAX_DELETE_OBJECTS,
+        ...(continuationToken === undefined ? {} : { ContinuationToken: continuationToken }),
+      }),
+    );
+    const listed = listedObjects(page.Contents ?? [], prefix);
+    objects += listed.length;
+    bytes += listed.reduce((total, entry) => total + entry.size, 0);
+    if (!(Number.isSafeInteger(objects) && Number.isSafeInteger(bytes))) {
+      throw internal('The workspace file inventory is too large to summarize safely.');
+    }
+    if (page.IsTruncated !== true) return { objects, bytes };
+    if (page.NextContinuationToken === undefined) {
+      throw internal('Object storage returned an incomplete workspace file listing.');
+    }
+    continuationToken = page.NextContinuationToken;
+  } while (continuationToken !== undefined);
+  return { objects, bytes };
+}
+
+async function versionPage(
+  client: S3Client,
+  bucket: string,
+  prefix: string,
+  keyMarker?: string,
+  versionIdMarker?: string,
+): Promise<ListObjectVersionsCommandOutput | null> {
+  try {
+    return await client.send(
+      new ListObjectVersionsCommand({
+        Bucket: bucket,
+        Prefix: prefix,
+        MaxKeys: MAX_DELETE_OBJECTS,
+        ...(keyMarker === undefined ? {} : { KeyMarker: keyMarker }),
+        ...(versionIdMarker === undefined ? {} : { VersionIdMarker: versionIdMarker }),
+      }),
+    );
+  } catch (error: unknown) {
+    if (versionListingUnavailable(error)) return null;
+    throw error;
+  }
+}
+
+function totalVersionBytes(entries: readonly { readonly Size?: number | undefined }[]): number {
+  return entries.reduce((total, entry) => {
+    const size = entry.Size ?? 0;
+    if (!Number.isSafeInteger(size) || size < 0) {
+      throw internal('Object storage returned an invalid workspace file-version listing.');
+    }
+    return total + size;
+  }, 0);
+}
+
+async function versionPrefixInventory(
+  client: S3Client,
+  bucket: string,
+  prefix: string,
+): Promise<PrefixInventory | null> {
+  let keyMarker: string | undefined;
+  let versionIdMarker: string | undefined;
+  let objects = 0;
+  let bytes = 0;
+  do {
+    const page = await versionPage(client, bucket, prefix, keyMarker, versionIdMarker);
+    if (page === null) return null;
+    const entries = page.Versions ?? [];
+    objects += listedVersions(entries, prefix).length;
+    bytes += totalVersionBytes(entries);
+    listedVersions(page.DeleteMarkers ?? [], prefix);
+    if (!(Number.isSafeInteger(objects) && Number.isSafeInteger(bytes))) {
+      throw internal('The workspace file-version inventory is too large to summarize safely.');
+    }
+    if (page.IsTruncated !== true) return { objects, bytes };
+    if (page.NextKeyMarker === undefined) {
+      throw internal('Object storage returned an incomplete workspace file-version listing.');
+    }
+    keyMarker = page.NextKeyMarker;
+    versionIdMarker = page.NextVersionIdMarker;
+  } while (keyMarker !== undefined);
+  return { objects, bytes };
+}
+
+async function deleteObjects(
+  client: S3Client,
+  bucket: string,
+  objects: readonly DeletionTarget[],
+  failureMessage: string,
+): Promise<void> {
+  for (let offset = 0; offset < objects.length; offset += MAX_DELETE_OBJECTS) {
+    const batch = objects.slice(offset, offset + MAX_DELETE_OBJECTS);
+    const deleted = await client.send(
+      new DeleteObjectsCommand({
+        Bucket: bucket,
+        Delete: { Objects: batch, Quiet: true },
+      }),
+    );
+    if ((deleted.Errors?.length ?? 0) > 0) throw internal(failureMessage);
+  }
+}
+
+async function deleteCurrentObjects(
+  client: S3Client,
+  bucket: string,
+  prefix: string,
+): Promise<void> {
+  while (true) {
+    const page = await client.send(
+      new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix, MaxKeys: MAX_DELETE_OBJECTS }),
+    );
+    const listed = listedObjects(page.Contents ?? [], prefix);
+    if (listed.length > 0) {
+      await deleteObjects(
+        client,
+        bucket,
+        listed.map((entry) => ({ Key: entry.key })),
+        'Object storage could not delete every workspace file.',
+      );
+      continue;
+    }
+    if (page.IsTruncated === true) {
+      throw internal('Object storage returned an incomplete workspace file listing.');
+    }
+    return;
+  }
+}
+
+async function deleteVersionedObjects(
+  client: S3Client,
+  bucket: string,
+  prefix: string,
+): Promise<void> {
+  while (true) {
+    const page = await versionPage(client, bucket, prefix);
+    if (page === null) return;
+    const versions = [
+      ...listedVersions(page.Versions ?? [], prefix),
+      ...listedVersions(page.DeleteMarkers ?? [], prefix),
+    ];
+    if (versions.length > 0) {
+      await deleteObjects(
+        client,
+        bucket,
+        versions,
+        'Object storage could not delete every workspace file version.',
+      );
+      continue;
+    }
+    if (page.IsTruncated === true) {
+      throw internal('Object storage returned an incomplete workspace file-version listing.');
+    }
+    return;
   }
 }
 
@@ -203,35 +424,15 @@ export class S3StorageDriver implements StorageDriver {
   async summarizePrefix(prefix: string): Promise<StoragePrefixSummary> {
     const safePrefix = assertSafePrefix(prefix);
     const client = await this.client();
-    let continuationToken: string | undefined;
-    let objects = 0;
-    let bytes = 0;
     try {
-      do {
-        const page = await client.send(
-          new ListObjectsV2Command({
-            Bucket: this.bucket,
-            Prefix: safePrefix,
-            MaxKeys: MAX_DELETE_OBJECTS,
-            ...(continuationToken === undefined ? {} : { ContinuationToken: continuationToken }),
-          }),
-        );
-        const listed = listedObjects(page.Contents ?? [], safePrefix);
-        objects += listed.length;
-        bytes += listed.reduce((total, entry) => total + entry.size, 0);
-        if (!(Number.isSafeInteger(objects) && Number.isSafeInteger(bytes))) {
-          throw internal('The workspace file inventory is too large to summarize safely.');
-        }
-        if (page.IsTruncated !== true) {
-          continuationToken = undefined;
-          continue;
-        }
-        if (page.NextContinuationToken === undefined) {
-          throw internal('Object storage returned an incomplete workspace file listing.');
-        }
-        continuationToken = page.NextContinuationToken;
-      } while (continuationToken !== undefined);
-      return { objects, bytes };
+      const current = await currentPrefixInventory(client, this.bucket, safePrefix);
+      const versions = await versionPrefixInventory(client, this.bucket, safePrefix);
+      return {
+        objects: current.objects,
+        bytes: current.bytes,
+        versions: versions?.objects ?? current.objects,
+        versionBytes: versions?.bytes ?? current.bytes,
+      };
     } catch (error: unknown) {
       throwStorageError('Could not inspect workspace files in storage.', error);
     }
@@ -241,37 +442,8 @@ export class S3StorageDriver implements StorageDriver {
     const safePrefix = assertSafePrefix(prefix);
     const client = await this.client();
     try {
-      while (true) {
-        const page = await client.send(
-          new ListObjectsV2Command({
-            Bucket: this.bucket,
-            Prefix: safePrefix,
-            MaxKeys: MAX_DELETE_OBJECTS,
-          }),
-        );
-        const listed = listedObjects(page.Contents ?? [], safePrefix);
-        if (listed.length === 0) {
-          if (page.IsTruncated === true) {
-            throw internal('Object storage returned an incomplete workspace file listing.');
-          }
-          return;
-        }
-        for (let offset = 0; offset < listed.length; offset += MAX_DELETE_OBJECTS) {
-          const batch = listed.slice(offset, offset + MAX_DELETE_OBJECTS);
-          const deleted = await client.send(
-            new DeleteObjectsCommand({
-              Bucket: this.bucket,
-              Delete: {
-                Objects: batch.map((entry) => ({ Key: entry.key })),
-                Quiet: true,
-              },
-            }),
-          );
-          if ((deleted.Errors?.length ?? 0) > 0) {
-            throw internal('Object storage could not delete every workspace file.');
-          }
-        }
-      }
+      await deleteCurrentObjects(client, this.bucket, safePrefix);
+      await deleteVersionedObjects(client, this.bucket, safePrefix);
     } catch (error: unknown) {
       throwStorageError('Could not delete workspace files from storage.', error);
     }

--- a/packages/services/src/storage/s3.ts
+++ b/packages/services/src/storage/s3.ts
@@ -1,7 +1,9 @@
 import {
   DeleteObjectCommand,
+  DeleteObjectsCommand,
   GetObjectCommand,
   HeadObjectCommand,
+  ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
@@ -9,14 +11,21 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import {
   formatBytes,
   internal,
+  isDomainError,
   MAX_UPLOAD_BYTES,
   payloadTooLarge,
   validationFailed,
 } from '@orbit/shared';
 import { z } from 'zod';
 import { createCredentialResolver, type ResolvedCredentials } from './credentials.ts';
-import { assertSafeKey } from './key.ts';
-import type { DownloadOptions, StorageDriver, StoredObject, UploadTarget } from './types.ts';
+import { assertSafeKey, assertSafePrefix } from './key.ts';
+import type {
+  DownloadOptions,
+  StorageDriver,
+  StoragePrefixSummary,
+  StoredObject,
+  UploadTarget,
+} from './types.ts';
 
 export const s3ConfigSchema = z.object({
   bucket: z.string().min(1),
@@ -30,8 +39,36 @@ export const s3ConfigSchema = z.object({
 
 export type S3Config = z.input<typeof s3ConfigSchema>;
 
-const UPLOAD_URL_TTL_SECONDS = 900;
+export const UPLOAD_URL_TTL_SECONDS = 900;
 const DEFAULT_CONTENT_TYPE = 'application/octet-stream';
+const MAX_DELETE_OBJECTS = 1000;
+
+interface ListedObject {
+  readonly key: string;
+  readonly size: number;
+}
+
+function listedObjects(
+  contents: readonly {
+    readonly Key?: string | undefined;
+    readonly Size?: number | undefined;
+  }[],
+  prefix: string,
+): ListedObject[] {
+  return contents.map((entry) => {
+    const key = entry.Key;
+    const size = entry.Size ?? 0;
+    if (key === undefined || !key.startsWith(prefix) || !Number.isSafeInteger(size) || size < 0) {
+      throw internal('Object storage returned an invalid workspace file listing.');
+    }
+    return { key, size };
+  });
+}
+
+function throwStorageError(message: string, error: unknown): never {
+  if (isDomainError(error)) throw error;
+  throw internal(message, error);
+}
 
 function assertSignableLength(contentLength: number): void {
   if (!Number.isSafeInteger(contentLength) || contentLength <= 0) {
@@ -53,12 +90,14 @@ export class S3StorageDriver implements StorageDriver {
     endpoint?: string;
   };
   private readonly resolveCredentials: () => Promise<ResolvedCredentials | undefined>;
+  private readonly providedClient: S3Client | null;
   private cached: { key: string; client: S3Client } | null = null;
 
-  constructor(config: S3Config) {
+  constructor(config: S3Config, providedClient: S3Client | null = null) {
     const parsed = s3ConfigSchema.parse(config);
     const { accessKeyId, secretAccessKey, sessionToken, endpoint } = parsed;
     this.bucket = parsed.bucket;
+    this.providedClient = providedClient;
     this.base = {
       region: parsed.region,
       forcePathStyle: parsed.forcePathStyle ?? endpoint !== undefined,
@@ -72,6 +111,7 @@ export class S3StorageDriver implements StorageDriver {
   }
 
   private async client(): Promise<S3Client> {
+    if (this.providedClient !== null) return this.providedClient;
     const credentials = await this.resolveCredentials();
     const key =
       credentials === undefined
@@ -158,6 +198,83 @@ export class S3StorageDriver implements StorageDriver {
     assertSafeKey(key);
     const client = await this.client();
     await client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
+  }
+
+  async summarizePrefix(prefix: string): Promise<StoragePrefixSummary> {
+    const safePrefix = assertSafePrefix(prefix);
+    const client = await this.client();
+    let continuationToken: string | undefined;
+    let objects = 0;
+    let bytes = 0;
+    try {
+      do {
+        const page = await client.send(
+          new ListObjectsV2Command({
+            Bucket: this.bucket,
+            Prefix: safePrefix,
+            MaxKeys: MAX_DELETE_OBJECTS,
+            ...(continuationToken === undefined ? {} : { ContinuationToken: continuationToken }),
+          }),
+        );
+        const listed = listedObjects(page.Contents ?? [], safePrefix);
+        objects += listed.length;
+        bytes += listed.reduce((total, entry) => total + entry.size, 0);
+        if (!(Number.isSafeInteger(objects) && Number.isSafeInteger(bytes))) {
+          throw internal('The workspace file inventory is too large to summarize safely.');
+        }
+        if (page.IsTruncated !== true) {
+          continuationToken = undefined;
+          continue;
+        }
+        if (page.NextContinuationToken === undefined) {
+          throw internal('Object storage returned an incomplete workspace file listing.');
+        }
+        continuationToken = page.NextContinuationToken;
+      } while (continuationToken !== undefined);
+      return { objects, bytes };
+    } catch (error: unknown) {
+      throwStorageError('Could not inspect workspace files in storage.', error);
+    }
+  }
+
+  async deletePrefix(prefix: string): Promise<void> {
+    const safePrefix = assertSafePrefix(prefix);
+    const client = await this.client();
+    try {
+      while (true) {
+        const page = await client.send(
+          new ListObjectsV2Command({
+            Bucket: this.bucket,
+            Prefix: safePrefix,
+            MaxKeys: MAX_DELETE_OBJECTS,
+          }),
+        );
+        const listed = listedObjects(page.Contents ?? [], safePrefix);
+        if (listed.length === 0) {
+          if (page.IsTruncated === true) {
+            throw internal('Object storage returned an incomplete workspace file listing.');
+          }
+          return;
+        }
+        for (let offset = 0; offset < listed.length; offset += MAX_DELETE_OBJECTS) {
+          const batch = listed.slice(offset, offset + MAX_DELETE_OBJECTS);
+          const deleted = await client.send(
+            new DeleteObjectsCommand({
+              Bucket: this.bucket,
+              Delete: {
+                Objects: batch.map((entry) => ({ Key: entry.key })),
+                Quiet: true,
+              },
+            }),
+          );
+          if ((deleted.Errors?.length ?? 0) > 0) {
+            throw internal('Object storage could not delete every workspace file.');
+          }
+        }
+      }
+    } catch (error: unknown) {
+      throwStorageError('Could not delete workspace files from storage.', error);
+    }
   }
 
   async stat(key: string): Promise<StoredObject | null> {

--- a/packages/services/src/storage/types.ts
+++ b/packages/services/src/storage/types.ts
@@ -22,6 +22,11 @@ export interface DownloadOptions {
   readonly disposition?: string;
 }
 
+export interface StoragePrefixSummary {
+  readonly objects: number;
+  readonly bytes: number;
+}
+
 export interface StorageDriver {
   readonly name: 's3';
   createUploadTarget(
@@ -32,5 +37,7 @@ export interface StorageDriver {
   put(key: string, body: Uint8Array, contentType: string): Promise<void>;
   getUrl(key: string, expiresInSeconds: number, options?: DownloadOptions): Promise<string>;
   delete(key: string): Promise<void>;
+  summarizePrefix(prefix: string): Promise<StoragePrefixSummary>;
+  deletePrefix(prefix: string): Promise<void>;
   stat(key: string): Promise<StoredObject | null>;
 }

--- a/packages/services/src/storage/types.ts
+++ b/packages/services/src/storage/types.ts
@@ -25,6 +25,8 @@ export interface DownloadOptions {
 export interface StoragePrefixSummary {
   readonly objects: number;
   readonly bytes: number;
+  readonly versions: number;
+  readonly versionBytes: number;
 }
 
 export interface StorageDriver {

--- a/packages/services/tests/storage/parent.test.ts
+++ b/packages/services/tests/storage/parent.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { eq } from '@orbit/db';
 import {
   comment,
   doc,
@@ -254,6 +255,24 @@ describe('isPubliclyReadable', () => {
       expect(await isPubliclyReadable(tx, { ...owner, parentId: fixture.archivedDocId })).toBe(
         false,
       );
+    });
+  });
+
+  it('is false while permanent workspace deletion is pending', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await tx
+        .update(organization)
+        .set({ deletionRequestedAt: new Date() })
+        .where(eq(organization.id, fixture.organizationId));
+
+      expect(
+        await isPubliclyReadable(tx, {
+          organizationId: fixture.organizationId,
+          parentType: 'doc',
+          parentId: fixture.publishedDocId,
+        }),
+      ).toBe(false);
     });
   });
 

--- a/packages/services/tests/storage/storage-prefix.test.ts
+++ b/packages/services/tests/storage/storage-prefix.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, mock } from 'bun:test';
-import { DeleteObjectsCommand, ListObjectsV2Command, type S3Client } from '@aws-sdk/client-s3';
+import {
+  DeleteObjectsCommand,
+  ListObjectsV2Command,
+  ListObjectVersionsCommand,
+  type S3Client,
+} from '@aws-sdk/client-s3';
 import { DomainError } from '@orbit/shared';
 import * as storage from '../../src/storage/index.ts';
 
@@ -25,6 +30,12 @@ function controlledClient(send: (command: unknown) => unknown): {
   return { client: { send: recorded } as unknown as S3Client, send: recorded };
 }
 
+function versionApiUnavailable(): Error {
+  const error = new Error('Version listing is not implemented.');
+  error.name = 'NotImplemented';
+  return Object.assign(error, { $metadata: { httpStatusCode: 501 } });
+}
+
 describe('organization storage prefixes', () => {
   it('derives one exact prefix from an organization id', () => {
     expect(storagePrefixFor('org_1')).toBe('org_1/');
@@ -40,29 +51,56 @@ describe('organization storage prefixes', () => {
 describe('S3StorageDriver prefix summary', () => {
   it('paginates every stored object and totals bytes independently of attachment rows', async () => {
     const { client, send } = controlledClient((command) => {
-      if (!(command instanceof ListObjectsV2Command)) throw new Error('Unexpected command');
-      if (command.input.ContinuationToken === undefined) {
+      if (command instanceof ListObjectsV2Command) {
+        if (command.input.ContinuationToken === undefined) {
+          return {
+            $metadata: {},
+            Contents: [
+              { Key: 'org_1/a', Size: 10 },
+              { Key: 'org_1/b', Size: 20 },
+            ],
+            IsTruncated: true,
+            NextContinuationToken: 'page_2',
+          };
+        }
+        expect(command.input.ContinuationToken).toBe('page_2');
         return {
           $metadata: {},
-          Contents: [
-            { Key: 'org_1/a', Size: 10 },
-            { Key: 'org_1/b', Size: 20 },
-          ],
-          IsTruncated: true,
-          NextContinuationToken: 'page_2',
+          Contents: [{ Key: 'org_1/orphan', Size: 30 }],
+          IsTruncated: false,
         };
       }
-      expect(command.input.ContinuationToken).toBe('page_2');
-      return {
-        $metadata: {},
-        Contents: [{ Key: 'org_1/orphan', Size: 30 }],
-        IsTruncated: false,
-      };
+      if (command instanceof ListObjectVersionsCommand) {
+        return command.input.KeyMarker === undefined
+          ? {
+              $metadata: {},
+              Versions: [
+                { Key: 'org_1/a', VersionId: 'a_1', Size: 10 },
+                { Key: 'org_1/a', VersionId: 'a_0', Size: 9 },
+                { Key: 'org_1/b', VersionId: 'b_1', Size: 20 },
+              ],
+              IsTruncated: true,
+              NextKeyMarker: 'org_1/a',
+              NextVersionIdMarker: 'a_0',
+            }
+          : {
+              $metadata: {},
+              Versions: [{ Key: 'org_1/orphan', VersionId: 'orphan_1', Size: 30 }],
+              DeleteMarkers: [{ Key: 'org_1/removed', VersionId: 'marker_1' }],
+              IsTruncated: false,
+            };
+      }
+      throw new Error('Unexpected command');
     });
     const driver = new S3StorageDriver(config, client);
 
-    expect(await driver.summarizePrefix('org_1/')).toEqual({ objects: 3, bytes: 60 });
-    expect(send).toHaveBeenCalledTimes(2);
+    expect(await driver.summarizePrefix('org_1/')).toEqual({
+      objects: 3,
+      bytes: 60,
+      versions: 4,
+      versionBytes: 69,
+    });
+    expect(send).toHaveBeenCalledTimes(4);
   });
 
   it('rejects a truncated response without a continuation token', async () => {
@@ -71,6 +109,43 @@ describe('S3StorageDriver prefix summary', () => {
       Contents: [{ Key: 'org_1/a', Size: 10 }],
       IsTruncated: true,
     }));
+    const driver = new S3StorageDriver(config, client);
+
+    await expect(driver.summarizePrefix('org_1/')).rejects.toMatchObject({ code: 'internal' });
+  });
+
+  it('uses current objects as the version inventory when the provider has no version API', async () => {
+    const { client } = controlledClient((command) => {
+      if (command instanceof ListObjectsV2Command) {
+        return {
+          $metadata: {},
+          Contents: [{ Key: 'org_1/a', Size: 10 }],
+          IsTruncated: false,
+        };
+      }
+      throw versionApiUnavailable();
+    });
+    const driver = new S3StorageDriver(config, client);
+
+    expect(await driver.summarizePrefix('org_1/')).toEqual({
+      objects: 1,
+      bytes: 10,
+      versions: 1,
+      versionBytes: 10,
+    });
+  });
+
+  it('rejects a truncated version response without its next key marker', async () => {
+    const { client } = controlledClient((command) => {
+      if (command instanceof ListObjectsV2Command) {
+        return { $metadata: {}, Contents: [], IsTruncated: false };
+      }
+      return {
+        $metadata: {},
+        Versions: [{ Key: 'org_1/a', VersionId: 'version_1', Size: 10 }],
+        IsTruncated: true,
+      };
+    });
     const driver = new S3StorageDriver(config, client);
 
     await expect(driver.summarizePrefix('org_1/')).rejects.toMatchObject({ code: 'internal' });
@@ -91,6 +166,9 @@ describe('S3StorageDriver prefix deletion', () => {
           IsTruncated: false,
         };
       }
+      if (command instanceof ListObjectVersionsCommand) {
+        return { $metadata: {}, Versions: [], DeleteMarkers: [], IsTruncated: false };
+      }
       if (command instanceof DeleteObjectsCommand) {
         deleted.push((command.input.Delete?.Objects ?? []).map((entry) => entry.Key ?? ''));
         return { $metadata: {}, Deleted: command.input.Delete?.Objects ?? [], Errors: [] };
@@ -106,6 +184,99 @@ describe('S3StorageDriver prefix deletion', () => {
     expect(listCalls).toBe(2);
   });
 
+  it('permanently deletes historical versions and delete markers under the exact prefix', async () => {
+    const deleted: { Key?: string | undefined; VersionId?: string | undefined }[][] = [];
+    let versionLists = 0;
+    const { client } = controlledClient((command) => {
+      if (command instanceof ListObjectsV2Command) {
+        return { $metadata: {}, Contents: [], IsTruncated: false };
+      }
+      if (command instanceof ListObjectVersionsCommand) {
+        versionLists += 1;
+        return versionLists === 1
+          ? {
+              $metadata: {},
+              Versions: [
+                { Key: 'org_1/file', VersionId: 'version_1' },
+                { Key: 'org_1/file', VersionId: 'version_2' },
+              ],
+              DeleteMarkers: [{ Key: 'org_1/removed', VersionId: 'marker_1' }],
+              IsTruncated: false,
+            }
+          : { $metadata: {}, Versions: [], DeleteMarkers: [], IsTruncated: false };
+      }
+      if (command instanceof DeleteObjectsCommand) {
+        deleted.push([...(command.input.Delete?.Objects ?? [])]);
+        return { $metadata: {}, Errors: [] };
+      }
+      throw new Error('Unexpected command');
+    });
+    const driver = new S3StorageDriver(config, client);
+
+    await driver.deletePrefix('org_1/');
+
+    expect(deleted.flat()).toEqual([
+      { Key: 'org_1/file', VersionId: 'version_1' },
+      { Key: 'org_1/file', VersionId: 'version_2' },
+      { Key: 'org_1/removed', VersionId: 'marker_1' },
+    ]);
+    expect(versionLists).toBe(2);
+  });
+
+  it('supports providers without an object-version listing API', async () => {
+    const { client, send } = controlledClient((command) => {
+      if (command instanceof ListObjectsV2Command) {
+        return { $metadata: {}, Contents: [], IsTruncated: false };
+      }
+      if (command instanceof ListObjectVersionsCommand) {
+        throw versionApiUnavailable();
+      }
+      throw new Error('Unexpected command');
+    });
+    const driver = new S3StorageDriver(config, client);
+
+    await expect(driver.deletePrefix('org_1/')).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a version deletion error instead of claiming permanent cleanup', async () => {
+    const { client } = controlledClient((command) => {
+      if (command instanceof ListObjectsV2Command) {
+        return { $metadata: {}, Contents: [], IsTruncated: false };
+      }
+      if (command instanceof ListObjectVersionsCommand) {
+        return {
+          $metadata: {},
+          Versions: [{ Key: 'org_1/file', VersionId: 'version_1' }],
+          IsTruncated: false,
+        };
+      }
+      return {
+        $metadata: {},
+        Errors: [{ Key: 'org_1/file', VersionId: 'version_1', Code: 'AccessDenied' }],
+      };
+    });
+    const driver = new S3StorageDriver(config, client);
+
+    await expect(driver.deletePrefix('org_1/')).rejects.toMatchObject({ code: 'internal' });
+  });
+
+  it('refuses a historical version outside the requested prefix', async () => {
+    const { client } = controlledClient((command) => {
+      if (command instanceof ListObjectsV2Command) {
+        return { $metadata: {}, Contents: [], IsTruncated: false };
+      }
+      return {
+        $metadata: {},
+        Versions: [{ Key: 'org_2/secret', VersionId: 'version_1' }],
+        IsTruncated: false,
+      };
+    });
+    const driver = new S3StorageDriver(config, client);
+
+    await expect(driver.deletePrefix('org_1/')).rejects.toMatchObject({ code: 'internal' });
+  });
+
   it('treats an already empty prefix as a successful idempotent cleanup', async () => {
     const { client, send } = controlledClient(() => ({
       $metadata: {},
@@ -115,8 +286,9 @@ describe('S3StorageDriver prefix deletion', () => {
     const driver = new S3StorageDriver(config, client);
 
     await expect(driver.deletePrefix('org_1/')).resolves.toBeUndefined();
-    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledTimes(2);
     expect(send.mock.calls[0]?.[0]).toBeInstanceOf(ListObjectsV2Command);
+    expect(send.mock.calls[1]?.[0]).toBeInstanceOf(ListObjectVersionsCommand);
   });
 
   it('reports a per-object deletion error instead of claiming success', async () => {

--- a/packages/services/tests/storage/storage-prefix.test.ts
+++ b/packages/services/tests/storage/storage-prefix.test.ts
@@ -144,6 +144,24 @@ describe('S3StorageDriver prefix summary', () => {
         $metadata: {},
         Versions: [{ Key: 'org_1/a', VersionId: 'version_1', Size: 10 }],
         IsTruncated: true,
+        NextVersionIdMarker: 'version_1',
+      };
+    });
+    const driver = new S3StorageDriver(config, client);
+
+    await expect(driver.summarizePrefix('org_1/')).rejects.toMatchObject({ code: 'internal' });
+  });
+
+  it('rejects a truncated version response without its next version marker', async () => {
+    const { client } = controlledClient((command) => {
+      if (command instanceof ListObjectsV2Command) {
+        return { $metadata: {}, Contents: [], IsTruncated: false };
+      }
+      return {
+        $metadata: {},
+        Versions: [{ Key: 'org_1/a', VersionId: 'version_1', Size: 10 }],
+        IsTruncated: true,
+        NextKeyMarker: 'org_1/a',
       };
     });
     const driver = new S3StorageDriver(config, client);

--- a/packages/services/tests/storage/storage-prefix.test.ts
+++ b/packages/services/tests/storage/storage-prefix.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { DeleteObjectsCommand, ListObjectsV2Command, type S3Client } from '@aws-sdk/client-s3';
+import { DomainError } from '@orbit/shared';
+import * as storage from '../../src/storage/index.ts';
+
+const expectedStorage = storage as typeof storage & {
+  readonly assertSafePrefix: (prefix: string) => string;
+  readonly storagePrefixFor: (organizationId: string) => string;
+};
+const { assertSafePrefix, storagePrefixFor } = expectedStorage;
+const { S3StorageDriver } = storage;
+
+const config = {
+  bucket: 'orbit-uploads',
+  region: 'us-east-1',
+  accessKeyId: 'test-key',
+  secretAccessKey: 'test-secret',
+};
+
+function controlledClient(send: (command: unknown) => unknown): {
+  readonly client: S3Client;
+  readonly send: ReturnType<typeof mock>;
+} {
+  const recorded = mock((command: unknown) => Promise.resolve(send(command)));
+  return { client: { send: recorded } as unknown as S3Client, send: recorded };
+}
+
+describe('organization storage prefixes', () => {
+  it('derives one exact prefix from an organization id', () => {
+    expect(storagePrefixFor('org_1')).toBe('org_1/');
+  });
+
+  it('rejects prefixes that are empty, broad, traversing, or not terminated', () => {
+    for (const prefix of ['', '/', '../', 'org_1', 'org_1/../', 'org_1\\']) {
+      expect(() => assertSafePrefix(prefix), prefix).toThrow(DomainError);
+    }
+  });
+});
+
+describe('S3StorageDriver prefix summary', () => {
+  it('paginates every stored object and totals bytes independently of attachment rows', async () => {
+    const { client, send } = controlledClient((command) => {
+      if (!(command instanceof ListObjectsV2Command)) throw new Error('Unexpected command');
+      if (command.input.ContinuationToken === undefined) {
+        return {
+          $metadata: {},
+          Contents: [
+            { Key: 'org_1/a', Size: 10 },
+            { Key: 'org_1/b', Size: 20 },
+          ],
+          IsTruncated: true,
+          NextContinuationToken: 'page_2',
+        };
+      }
+      expect(command.input.ContinuationToken).toBe('page_2');
+      return {
+        $metadata: {},
+        Contents: [{ Key: 'org_1/orphan', Size: 30 }],
+        IsTruncated: false,
+      };
+    });
+    const driver = new S3StorageDriver(config, client);
+
+    expect(await driver.summarizePrefix('org_1/')).toEqual({ objects: 3, bytes: 60 });
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects a truncated response without a continuation token', async () => {
+    const { client } = controlledClient(() => ({
+      $metadata: {},
+      Contents: [{ Key: 'org_1/a', Size: 10 }],
+      IsTruncated: true,
+    }));
+    const driver = new S3StorageDriver(config, client);
+
+    await expect(driver.summarizePrefix('org_1/')).rejects.toMatchObject({ code: 'internal' });
+  });
+});
+
+describe('S3StorageDriver prefix deletion', () => {
+  it('deletes exact listed keys in S3 batches and proves the prefix is empty', async () => {
+    const keys = Array.from({ length: 1001 }, (_, index) => `org_1/file_${String(index)}`);
+    const deleted: string[][] = [];
+    let listCalls = 0;
+    const { client } = controlledClient((command) => {
+      if (command instanceof ListObjectsV2Command) {
+        listCalls += 1;
+        return {
+          $metadata: {},
+          Contents: listCalls === 1 ? keys.map((Key) => ({ Key, Size: 1 })) : [],
+          IsTruncated: false,
+        };
+      }
+      if (command instanceof DeleteObjectsCommand) {
+        deleted.push((command.input.Delete?.Objects ?? []).map((entry) => entry.Key ?? ''));
+        return { $metadata: {}, Deleted: command.input.Delete?.Objects ?? [], Errors: [] };
+      }
+      throw new Error('Unexpected command');
+    });
+    const driver = new S3StorageDriver(config, client);
+
+    await driver.deletePrefix('org_1/');
+
+    expect(deleted.map((batch) => batch.length)).toEqual([1000, 1]);
+    expect(deleted.flat()).toEqual(keys);
+    expect(listCalls).toBe(2);
+  });
+
+  it('treats an already empty prefix as a successful idempotent cleanup', async () => {
+    const { client, send } = controlledClient(() => ({
+      $metadata: {},
+      Contents: [],
+      IsTruncated: false,
+    }));
+    const driver = new S3StorageDriver(config, client);
+
+    await expect(driver.deletePrefix('org_1/')).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toBeInstanceOf(ListObjectsV2Command);
+  });
+
+  it('reports a per-object deletion error instead of claiming success', async () => {
+    const { client } = controlledClient((command) => {
+      if (command instanceof ListObjectsV2Command) {
+        return {
+          $metadata: {},
+          Contents: [{ Key: 'org_1/stuck', Size: 7 }],
+          IsTruncated: false,
+        };
+      }
+      return {
+        $metadata: {},
+        Deleted: [],
+        Errors: [{ Key: 'org_1/stuck', Code: 'AccessDenied', Message: 'denied' }],
+      };
+    });
+    const driver = new S3StorageDriver(config, client);
+
+    await expect(driver.deletePrefix('org_1/')).rejects.toMatchObject({ code: 'internal' });
+  });
+
+  it('refuses a key outside the requested prefix even if storage returns it', async () => {
+    const { client } = controlledClient(() => ({
+      $metadata: {},
+      Contents: [{ Key: 'org_2/secret', Size: 9 }],
+      IsTruncated: false,
+    }));
+    const driver = new S3StorageDriver(config, client);
+
+    await expect(driver.deletePrefix('org_1/')).rejects.toMatchObject({ code: 'internal' });
+  });
+});

--- a/packages/services/tests/storage/storage-prefix.test.ts
+++ b/packages/services/tests/storage/storage-prefix.test.ts
@@ -114,6 +114,27 @@ describe('S3StorageDriver prefix summary', () => {
     await expect(driver.summarizePrefix('org_1/')).rejects.toMatchObject({ code: 'internal' });
   });
 
+  it('rejects a truncated response with an empty continuation token', async () => {
+    const { client, send } = controlledClient((command) => {
+      if (
+        command instanceof ListObjectsV2Command &&
+        command.input.ContinuationToken === undefined
+      ) {
+        return {
+          $metadata: {},
+          Contents: [{ Key: 'org_1/a', Size: 10 }],
+          IsTruncated: true,
+          NextContinuationToken: '',
+        };
+      }
+      throw new Error('The empty continuation token was reused.');
+    });
+    const driver = new S3StorageDriver(config, client);
+
+    await expect(driver.summarizePrefix('org_1/')).rejects.toMatchObject({ code: 'internal' });
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
   it('uses current objects as the version inventory when the provider has no version API', async () => {
     const { client } = controlledClient((command) => {
       if (command instanceof ListObjectsV2Command) {
@@ -167,6 +188,28 @@ describe('S3StorageDriver prefix summary', () => {
     const driver = new S3StorageDriver(config, client);
 
     await expect(driver.summarizePrefix('org_1/')).rejects.toMatchObject({ code: 'internal' });
+  });
+
+  it('rejects a truncated version response with an empty marker', async () => {
+    const { client, send } = controlledClient((command) => {
+      if (command instanceof ListObjectsV2Command) {
+        return { $metadata: {}, Contents: [], IsTruncated: false };
+      }
+      if (command instanceof ListObjectVersionsCommand && command.input.KeyMarker === undefined) {
+        return {
+          $metadata: {},
+          Versions: [{ Key: 'org_1/a', VersionId: 'version_1', Size: 10 }],
+          IsTruncated: true,
+          NextKeyMarker: '',
+          NextVersionIdMarker: 'version_1',
+        };
+      }
+      throw new Error('The empty version marker was reused.');
+    });
+    const driver = new S3StorageDriver(config, client);
+
+    await expect(driver.summarizePrefix('org_1/')).rejects.toMatchObject({ code: 'internal' });
+    expect(send).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/shared/src/events/control.ts
+++ b/packages/shared/src/events/control.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 
-export const controlMessageSchema = z.object({
-  type: z.literal('session_revoked'),
-  userId: z.string().min(1),
-});
+export const controlMessageSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('session_revoked'),
+    userId: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal('organization_deleted'),
+    organizationId: z.string().min(1),
+  }),
+]);
 
 export type ControlMessage = z.infer<typeof controlMessageSchema>;

--- a/packages/shared/src/policy/index.ts
+++ b/packages/shared/src/policy/index.ts
@@ -26,6 +26,7 @@ export const PERMISSIONS = [
   'member:manage',
   'integration:manage',
   'org:manage',
+  'org:delete',
 ] as const;
 
 export type Permission = (typeof PERMISSIONS)[number];
@@ -67,6 +68,7 @@ const ADMIN_PERMISSIONS: readonly Permission[] = [
   'member:manage',
   'integration:manage',
   'org:manage',
+  'org:delete',
 ];
 
 const PERMISSIONS_BY_ROLE: Record<OrgRole, readonly Permission[]> = {

--- a/packages/shared/src/validators/organization.ts
+++ b/packages/shared/src/validators/organization.ts
@@ -37,6 +37,36 @@ export const organizationDeleteSchema = z
   })
   .strict();
 
+export const organizationDeletionSummarySchema = z
+  .object({
+    organizationName: z.string(),
+    members: z.number().int().nonnegative(),
+    teams: z.number().int().nonnegative(),
+    projects: z.number().int().nonnegative(),
+    issues: z.number().int().nonnegative(),
+    documents: z.number().int().nonnegative(),
+    files: z.number().int().nonnegative(),
+    fileBytes: z.number().int().nonnegative(),
+    fileVersions: z.number().int().nonnegative(),
+    fileVersionBytes: z.number().int().nonnegative(),
+    integrations: z.number().int().nonnegative(),
+    webhooks: z.number().int().nonnegative(),
+    availableAt: z.string().datetime().nullable(),
+    deletionRequestedAt: z.string().datetime().nullable(),
+  })
+  .strict();
+
+export const organizationDeletionSummaryResponseSchema = z
+  .object({ summary: organizationDeletionSummarySchema })
+  .strict();
+
+export const organizationDeletionResponseSchema = z
+  .object({
+    deletedOrganizationId: idSchema,
+    nextOrganizationId: idSchema.nullable(),
+  })
+  .strict();
+
 export const inviteCreateSchema = z.object({
   email: emailSchema,
   role: z.enum(ORG_ROLES).default('member'),
@@ -53,4 +83,9 @@ export const memberUpdateSchema = z.object({
 
 export type OrganizationCreateInput = z.infer<typeof organizationCreateSchema>;
 export type OrganizationDeleteInput = z.infer<typeof organizationDeleteSchema>;
+export type OrganizationDeletionSummary = z.infer<typeof organizationDeletionSummarySchema>;
+export type OrganizationDeletionSummaryResponse = z.infer<
+  typeof organizationDeletionSummaryResponseSchema
+>;
+export type OrganizationDeletionResponse = z.infer<typeof organizationDeletionResponseSchema>;
 export type InviteCreateInput = z.infer<typeof inviteCreateSchema>;

--- a/packages/shared/src/validators/organization.ts
+++ b/packages/shared/src/validators/organization.ts
@@ -27,6 +27,12 @@ export const organizationUpdateSchema = z
   })
   .partial();
 
+export const organizationDeleteSchema = z
+  .object({
+    confirmation: z.string().trim().min(1).max(64),
+  })
+  .strict();
+
 export const inviteCreateSchema = z.object({
   email: emailSchema,
   role: z.enum(ORG_ROLES).default('member'),
@@ -42,4 +48,5 @@ export const memberUpdateSchema = z.object({
 });
 
 export type OrganizationCreateInput = z.infer<typeof organizationCreateSchema>;
+export type OrganizationDeleteInput = z.infer<typeof organizationDeleteSchema>;
 export type InviteCreateInput = z.infer<typeof inviteCreateSchema>;

--- a/packages/shared/src/validators/organization.ts
+++ b/packages/shared/src/validators/organization.ts
@@ -29,7 +29,7 @@ export const organizationUpdateSchema = z
 
 export const organizationDeleteSchema = z
   .object({
-    confirmation: z.string().trim().min(1).max(64),
+    confirmation: z.string().trim().min(1).max(80),
   })
   .strict();
 

--- a/packages/shared/src/validators/organization.ts
+++ b/packages/shared/src/validators/organization.ts
@@ -29,7 +29,11 @@ export const organizationUpdateSchema = z
 
 export const organizationDeleteSchema = z
   .object({
-    confirmation: z.string().trim().min(1).max(80),
+    confirmation: z
+      .string()
+      .min(1)
+      .max(80)
+      .refine((value) => value === value.trim()),
   })
   .strict();
 

--- a/packages/shared/tests/events/control.test.ts
+++ b/packages/shared/tests/events/control.test.ts
@@ -11,6 +11,17 @@ describe('control message', () => {
     expect(parsed.success).toBe(true);
   });
 
+  it('accepts an organization_deleted message', () => {
+    const parsed = controlMessageSchema.safeParse({
+      type: 'organization_deleted',
+      organizationId: 'org_1',
+    });
+    expect(parsed).toMatchObject({
+      success: true,
+      data: { type: 'organization_deleted', organizationId: 'org_1' },
+    });
+  });
+
   it('rejects an unknown type', () => {
     const parsed = controlMessageSchema.safeParse({ type: 'nope', userId: 'user_1' });
     expect(parsed.success).toBe(false);
@@ -18,6 +29,14 @@ describe('control message', () => {
 
   it('rejects an empty userId', () => {
     const parsed = controlMessageSchema.safeParse({ type: 'session_revoked', userId: '' });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects an empty organizationId', () => {
+    const parsed = controlMessageSchema.safeParse({
+      type: 'organization_deleted',
+      organizationId: '',
+    });
     expect(parsed.success).toBe(false);
   });
 

--- a/packages/shared/tests/policy/policy.test.ts
+++ b/packages/shared/tests/policy/policy.test.ts
@@ -52,6 +52,13 @@ describe('can', () => {
     expect(can(principal('admin'), 'team:manage')).toBe(true);
   });
 
+  it('reserves permanent workspace deletion for administrators', () => {
+    expect(can(principal('admin'), 'org:delete')).toBe(true);
+    expect(can(principal('member'), 'org:delete')).toBe(false);
+    expect(can(principal('contributor'), 'org:delete')).toBe(false);
+    expect(can(principal('guest'), 'org:delete')).toBe(false);
+  });
+
   it('reports no capability that no route enforces', () => {
     const retired = ['attachment:delete', 'agent:delegate', 'audit:read'];
     for (const permission of retired) expect(permissionsFor('admin')).not.toContain(permission);

--- a/packages/shared/tests/validators/organization.test.ts
+++ b/packages/shared/tests/validators/organization.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test';
+import { organizationDeleteSchema } from '../../src/validators/organization.ts';
+
+describe('organizationDeleteSchema', () => {
+  it('trims the exact workspace-name confirmation', () => {
+    expect(organizationDeleteSchema.parse({ confirmation: '  Nova  ' })).toEqual({
+      confirmation: 'Nova',
+    });
+  });
+
+  it('rejects empty and oversized confirmations', () => {
+    expect(organizationDeleteSchema.safeParse({ confirmation: '   ' }).success).toBe(false);
+    expect(organizationDeleteSchema.safeParse({ confirmation: 'n'.repeat(65) }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects organization selectors outside the confirmation contract', () => {
+    expect(
+      organizationDeleteSchema.safeParse({ confirmation: 'Nova', organizationId: 'org_2' }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/shared/tests/validators/organization.test.ts
+++ b/packages/shared/tests/validators/organization.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from 'bun:test';
 import { organizationDeleteSchema } from '../../src/validators/organization.ts';
 
 describe('organizationDeleteSchema', () => {
-  it('trims the exact workspace-name confirmation', () => {
-    expect(organizationDeleteSchema.parse({ confirmation: '  Nova  ' })).toEqual({
+  it('rejects surrounding spaces instead of changing the exact confirmation', () => {
+    expect(organizationDeleteSchema.safeParse({ confirmation: '  Nova  ' }).success).toBe(false);
+    expect(organizationDeleteSchema.parse({ confirmation: 'Nova' })).toEqual({
       confirmation: 'Nova',
     });
   });

--- a/packages/shared/tests/validators/organization.test.ts
+++ b/packages/shared/tests/validators/organization.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test';
-import { organizationDeleteSchema } from '../../src/validators/organization.ts';
+import {
+  organizationDeleteSchema,
+  organizationDeletionResponseSchema,
+  organizationDeletionSummaryResponseSchema,
+} from '../../src/validators/organization.ts';
 
 describe('organizationDeleteSchema', () => {
   it('rejects surrounding spaces instead of changing the exact confirmation', () => {
@@ -20,6 +24,47 @@ describe('organizationDeleteSchema', () => {
   it('rejects organization selectors outside the confirmation contract', () => {
     expect(
       organizationDeleteSchema.safeParse({ confirmation: 'Nova', organizationId: 'org_2' }).success,
+    ).toBe(false);
+  });
+});
+
+describe('organization deletion response schemas', () => {
+  it('parses the complete deletion inventory returned by the API', () => {
+    expect(
+      organizationDeletionSummaryResponseSchema.parse({
+        summary: {
+          organizationName: 'Nova',
+          members: 4,
+          teams: 3,
+          projects: 2,
+          issues: 17,
+          documents: 5,
+          files: 8,
+          fileBytes: 4096,
+          fileVersions: 12,
+          fileVersionBytes: 6144,
+          integrations: 1,
+          webhooks: 2,
+          availableAt: null,
+          deletionRequestedAt: '2026-08-08T12:00:00.000Z',
+        },
+      }).summary.organizationName,
+    ).toBe('Nova');
+  });
+
+  it('rejects malformed deletion results and extra selectors', () => {
+    expect(
+      organizationDeletionResponseSchema.safeParse({
+        deletedOrganizationId: 'org_1',
+        nextOrganizationId: null,
+      }).success,
+    ).toBe(true);
+    expect(
+      organizationDeletionResponseSchema.safeParse({
+        deletedOrganizationId: 'org_1',
+        nextOrganizationId: null,
+        organizationId: 'org_2',
+      }).success,
     ).toBe(false);
   });
 });

--- a/packages/shared/tests/validators/organization.test.ts
+++ b/packages/shared/tests/validators/organization.test.ts
@@ -8,9 +8,10 @@ describe('organizationDeleteSchema', () => {
     });
   });
 
-  it('rejects empty and oversized confirmations', () => {
+  it('accepts the longest creatable name and rejects anything larger', () => {
     expect(organizationDeleteSchema.safeParse({ confirmation: '   ' }).success).toBe(false);
-    expect(organizationDeleteSchema.safeParse({ confirmation: 'n'.repeat(65) }).success).toBe(
+    expect(organizationDeleteSchema.safeParse({ confirmation: 'n'.repeat(80) }).success).toBe(true);
+    expect(organizationDeleteSchema.safeParse({ confirmation: 'n'.repeat(81) }).success).toBe(
       false,
     );
   });


### PR DESCRIPTION
## Summary

- add an administrator-only danger zone for permanently deleting the active workspace
- show a fresh, server-computed deletion inventory and require the exact case-sensitive workspace name
- lock normal workspace access as soon as deletion is confirmed, safely drain outstanding upload capabilities, and expose a durable retry flow
- remove the complete workspace database graph and exact object-storage prefix while preserving shared users and data in other workspaces
- disconnect realtime clients and recover each client into a surviving workspace or workspace creation

## Safety and authorization

- the API always targets the authenticated session's current workspace and accepts no caller-supplied workspace id, slug, or storage prefix
- shared server policy grants `org:delete` only to workspace administrators
- marker, readiness, and final database phases lock the organization and current member rows, then recheck the current role and confirmation inside each transaction
- the first phase commits `organization.deletion_requested_at`, which blocks normal web, realtime, MCP, upload, invite, public-doc, and public-attachment access
- final cleanup waits for the later of every recorded upload expiration plus completion grace and the deletion marker plus one full URL lifetime and completion grace
- the marker-based 30-minute drain covers a presigned target whose attachment insert or transaction commit failed
- the retry endpoint remains available to administrators, and pending workspaces remain discoverable only for an administrator retry

## Data and storage cleanup

- the dialog counts members, teams, projects, issues, documents, stored files and versions, integrations, and webhooks
- it identifies nested comments, attachments, activity, notifications, automations, saved views, cycles, labels, workflow states, credentials, and other cascade-owned records
- a schema regression requires every direct `organization_id` foreign key to cascade from `organization.id`
- active workspace pointers are cleared, while user, account, passkey, avatar, session, and other-workspace records are preserved
- exact-prefix storage cleanup runs without an open database transaction, followed by a short cascaded-delete transaction; storage, statement, or commit failure leaves the durable retry marker intact
- S3-compatible cleanup uses the exact `<organizationId>/` prefix, bounded batches, current objects, historical versions, and delete markers
- partial responses and malformed pagination fail closed, while providers that explicitly lack the version API use current-object cleanup

## Migration and deployment

- preserve the latest `main` migration as `0001` and add this feature as migration `0002`
- add nullable `attachment.upload_expires_at` with a conservative rolling-deploy default and backfill
- add nullable `organization.deletion_requested_at` for durable, fail-closed retries
- versioned AWS buckets require `s3:ListBucketVersions` and `s3:DeleteObjectVersion` in addition to existing list and delete permissions

## Verification

- `ORBIT_TEST_LANE=workspace_deletion_final10 bun run verify`
- all package test suites passed, including 237 shared tests, 538 services tests, 757 core tests, 161 database tests, and 1,689 web tests
- all nine package typechecks passed
- lint, comment policy, source-byte policy, runtime import policy, and dependency checks passed
- the complete migration chain applied successfully to an empty disposable database and produced all three expected migrations
- focused regressions cover failed upload registration after URL issuance, exact protection boundaries, transaction failures, idempotent storage retries, access lockout, tenant isolation, and UI retry behavior

## Notes

This PR adds the deletion capability only. It does not invoke deletion against any deployed workspace, and it does not modify the protected `noveum.ai` organization.
