### PR TITLE
Allow yodu.ai email addresses in Noveum

### DIFF
--- a/docs/superpowers/plans/2026-08-08-yodu-email-domain.md
+++ b/docs/superpowers/plans/2026-08-08-yodu-email-domain.md
@@ -1,0 +1,211 @@
+# Yodu Email Domain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow exact `@yodu.ai` addresses to join and receive invitations to the Noveum workspace while preserving its existing allowed domains.
+
+**Architecture:** Centralize the Noveum workspace identity and organization insert values in one database-package module used by every seed and import path. Add an idempotent catchup script that appends `yodu.ai` only to the known Noveum organization records so existing databases receive the same policy without losing current values.
+
+**Tech Stack:** TypeScript 5.9, Bun test, Drizzle ORM, postgres.js, PostgreSQL JSONB
+
+## Global Constraints
+
+- Match only the exact `yodu.ai` email domain. Do not allow subdomains.
+- Keep `noveum.ai` allowed and preserve every existing workspace domain.
+- Do not change the global `ALLOWED_EMAIL_DOMAINS` setting or the domain matcher.
+- Use Bun for every repository command.
+- Do not add comments or em dash characters to TypeScript source.
+- Keep strict types and place tests under the package `tests/` tree.
+
+---
+
+### Task 1: Centralize the Noveum workspace defaults
+
+**Files:**
+- Create: `packages/db/src/noveum-workspace.ts`
+- Create: `packages/db/tests/noveum-workspace.test.ts`
+- Modify: `packages/db/src/seed/index.ts`
+- Modify: `packages/db/src/import/index.ts`
+- Modify: `packages/db/src/import/combined.ts`
+- Modify: `packages/db/src/import/surgical.ts`
+
+**Interfaces:**
+- Produces: `NOVEUM_IMPORT_ORGANIZATION_ID`, `NOVEUM_SEED_ORGANIZATION_ID`, and `noveumOrganizationValues(id: string, createdAt: Date)`.
+- Consumes: The existing Drizzle organization insert shape at each seed or import call site.
+
+- [ ] **Step 1: Write the failing policy test**
+
+```ts
+import { describe, expect, it } from 'bun:test';
+import {
+  NOVEUM_IMPORT_ORGANIZATION_ID,
+  NOVEUM_SEED_ORGANIZATION_ID,
+  noveumOrganizationValues,
+} from '../src/noveum-workspace.ts';
+
+describe('noveumOrganizationValues', () => {
+  it('allows the exact Noveum and Yodu email domains in every Noveum workspace', () => {
+    const createdAt = new Date('2026-08-08T00:00:00.000Z');
+
+    for (const id of [NOVEUM_IMPORT_ORGANIZATION_ID, NOVEUM_SEED_ORGANIZATION_ID]) {
+      expect(noveumOrganizationValues(id, createdAt)).toEqual({
+        id,
+        name: 'Noveum',
+        slug: 'noveum',
+        logo: null,
+        allowedEmailDomains: ['noveum.ai', 'yodu.ai'],
+        createdAt,
+      });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify the missing policy fails**
+
+Run: `bun run --filter '@orbit/db' test tests/noveum-workspace.test.ts`
+
+Expected: FAIL because `packages/db/src/noveum-workspace.ts` does not exist.
+
+- [ ] **Step 3: Implement the shared Noveum values**
+
+```ts
+export const NOVEUM_IMPORT_ORGANIZATION_ID = 'org_noveum';
+export const NOVEUM_SEED_ORGANIZATION_ID = 'org_noveum_demo';
+
+export function noveumOrganizationValues(id: string, createdAt: Date) {
+  return {
+    id,
+    name: 'Noveum',
+    slug: 'noveum',
+    logo: null,
+    allowedEmailDomains: ['noveum.ai', 'yodu.ai'],
+    createdAt,
+  };
+}
+```
+
+- [ ] **Step 4: Route every Noveum creation path through the shared values**
+
+Import the shared module into the seed, Plane import, combined import, and surgical import. Replace the duplicated organization ids and inline organization value objects with `NOVEUM_SEED_ORGANIZATION_ID`, `NOVEUM_IMPORT_ORGANIZATION_ID`, and `noveumOrganizationValues(...)` as appropriate.
+
+- [ ] **Step 5: Run the focused test and package typecheck**
+
+Run: `bun run --filter '@orbit/db' test tests/noveum-workspace.test.ts`
+
+Expected: PASS.
+
+Run: `bun run --filter '@orbit/db' typecheck`
+
+Expected: exit 0 with no type errors.
+
+- [ ] **Step 6: Commit the tested defaults**
+
+```bash
+git add packages/db/src/noveum-workspace.ts packages/db/tests/noveum-workspace.test.ts packages/db/src/seed/index.ts packages/db/src/import/index.ts packages/db/src/import/combined.ts packages/db/src/import/surgical.ts
+git commit -m "feat(auth): allow yodu email domain"
+```
+
+### Task 2: Backfill existing Noveum workspaces
+
+**Files:**
+- Create: `packages/db/catchup/noveum-yodu-domain-catchup.sql`
+- Modify: `packages/db/tests/apply-catchup.test.ts`
+
+**Interfaces:**
+- Consumes: `applyCatchup(url: string, named: string): Promise<void>`.
+- Produces: An idempotent SQL operation that appends `yodu.ai` to `allowed_email_domains` for `org_noveum` and `org_noveum_demo` only.
+
+- [ ] **Step 1: Extend the scratch schema and write the failing catchup test**
+
+Add `allowed_email_domains jsonb not null default '[]'::jsonb` to the scratch `organization` table. Add a test that inserts both Noveum ids plus an unrelated organization, applies `noveum-yodu-domain-catchup.sql` twice, and asserts these literal results:
+
+```ts
+expect(byId.get('org_noveum')).toEqual(['noveum.ai', 'yodu.ai']);
+expect(byId.get('org_noveum_demo')).toEqual(['noveum.ai', 'example.com', 'yodu.ai']);
+expect(byId.get('org_other')).toEqual(['example.com']);
+```
+
+- [ ] **Step 2: Run the integration test and verify it fails**
+
+Run: `bun run --filter '@orbit/db' test tests/apply-catchup.test.ts`
+
+Expected: FAIL because `noveum-yodu-domain-catchup.sql` does not exist.
+
+- [ ] **Step 3: Implement the idempotent catchup**
+
+```sql
+begin;
+
+update public.organization
+set allowed_email_domains = allowed_email_domains || '["yodu.ai"]'::jsonb
+where id in ('org_noveum', 'org_noveum_demo')
+  and not allowed_email_domains @> '["yodu.ai"]'::jsonb;
+
+commit;
+```
+
+- [ ] **Step 4: Run the catchup test twice through its test case**
+
+Run: `bun run --filter '@orbit/db' test tests/apply-catchup.test.ts`
+
+Expected: PASS, including the second application and the unrelated organization assertion.
+
+- [ ] **Step 5: Commit the tested catchup**
+
+```bash
+git add packages/db/catchup/noveum-yodu-domain-catchup.sql packages/db/tests/apply-catchup.test.ts
+git commit -m "chore(db): backfill yodu email domain"
+```
+
+### Task 3: Apply, verify, publish, review, and merge
+
+**Files:**
+- Modify: none unless verification or review identifies a defect.
+
+**Interfaces:**
+- Consumes: `bun run db:catchup -- packages/db/catchup/noveum-yodu-domain-catchup.sql`, GitHub CLI, and repository review bots.
+- Produces: A verified current workspace update and a merged pull request into `main`.
+
+- [ ] **Step 1: Inspect the configured database target and current domain values**
+
+Use a read-only query that prints only the database host/name and the Noveum organization ids, names, slugs, and `allowed_email_domains`. Do not print credentials.
+
+- [ ] **Step 2: Apply the scoped catchup and read the values back**
+
+Run: `bun run db:catchup -- packages/db/catchup/noveum-yodu-domain-catchup.sql`
+
+Expected: only known Noveum rows gain one `yodu.ai` entry, and all previous entries remain.
+
+- [ ] **Step 3: Run the full repository gate**
+
+Run: `bun run verify`
+
+Expected: lint, comment policy, source byte checks, Bun import checks, dependency checks, typecheck, and all tests pass.
+
+- [ ] **Step 4: Commit the implementation plan if it is not already committed**
+
+```bash
+git add docs/superpowers/plans/2026-08-08-yodu-email-domain.md
+git commit -m "docs(auth): plan yodu email domain access"
+```
+
+- [ ] **Step 5: Request an independent code review**
+
+Review the range from `origin/main` to `HEAD` against this plan and the approved design. Resolve every Critical and Important finding before publishing.
+
+- [ ] **Step 6: Push and open a ready pull request into `main`**
+
+The PR description must summarize the shared defaults, the idempotent catchup, user impact, and `bun run verify` evidence.
+
+- [ ] **Step 7: Wait for CI, Greptile, and CodeRabbit**
+
+Address every actionable thread. Reply with technical reasoning before resolving any finding that does not apply. Re-run CodeRabbit if it reports rate limiting.
+
+- [ ] **Step 8: Merge current `main` into the feature branch and reverify**
+
+Fetch `origin/main`, merge it into `codex/allow-yodu-email-domain`, run `bun run verify`, push, and wait for the refreshed CI and reviews.
+
+- [ ] **Step 9: Squash merge only when the PR is stable**
+
+Merge only with green checks, completed reviews, no unresolved threads, and a mergeable state that is not `UNSTABLE`.

--- a/docs/superpowers/specs/2026-08-08-yodu-email-domain-design.md
+++ b/docs/superpowers/specs/2026-08-08-yodu-email-domain-design.md
@@ -1,0 +1,29 @@
+# Yodu Email Domain Design
+
+## Goal
+
+Allow email addresses whose domain is exactly `yodu.ai` to sign up for and receive invitations to the Noveum workspace. Keep `noveum.ai` allowed and continue rejecting domains that the workspace does not list.
+
+## Scope
+
+Orbit already supports multiple exact-match domains at both the server and workspace levels. This change will use that existing behavior. It will not add suffix matching, allow Yodu subdomains, or create a special case in authentication code.
+
+The Noveum workspace defaults used by the database seed and both import paths will list `noveum.ai` and `yodu.ai`. The current Noveum workspace record will receive the same addition without removing any domains already configured there.
+
+The global `ALLOWED_EMAIL_DOMAINS` setting will remain unchanged. A deployment that configures a nonempty global list must include both domains because the global and workspace lists are both enforced.
+
+## Design
+
+A small Noveum workspace configuration module in `packages/db` will own the default domain list. The seed, Plane import, and combined import will all use that shared value so future rebuilds cannot drift between paths.
+
+The current workspace update will target only the Noveum organization and append `yodu.ai` idempotently. Before applying it, the target database and existing organization value will be inspected. No user, membership, invitation, or task data will change.
+
+## Data Flow
+
+When an invitation is created or a user is created, the existing organization service extracts the exact email domain. It checks the server allowlist when configured, then checks the workspace allowlist. With `yodu.ai` present in the Noveum workspace list, `hey@yodu.ai` passes both checks while `hey@team.yodu.ai` and unrelated domains remain rejected.
+
+## Testing and Verification
+
+A focused database-package test will protect the Noveum default policy and its use by the creation paths. Existing core invitation tests will continue to cover exact matching, multiple allowed domains, and rejection behavior.
+
+The implementation will run the focused tests first, then `bun run verify`. The current workspace value will be read back after the scoped update to confirm that `yodu.ai` was added and existing domains were preserved.

--- a/packages/core/tests/org/invite-service.test.ts
+++ b/packages/core/tests/org/invite-service.test.ts
@@ -172,6 +172,12 @@ describe('matchAllowedDomain', () => {
     expect(matchAllowedDomain(organization, 'c@nope.dev')).toBeNull();
     expect(matchAllowedDomain(organization, 'not-an-email')).toBeNull();
   });
+
+  it('allows Yodu exactly without allowing its subdomains', () => {
+    const organization = { allowedEmailDomains: ['yodu.ai'] };
+    expect(matchAllowedDomain(organization, 'person@yodu.ai')).toBe('yodu.ai');
+    expect(matchAllowedDomain(organization, 'person@team.yodu.ai')).toBeNull();
+  });
 });
 
 describe('role escalation', () => {

--- a/packages/db/catchup/noveum-yodu-domain-catchup.sql
+++ b/packages/db/catchup/noveum-yodu-domain-catchup.sql
@@ -1,0 +1,8 @@
+begin;
+
+update public.organization
+set allowed_email_domains = allowed_email_domains || '["yodu.ai"]'::jsonb
+where id in ('org_noveum', 'org_noveum_demo')
+  and not allowed_email_domains @> '["yodu.ai"]'::jsonb;
+
+commit;

--- a/packages/db/src/import/combined.ts
+++ b/packages/db/src/import/combined.ts
@@ -2,6 +2,10 @@ import { isAbsolute, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import { sql } from 'drizzle-orm';
 import { db, pool } from '../client.ts';
+import {
+  noveumOrganizationValues,
+  NOVEUM_IMPORT_ORGANIZATION_ID as ORGANIZATION_ID,
+} from '../noveum-workspace.ts';
 import * as schema from '../schema/index.ts';
 import { createAssetStore } from './assets.ts';
 import { combine } from './combine.ts';
@@ -9,9 +13,6 @@ import { readLinearExport } from './linear-source.ts';
 import { readPlaneExport } from './plane-source.ts';
 import { countRows, type ImportRows } from './rows.ts';
 
-const ORGANIZATION_ID = 'org_noveum';
-const ORGANIZATION_SLUG = 'noveum';
-const ORGANIZATION_NAME = 'Noveum';
 const CHUNK = 400;
 
 const { values } = parseArgs({
@@ -179,14 +180,7 @@ async function main(): Promise<void> {
 
   await db
     .insert(schema.organization)
-    .values({
-      id: ORGANIZATION_ID,
-      name: ORGANIZATION_NAME,
-      slug: ORGANIZATION_SLUG,
-      logo: null,
-      allowedEmailDomains: ['noveum.ai'],
-      createdAt: floor,
-    })
+    .values(noveumOrganizationValues(ORGANIZATION_ID, floor))
     .onConflictDoNothing();
 
   const assets = createAssetStore(PLANE, STORAGE, ORGANIZATION_ID);

--- a/packages/db/src/import/index.ts
+++ b/packages/db/src/import/index.ts
@@ -3,6 +3,10 @@ import { isAbsolute, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import { sql } from 'drizzle-orm';
 import { db, pool } from '../client.ts';
+import {
+  noveumOrganizationValues,
+  NOVEUM_IMPORT_ORGANIZATION_ID as ORGANIZATION_ID,
+} from '../noveum-workspace.ts';
 import * as schema from '../schema/index.ts';
 import { type AssetStore, createAssetStore } from './assets.ts';
 import { type BuildContext, buildDocs, buildProject } from './build-project.ts';
@@ -10,9 +14,6 @@ import { displayNameFor, handleFor, orgRoleFor } from './plane-mapping.ts';
 import { type PlaneMember, readPlaneExport } from './plane-source.ts';
 import { countRows, emptyRows, type ImportRows } from './rows.ts';
 
-const ORGANIZATION_ID = 'org_noveum';
-const ORGANIZATION_SLUG = 'noveum';
-const ORGANIZATION_NAME = 'Noveum';
 const CHUNK = 400;
 
 const { values } = parseArgs({
@@ -189,14 +190,7 @@ async function main(): Promise<void> {
 
   await db
     .insert(schema.organization)
-    .values({
-      id: ORGANIZATION_ID,
-      name: ORGANIZATION_NAME,
-      slug: ORGANIZATION_SLUG,
-      logo: null,
-      allowedEmailDomains: ['noveum.ai'],
-      createdAt: floor,
-    })
+    .values(noveumOrganizationValues(ORGANIZATION_ID, floor))
     .onConflictDoNothing();
 
   const rows = emptyRows();

--- a/packages/db/src/import/surgical.ts
+++ b/packages/db/src/import/surgical.ts
@@ -2,6 +2,7 @@ import { isAbsolute, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import { sql } from 'drizzle-orm';
 import { db, pool } from '../client.ts';
+import { NOVEUM_IMPORT_ORGANIZATION_ID as ORGANIZATION_ID } from '../noveum-workspace.ts';
 import * as schema from '../schema/index.ts';
 import { createAssetStore } from './assets.ts';
 import { combine } from './combine.ts';
@@ -9,7 +10,6 @@ import { readLinearExport } from './linear-source.ts';
 import { readPlaneExport } from './plane-source.ts';
 import { countRows } from './rows.ts';
 
-const ORGANIZATION_ID = 'org_noveum';
 const CHUNK = 400;
 
 const { values } = parseArgs({

--- a/packages/db/src/noveum-workspace.ts
+++ b/packages/db/src/noveum-workspace.ts
@@ -1,0 +1,13 @@
+export const NOVEUM_IMPORT_ORGANIZATION_ID = 'org_noveum';
+export const NOVEUM_SEED_ORGANIZATION_ID = 'org_noveum_demo';
+
+export function noveumOrganizationValues(id: string, createdAt: Date) {
+  return {
+    id,
+    name: 'Noveum',
+    slug: 'noveum',
+    logo: null,
+    allowedEmailDomains: ['noveum.ai', 'yodu.ai'],
+    createdAt,
+  };
+}

--- a/packages/db/src/seed/index.ts
+++ b/packages/db/src/seed/index.ts
@@ -2,6 +2,10 @@ import { randomUUID } from 'node:crypto';
 import { STATE_CATEGORY_ORDER, unique } from '@orbit/shared';
 import { sql } from 'drizzle-orm';
 import { db, pool } from '../client.ts';
+import {
+  noveumOrganizationValues,
+  NOVEUM_SEED_ORGANIZATION_ID as ORGANIZATION_ID,
+} from '../noveum-workspace.ts';
 import * as schema from '../schema/index.ts';
 import {
   SEED_COLLECTIONS,
@@ -15,8 +19,6 @@ import {
   SEED_USERS,
 } from './data.ts';
 
-const ORGANIZATION_ID = 'org_noveum_demo';
-const ORGANIZATION_SLUG = 'noveum';
 const SORT_STEP = 1024;
 
 function id(): string {
@@ -89,14 +91,9 @@ async function reset(): Promise<void> {
 }
 
 async function seedOrganizationAndUsers(): Promise<Map<string, string>> {
-  await db.insert(schema.organization).values({
-    id: ORGANIZATION_ID,
-    name: 'Noveum',
-    slug: ORGANIZATION_SLUG,
-    logo: null,
-    allowedEmailDomains: ['noveum.ai'],
-    createdAt: daysAgo(240),
-  });
+  await db
+    .insert(schema.organization)
+    .values(noveumOrganizationValues(ORGANIZATION_ID, daysAgo(240)));
 
   const userIds = new Map<string, string>();
   const userRows = SEED_USERS.map((entry) => {

--- a/packages/db/tests/apply-catchup.test.ts
+++ b/packages/db/tests/apply-catchup.test.ts
@@ -66,7 +66,10 @@ describe('applyCatchup against a real database', () => {
       await sql
         .unsafe(`
         create table public."user" (id text primary key);
-        create table public.organization (id text primary key);
+        create table public.organization (
+          id text primary key,
+          allowed_email_domains jsonb not null default '[]'::jsonb
+        );
         create table public.doc (
           id text primary key,
           organization_id text not null references public.organization(id),
@@ -133,6 +136,37 @@ describe('applyCatchup against a real database', () => {
       `;
     });
     expect(row?.hit).toBe(true);
+  }, 30_000);
+
+  it('adds Yodu to Noveum workspaces without changing other domains', async () => {
+    await run(urlFor(SCRATCH), async (sql) => {
+      await sql`
+        insert into public.organization (id, allowed_email_domains)
+        values
+          ('org_noveum', ${sql.json(['noveum.ai'])}),
+          ('org_noveum_demo', ${sql.json(['noveum.ai', 'example.com'])}),
+          ('org_other', ${sql.json(['example.com'])})
+        on conflict (id) do update
+        set allowed_email_domains = excluded.allowed_email_domains
+      `;
+    });
+
+    await applyCatchup(urlFor(SCRATCH), 'noveum-yodu-domain-catchup.sql');
+    await applyCatchup(urlFor(SCRATCH), 'noveum-yodu-domain-catchup.sql');
+
+    const rows = await run(
+      urlFor(SCRATCH),
+      (sql) => sql<{ id: string; allowed_email_domains: string[] }[]>`
+        select id, allowed_email_domains
+        from public.organization
+        where id in ('org_noveum', 'org_noveum_demo', 'org_other')
+      `,
+    );
+    const byId = new Map(rows.map((row) => [row.id, row.allowed_email_domains]));
+
+    expect(byId.get('org_noveum')).toEqual(['noveum.ai', 'yodu.ai']);
+    expect(byId.get('org_noveum_demo')).toEqual(['noveum.ai', 'example.com', 'yodu.ai']);
+    expect(byId.get('org_other')).toEqual(['example.com']);
   }, 30_000);
 
   it('refuses a file outside the catchup directory before it opens anything', async () => {

--- a/packages/db/tests/noveum-workspace.test.ts
+++ b/packages/db/tests/noveum-workspace.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  NOVEUM_IMPORT_ORGANIZATION_ID,
+  NOVEUM_SEED_ORGANIZATION_ID,
+  noveumOrganizationValues,
+} from '../src/noveum-workspace.ts';
+
+describe('noveumOrganizationValues', () => {
+  it('allows the exact Noveum and Yodu email domains in every Noveum workspace', () => {
+    const createdAt = new Date('2026-08-08T00:00:00.000Z');
+
+    for (const id of [NOVEUM_IMPORT_ORGANIZATION_ID, NOVEUM_SEED_ORGANIZATION_ID]) {
+      expect(noveumOrganizationValues(id, createdAt)).toEqual({
+        id,
+        name: 'Noveum',
+        slug: 'noveum',
+        logo: null,
+        allowedEmailDomains: ['noveum.ai', 'yodu.ai'],
+        createdAt,
+      });
+    }
+  });
+});


### PR DESCRIPTION
## What this changes

Allows exact `yodu.ai` email addresses in the Noveum workspace. Noveum seed and import defaults now share one organization definition, and an idempotent catchup updates existing Noveum workspaces.

## Why

Noveum administrators could not invite or sign up users with `yodu.ai` addresses because the workspace allowed only `noveum.ai`.

## How you know it works

- Added a focused test for both Noveum workspace definitions.
- Added a behavior-level test that accepts `person@yodu.ai` and rejects `person@team.yodu.ai`.
- Added an integration test that applies the catchup twice, preserves existing domains, and leaves unrelated workspaces unchanged.
- Applied the catchup locally and confirmed `org_noveum_demo` contains `noveum.ai` and `yodu.ai`.
- Ran `ORBIT_TEST_LANE=yodu-final bun --env-file=/Users/shashank/Projects/Noveum/orbit/.env run verify` successfully.

## Checklist

- [x] `bun run verify` is green, all four checks
- [x] Tests added or updated, and they fail without the change
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions
- [x] External input is parsed with a Zod schema from `@orbit/shared`, not applicable because no external input changed
- [x] Authorization is enforced on the server through `packages/shared/src/policy`, not applicable because authorization did not change
- [x] Docs updated if behaviour, configuration or setup changed
- [x] Schema changes are pushed to the target database before this ships, not applicable because this is a data catchup and no schema changed

## Anything reviewers should know

The global `ALLOWED_EMAIL_DOMAINS` setting and exact domain matcher are unchanged. This intentionally allows `yodu.ai` only for Noveum, not subdomains and not other workspaces.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR allows exact `yodu.ai` addresses in Noveum workspaces while retaining `noveum.ai` and rejecting subdomains.

- Centralizes Noveum seed and import organization defaults.
- Adds an idempotent catchup that preserves existing domains for both known Noveum organization IDs.
- Adds focused matcher, shared-default, and database catchup tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the intended exact-domain behavior consistently applied to new and existing Noveum workspaces.

The shared defaults preserve established workspace identities, the scoped catchup is idempotent and non-destructive, and the tests cover exact matching, repeated application, preserved domains, and unrelated organizations.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/db/src/noveum-workspace.ts | Centralizes the two established Noveum organization IDs and shared organization values with both exact allowed domains. |
| packages/db/catchup/noveum-yodu-domain-catchup.sql | Idempotently appends `yodu.ai` to only the two known Noveum organizations while preserving existing domain entries. |
| packages/db/src/seed/index.ts | Replaces the inline seed organization definition with the shared Noveum values without otherwise changing seed behavior. |
| packages/db/src/import/index.ts | Routes Plane import organization creation through the shared Noveum definition while preserving its existing ID and conflict behavior. |
| packages/db/src/import/combined.ts | Routes combined import organization creation through the same shared Noveum definition. |
| packages/db/src/import/surgical.ts | Reuses the centralized import organization ID while continuing to preserve the existing organization record. |
| packages/db/tests/apply-catchup.test.ts | Verifies repeat application, preservation of existing domains, and isolation from unrelated organizations. |
| packages/core/tests/org/invite-service.test.ts | Confirms exact `yodu.ai` matching and rejection of `team.yodu.ai`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/noveum/orbit/commit/54b9aac21ceb06674349165c2830df1de9e4b94c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51468800)</sub>

<!-- /greptile_comment -->