### PR TITLE
perf(web): turn on the React Compiler

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -26,6 +26,7 @@ export default function config(phase: string): NextConfig {
   const isDevServer = phase === PHASE_DEVELOPMENT_SERVER;
   return {
     reactStrictMode: true,
+    reactCompiler: true,
     ...standaloneOutputUnlessVercelTracesItItself(),
     outputFileTracingRoot: workspaceRoot,
     turbopack: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -88,6 +88,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@types/ws": "^8.18.1",
+    "babel-plugin-react-compiler": "^1.0.0",
     "tailwindcss": "^4.3.3",
     "typescript": "5.9.3"
   }

--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,7 @@
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "@types/ws": "^8.18.1",
+        "babel-plugin-react-compiler": "^1.0.0",
         "tailwindcss": "^4.3.3",
         "typescript": "5.9.3",
       },
@@ -298,9 +299,13 @@
 
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
 
     "@better-auth/core": ["@better-auth/core@1.6.26", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.7", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-Ud4FqnjIJDvmeo+3bN+OsuVVAiuvFjNERbW7G8/65ictSxCox62gNgTOsJ4YXmbwXzBzyyekStzrupg2qNGEkA=="],
 
@@ -995,6 +1000,8 @@
     "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
+
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@1.0.0", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.11.1", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A=="],
 


### PR DESCRIPTION
## Why here specifically

Three things make this codebase an unusually good fit:

- **There is not a single `memo()` in `apps/web/src`.** No `useDeferredValue`, no `startTransition` either.
- **193 of 269 `.tsx` files are client components.**
- **A websocket fans deltas into the query cache continuously.** A delta for one issue currently re-renders far more than the row that changed.

Automatic memoization is aimed exactly at that shape.

## It costs nothing to build

Next runs an SWC pass first and only hands Babel the files that actually contain JSX or hooks, so the usual "Babel makes builds slow" objection does not apply here. Measured, full production build on this machine:

| | Wall clock |
| --- | --- |
| Without | 54.1s |
| With | **52.9s** |

That difference is noise. The point is that there is no penalty to weigh against the runtime benefit.

## What this does not do

Worth stating plainly rather than overselling. The compiler compresses **processing duration** for re-render-bound work. It does nothing for input delay or presentation delay, so it is not a fix for everything that shows up in INP.

## Verification, and its limits

Full web suite: **1620 pass, 0 fail**.

But that suite proves less than it looks like it does here. The compiler only affects the built bundle, and the unit tests import source directly, so **they do not exercise compiled output at all**. The e2e suite is the only thing in CI that runs the built app, so it is the real check on this change.

One gap I want on the record: the repo lints with biome, not eslint, so `eslint-plugin-react-hooks` and its compiler rules are not running. There is no static safety net catching Rules of React violations before they reach the compiler. If anything subtle shows up in this area later, that is the first thing to add.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enables the React Compiler for the Next.js web application and adds its Babel plugin to the build toolchain.
- Sets `reactCompiler: true` in the web application’s Next configuration.
- Adds and locks `babel-plugin-react-compiler` version 1.0.0.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issue identified.

The installed Next.js and React versions support the enabled compiler configuration, and frozen dependency installation preserves the reviewed compiler version across CI and deployment.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/next.config.ts | Enables Next.js’s supported React Compiler integration globally; no concrete configuration defect was identified. |
| apps/web/package.json | Adds the compiler plugin as a development dependency consistent with its build-time use. |
| bun.lock | Locks the compiler plugin and its Babel dependencies with integrity metadata. |

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(web): turn on the React Compiler"](https://github.com/noveum/orbit/commit/742e4d6b698dc4a148e3a981605a0d9f40f470ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51464045)</sub>

<!-- /greptile_comment -->