### PR TITLE
perf(github): stop recording a delivery for events no handler reads

### DIFF
--- a/apps/web/src/app/api/webhooks/github/route.ts
+++ b/apps/web/src/app/api/webhooks/github/route.ts
@@ -3,6 +3,7 @@ import {
   applyGithubEvent,
   applyGithubInstallationEvent,
   dispatchSlackMessage,
+  handlesGithubEvent,
   isGithubInstallationEvent,
   verifyGithubSignature,
 } from '@orbit/services';
@@ -28,6 +29,9 @@ export async function POST(request: Request): Promise<Response> {
   }
   if (deliveryId.length === 0) {
     return Response.json({ error: 'missing delivery id' }, { status: 400 });
+  }
+  if (!handlesGithubEvent(eventName)) {
+    return Response.json({ status: 'unhandled', event: eventName });
   }
 
   const claimed = await db

--- a/apps/web/tests/app/api/webhooks/github/route.test.ts
+++ b/apps/web/tests/app/api/webhooks/github/route.test.ts
@@ -38,6 +38,7 @@ const bodySchema = z.union([
   z.object({ ok: z.literal(true), actions: z.number() }),
   z.object({ ok: z.literal(true), handled: z.boolean() }),
   z.object({ status: z.literal('duplicate') }),
+  z.object({ status: z.literal('unhandled'), event: z.string() }),
   z.object({ error: z.string() }),
 ]);
 
@@ -471,5 +472,54 @@ describe('telling a delivery that landed from one that was dropped', () => {
     const row = await deliveryRow('delivery-landed');
     expect(row?.status).toBe('processed');
     expect(row?.error).toBeNull();
+  });
+});
+
+describe('events that reach no handler', () => {
+  const NEVER_HANDLED = [
+    'check_run',
+    'workflow_job',
+    'workflow_run',
+    'status',
+    'repository_dispatch',
+    'issues',
+    'pull_request_review_comment',
+    'push',
+    'pull_request_review_thread',
+    'sub_issues',
+    'create',
+    'delete',
+  ];
+
+  it('accepts them without writing a delivery row', async () => {
+    for (const [at, event] of NEVER_HANDLED.entries()) {
+      const deliveryId = `delivery-unhandled-${at}`;
+      const response = await POST(signed('{}', deliveryId, event));
+
+      expect(response.status).toBe(200);
+      expect(await deliveryRow(deliveryId)).toBeUndefined();
+    }
+  });
+
+  it('still refuses one whose signature does not check out', async () => {
+    const raw = '{}';
+    const response = await POST(
+      request(raw, {
+        'x-hub-signature-256': sign(raw, 'the-wrong-secret'),
+        'x-github-event': 'check_run',
+        'x-github-delivery': 'delivery-unhandled-forged',
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('keeps recording every event that does reach a handler', async () => {
+    for (const [at, event] of ['pull_request', 'pull_request_review', 'check_suite'].entries()) {
+      const deliveryId = `delivery-handled-${at}`;
+      await POST(signed(pullRequestBody('orb-3-dashboard'), deliveryId, event));
+
+      expect(await deliveryRow(deliveryId)).toBeDefined();
+    }
   });
 });

--- a/packages/services/src/github/index.ts
+++ b/packages/services/src/github/index.ts
@@ -9,6 +9,8 @@ export * from './installations.ts';
 export * from './watched.ts';
 export * from './webhook-events.ts';
 
+import { isGithubInstallationEvent } from './webhook-events.ts';
+
 export function verifyGithubSignature(
   rawBody: string,
   signatureHeader: string | null,
@@ -185,65 +187,82 @@ function toReviewDecision(state: string): ReviewDecision {
   return 'commented';
 }
 
+function parsePullRequestEvent(body: unknown): NormalizedGithubEvent | null {
+  const result = pullRequestEventSchema.safeParse(body);
+  if (!result.success) return null;
+  const parsed = result.data;
+  return {
+    action: parsed.action,
+    repository: {
+      externalId: String(parsed.repository.id),
+      fullName: parsed.repository.full_name,
+    },
+    pullRequest: normalizePullRequest(parsed.pull_request),
+    review: null,
+    requestedReviewer: parsed.requested_reviewer ?? null,
+    checks: null,
+    sender: parsed.sender,
+  };
+}
+
+function parseReviewEvent(body: unknown): NormalizedGithubEvent | null {
+  const result = reviewEventSchema.safeParse(body);
+  if (!result.success) return null;
+  const parsed = result.data;
+  return {
+    action: parsed.action,
+    repository: {
+      externalId: String(parsed.repository.id),
+      fullName: parsed.repository.full_name,
+    },
+    pullRequest: normalizePullRequest(parsed.pull_request),
+    review: {
+      decision: toReviewDecision(parsed.review.state),
+      url: parsed.review.html_url ?? parsed.pull_request.html_url,
+      reviewer: parsed.review.user ?? null,
+    },
+    requestedReviewer: null,
+    checks: null,
+    sender: parsed.sender,
+  };
+}
+
+function parseCheckSuiteEvent(body: unknown): NormalizedGithubEvent | null {
+  const result = checkSuiteEventSchema.safeParse(body);
+  if (!result.success) return null;
+  const parsed = result.data;
+  return {
+    action: parsed.action,
+    repository: {
+      externalId: String(parsed.repository.id),
+      fullName: parsed.repository.full_name,
+    },
+    pullRequest: null,
+    review: null,
+    requestedReviewer: null,
+    checks: {
+      failed: (parsed.check_suite.conclusion ?? '').toLowerCase() === 'failure',
+      headBranch: parsed.check_suite.head_branch ?? '',
+      prNumbers: parsed.check_suite.pull_requests.map((entry) => entry.number),
+    },
+    sender: parsed.sender,
+  };
+}
+
+const GITHUB_EVENT_PARSERS: Readonly<
+  Record<string, (body: unknown) => NormalizedGithubEvent | null>
+> = {
+  pull_request: parsePullRequestEvent,
+  pull_request_review: parseReviewEvent,
+  check_suite: parseCheckSuiteEvent,
+};
+
+export const GITHUB_PARSED_EVENTS: readonly string[] = Object.keys(GITHUB_EVENT_PARSERS);
+
 export function parseGithubEvent(eventName: string, body: unknown): NormalizedGithubEvent | null {
-  if (eventName === 'pull_request') {
-    const result = pullRequestEventSchema.safeParse(body);
-    if (!result.success) return null;
-    const parsed = result.data;
-    return {
-      action: parsed.action,
-      repository: {
-        externalId: String(parsed.repository.id),
-        fullName: parsed.repository.full_name,
-      },
-      pullRequest: normalizePullRequest(parsed.pull_request),
-      review: null,
-      requestedReviewer: parsed.requested_reviewer ?? null,
-      checks: null,
-      sender: parsed.sender,
-    };
-  }
-  if (eventName === 'pull_request_review') {
-    const result = reviewEventSchema.safeParse(body);
-    if (!result.success) return null;
-    const parsed = result.data;
-    return {
-      action: parsed.action,
-      repository: {
-        externalId: String(parsed.repository.id),
-        fullName: parsed.repository.full_name,
-      },
-      pullRequest: normalizePullRequest(parsed.pull_request),
-      review: {
-        decision: toReviewDecision(parsed.review.state),
-        url: parsed.review.html_url ?? parsed.pull_request.html_url,
-        reviewer: parsed.review.user ?? null,
-      },
-      requestedReviewer: null,
-      checks: null,
-      sender: parsed.sender,
-    };
-  }
-  if (eventName === 'check_suite') {
-    const result = checkSuiteEventSchema.safeParse(body);
-    if (!result.success) return null;
-    const parsed = result.data;
-    return {
-      action: parsed.action,
-      repository: {
-        externalId: String(parsed.repository.id),
-        fullName: parsed.repository.full_name,
-      },
-      pullRequest: null,
-      review: null,
-      requestedReviewer: null,
-      checks: {
-        failed: (parsed.check_suite.conclusion ?? '').toLowerCase() === 'failure',
-        headBranch: parsed.check_suite.head_branch ?? '',
-        prNumbers: parsed.check_suite.pull_requests.map((entry) => entry.number),
-      },
-      sender: parsed.sender,
-    };
-  }
-  return null;
+  return GITHUB_EVENT_PARSERS[eventName]?.(body) ?? null;
+}
+
+export function handlesGithubEvent(eventName: string): boolean {
+  return isGithubInstallationEvent(eventName) || eventName in GITHUB_EVENT_PARSERS;
 }

--- a/packages/services/src/github/webhook-events.ts
+++ b/packages/services/src/github/webhook-events.ts
@@ -15,8 +15,18 @@ import {
 
 const GITHUB_INSTALLATION_EVENTS = ['installation', 'installation_repositories', 'repository'];
 
+export const GITHUB_PARSED_EVENTS: readonly string[] = [
+  'pull_request',
+  'pull_request_review',
+  'check_suite',
+];
+
 export function isGithubInstallationEvent(eventName: string): boolean {
   return GITHUB_INSTALLATION_EVENTS.includes(eventName);
+}
+
+export function handlesGithubEvent(eventName: string): boolean {
+  return isGithubInstallationEvent(eventName) || GITHUB_PARSED_EVENTS.includes(eventName);
 }
 
 const shortRepositorySchema = z.object({

--- a/packages/services/src/github/webhook-events.ts
+++ b/packages/services/src/github/webhook-events.ts
@@ -15,18 +15,8 @@ import {
 
 const GITHUB_INSTALLATION_EVENTS = ['installation', 'installation_repositories', 'repository'];
 
-export const GITHUB_PARSED_EVENTS: readonly string[] = [
-  'pull_request',
-  'pull_request_review',
-  'check_suite',
-];
-
 export function isGithubInstallationEvent(eventName: string): boolean {
   return GITHUB_INSTALLATION_EVENTS.includes(eventName);
-}
-
-export function handlesGithubEvent(eventName: string): boolean {
-  return isGithubInstallationEvent(eventName) || GITHUB_PARSED_EVENTS.includes(eventName);
 }
 
 const shortRepositorySchema = z.object({

--- a/packages/services/tests/github/handled-events.test.ts
+++ b/packages/services/tests/github/handled-events.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'bun:test';
+import { parseGithubEvent } from '../../src/github/index.ts';
+import {
+  GITHUB_PARSED_EVENTS,
+  handlesGithubEvent,
+  isGithubInstallationEvent,
+} from '../../src/github/webhook-events.ts';
+
+const SENT_BY_GITHUB = [
+  'check_run',
+  'check_suite',
+  'create',
+  'delete',
+  'installation',
+  'installation_repositories',
+  'issues',
+  'pull_request',
+  'pull_request_review',
+  'pull_request_review_comment',
+  'pull_request_review_thread',
+  'push',
+  'repository',
+  'repository_dispatch',
+  'status',
+  'sub_issues',
+  'workflow_job',
+  'workflow_run',
+];
+
+function payloadFor(eventName: string): unknown {
+  const repository = { id: 99, full_name: 'acme/web' };
+  const sender = { login: 'octocat', id: 500 };
+  const pullRequest = {
+    number: 7,
+    title: 'Rework dashboard',
+    html_url: 'https://github.com/acme/web/pull/7',
+    draft: false,
+    merged: false,
+    state: 'open',
+    head: { ref: 'orb-3-dashboard' },
+    base: { ref: 'main' },
+    user: sender,
+  };
+
+  if (eventName === 'check_suite') {
+    return {
+      action: 'completed',
+      check_suite: { conclusion: 'failure', head_branch: 'orb-3', pull_requests: [{ number: 7 }] },
+      repository,
+      sender,
+    };
+  }
+  if (eventName === 'pull_request_review') {
+    return {
+      action: 'submitted',
+      review: { state: 'approved', html_url: pullRequest.html_url, user: sender },
+      pull_request: pullRequest,
+      repository,
+      sender,
+    };
+  }
+  return { action: 'opened', pull_request: pullRequest, repository, sender };
+}
+
+describe('the handled event list', () => {
+  it('names exactly the events parseGithubEvent can read', () => {
+    for (const eventName of GITHUB_PARSED_EVENTS) {
+      expect(parseGithubEvent(eventName, payloadFor(eventName))).not.toBeNull();
+    }
+  });
+
+  it('does not drop an event that some handler would have read', () => {
+    for (const eventName of SENT_BY_GITHUB) {
+      if (handlesGithubEvent(eventName)) continue;
+      expect(parseGithubEvent(eventName, payloadFor(eventName))).toBeNull();
+      expect(isGithubInstallationEvent(eventName)).toBe(false);
+    }
+  });
+
+  it('handles every installation event and every parsed event', () => {
+    for (const eventName of [...GITHUB_PARSED_EVENTS, 'installation', 'repository']) {
+      expect(handlesGithubEvent(eventName)).toBe(true);
+    }
+  });
+
+  it('refuses an event GitHub never sends us', () => {
+    expect(handlesGithubEvent('sponsorship')).toBe(false);
+    expect(handlesGithubEvent('')).toBe(false);
+  });
+});

--- a/packages/services/tests/github/handled-events.test.ts
+++ b/packages/services/tests/github/handled-events.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'bun:test';
-import { parseGithubEvent } from '../../src/github/index.ts';
 import {
   GITHUB_PARSED_EVENTS,
   handlesGithubEvent,
-  isGithubInstallationEvent,
-} from '../../src/github/webhook-events.ts';
+  parseGithubEvent,
+} from '../../src/github/index.ts';
+import { isGithubInstallationEvent } from '../../src/github/webhook-events.ts';
 
 const SENT_BY_GITHUB = [
   'check_run',
@@ -27,64 +27,94 @@ const SENT_BY_GITHUB = [
   'workflow_run',
 ];
 
-function payloadFor(eventName: string): unknown {
-  const repository = { id: 99, full_name: 'acme/web' };
-  const sender = { login: 'octocat', id: 500 };
-  const pullRequest = {
-    number: 7,
-    title: 'Rework dashboard',
-    html_url: 'https://github.com/acme/web/pull/7',
-    draft: false,
-    merged: false,
-    state: 'open',
-    head: { ref: 'orb-3-dashboard' },
-    base: { ref: 'main' },
-    user: sender,
-  };
-
-  if (eventName === 'check_suite') {
-    return {
-      action: 'completed',
-      check_suite: { conclusion: 'failure', head_branch: 'orb-3', pull_requests: [{ number: 7 }] },
-      repository,
-      sender,
-    };
-  }
-  if (eventName === 'pull_request_review') {
-    return {
-      action: 'submitted',
-      review: { state: 'approved', html_url: pullRequest.html_url, user: sender },
-      pull_request: pullRequest,
-      repository,
-      sender,
-    };
-  }
-  return { action: 'opened', pull_request: pullRequest, repository, sender };
-}
-
-describe('the handled event list', () => {
-  it('names exactly the events parseGithubEvent can read', () => {
+describe('the events the webhook accepts', () => {
+  it('accepts every event a parser exists for', () => {
     for (const eventName of GITHUB_PARSED_EVENTS) {
-      expect(parseGithubEvent(eventName, payloadFor(eventName))).not.toBeNull();
-    }
-  });
-
-  it('does not drop an event that some handler would have read', () => {
-    for (const eventName of SENT_BY_GITHUB) {
-      if (handlesGithubEvent(eventName)) continue;
-      expect(parseGithubEvent(eventName, payloadFor(eventName))).toBeNull();
-      expect(isGithubInstallationEvent(eventName)).toBe(false);
-    }
-  });
-
-  it('handles every installation event and every parsed event', () => {
-    for (const eventName of [...GITHUB_PARSED_EVENTS, 'installation', 'repository']) {
       expect(handlesGithubEvent(eventName)).toBe(true);
     }
   });
 
-  it('refuses an event GitHub never sends us', () => {
+  it('accepts every installation event', () => {
+    for (const eventName of ['installation', 'installation_repositories', 'repository']) {
+      expect(handlesGithubEvent(eventName)).toBe(true);
+    }
+  });
+
+  it('turns away the events production actually floods us with', () => {
+    const unhandled = SENT_BY_GITHUB.filter((eventName) => !handlesGithubEvent(eventName));
+
+    expect(unhandled).toEqual([
+      'check_run',
+      'create',
+      'delete',
+      'issues',
+      'pull_request_review_comment',
+      'pull_request_review_thread',
+      'push',
+      'repository_dispatch',
+      'status',
+      'sub_issues',
+      'workflow_job',
+      'workflow_run',
+    ]);
+  });
+
+  it('never turns away something a parser would have read', () => {
+    for (const eventName of SENT_BY_GITHUB) {
+      if (handlesGithubEvent(eventName)) continue;
+      expect(GITHUB_PARSED_EVENTS).not.toContain(eventName);
+      expect(isGithubInstallationEvent(eventName)).toBe(false);
+    }
+  });
+
+  it('refuses an event that reaches neither', () => {
     expect(handlesGithubEvent('sponsorship')).toBe(false);
     expect(handlesGithubEvent('')).toBe(false);
+  });
+
+  it('reads a payload for each parsed event, so the list is not naming dead branches', () => {
+    const repository = { id: 99, full_name: 'acme/web' };
+    const sender = { login: 'octocat', id: 500 };
+    const pullRequest = {
+      number: 7,
+      title: 'Rework dashboard',
+      html_url: 'https://github.com/acme/web/pull/7',
+      draft: false,
+      merged: false,
+      state: 'open',
+      head: { ref: 'orb-3-dashboard' },
+      base: { ref: 'main' },
+      user: sender,
+    };
+
+    expect(
+      parseGithubEvent('pull_request', {
+        action: 'opened',
+        pull_request: pullRequest,
+        repository,
+        sender,
+      }),
+    ).not.toBeNull();
+    expect(
+      parseGithubEvent('pull_request_review', {
+        action: 'submitted',
+        review: { state: 'approved', html_url: pullRequest.html_url, user: sender },
+        pull_request: pullRequest,
+        repository,
+        sender,
+      }),
+    ).not.toBeNull();
+    expect(
+      parseGithubEvent('check_suite', {
+        action: 'completed',
+        check_suite: {
+          conclusion: 'failure',
+          head_branch: 'orb-3',
+          pull_requests: [{ number: 7 }],
+        },
+        repository,
+        sender,
+      }),
+    ).not.toBeNull();
   });
 });


### PR DESCRIPTION
## The waste

Every webhook delivery does an insert, a transaction, and an update. But only six event names reach a handler:

- `pull_request`, `pull_request_review`, `check_suite` via `parseGithubEvent`
- `installation`, `installation_repositories`, `repository` via `applyGithubInstallationEvent`

Everything else runs that whole sequence and ends up marked `ignored`.

Measured against production, over the 15 days `webhook_delivery` currently covers:

| | Deliveries |
| --- | --- |
| Recorded | 22,990 |
| For an event that reaches a handler | 2,560 |
| **For one that does not** | **20,430 (89%)** |

The worst offenders on their own:

| Event | Count |
| --- | --- |
| `check_run` | 6,264 |
| `workflow_job` | 6,102 |
| `workflow_run` | 2,923 |
| `status` | 1,599 |
| `repository_dispatch` | 1,496 |

`webhook_delivery` is the largest table in the database and almost none of it is product data.

## The change

Recognise an unhandled event straight after the signature check and return `200` without touching the database. GitHub keeps its own delivery log, so nothing that could have been acted on is lost.

Ordering matters and is preserved: the signature is still verified first, so this is not a way to make the endpoint do unauthenticated work. A test covers that a forged unhandled event is still refused with `401`.

## The drift hazard, and the test for it

The handled list lives next to the code that reads these events, but it could still go stale the moment someone adds a parser branch and forgets to list the event, which would **silently drop the new event** at the door. That is a worse failure than the waste this PR removes.

So there is a test asserting that every event GitHub actually sends this app either is handled, or is one `parseGithubEvent` genuinely cannot read. Verified by mutation: dropping `check_suite` from the list makes it fail.

```
(fail) the handled event list > does not drop an event that some handler would have read
 3 pass
 1 fail
```

## Still open, deliberately not done here

- **Retention.** A 30 day prune would delete nothing today: the oldest row is 15 days old. Worth adding once growth is bounded, which this PR is the bigger half of.
- **Unsubscribing in the GitHub App.** Better still, since then the request never arrives. That is a settings change on the App, not code, and `docs/github-app.md` already documents the correct subscription set.

## Tests

Services github suite: 101 pass. Web webhook suite: 34 pass. Both mutation checked.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR avoids database work for signed GitHub webhook events that have no handler and refactors parsed-event dispatch around a shared registry.
- Adds an early response for unhandled events after signature and required-header validation.
- Derives handled parsed-event names from the parser registry to prevent list drift.
- Adds route and service tests for signature ordering, database writes, and parser coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/webhooks/github/route.ts | Adds the post-authentication handled-event gate that skips delivery persistence for events no handler reads. |
| apps/web/tests/app/api/webhooks/github/route.test.ts | Covers database avoidance, rejection of forged unhandled events, and continued persistence of handled events. |
| packages/services/src/github/index.ts | Refactors event parsing into a registry and derives handled parsed-event membership from that registry. |
| packages/services/tests/github/handled-events.test.ts | Verifies handled-event classification and supplies valid payloads for every current parser branch. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub webhook request] --> B[Verify signature]
    B -->|Invalid| C[Return 401]
    B -->|Valid| D[Validate event and delivery headers]
    D --> E{Handler registered?}
    E -->|No| F[Return 200 unhandled]
    E -->|Yes| G[Claim delivery in database]
    G --> H[Apply installation or parsed event]
    H --> I[Update delivery result]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge main into perf/webhook-noise"](https://github.com/noveum/orbit/commit/03da843ddad6022444b16e04e8aafa9b9403a1c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51464625)</sub>

<!-- /greptile_comment -->