### PR TITLE
Scope the inbox issue lookups to one workspace

### DIFF
--- a/packages/mcp-server/src/tools/inbox.ts
+++ b/packages/mcp-server/src/tools/inbox.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { db, eq, inArray, schema } from '@orbit/db';
+import { and, db, eq, inArray, schema } from '@orbit/db';
 import { listInbox, markRead } from '@orbit/services/notifications';
 import { NOTIFICATION_TYPES } from '@orbit/shared/constants';
 import type { Principal } from '@orbit/shared/policy';
@@ -12,16 +12,27 @@ interface IssueSummary {
   readonly teamKey: string;
 }
 
-async function issueIdsForComments(commentIds: readonly string[]): Promise<Map<string, string>> {
+async function issueIdsForComments(
+  organizationId: string,
+  commentIds: readonly string[],
+): Promise<Map<string, string>> {
   if (commentIds.length === 0) return new Map();
   const rows = await db
     .select({ id: schema.comment.id, issueId: schema.comment.issueId })
     .from(schema.comment)
-    .where(inArray(schema.comment.id, [...commentIds]));
+    .where(
+      and(
+        eq(schema.comment.organizationId, organizationId),
+        inArray(schema.comment.id, [...commentIds]),
+      ),
+    );
   return new Map(rows.map((row) => [row.id, row.issueId]));
 }
 
-async function issueSummaries(issueIds: readonly string[]): Promise<Map<string, IssueSummary>> {
+async function issueSummaries(
+  organizationId: string,
+  issueIds: readonly string[],
+): Promise<Map<string, IssueSummary>> {
   if (issueIds.length === 0) return new Map();
   const rows = await db
     .select({
@@ -32,7 +43,9 @@ async function issueSummaries(issueIds: readonly string[]): Promise<Map<string, 
     })
     .from(schema.issue)
     .innerJoin(schema.team, eq(schema.team.id, schema.issue.teamId))
-    .where(inArray(schema.issue.id, [...issueIds]));
+    .where(
+      and(eq(schema.issue.organizationId, organizationId), inArray(schema.issue.id, [...issueIds])),
+    );
   return new Map(
     rows.map((row) => [
       row.id,
@@ -73,14 +86,14 @@ export function registerInboxTools(server: McpServer, principal: Principal): voi
       const commentIds = page.items
         .filter((item) => item.entityType === 'comment')
         .map((item) => item.entityId);
-      const byComment = await issueIdsForComments(commentIds);
+      const byComment = await issueIdsForComments(principal.organizationId, commentIds);
 
       const issueIds = page.items.flatMap((item) => {
         if (item.entityType === 'issue') return [item.entityId];
         const resolved = byComment.get(item.entityId);
         return resolved === undefined ? [] : [resolved];
       });
-      const byIssue = await issueSummaries(issueIds);
+      const byIssue = await issueSummaries(principal.organizationId, issueIds);
 
       return {
         notifications: page.items.map((item) => {

--- a/packages/mcp-server/tests/tools/inbox.test.ts
+++ b/packages/mcp-server/tests/tools/inbox.test.ts
@@ -61,10 +61,28 @@ describe('list_notifications', () => {
     expect(rows.every((row) => !row.title.includes('Replying to myself'))).toBe(true);
   });
 
-  it('filters by type', async () => {
+  it('filters by type, returning that type and withholding the others', async () => {
+    const assigned = await admin.result('create_issue', {
+      team: workspace.teamKey,
+      title: 'Rotate the signing key',
+      assignee: agentHandle,
+    });
+    const assignedIdentifier = (assigned['issue'] as { identifier: string }).identifier;
+
     const result = await agent.result('list_notifications', { type: 'issue_assigned' });
-    const rows = result['notifications'] as { type: string }[];
+    const rows = result['notifications'] as {
+      type: string;
+      issue: { identifier: string } | null;
+    }[];
+
+    expect(rows.length).toBeGreaterThan(0);
     expect(rows.every((row) => row.type === 'issue_assigned')).toBe(true);
+    expect(rows.some((row) => row.issue?.identifier === assignedIdentifier)).toBe(true);
+    expect(rows.some((row) => row.issue?.identifier === issueIdentifier)).toBe(false);
+
+    const unfiltered = await agent.result('list_notifications', {});
+    const everything = unfiltered['notifications'] as { type: string }[];
+    expect(everything.some((row) => row.type === 'mention')).toBe(true);
   });
 
   it('scopes to the caller, so one user never sees another inbox', async () => {


### PR DESCRIPTION
Follow-up to #244. These two changes were reviewed and written as part of that work but were left out of the merge: the commit existed locally and was never pushed, so #244 merged the state before it. This lands them.

## Scope the batch resolvers

`list_notifications` resolves each row's issue in two batched lookups, and neither was scoped to the caller's workspace. They relied on the invariant that a notification and its entity are written together with the same organization, which does hold, so this was never a cross-workspace leak.

It is still wrong. The comparable resolver in `issues.ts` runs downstream of `getIssue`, which has already applied the org and policy checks; these run on raw notification rows with no check at all, and they return the issue's current title. So an account removed from a team still resolves fresh titles for its old notifications, which `get_issue` would refuse. Both tables carry `organization_id`, so the predicate is two lines.

## Make the type-filter test real

The existing test asserted over an array that was always empty: nothing in the fixture ever produced a second notification type, so `[].every(...)` passed trivially and the filter was never exercised. It now creates an assigned issue so a differently-typed notification exists, and asserts both that the filtered type comes back and that the other one does not.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR scopes notification issue and comment resolution to the caller’s workspace and strengthens the notification type-filter test.
- Adds organization predicates to batched comment and issue lookups.
- Passes the authenticated principal’s organization into both resolvers.
- Creates a second notification type and verifies filtered and unfiltered results explicitly.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or test-reliability issues identified.

The new predicates align with existing non-null organization relationships and notification scoping, while the revised test synchronously creates and meaningfully distinguishes both notification types.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/mcp-server/src/tools/inbox.ts | Correctly adds workspace scoping to both batched entity lookups without changing valid notification resolution. |
| packages/mcp-server/tests/tools/inbox.test.ts | Makes type-filter coverage non-vacuous by creating an assignment notification and checking both inclusion and exclusion. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): scope the inbox issue lookups ..."](https://github.com/noveum/orbit/commit/1c1ac357f43134a28fd27b9d366c0da4875131da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51475235)</sub>

<!-- /greptile_comment -->