### PR TITLE
perf(deploy): put the functions in the same region as the database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,16 @@ Upgrade before doing any other work in that route. Awaiting redis, the database
 or anything else first stops the handshake reaching a 101, so attach the hub
 after the socket is open and buffer whatever arrives in between.
 
+Functions run in `hnd1` because Supabase is in `ap-northeast-1`, and `regions`
+in `apps/web/vercel.json` is what keeps them together. Vercel defaults to `iad1`,
+which put every query on a Virginia to Tokyo round trip of about 170ms. A page
+that reaches the database four times sequentially paid most of a second for it,
+which is why tuning the queries themselves changed almost nothing: they run in
+under 3ms and the trip to reach them was fifty times that. Move the database and
+this line moves with it. Serving users from the region nearest them is the wrong
+instinct here, because a page makes several database round trips and only one
+trip from the browser.
+
 Migrations are applied locally against the target database, never by a job in the
 platform, so any schema change must be pushed before the code that depends on it
 ships.

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "rm -rf ../../node_modules node_modules && bun install --frozen-lockfile",
+  "regions": ["hnd1"],
   "crons": [{ "path": "/api/cron/prune", "schedule": "0 4 * * *" }]
 }


### PR DESCRIPTION
This is the largest single thing wrong with Orbit's performance, and it is one line.

## What is happening

```
x-vercel-id: bom1::iad1::...                      ← functions run in Virginia
aws-0-ap-northeast-1.pooler.supabase.com          ← database is in Tokyo
```

Vercel defaults to `iad1`. Supabase is in `ap-northeast-1`. **Every query this app has ever made crossed the Pacific**, about 170ms each way, and a page that reaches the database four times in sequence paid most of a second in network before rendering anything.

## Why the query work has barely moved the numbers

Measured against production:

| Statement | Mean |
| --- | --- |
| `bootstrapVersion` | 0.154ms |
| issue subscriptions | 0.96ms |
| issue activity | 1.11ms |
| sub-issue list | 3.29ms |

**The trip to reach them was fifty times the cost of running them.** I have spent several PRs removing round trips and parallelising tiers, which was worth doing, but each remaining trip still cost ~170ms because of where it went.

## Why hnd1 and not bom1

Mumbai is closer to the people using this, and it is the wrong answer:

| Function region | Browser → function | 4 sequential DB tiers | Total |
| --- | --- | --- | --- |
| `iad1` (today) | ~220ms | 4 × ~170ms = ~680ms | **~900ms** |
| `bom1` (Mumbai) | ~20ms | 4 × ~80ms = ~320ms | ~340ms |
| **`hnd1` (Tokyo)** | ~120ms | 4 × ~1ms | **~124ms** |

A page makes **one** trip from the browser and **several** to the database, so sitting next to the database wins by a wide margin. Tokyo also happens to be nearer India than Virginia is, so the browser leg gets shorter too rather than being traded away.

Vercel's own guidance says the same thing: select regions close to your external services.

## Baseline, so the effect is checkable

From a machine in the same part of the world, on an endpoint that does **no database work at all**:

```
/api/health   0.34, 0.34, 0.36, 0.38, 0.39, 0.44, 0.51, 0.52   median ~0.38s
```

That floor is purely the browser → Virginia leg. Everything the database adds sits on top of it. I will re-measure the same way after this deploys and post the comparison.

## Safety

`regions` does not affect the runtime. `/api/ws` still upgrades through `experimental_upgradeWebSocket` on node, which is the thing `apps/web/vercel.json` must never break, and that is governed by `bunVersion`, untouched here. The change is reversible by deleting one line.

`CLAUDE.md` records the invariant, including the trap that serving users from their nearest region is the wrong instinct for this app, so that moving the database moves this line with it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR colocates Vercel functions with the Tokyo-hosted Supabase database to reduce cross-region query latency.
- Pins the web application’s Vercel functions to `hnd1`.
- Documents why function placement should follow the database region rather than the users’ nearest region.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/vercel.json | Adds the documented `hnd1` function-region setting without altering runtime selection or cron configuration. |
| CLAUDE.md | Records the deployment-region invariant and its database-latency rationale. |

</details>

<sub>Reviews (2): Last reviewed commit: ["perf(deploy): put the functions in the s..."](https://github.com/noveum/orbit/commit/6da09a03cfcff559d753c38274bf2fcc7b40f119) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51545066)</sub>

<!-- /greptile_comment -->