### PR TITLE
Open a document rendered, not as its source

### DIFF
--- a/apps/web/e2e/doc-outline.spec.ts
+++ b/apps/web/e2e/doc-outline.spec.ts
@@ -17,7 +17,7 @@ test('an editable doc still has a table of contents that navigates it', async ({
   await page.goto(`${BASE}/docs`);
   await page.getByTestId('doc-tree').getByText('Realtime delta protocol').click();
 
-  await expect(page.getByTestId('doc-editor-input')).toBeVisible();
+  await expect(page.getByTestId('doc-rich-editor')).toBeVisible();
 
   const outline = page.getByTestId('doc-outline');
   await expect(outline).toBeVisible();
@@ -28,10 +28,10 @@ test('an editable doc still has a table of contents that navigates it', async ({
   ]);
 
   await outline.locator('a', { hasText: 'Rules' }).first().click();
-  await expect(page.getByTestId('doc-editor-input')).toBeFocused();
+  await expect(outline.locator('[aria-current="location"]')).toHaveText('Rules');
 
-  await page.getByTestId('editor-mode-rich').click();
-  await expect(page.getByTestId('doc-rich-editor')).toBeVisible();
+  await page.getByTestId('editor-mode-markdown').click();
+  await expect(page.getByTestId('doc-editor-input')).toBeVisible();
 
   await expect(outline.locator('a')).toHaveText([
     'Realtime delta protocol',
@@ -39,7 +39,7 @@ test('an editable doc still has a table of contents that navigates it', async ({
     'Rules',
   ]);
   await outline.locator('a', { hasText: 'Rules' }).first().click();
-  await expect(outline.locator('[aria-current="location"]')).toHaveText('Rules');
+  await expect(page.getByTestId('doc-editor-input')).toBeFocused();
 
   await context.close();
 });

--- a/apps/web/src/features/docs/use-doc-preferences.ts
+++ b/apps/web/src/features/docs/use-doc-preferences.ts
@@ -16,7 +16,7 @@ export interface DocPreferences {
 }
 
 export const DEFAULT_DOC_PREFERENCES: DocPreferences = {
-  mode: 'markdown',
+  mode: 'rich',
   toolbar: false,
   width: 'wide',
 };

--- a/apps/web/tests/features/docs/doc-preferences.test.ts
+++ b/apps/web/tests/features/docs/doc-preferences.test.ts
@@ -10,8 +10,8 @@ import {
 } from '@/features/docs/use-doc-preferences.ts';
 
 describe('doc preferences', () => {
-  it('opens a document in markdown with the formatting bar out of the way', () => {
-    expect(DEFAULT_DOC_PREFERENCES.mode).toBe('markdown');
+  it('opens a document rendered, with the formatting bar out of the way', () => {
+    expect(DEFAULT_DOC_PREFERENCES.mode).toBe('rich');
     expect(DEFAULT_DOC_PREFERENCES.toolbar).toBe(false);
   });
 


### PR DESCRIPTION
## What you see now

Opening a document dropped you straight into the markdown source editor, so the first thing on screen was raw markup: hashes, pipes, asterisks, escaped dollar signs.

That was my reading of "the default way we add everything will be markdown always", and it was the wrong one. Markdown is the format Orbit **stores**. It is not what a reader should have to parse.

## What changed

One default: a document opens in the rendered editor.

This changes nothing about storage. The rich editor serialises to markdown on every keystroke through `docToMarkdown`, so a document is markdown on disk either way. Choosing "Rich text" is not choosing a different format, it is choosing to see the format rendered.

The Markdown toggle is still one click away for editing the source, and both modes carry the table of contents.

Unchanged: the formatting bar still starts hidden, and reading width still defaults to wide.

## The renderer was never the problem

Checked before changing anything. Against a sample matching the reported document, with a table, bold inside cells, escaped currency, a task list and a fenced code block:

```
<h2          yes
<strong>     yes
<table       yes
<th          yes
<td          yes
<code        yes
<pre         yes
checkbox     yes
```

Headings, tables, code and task lists all render. Nothing needed fixing there.

## Verification

- `apps/web` docs tests: 352 pass
- the preference test now asserts the rendered default
- the e2e spec follows the flip: it checks the rendered editor and active-heading tracking first, then switches to Markdown and checks source navigation, so both modes stay covered
- the anchored-comment suites already seeded rich mode explicitly and are unaffected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes the default editable-document view from Markdown source to rendered rich text while preserving the stored preference for returning users.
- Updates the document preference default to rich mode.
- Adjusts unit coverage to assert the new default.
- Reorders end-to-end outline coverage to exercise rich mode first and Markdown mode after switching.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The new default is applied consistently, persisted user choices remain respected, and opening rich mode does not trigger content updates or autosaves.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/docs/use-doc-preferences.ts | Changes the fallback document editor mode from Markdown to rich text without altering preference parsing or persistence. |
| apps/web/tests/features/docs/doc-preferences.test.ts | Updates the preference test to assert the new rendered-editor default. |
| apps/web/e2e/doc-outline.spec.ts | Reorders outline navigation coverage to begin in rich mode and then verify Markdown-mode navigation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): open a document rendered, not..."](https://github.com/noveum/orbit/commit/41f7a1cd1493ed170e90e0c46b7f7bf2117e3598) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51474317)</sub>

<!-- /greptile_comment -->