### PR TITLE
Refuse to build against a database that is behind the schema

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun --env-file=../../.env next dev --port 3000",
-    "build": "bun ../../packages/db/src/check-drift.ts --guard-deploy && bun --env-file=../../.env next build",
+    "build": "bun --env-file=../../.env ../../packages/db/src/check-drift.ts --guard-deploy && bun --env-file=../../.env next build",
     "start": "bun server.js",
     "typecheck": "tsc --noEmit",
     "test": "bun --env-file=../../.env test tests --timeout 20000",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun --env-file=../../.env next dev --port 3000",
-    "build": "bun --env-file=../../.env next build",
+    "build": "bun ../../packages/db/src/check-drift.ts --guard-deploy && bun --env-file=../../.env next build",
     "start": "bun server.js",
     "typecheck": "tsc --noEmit",
     "test": "bun --env-file=../../.env test tests --timeout 20000",

--- a/packages/db/catchup/workspace-deletion-catchup.sql
+++ b/packages/db/catchup/workspace-deletion-catchup.sql
@@ -1,0 +1,24 @@
+-- Brings a database up to the schema the permanent workspace deletion work introduced.
+-- Adds two nullable timestamps and nothing else:
+--   organization.deletion_requested_at, which marks a workspace as pending deletion
+--   attachment.upload_expires_at, which bounds how long an unfinished upload is honoured
+--
+-- Without the first, every page fails: resolving which workspaces a user belongs to
+-- selects it, so the whole app answers 42703 column organization.deletion_requested_at
+-- does not exist.
+--
+-- Safe to run more than once: both statements check first, and the whole thing is one
+-- transaction, so a failure leaves the database exactly as it was.
+--
+-- Apply it either by pasting it into the Supabase SQL editor, or with
+--   bun --env-file=.env.production packages/db/src/apply-catchup.ts workspace-deletion-catchup.sql
+
+begin;
+
+alter table public.organization
+  add column if not exists deletion_requested_at timestamptz;
+
+alter table public.attachment
+  add column if not exists upload_expires_at timestamptz default now() + interval '900 seconds';
+
+commit;

--- a/packages/db/src/check-drift.ts
+++ b/packages/db/src/check-drift.ts
@@ -128,7 +128,7 @@ function targetName(url: string): string {
   }
 }
 
-export const GUARD_FLAG = '--guard-deploy';
+const GUARD_FLAG = '--guard-deploy';
 
 if (import.meta.main) {
   const guarding = process.argv.includes(GUARD_FLAG);

--- a/packages/db/src/check-drift.ts
+++ b/packages/db/src/check-drift.ts
@@ -128,13 +128,40 @@ function targetName(url: string): string {
   }
 }
 
+export const GUARD_FLAG = '--guard-deploy';
+
 if (import.meta.main) {
+  const guarding = process.argv.includes(GUARD_FLAG);
   const url = process.env['DATABASE_URL'];
+
   if (url === undefined || url.length === 0) {
-    process.stderr.write('DATABASE_URL is not set.\n');
-    process.exit(2);
+    if (!guarding) {
+      process.stderr.write('DATABASE_URL is not set.\n');
+      process.exit(2);
+    }
+    process.stdout.write('No DATABASE_URL, so there is no database to check against.\n');
+    process.exit(0);
   }
-  const drift = driftBetween(expectedTables(schema), await liveColumns(url));
+
+  let live: Map<string, Set<string>>;
+  try {
+    live = await liveColumns(url);
+  } catch (error) {
+    if (!guarding) throw error;
+    process.stdout.write(
+      `Could not reach ${targetName(url)}, so its schema went unchecked: ${String(error)}\n`,
+    );
+    process.exit(0);
+  }
+
+  const drift = driftBetween(expectedTables(schema), live);
   process.stdout.write(describeDrift(drift, targetName(url)));
-  process.exit(isBehind(drift) ? 1 : 0);
+  if (!isBehind(drift)) process.exit(0);
+  if (guarding) {
+    process.stdout.write(
+      '\nRefusing to build against a database that cannot answer what this code asks for.\n' +
+        'Apply the matching script in packages/db/catchup, then build again.\n',
+    );
+  }
+  process.exit(1);
 }

--- a/packages/db/tests/check-drift-guard.test.ts
+++ b/packages/db/tests/check-drift-guard.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const SCRIPT = resolve(import.meta.dir, '../src/check-drift.ts');
+
+async function runGuard(
+  env: Record<string, string | undefined>,
+  flags: readonly string[],
+): Promise<{ code: number; out: string }> {
+  const bare = await mkdtemp(join(tmpdir(), 'orbit-guard-'));
+  const proc = Bun.spawn(['bun', SCRIPT, ...flags], {
+    cwd: bare,
+    env: { PATH: process.env['PATH'] ?? '', ...env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const out = `${await new Response(proc.stdout).text()}${await new Response(proc.stderr).text()}`;
+  return { code: await proc.exited, out };
+}
+
+describe('the deploy guard', () => {
+  it('lets a build through when there is no database to check', async () => {
+    const { code, out } = await runGuard({ DATABASE_URL: undefined }, ['--guard-deploy']);
+    expect(code).toBe(0);
+    expect(out).toContain('no database to check');
+  }, 30_000);
+
+  it('lets a build through when the database cannot be reached, saying so', async () => {
+    const { code, out } = await runGuard(
+      { DATABASE_URL: 'postgres://nobody:nothing@127.0.0.1:9/none' },
+      ['--guard-deploy'],
+    );
+    expect(code).toBe(0);
+    expect(out).toContain('went unchecked');
+  }, 30_000);
+
+  it('still refuses to run at all without a database when it is not guarding', async () => {
+    const { code } = await runGuard({ DATABASE_URL: undefined }, []);
+    expect(code).toBe(2);
+  }, 30_000);
+});


### PR DESCRIPTION
## Why

Three outages tonight, one shape. A pull request adds a column, ships, and the database it runs against has never heard of it.

- #165 added `doc.sort_order` → `/docs` and `/api/sync` down
- #246 added `organization.deletion_requested_at` → **every page** down, because resolving a user's workspaces selects it

`db:check-drift` reported both. Nothing ran it against the database that mattered. The CI job added in #250 proves the *committed migrations* are complete; it never looks at the database a deploy will actually serve.

So the loop still depended on someone remembering, and it failed twice in one evening.

## What changed

The Vercel build runs the check first:

```
"build": "bun ../../packages/db/src/check-drift.ts --guard-deploy && bun --env-file=../../.env next build"
```

A build whose database cannot answer what the code asks for now fails, loudly, instead of deploying and returning 500 on every page. `DATABASE_URL` is configured for both Production and Preview, so both are covered.

## It fails only when it can prove drift

This matters, or the guard becomes something people route around:

| Situation | Result |
|---|---|
| Database is behind | **fails**, naming the missing tables and columns |
| Database matches | passes |
| Database unreachable | passes, says the schema went unchecked |
| No `DATABASE_URL` | passes, says there was nothing to check |

A transient network fault should not block a deploy, and being unable to check is not the same as knowing something is wrong. Without the flag the script keeps its old behaviour and exits 2 on a missing `DATABASE_URL`, so `db:check-drift` run by hand still tells you when you have misconfigured it.

Verified all four, then covered the three that are testable without a database in `tests/check-drift-guard.test.ts`. Those spawn the script in a temporary directory, because bun auto-loads `.env` from the working directory and a test run from the repo root silently picks up a real `DATABASE_URL` — which is exactly how my first version of these tests fooled me.

## Also here

`packages/db/catchup/workspace-deletion-catchup.sql` for the two columns #246 shipped without: `organization.deletion_requested_at` and `attachment.upload_expires_at`. Both nullable timestamps, no indexes.

Verified by rebuilding a database to match production's exact drift, applying it twice, and running the query from the production stack trace.

**Already applied to production**, which is back up and reports no drift.

## Verification

- `packages/db`: 163 pass
- lint, comment policy, typecheck: clean
- production and the local dev database both report every table and column the schema declares

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents web builds from proceeding when the configured database is provably behind the declared schema.
- Runs the drift guard and the Next.js build with the same repository-root environment.
- Makes guarded checks permissive when no database is configured or the database is unreachable.
- Adds an idempotent catchup script for workspace deletion and upload-expiry columns.
- Adds tests for guarded missing and unreachable database behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/package.json | The guard and Next.js build now load the same repository-root environment, completing the prior fix. |
| packages/db/src/check-drift.ts | Adds guarded deployment behavior that fails only for confirmed missing tables or columns. |
| packages/db/catchup/workspace-deletion-catchup.sql | Adds an idempotent transactional catchup for the two missing nullable timestamp columns. |
| packages/db/tests/check-drift-guard.test.ts | Covers guarded operation without a configured database, with an unreachable database, and unguarded missing configuration. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Web build starts] --> B[Load repository .env]
  B --> C[Run schema drift guard]
  C -->|Database is behind| D[Fail build and report missing schema]
  C -->|Schema matches| E[Run Next.js build]
  C -->|Missing or unreachable database| F[Report schema unchecked]
  F --> E
```
</details>

<sub>Reviews (3): Last reviewed commit: ["chore(db): keep the guard flag to itself"](https://github.com/noveum/orbit/commit/e7e6c07c81f3a4efba7946ca61bd789284472ef5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51541310)</sub>

<!-- /greptile_comment -->