### PR TITLE
Make the committed migrations produce the schema they claim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,40 @@ jobs:
       - name: Run tests
         run: bun run test
 
+  schema:
+    name: Migrations match the schema
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: orbit
+          POSTGRES_PASSWORD: orbit
+          POSTGRES_DB: orbit
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U orbit"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgres://orbit:orbit@localhost:5433/orbit_from_migrations
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - run: bun install --frozen-lockfile
+      - name: A database built the way someone installing this would build one
+        run: |
+          PGPASSWORD=orbit createdb -h localhost -p 5433 -U orbit orbit_from_migrations
+          PGPASSWORD=orbit psql -h localhost -p 5433 -U orbit -d orbit_from_migrations \
+            -c 'create extension if not exists pg_trgm'
+          bun run --filter '@orbit/db' migrate
+      - name: The committed migrations carry everything the schema declares
+        run: bun run db:check-drift
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,6 @@ jobs:
       - name: A database built the way someone installing this would build one
         run: |
           PGPASSWORD=orbit createdb -h localhost -p 5433 -U orbit orbit_from_migrations
-          PGPASSWORD=orbit psql -h localhost -p 5433 -U orbit -d orbit_from_migrations \
-            -c 'create extension if not exists pg_trgm'
           bun run --filter '@orbit/db' migrate
       - name: The committed migrations carry everything the schema declares
         run: bun run db:check-drift

--- a/packages/db/drizzle/0000_shocking_baron_zemo.sql
+++ b/packages/db/drizzle/0000_shocking_baron_zemo.sql
@@ -1,5 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS "pg_trgm";--> statement-breakpoint
-CREATE TYPE "public"."notification_reason" AS ENUM('assigned', 'mentioned', 'subscribed', 'commented', 'state_changed', 'review_requested', 'review_approved', 'pull_request_merged', 'due_soon', 'manual');--> statement-breakpoint
+CREATE TYPE "public"."notification_reason" AS ENUM('assigned', 'mentioned', 'subscribed', 'commented', 'state_changed', 'review_requested', 'review_approved', 'pull_request_merged', 'due_soon', 'access_requested', 'access_granted', 'manual');--> statement-breakpoint
 CREATE SEQUENCE "public"."sync_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1;--> statement-breakpoint
 CREATE TABLE "account" (
 	"id" text PRIMARY KEY NOT NULL,
@@ -158,6 +157,23 @@ CREATE TABLE "github_comment_sync" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
+CREATE TABLE "github_installation" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"integration_id" text NOT NULL,
+	"installation_id" text NOT NULL,
+	"account_login" text DEFAULT '' NOT NULL,
+	"account_id" text DEFAULT '' NOT NULL,
+	"account_type" text DEFAULT 'Organization' NOT NULL,
+	"repository_selection" text DEFAULT 'selected' NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"connected_by_id" text NOT NULL,
+	"repositories_synced_at" timestamp with time zone,
+	"sync_id" bigint DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
 CREATE TABLE "github_issue_sync" (
 	"id" text PRIMARY KEY NOT NULL,
 	"organization_id" text NOT NULL,
@@ -183,11 +199,39 @@ CREATE TABLE "github_pr_state_mapping" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
+CREATE TABLE "github_repository" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"installation_row_id" text NOT NULL,
+	"repository_id" text NOT NULL,
+	"full_name" text NOT NULL,
+	"name" text DEFAULT '' NOT NULL,
+	"owner_login" text DEFAULT '' NOT NULL,
+	"private" boolean DEFAULT false NOT NULL,
+	"archived" boolean DEFAULT false NOT NULL,
+	"default_branch" text DEFAULT 'main' NOT NULL,
+	"html_url" text DEFAULT '' NOT NULL,
+	"sync_id" bigint DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "github_repository_link" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"repository_row_id" text NOT NULL,
+	"project_id" text,
+	"linked_by_id" text,
+	"sync_id" bigint DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
 CREATE TABLE "github_repository_sync" (
 	"id" text PRIMARY KEY NOT NULL,
 	"organization_id" text NOT NULL,
 	"integration_id" text NOT NULL,
-	"team_id" text NOT NULL,
+	"team_id" text,
 	"repository_id" text NOT NULL,
 	"repository_name" text NOT NULL,
 	"installation_id" text DEFAULT '' NOT NULL,
@@ -219,6 +263,15 @@ CREATE TABLE "integration_channel" (
 	"channel_id" text NOT NULL,
 	"channel_name" text NOT NULL,
 	"events" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "integration_oauth_state" (
+	"nonce" text PRIMARY KEY NOT NULL,
+	"provider" text NOT NULL,
+	"organization_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
@@ -354,7 +407,10 @@ CREATE TABLE "doc" (
 	"parent_id" text,
 	"project_id" text,
 	"title" text NOT NULL,
+	"slug" text DEFAULT '' NOT NULL,
 	"content" text DEFAULT '' NOT NULL,
+	"sort_order" double precision DEFAULT 0 NOT NULL,
+	"search_vector" "tsvector" GENERATED ALWAYS AS (setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', left(coalesce(content, ''), 200000)), 'B')) STORED,
 	"visibility" text DEFAULT 'workspace' NOT NULL,
 	"publish_token" text,
 	"author_id" text NOT NULL,
@@ -366,13 +422,54 @@ CREATE TABLE "doc" (
 	CONSTRAINT "doc_publish_token_unique" UNIQUE("publish_token")
 );
 --> statement-breakpoint
+CREATE TABLE "doc_access" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"doc_id" text NOT NULL,
+	"subject_type" text NOT NULL,
+	"subject_id" text NOT NULL,
+	"level" text DEFAULT 'read' NOT NULL,
+	"granted_by_id" text,
+	"sync_id" bigint DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "doc_access_request" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"doc_id" text NOT NULL,
+	"requester_id" text NOT NULL,
+	"message" text,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"decided_by_id" text,
+	"decided_at" timestamp with time zone,
+	"sync_id" bigint DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
 CREATE TABLE "doc_collection" (
 	"id" text PRIMARY KEY NOT NULL,
 	"organization_id" text NOT NULL,
 	"name" text NOT NULL,
 	"icon" text DEFAULT 'book' NOT NULL,
+	"position" double precision DEFAULT 0 NOT NULL,
 	"sync_id" bigint DEFAULT 0 NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "doc_comment" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"doc_id" text NOT NULL,
+	"author_id" text NOT NULL,
+	"parent_id" text,
+	"body" text NOT NULL,
+	"anchor" jsonb,
+	"edited_at" timestamp with time zone,
+	"sync_id" bigint DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
 );
 --> statement-breakpoint
 CREATE TABLE "doc_subscription" (
@@ -384,12 +481,13 @@ CREATE TABLE "doc_subscription" (
 --> statement-breakpoint
 CREATE TABLE "doc_version" (
 	"id" text PRIMARY KEY NOT NULL,
-	"organization_id" text NOT NULL,
 	"doc_id" text NOT NULL,
-	"version" integer NOT NULL,
+	"organization_id" text NOT NULL,
 	"title" text NOT NULL,
-	"content" text DEFAULT '' NOT NULL,
-	"author_id" text NOT NULL,
+	"content" text NOT NULL,
+	"owned_by_id" text NOT NULL,
+	"restored_from_id" text,
+	"last_saved_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"sync_id" bigint DEFAULT 0 NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
@@ -426,8 +524,7 @@ CREATE TABLE "reaction" (
 	"user_id" text NOT NULL,
 	"emoji" text NOT NULL,
 	"sync_id" bigint DEFAULT 0 NOT NULL,
-	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "reaction_one_parent" CHECK (num_nonnulls("reaction"."comment_id", "reaction"."issue_id") = 1)
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "recent_visit" (
@@ -439,6 +536,58 @@ CREATE TABLE "recent_visit" (
 	"visited_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"sync_id" bigint DEFAULT 0 NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "mcp_grant" (
+	"id" text PRIMARY KEY NOT NULL,
+	"client_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"organization_id" text NOT NULL,
+	"scopes" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_used_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "oauth_access_token" (
+	"id" text PRIMARY KEY NOT NULL,
+	"access_token" text NOT NULL,
+	"refresh_token" text NOT NULL,
+	"access_token_expires_at" timestamp with time zone NOT NULL,
+	"refresh_token_expires_at" timestamp with time zone NOT NULL,
+	"client_id" text NOT NULL,
+	"user_id" text,
+	"scopes" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "oauth_access_token_access_token_unique" UNIQUE("access_token"),
+	CONSTRAINT "oauth_access_token_refresh_token_unique" UNIQUE("refresh_token")
+);
+--> statement-breakpoint
+CREATE TABLE "oauth_application" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"icon" text,
+	"metadata" text,
+	"client_id" text NOT NULL,
+	"client_secret" text,
+	"redirect_urls" text NOT NULL,
+	"type" text NOT NULL,
+	"disabled" boolean DEFAULT false NOT NULL,
+	"user_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "oauth_application_client_id_unique" UNIQUE("client_id")
+);
+--> statement-breakpoint
+CREATE TABLE "oauth_consent" (
+	"id" text PRIMARY KEY NOT NULL,
+	"client_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"scopes" text NOT NULL,
+	"consent_given" boolean NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "invitation" (
@@ -661,6 +810,7 @@ CREATE TABLE "issue_subscription" (
 	"id" text PRIMARY KEY NOT NULL,
 	"issue_id" text NOT NULL,
 	"user_id" text NOT NULL,
+	"sync_id" bigint DEFAULT 0 NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
@@ -795,8 +945,22 @@ CREATE TABLE "view" (
 	"layout" text DEFAULT 'list' NOT NULL,
 	"group_by" text DEFAULT 'state' NOT NULL,
 	"shared" text DEFAULT 'false' NOT NULL,
+	"visibility" text DEFAULT 'private' NOT NULL,
+	"team_id" text,
 	"sync_id" bigint DEFAULT 0 NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "view_preference" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"page" text NOT NULL,
+	"scope" text DEFAULT '' NOT NULL,
+	"layout" text DEFAULT 'list' NOT NULL,
+	"display" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "workflow_state" (
@@ -824,18 +988,29 @@ ALTER TABLE "git_link" ADD CONSTRAINT "git_link_issue_id_issue_id_fk" FOREIGN KE
 ALTER TABLE "github_comment_sync" ADD CONSTRAINT "github_comment_sync_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "github_comment_sync" ADD CONSTRAINT "github_comment_sync_comment_id_comment_id_fk" FOREIGN KEY ("comment_id") REFERENCES "public"."comment"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "github_comment_sync" ADD CONSTRAINT "github_comment_sync_repository_sync_fk" FOREIGN KEY ("repository_sync_id") REFERENCES "public"."github_repository_sync"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "github_installation" ADD CONSTRAINT "github_installation_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "github_installation" ADD CONSTRAINT "github_installation_integration_id_integration_id_fk" FOREIGN KEY ("integration_id") REFERENCES "public"."integration"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "github_installation" ADD CONSTRAINT "github_installation_connected_by_id_user_id_fk" FOREIGN KEY ("connected_by_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "github_issue_sync" ADD CONSTRAINT "github_issue_sync_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "github_issue_sync" ADD CONSTRAINT "github_issue_sync_issue_id_issue_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issue"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "github_issue_sync" ADD CONSTRAINT "github_issue_sync_repository_sync_fk" FOREIGN KEY ("repository_sync_id") REFERENCES "public"."github_repository_sync"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "github_pr_state_mapping" ADD CONSTRAINT "github_pr_state_mapping_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "github_pr_state_mapping" ADD CONSTRAINT "github_pr_state_mapping_state_id_workflow_state_id_fk" FOREIGN KEY ("state_id") REFERENCES "public"."workflow_state"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "github_pr_state_mapping" ADD CONSTRAINT "github_pr_state_mapping_repository_sync_fk" FOREIGN KEY ("repository_sync_id") REFERENCES "public"."github_repository_sync"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "github_repository" ADD CONSTRAINT "github_repository_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "github_repository" ADD CONSTRAINT "github_repository_installation_row_id_github_installation_id_fk" FOREIGN KEY ("installation_row_id") REFERENCES "public"."github_installation"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "github_repository_link" ADD CONSTRAINT "github_repository_link_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "github_repository_link" ADD CONSTRAINT "github_repository_link_repository_row_id_github_repository_id_fk" FOREIGN KEY ("repository_row_id") REFERENCES "public"."github_repository"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "github_repository_link" ADD CONSTRAINT "github_repository_link_project_id_project_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."project"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "github_repository_link" ADD CONSTRAINT "github_repository_link_linked_by_id_user_id_fk" FOREIGN KEY ("linked_by_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "github_repository_sync" ADD CONSTRAINT "github_repository_sync_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "github_repository_sync" ADD CONSTRAINT "github_repository_sync_integration_id_integration_id_fk" FOREIGN KEY ("integration_id") REFERENCES "public"."integration"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "github_repository_sync" ADD CONSTRAINT "github_repository_sync_team_id_team_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."team"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "integration" ADD CONSTRAINT "integration_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "integration" ADD CONSTRAINT "integration_connected_by_id_user_id_fk" FOREIGN KEY ("connected_by_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "integration_channel" ADD CONSTRAINT "integration_channel_integration_id_integration_id_fk" FOREIGN KEY ("integration_id") REFERENCES "public"."integration"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "integration_oauth_state" ADD CONSTRAINT "integration_oauth_state_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "integration_oauth_state" ADD CONSTRAINT "integration_oauth_state_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "notification" ADD CONSTRAINT "notification_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "notification" ADD CONSTRAINT "notification_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "notification_preference" ADD CONSTRAINT "notification_preference_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
@@ -857,12 +1032,23 @@ ALTER TABLE "doc" ADD CONSTRAINT "doc_collection_id_doc_collection_id_fk" FOREIG
 ALTER TABLE "doc" ADD CONSTRAINT "doc_parent_id_doc_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."doc"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "doc" ADD CONSTRAINT "doc_project_id_project_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."project"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "doc" ADD CONSTRAINT "doc_author_id_user_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."user"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doc_access" ADD CONSTRAINT "doc_access_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doc_access" ADD CONSTRAINT "doc_access_doc_id_doc_id_fk" FOREIGN KEY ("doc_id") REFERENCES "public"."doc"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doc_access" ADD CONSTRAINT "doc_access_granted_by_id_user_id_fk" FOREIGN KEY ("granted_by_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doc_access_request" ADD CONSTRAINT "doc_access_request_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doc_access_request" ADD CONSTRAINT "doc_access_request_doc_id_doc_id_fk" FOREIGN KEY ("doc_id") REFERENCES "public"."doc"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doc_access_request" ADD CONSTRAINT "doc_access_request_requester_id_user_id_fk" FOREIGN KEY ("requester_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doc_access_request" ADD CONSTRAINT "doc_access_request_decided_by_id_user_id_fk" FOREIGN KEY ("decided_by_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "doc_collection" ADD CONSTRAINT "doc_collection_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doc_comment" ADD CONSTRAINT "doc_comment_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doc_comment" ADD CONSTRAINT "doc_comment_doc_id_doc_id_fk" FOREIGN KEY ("doc_id") REFERENCES "public"."doc"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doc_comment" ADD CONSTRAINT "doc_comment_author_id_user_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."user"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doc_comment" ADD CONSTRAINT "doc_comment_parent_id_doc_comment_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."doc_comment"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "doc_subscription" ADD CONSTRAINT "doc_subscription_doc_id_doc_id_fk" FOREIGN KEY ("doc_id") REFERENCES "public"."doc"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "doc_subscription" ADD CONSTRAINT "doc_subscription_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "doc_version" ADD CONSTRAINT "doc_version_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "doc_version" ADD CONSTRAINT "doc_version_doc_id_doc_id_fk" FOREIGN KEY ("doc_id") REFERENCES "public"."doc"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "doc_version" ADD CONSTRAINT "doc_version_author_id_user_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."user"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doc_version" ADD CONSTRAINT "doc_version_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "doc_version" ADD CONSTRAINT "doc_version_owned_by_id_user_id_fk" FOREIGN KEY ("owned_by_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "favorite" ADD CONSTRAINT "favorite_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "favorite" ADD CONSTRAINT "favorite_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "home_widget_preference" ADD CONSTRAINT "home_widget_preference_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
@@ -873,6 +1059,14 @@ ALTER TABLE "reaction" ADD CONSTRAINT "reaction_issue_id_issue_id_fk" FOREIGN KE
 ALTER TABLE "reaction" ADD CONSTRAINT "reaction_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "recent_visit" ADD CONSTRAINT "recent_visit_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "recent_visit" ADD CONSTRAINT "recent_visit_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mcp_grant" ADD CONSTRAINT "mcp_grant_client_id_oauth_application_client_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."oauth_application"("client_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mcp_grant" ADD CONSTRAINT "mcp_grant_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mcp_grant" ADD CONSTRAINT "mcp_grant_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_access_token" ADD CONSTRAINT "oauth_access_token_client_id_oauth_application_client_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."oauth_application"("client_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_access_token" ADD CONSTRAINT "oauth_access_token_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_application" ADD CONSTRAINT "oauth_application_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_consent" ADD CONSTRAINT "oauth_consent_client_id_oauth_application_client_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."oauth_application"("client_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_consent" ADD CONSTRAINT "oauth_consent_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "invitation" ADD CONSTRAINT "invitation_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "invitation" ADD CONSTRAINT "invitation_inviter_id_user_id_fk" FOREIGN KEY ("inviter_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "member" ADD CONSTRAINT "member_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
@@ -942,6 +1136,9 @@ ALTER TABLE "saved_analytics_view" ADD CONSTRAINT "saved_analytics_view_organiza
 ALTER TABLE "saved_analytics_view" ADD CONSTRAINT "saved_analytics_view_owner_id_user_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "view" ADD CONSTRAINT "view_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "view" ADD CONSTRAINT "view_owner_id_user_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "view" ADD CONSTRAINT "view_team_id_team_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."team"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "view_preference" ADD CONSTRAINT "view_preference_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "view_preference" ADD CONSTRAINT "view_preference_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "workflow_state" ADD CONSTRAINT "workflow_state_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "workflow_state" ADD CONSTRAINT "workflow_state_team_id_team_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."team"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "account_user_idx" ON "account" USING btree ("user_id");--> statement-breakpoint
@@ -958,13 +1155,22 @@ CREATE UNIQUE INDEX "git_link_unique" ON "git_link" USING btree ("provider","ext
 CREATE INDEX "git_link_issue_idx" ON "git_link" USING btree ("issue_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "github_comment_sync_unique" ON "github_comment_sync" USING btree ("repository_sync_id","external_id");--> statement-breakpoint
 CREATE INDEX "github_comment_sync_comment_idx" ON "github_comment_sync" USING btree ("comment_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "github_installation_installation_unique" ON "github_installation" USING btree ("installation_id");--> statement-breakpoint
+CREATE INDEX "github_installation_org_idx" ON "github_installation" USING btree ("organization_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "github_issue_sync_unique" ON "github_issue_sync" USING btree ("repository_sync_id","external_id");--> statement-breakpoint
 CREATE INDEX "github_issue_sync_issue_idx" ON "github_issue_sync" USING btree ("issue_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "github_pr_state_mapping_unique" ON "github_pr_state_mapping" USING btree ("repository_sync_id","pull_request_state");--> statement-breakpoint
+CREATE UNIQUE INDEX "github_repository_unique" ON "github_repository" USING btree ("installation_row_id","repository_id");--> statement-breakpoint
+CREATE INDEX "github_repository_org_idx" ON "github_repository" USING btree ("organization_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "github_repository_link_project_unique" ON "github_repository_link" USING btree ("repository_row_id","project_id") WHERE "github_repository_link"."project_id" is not null;--> statement-breakpoint
+CREATE UNIQUE INDEX "github_repository_link_workspace_unique" ON "github_repository_link" USING btree ("repository_row_id") WHERE "github_repository_link"."project_id" is null;--> statement-breakpoint
+CREATE INDEX "github_repository_link_project_idx" ON "github_repository_link" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX "github_repository_link_org_idx" ON "github_repository_link" USING btree ("organization_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "github_repository_sync_unique" ON "github_repository_sync" USING btree ("organization_id","repository_id");--> statement-breakpoint
 CREATE INDEX "github_repository_sync_team_idx" ON "github_repository_sync" USING btree ("team_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "integration_org_provider_unique" ON "integration" USING btree ("organization_id","provider","external_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "integration_channel_unique" ON "integration_channel" USING btree ("integration_id","entity_type","entity_id","channel_id");--> statement-breakpoint
+CREATE INDEX "integration_oauth_state_expires_idx" ON "integration_oauth_state" USING btree ("expires_at");--> statement-breakpoint
 CREATE INDEX "notification_user_idx" ON "notification" USING btree ("user_id","created_at");--> statement-breakpoint
 CREATE INDEX "notification_unread_idx" ON "notification" USING btree ("user_id","read_at");--> statement-breakpoint
 CREATE UNIQUE INDEX "notification_preference_unique" ON "notification_preference" USING btree ("user_id","channel","type");--> statement-breakpoint
@@ -979,21 +1185,35 @@ CREATE INDEX "comment_parent_idx" ON "comment" USING btree ("parent_id");--> sta
 CREATE INDEX "doc_org_idx" ON "doc" USING btree ("organization_id");--> statement-breakpoint
 CREATE INDEX "doc_project_idx" ON "doc" USING btree ("project_id");--> statement-breakpoint
 CREATE INDEX "doc_parent_idx" ON "doc" USING btree ("parent_id");--> statement-breakpoint
+CREATE INDEX "doc_collection_order_idx" ON "doc" USING btree ("collection_id","sort_order");--> statement-breakpoint
 CREATE INDEX "doc_title_trgm_idx" ON "doc" USING gin ("title" gin_trgm_ops);--> statement-breakpoint
 CREATE INDEX "doc_content_trgm_idx" ON "doc" USING gin ("content" gin_trgm_ops);--> statement-breakpoint
-CREATE INDEX "doc_collection_org_idx" ON "doc_collection" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "doc_search_idx" ON "doc" USING gin ("search_vector");--> statement-breakpoint
+CREATE UNIQUE INDEX "doc_access_unique" ON "doc_access" USING btree ("doc_id","subject_type","subject_id");--> statement-breakpoint
+CREATE INDEX "doc_access_subject_idx" ON "doc_access" USING btree ("subject_type","subject_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "doc_access_request_pending_unique" ON "doc_access_request" USING btree ("doc_id","requester_id") WHERE status = 'pending';--> statement-breakpoint
+CREATE INDEX "doc_access_request_doc_idx" ON "doc_access_request" USING btree ("doc_id","created_at");--> statement-breakpoint
+CREATE INDEX "doc_access_request_requester_idx" ON "doc_access_request" USING btree ("requester_id");--> statement-breakpoint
+CREATE INDEX "doc_collection_org_idx" ON "doc_collection" USING btree ("organization_id","position");--> statement-breakpoint
+CREATE INDEX "doc_comment_doc_idx" ON "doc_comment" USING btree ("doc_id","created_at");--> statement-breakpoint
+CREATE INDEX "doc_comment_parent_idx" ON "doc_comment" USING btree ("parent_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "doc_subscription_unique" ON "doc_subscription" USING btree ("doc_id","user_id");--> statement-breakpoint
-CREATE UNIQUE INDEX "doc_version_unique" ON "doc_version" USING btree ("doc_id","version");--> statement-breakpoint
-CREATE INDEX "doc_version_doc_idx" ON "doc_version" USING btree ("doc_id","created_at");--> statement-breakpoint
+CREATE INDEX "doc_version_doc_idx" ON "doc_version" USING btree ("doc_id","last_saved_at");--> statement-breakpoint
 CREATE UNIQUE INDEX "favorite_unique" ON "favorite" USING btree ("user_id","entity_type","entity_id");--> statement-breakpoint
 CREATE INDEX "favorite_user_idx" ON "favorite" USING btree ("user_id","sort_order");--> statement-breakpoint
 CREATE UNIQUE INDEX "home_widget_preference_unique" ON "home_widget_preference" USING btree ("user_id","organization_id","widget");--> statement-breakpoint
 CREATE UNIQUE INDEX "reaction_comment_unique" ON "reaction" USING btree ("comment_id","user_id","emoji");--> statement-breakpoint
-CREATE UNIQUE INDEX "reaction_issue_unique" ON "reaction" USING btree ("issue_id","user_id","emoji");--> statement-breakpoint
 CREATE INDEX "reaction_comment_idx" ON "reaction" USING btree ("comment_id");--> statement-breakpoint
 CREATE INDEX "reaction_issue_idx" ON "reaction" USING btree ("issue_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "recent_visit_unique" ON "recent_visit" USING btree ("user_id","organization_id","entity_type","entity_id");--> statement-breakpoint
 CREATE INDEX "recent_visit_user_idx" ON "recent_visit" USING btree ("user_id","visited_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "mcp_grant_client_user_unique" ON "mcp_grant" USING btree ("client_id","user_id");--> statement-breakpoint
+CREATE INDEX "mcp_grant_user_idx" ON "mcp_grant" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "oauth_access_token_client_idx" ON "oauth_access_token" USING btree ("client_id");--> statement-breakpoint
+CREATE INDEX "oauth_access_token_user_idx" ON "oauth_access_token" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "oauth_application_user_idx" ON "oauth_application" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "oauth_consent_client_idx" ON "oauth_consent" USING btree ("client_id");--> statement-breakpoint
+CREATE INDEX "oauth_consent_user_idx" ON "oauth_consent" USING btree ("user_id");--> statement-breakpoint
 CREATE INDEX "invitation_org_idx" ON "invitation" USING btree ("organization_id");--> statement-breakpoint
 CREATE INDEX "invitation_email_idx" ON "invitation" USING btree ("email");--> statement-breakpoint
 CREATE UNIQUE INDEX "invitation_org_email_pending_unique" ON "invitation" USING btree ("organization_id",lower("email")) WHERE "invitation"."status" = 'pending';--> statement-breakpoint
@@ -1023,6 +1243,7 @@ CREATE INDEX "issue_project_idx" ON "issue" USING btree ("project_id");--> state
 CREATE INDEX "issue_cycle_idx" ON "issue" USING btree ("cycle_id");--> statement-breakpoint
 CREATE INDEX "issue_parent_idx" ON "issue" USING btree ("parent_id");--> statement-breakpoint
 CREATE INDEX "issue_sync_idx" ON "issue" USING btree ("organization_id","sync_id");--> statement-breakpoint
+CREATE INDEX "issue_org_active_idx" ON "issue" USING btree ("organization_id","completed_at") WHERE "issue"."archived_at" is null;--> statement-breakpoint
 CREATE INDEX "issue_team_order_idx" ON "issue" USING btree ("team_id","sort_order","id") WHERE "issue"."archived_at" is null;--> statement-breakpoint
 CREATE INDEX "issue_team_updated_idx" ON "issue" USING btree ("team_id","updated_at") WHERE "issue"."archived_at" is null;--> statement-breakpoint
 CREATE INDEX "issue_team_created_idx" ON "issue" USING btree ("team_id","created_at") WHERE "issue"."archived_at" is null;--> statement-breakpoint
@@ -1030,6 +1251,7 @@ CREATE INDEX "issue_milestone_idx" ON "issue" USING btree ("milestone_id") WHERE
 CREATE INDEX "issue_title_trgm_idx" ON "issue" USING gin ("title" gin_trgm_ops);--> statement-breakpoint
 CREATE INDEX "issue_description_trgm_idx" ON "issue" USING gin ("description" gin_trgm_ops);--> statement-breakpoint
 CREATE INDEX "issue_activity_issue_idx" ON "issue_activity" USING btree ("issue_id","created_at");--> statement-breakpoint
+CREATE INDEX "issue_activity_cycle_moves_idx" ON "issue_activity" USING btree ("organization_id","created_at") WHERE "issue_activity"."field" = 'cycleId';--> statement-breakpoint
 CREATE UNIQUE INDEX "issue_identifier_alias_unique" ON "issue_identifier_alias" USING btree ("organization_id","identifier");--> statement-breakpoint
 CREATE INDEX "issue_identifier_alias_issue_idx" ON "issue_identifier_alias" USING btree ("issue_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "issue_label_unique" ON "issue_label" USING btree ("issue_id","label_id");--> statement-breakpoint
@@ -1057,5 +1279,7 @@ CREATE INDEX "project_update_project_idx" ON "project_update" USING btree ("proj
 CREATE INDEX "saved_analytics_view_org_idx" ON "saved_analytics_view" USING btree ("organization_id");--> statement-breakpoint
 CREATE INDEX "saved_analytics_view_owner_idx" ON "saved_analytics_view" USING btree ("owner_id");--> statement-breakpoint
 CREATE INDEX "view_org_idx" ON "view" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "view_team_idx" ON "view" USING btree ("team_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "view_preference_unique" ON "view_preference" USING btree ("user_id","organization_id","page","scope");--> statement-breakpoint
 CREATE INDEX "workflow_state_team_idx" ON "workflow_state" USING btree ("team_id","position");--> statement-breakpoint
 CREATE UNIQUE INDEX "workflow_state_team_name_unique" ON "workflow_state" USING btree ("team_id","name");

--- a/packages/db/drizzle/meta/0000_snapshot.json
+++ b/packages/db/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "fab88ec0-4520-4b36-bc91-870b1de5a308",
+  "id": "584a0eb2-7e44-4ba7-9231-2d2f9f2d1424",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -1374,6 +1374,182 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.github_installation": {
+      "name": "github_installation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Organization'"
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'selected'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "connected_by_id": {
+          "name": "connected_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repositories_synced_at": {
+          "name": "repositories_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installation_installation_unique": {
+          "name": "github_installation_installation_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installation_org_idx": {
+          "name": "github_installation_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installation_organization_id_organization_id_fk": {
+          "name": "github_installation_organization_id_organization_id_fk",
+          "tableFrom": "github_installation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installation_integration_id_integration_id_fk": {
+          "name": "github_installation_integration_id_integration_id_fk",
+          "tableFrom": "github_installation",
+          "tableTo": "integration",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installation_connected_by_id_user_id_fk": {
+          "name": "github_installation_connected_by_id_user_id_fk",
+          "tableFrom": "github_installation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "connected_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.github_issue_sync": {
       "name": "github_issue_sync",
       "schema": "",
@@ -1660,6 +1836,362 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.github_repository": {
+      "name": "github_repository",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "owner_login": {
+          "name": "owner_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repository_unique": {
+          "name": "github_repository_unique",
+          "columns": [
+            {
+              "expression": "installation_row_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_org_idx": {
+          "name": "github_repository_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_organization_id_organization_id_fk": {
+          "name": "github_repository_organization_id_organization_id_fk",
+          "tableFrom": "github_repository",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_installation_row_id_github_installation_id_fk": {
+          "name": "github_repository_installation_row_id_github_installation_id_fk",
+          "tableFrom": "github_repository",
+          "tableTo": "github_installation",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_link": {
+      "name": "github_repository_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_row_id": {
+          "name": "repository_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_by_id": {
+          "name": "linked_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repository_link_project_unique": {
+          "name": "github_repository_link_project_unique",
+          "columns": [
+            {
+              "expression": "repository_row_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_repository_link\".\"project_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_link_workspace_unique": {
+          "name": "github_repository_link_workspace_unique",
+          "columns": [
+            {
+              "expression": "repository_row_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_repository_link\".\"project_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_link_project_idx": {
+          "name": "github_repository_link_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_link_org_idx": {
+          "name": "github_repository_link_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_link_organization_id_organization_id_fk": {
+          "name": "github_repository_link_organization_id_organization_id_fk",
+          "tableFrom": "github_repository_link",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_link_repository_row_id_github_repository_id_fk": {
+          "name": "github_repository_link_repository_row_id_github_repository_id_fk",
+          "tableFrom": "github_repository_link",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_link_project_id_project_id_fk": {
+          "name": "github_repository_link_project_id_project_id_fk",
+          "tableFrom": "github_repository_link",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_link_linked_by_id_user_id_fk": {
+          "name": "github_repository_link_linked_by_id_user_id_fk",
+          "tableFrom": "github_repository_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "linked_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.github_repository_sync": {
       "name": "github_repository_sync",
       "schema": "",
@@ -1686,7 +2218,7 @@
           "name": "team_id",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "repository_id": {
           "name": "repository_id",
@@ -2057,6 +2589,99 @@
           "tableTo": "integration",
           "columnsFrom": [
             "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_oauth_state": {
+      "name": "integration_oauth_state",
+      "schema": "",
+      "columns": {
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_oauth_state_expires_idx": {
+          "name": "integration_oauth_state_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_oauth_state_organization_id_organization_id_fk": {
+          "name": "integration_oauth_state_organization_id_organization_id_fk",
+          "tableFrom": "integration_oauth_state",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_oauth_state_user_id_user_id_fk": {
+          "name": "integration_oauth_state_user_id_user_id_fk",
+          "tableFrom": "integration_oauth_state",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
           ],
           "columnsTo": [
             "id"
@@ -3298,12 +3923,36 @@
           "primaryKey": false,
           "notNull": true
         },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
         "content": {
           "name": "content",
           "type": "text",
           "primaryKey": false,
           "notNull": true,
           "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', left(coalesce(content, ''), 200000)), 'B')",
+            "type": "stored"
+          }
         },
         "visibility": {
           "name": "visibility",
@@ -3404,6 +4053,27 @@
           "method": "btree",
           "with": {}
         },
+        "doc_collection_order_idx": {
+          "name": "doc_collection_order_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
         "doc_title_trgm_idx": {
           "name": "doc_title_trgm_idx",
           "columns": [
@@ -3429,6 +4099,21 @@
               "asc": true,
               "nulls": "last",
               "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "doc_search_idx": {
+          "name": "doc_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
             }
           ],
           "isUnique": false,
@@ -3518,6 +4203,353 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.doc_access": {
+      "name": "doc_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_access_unique": {
+          "name": "doc_access_unique",
+          "columns": [
+            {
+              "expression": "doc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_access_subject_idx": {
+          "name": "doc_access_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_access_organization_id_organization_id_fk": {
+          "name": "doc_access_organization_id_organization_id_fk",
+          "tableFrom": "doc_access",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_access_doc_id_doc_id_fk": {
+          "name": "doc_access_doc_id_doc_id_fk",
+          "tableFrom": "doc_access",
+          "tableTo": "doc",
+          "columnsFrom": [
+            "doc_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_access_granted_by_id_user_id_fk": {
+          "name": "doc_access_granted_by_id_user_id_fk",
+          "tableFrom": "doc_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_access_request": {
+      "name": "doc_access_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "decided_by_id": {
+          "name": "decided_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_access_request_pending_unique": {
+          "name": "doc_access_request_pending_unique",
+          "columns": [
+            {
+              "expression": "doc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_access_request_doc_idx": {
+          "name": "doc_access_request_doc_idx",
+          "columns": [
+            {
+              "expression": "doc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_access_request_requester_idx": {
+          "name": "doc_access_request_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_access_request_organization_id_organization_id_fk": {
+          "name": "doc_access_request_organization_id_organization_id_fk",
+          "tableFrom": "doc_access_request",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_access_request_doc_id_doc_id_fk": {
+          "name": "doc_access_request_doc_id_doc_id_fk",
+          "tableFrom": "doc_access_request",
+          "tableTo": "doc",
+          "columnsFrom": [
+            "doc_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_access_request_requester_id_user_id_fk": {
+          "name": "doc_access_request_requester_id_user_id_fk",
+          "tableFrom": "doc_access_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_access_request_decided_by_id_user_id_fk": {
+          "name": "doc_access_request_decided_by_id_user_id_fk",
+          "tableFrom": "doc_access_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.doc_collection": {
       "name": "doc_collection",
       "schema": "",
@@ -3547,6 +4579,13 @@
           "notNull": true,
           "default": "'book'"
         },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
         "sync_id": {
           "name": "sync_id",
           "type": "bigint",
@@ -3571,6 +4610,12 @@
               "isExpression": false,
               "asc": true,
               "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
             }
           ],
           "isUnique": false,
@@ -3591,6 +4636,184 @@
             "id"
           ],
           "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_comment": {
+      "name": "doc_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "doc_comment_doc_idx": {
+          "name": "doc_comment_doc_idx",
+          "columns": [
+            {
+              "expression": "doc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_comment_parent_idx": {
+          "name": "doc_comment_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_comment_organization_id_organization_id_fk": {
+          "name": "doc_comment_organization_id_organization_id_fk",
+          "tableFrom": "doc_comment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_comment_doc_id_doc_id_fk": {
+          "name": "doc_comment_doc_id_doc_id_fk",
+          "tableFrom": "doc_comment",
+          "tableTo": "doc",
+          "columnsFrom": [
+            "doc_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_comment_author_id_user_id_fk": {
+          "name": "doc_comment_author_id_user_id_fk",
+          "tableFrom": "doc_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "doc_comment_parent_id_doc_comment_id_fk": {
+          "name": "doc_comment_parent_id_doc_comment_id_fk",
+          "tableFrom": "doc_comment",
+          "tableTo": "doc_comment",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
           "onUpdate": "no action"
         }
       },
@@ -3697,21 +4920,15 @@
           "primaryKey": true,
           "notNull": true
         },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
         "doc_id": {
           "name": "doc_id",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "version": {
-          "name": "version",
-          "type": "integer",
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
         },
@@ -3725,14 +4942,26 @@
           "name": "content",
           "type": "text",
           "primaryKey": false,
-          "notNull": true,
-          "default": "''"
+          "notNull": true
         },
-        "author_id": {
-          "name": "author_id",
+        "owned_by_id": {
+          "name": "owned_by_id",
           "type": "text",
           "primaryKey": false,
           "notNull": true
+        },
+        "restored_from_id": {
+          "name": "restored_from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_saved_at": {
+          "name": "last_saved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
         },
         "sync_id": {
           "name": "sync_id",
@@ -3750,27 +4979,6 @@
         }
       },
       "indexes": {
-        "doc_version_unique": {
-          "name": "doc_version_unique",
-          "columns": [
-            {
-              "expression": "doc_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "version",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
         "doc_version_doc_idx": {
           "name": "doc_version_doc_idx",
           "columns": [
@@ -3781,7 +4989,7 @@
               "nulls": "last"
             },
             {
-              "expression": "created_at",
+              "expression": "last_saved_at",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -3794,19 +5002,6 @@
         }
       },
       "foreignKeys": {
-        "doc_version_organization_id_organization_id_fk": {
-          "name": "doc_version_organization_id_organization_id_fk",
-          "tableFrom": "doc_version",
-          "tableTo": "organization",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
         "doc_version_doc_id_doc_id_fk": {
           "name": "doc_version_doc_id_doc_id_fk",
           "tableFrom": "doc_version",
@@ -3820,17 +5015,30 @@
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
-        "doc_version_author_id_user_id_fk": {
-          "name": "doc_version_author_id_user_id_fk",
+        "doc_version_organization_id_organization_id_fk": {
+          "name": "doc_version_organization_id_organization_id_fk",
           "tableFrom": "doc_version",
-          "tableTo": "user",
+          "tableTo": "organization",
           "columnsFrom": [
-            "author_id"
+            "organization_id"
           ],
           "columnsTo": [
             "id"
           ],
-          "onDelete": "restrict",
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "doc_version_owned_by_id_user_id_fk": {
+          "name": "doc_version_owned_by_id_user_id_fk",
+          "tableFrom": "doc_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owned_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
           "onUpdate": "no action"
         }
       },
@@ -4197,33 +5405,6 @@
           "method": "btree",
           "with": {}
         },
-        "reaction_issue_unique": {
-          "name": "reaction_issue_unique",
-          "columns": [
-            {
-              "expression": "issue_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "emoji",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
         "reaction_comment_idx": {
           "name": "reaction_comment_idx",
           "columns": [
@@ -4312,12 +5493,7 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {
-        "reaction_one_parent": {
-          "name": "reaction_one_parent",
-          "value": "num_nonnulls(\"reaction\".\"comment_id\", \"reaction\".\"issue_id\") = 1"
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.recent_visit": {
@@ -4449,6 +5625,534 @@
         "recent_visit_user_id_user_id_fk": {
           "name": "recent_visit_user_id_user_id_fk",
           "tableFrom": "recent_visit",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_grant": {
+      "name": "mcp_grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_grant_client_user_unique": {
+          "name": "mcp_grant_client_user_unique",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_grant_user_idx": {
+          "name": "mcp_grant_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_grant_client_id_oauth_application_client_id_fk": {
+          "name": "mcp_grant_client_id_oauth_application_client_id_fk",
+          "tableFrom": "mcp_grant",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_grant_user_id_user_id_fk": {
+          "name": "mcp_grant_user_id_user_id_fk",
+          "tableFrom": "mcp_grant",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_grant_organization_id_organization_id_fk": {
+          "name": "mcp_grant_organization_id_organization_id_fk",
+          "tableFrom": "mcp_grant",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_idx": {
+          "name": "oauth_access_token_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_idx": {
+          "name": "oauth_access_token_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_application_user_idx": {
+          "name": "oauth_application_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_application_user_id_user_id_fk": {
+          "name": "oauth_application_user_id_user_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_idx": {
+          "name": "oauth_consent_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_idx": {
+          "name": "oauth_consent_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
           "tableTo": "user",
           "columnsFrom": [
             "user_id"
@@ -6367,6 +8071,28 @@
           "method": "btree",
           "with": {}
         },
+        "issue_org_active_idx": {
+          "name": "issue_org_active_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
         "issue_team_order_idx": {
           "name": "issue_team_order_idx",
           "columns": [
@@ -6718,6 +8444,28 @@
             }
           ],
           "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_activity_cycle_moves_idx": {
+          "name": "issue_activity_cycle_moves_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue_activity\".\"field\" = 'cycleId'",
           "concurrently": false,
           "method": "btree",
           "with": {}
@@ -7128,6 +8876,13 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
         },
         "created_at": {
           "name": "created_at",
@@ -8670,6 +10425,19 @@
           "notNull": true,
           "default": "'false'"
         },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "sync_id": {
           "name": "sync_id",
           "type": "bigint",
@@ -8691,6 +10459,21 @@
           "columns": [
             {
               "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "view_team_idx": {
+          "name": "view_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -8722,6 +10505,152 @@
           "tableTo": "user",
           "columnsFrom": [
             "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "view_team_id_team_id_fk": {
+          "name": "view_team_id_team_id_fk",
+          "tableFrom": "view",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.view_preference": {
+      "name": "view_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page": {
+          "name": "page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'list'"
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "view_preference_unique": {
+          "name": "view_preference_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "view_preference_organization_id_organization_id_fk": {
+          "name": "view_preference_organization_id_organization_id_fk",
+          "tableFrom": "view_preference",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "view_preference_user_id_user_id_fk": {
+          "name": "view_preference_user_id_user_id_fk",
+          "tableFrom": "view_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
           ],
           "columnsTo": [
             "id"
@@ -8891,6 +10820,8 @@
         "review_approved",
         "pull_request_merged",
         "due_soon",
+        "access_requested",
+        "access_granted",
         "manual"
       ]
     }

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1784820887038,
-      "tag": "0000_shallow_richard_fisk",
+      "when": 1786212315993,
+      "tag": "0000_shocking_baron_zemo",
       "breakpoints": true
     }
   ]

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "generate": "drizzle-kit generate",
-    "migrate": "drizzle-kit migrate",
+    "migrate": "bun src/ensure-extensions.ts && drizzle-kit migrate",
     "push": "bun src/ensure-extensions.ts && drizzle-kit push --force",
     "studio": "drizzle-kit studio",
     "seed": "bun --env-file=../../.env src/seed/index.ts",


### PR DESCRIPTION
## The problem

Someone installing Orbit and following the migration path got a broken database.

`bun run db:migrate` on a fresh database, before this change:

```
localhost/orbit_fresh_migrate is behind packages/db/src/schema:
  missing table   doc_access
  missing table   doc_access_request
  missing table   doc_comment
  missing table   github_installation
  missing table   github_repository
  missing table   github_repository_link
  missing table   integration_oauth_state
  missing table   mcp_grant
  missing table   oauth_access_token
  missing table   oauth_application
  missing table   oauth_consent
  missing table   view_preference
  missing column  doc.search_vector
  missing column  doc.slug
  missing column  doc.sort_order
  missing column  doc_collection.position
  ...
```

Twelve tables and nine columns. `mcp_grant`, `oauth_application` and `oauth_access_token` are the MCP OAuth tables, so on that database the MCP server could not authenticate anyone at all.

The baseline was generated before the doc tree, GitHub connect, saved view and MCP OAuth work and was never regenerated. `db:push` builds the right thing because it reads the schema directly, so the two documented paths produced two different databases and only one of them worked.

This is the same class of failure that took `/docs` and `/api/sync` down: schema that exists in code but not in a database. That one was a database nobody had applied the change to. This one ships in the repository.

## What changed

The baseline is regenerated from `packages/db/src/schema`. A fresh `db:migrate` now answers:

```
localhost/orbit_fresh_migrate2 has every table and column the schema declares.
```

Including the pieces that are easy to lose: `doc.search_vector` as `GENERATED ALWAYS AS (...) STORED` with its GIN index, `doc.sort_order`, `doc_collection.position`, and all four of the MCP and doc access tables.

Replacing the baseline strands nobody: no database tracks the old journal. Checked production and a dev database, and neither has a `__drizzle_migrations` table, because production is brought forward with the scripts in `packages/db/catchup` and development uses `db:push`.

## So it cannot rot again

A CI job builds a database the way someone installing this would, with `db:migrate` and nothing else, then runs `db:check-drift` against it. If a schema change lands without regenerating the baseline, that job fails.

This is the check that would have caught the current state, and it is cheap: one Postgres service and two commands.

## Verification

- fresh database + `db:migrate` + `db:check-drift`: clean, confirmed before and after so the failure is reproducible
- fresh database + `db:push` + `db:check-drift`: clean, unchanged by this PR
- `packages/db` tests: 150 pass
- lint, comment policy, typecheck: clean

## Not in this PR

The four `standup*` tables are still in production and no longer in the schema, so `db:push` against production would drop them and the 31 rows they hold. `db:check-drift` reports them on every run. Removing them is a data decision, not a schema one.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR regenerates the baseline migration from the current schema and adds CI validation for fresh migration-based installations.
- Adds missing tables, columns, constraints, indexes, and schema metadata to the baseline.
- Installs `pg_trgm` through the database migration command before running Drizzle migrations.
- Creates a fresh PostgreSQL database in CI, migrates it, and checks it for schema drift.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the migration command now installs `pg_trgm` before applying the baseline, and the CI job exercises that same fresh-database path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/db/drizzle/0000_shocking_baron_zemo.sql | Regenerates the baseline with the current schema; its trigram indexes are now preceded by extension installation in the migration command. |
| packages/db/package.json | Updates the migrate command to install required PostgreSQL extensions before invoking Drizzle. |
| .github/workflows/ci.yml | Adds a fresh-database migration and drift-check job that exercises the corrected migration path. |
| packages/db/drizzle/meta/0000_snapshot.json | Updates the Drizzle snapshot to represent the regenerated baseline schema. |
| packages/db/drizzle/meta/_journal.json | Replaces the journal entry with the regenerated baseline migration identifier. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CI
    participant Installer as ensure-extensions.ts
    participant DB as Fresh PostgreSQL
    participant Drizzle
    participant Drift as check-drift.ts
    CI->>DB: Create orbit_from_migrations
    CI->>Installer: "Run @orbit/db migrate"
    Installer->>DB: CREATE EXTENSION IF NOT EXISTS pg_trgm
    Installer->>Drizzle: Continue after extension succeeds
    Drizzle->>DB: Apply regenerated baseline
    CI->>Drift: Run db:check-drift
    Drift->>DB: Read migrated tables and columns
    Drift-->>CI: Confirm migration matches schema
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(db): let migrate install the extensi..."](https://github.com/noveum/orbit/commit/b4bc745b6e9c0055d87509ecdad4d851ec397c64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51465525)</sub>

<!-- /greptile_comment -->