### PR TITLE
Give people a handle they can be mentioned by

### DIFF
--- a/apps/web/src/lib/auth/handle.ts
+++ b/apps/web/src/lib/auth/handle.ts
@@ -1,0 +1,28 @@
+import { randomUUID } from 'node:crypto';
+import { slugify } from '@orbit/shared/utils';
+
+const NUMBERED_CANDIDATES = 20;
+
+export function handleBaseFor(email: string, name: string): string {
+  return slugify(name) || slugify(email.split('@')[0] ?? '') || 'member';
+}
+
+function candidatesFor(base: string): string[] {
+  const numbered = Array.from(
+    { length: NUMBERED_CANDIDATES - 1 },
+    (_unused, index) => `${base}-${index + 2}`,
+  );
+  return [base, ...numbered];
+}
+
+export async function uniqueHandleFor(
+  email: string,
+  name: string,
+  taken: (candidates: readonly string[]) => Promise<Set<string>>,
+): Promise<string> {
+  const base = handleBaseFor(email, name);
+  const candidates = candidatesFor(base);
+  const used = await taken(candidates);
+  const free = candidates.find((candidate) => !used.has(candidate));
+  return free ?? `${base}-${randomUUID().replaceAll('-', '').slice(0, 10)}`;
+}

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { passkey } from '@better-auth/passkey';
 import {
   assertEmailDomainAllowed,
@@ -6,10 +5,9 @@ import {
   isExternalImageUrl,
   publishSessionRevoked,
 } from '@orbit/core';
-import { db, eq, schema } from '@orbit/db';
+import { db, eq, inArray, schema } from '@orbit/db';
 import { inviteEmail, magicLinkEmail, resetPasswordEmail, sendEmail } from '@orbit/services/email';
 import { DomainError } from '@orbit/shared/errors';
-import { slugify } from '@orbit/shared/utils';
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { APIError, createAuthMiddleware, getSessionFromCtx } from 'better-auth/api';
@@ -18,6 +16,7 @@ import { magicLink, mcp, organization } from 'better-auth/plugins';
 import { z } from 'zod';
 import { isDevLoginRequest } from '@/lib/api/dev-login.ts';
 import { mcpServerUrl, serverEnv } from '@/lib/env.ts';
+import { uniqueHandleFor } from './handle.ts';
 import { hashPassword, verifyPassword } from './password.ts';
 
 export const MCP_SCOPES = [
@@ -83,9 +82,16 @@ export const passwordAuthEnabled: boolean = serverEnv().ORBIT_PASSWORD_AUTH;
 const SIGN_IN_ATTEMPTS_PER_MINUTE = 5;
 const SIGN_UP_ATTEMPTS_PER_HOUR = 5;
 
-function handleFor(email: string, name: string): string {
-  const base = slugify(name) || slugify(email.split('@')[0] ?? '') || 'member';
-  return `${base}-${randomUUID().replaceAll('-', '').slice(0, 10)}`;
+async function takenHandles(candidates: readonly string[]): Promise<Set<string>> {
+  const rows = await db
+    .select({ handle: schema.user.handle })
+    .from(schema.user)
+    .where(inArray(schema.user.handle, [...candidates]));
+  return new Set(rows.map((row) => row.handle));
+}
+
+function handleFor(email: string, name: string): Promise<string> {
+  return uniqueHandleFor(email, name, takenHandles);
 }
 
 function emailAndPassword() {
@@ -178,11 +184,9 @@ export const auth = betterAuth({
   databaseHooks: {
     user: {
       create: {
-        before: (user) => {
+        before: async (user) => {
           assertSignUpAllowed(user.email);
-          return Promise.resolve({
-            data: { ...user, handle: handleFor(user.email, user.name) },
-          });
+          return { data: { ...user, handle: await handleFor(user.email, user.name) } };
         },
         after: async (user) => {
           const image = user.image ?? null;

--- a/apps/web/tests/lib/auth/handle.test.ts
+++ b/apps/web/tests/lib/auth/handle.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'bun:test';
+import { handleBaseFor, uniqueHandleFor } from '../../../src/lib/auth/handle.ts';
+
+function nothingTaken(): Promise<Set<string>> {
+  return Promise.resolve(new Set<string>());
+}
+
+function alreadyTaken(...handles: string[]): () => Promise<Set<string>> {
+  return () => Promise.resolve(new Set(handles));
+}
+
+describe('handleBaseFor', () => {
+  it('prefers the name', () => {
+    expect(handleBaseFor('hey@yodu.ai', 'Yodu AI')).toBe('yodu-ai');
+  });
+
+  it('falls back to the email local part when there is no name', () => {
+    expect(handleBaseFor('hey@yodu.ai', '')).toBe('hey');
+  });
+
+  it('falls back to member when neither slugifies', () => {
+    expect(handleBaseFor('!!!@example.com', '???')).toBe('member');
+  });
+});
+
+describe('uniqueHandleFor', () => {
+  it('gives a clean handle when nothing is taken', async () => {
+    expect(await uniqueHandleFor('hey@yodu.ai', 'Yodu AI', nothingTaken)).toBe('yodu-ai');
+  });
+
+  it('does not append a suffix to the first person with a name', async () => {
+    const handle = await uniqueHandleFor('ada@example.com', 'Ada Lovelace', nothingTaken);
+    expect(handle).toBe('ada-lovelace');
+    expect(handle).not.toMatch(/-[0-9a-f]{10}$/);
+  });
+
+  it('numbers the second person with the same name', async () => {
+    expect(
+      await uniqueHandleFor('ada2@example.com', 'Ada Lovelace', alreadyTaken('ada-lovelace')),
+    ).toBe('ada-lovelace-2');
+  });
+
+  it('keeps counting past the first collision', async () => {
+    const taken = alreadyTaken('ada-lovelace', 'ada-lovelace-2', 'ada-lovelace-3');
+    expect(await uniqueHandleFor('ada4@example.com', 'Ada Lovelace', taken)).toBe('ada-lovelace-4');
+  });
+
+  it('falls back to a random suffix when every numbered candidate is taken', async () => {
+    const crowded = Array.from({ length: 40 }, (_, index) =>
+      index === 0 ? 'ada-lovelace' : `ada-lovelace-${index + 1}`,
+    );
+    const handle = await uniqueHandleFor(
+      'ada@example.com',
+      'Ada Lovelace',
+      alreadyTaken(...crowded),
+    );
+    expect(handle).toMatch(/^ada-lovelace-[0-9a-f]{10}$/);
+  });
+
+  it('asks about every candidate in one call', async () => {
+    const calls: string[][] = [];
+    await uniqueHandleFor('ada@example.com', 'Ada Lovelace', (candidates) => {
+      calls.push([...candidates]);
+      return Promise.resolve(new Set<string>());
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[0]).toBe('ada-lovelace');
+    expect(calls[0]?.[1]).toBe('ada-lovelace-2');
+  });
+});


### PR DESCRIPTION
Every account created through sign-up gets a handle like `ada-lovelace-3402a5fa15`, because `handleFor` appended ten random characters unconditionally. Handles are how mentions resolve, so in practice nobody could be @-mentioned unless their handle predated sign-up, which meant only imported accounts had a usable one.

Found while setting up an integration account: it was invited as `hey@yodu.ai` and came out as `hey-3402a5fa15`, which no colleague is going to type.

## What changes

The base handle now stands on its own. A real collision takes `ada-lovelace-2`, then `-3`, and the random suffix survives only as a last resort once twenty numbered candidates are gone. All candidates are checked in one query.

Generation moves to `apps/web/src/lib/auth/handle.ts` so it can be tested without standing up auth: the caller passes in the "which of these are taken" lookup, and the sign-up hook supplies the database one.

## Existing accounts

Not touched. Anyone already carrying a random suffix can change it in profile settings, which already validates uniqueness.

## Testing

Nine cases in `apps/web/tests/lib/auth/handle.test.ts` covering the name and email bases, the `member` fallback, first-come clean handles, numbering on collision, and the random-suffix last resort. Verified by mutation: restoring the unconditional suffix fails four of them.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extracts handle generation into a testable module and assigns clean handles first, followed by numbered candidates and a random fallback.
- Adds batched availability lookup for the base and numbered handle candidates.
- Updates the sign-up hook to generate handles asynchronously.
- Adds unit coverage for base derivation, collisions, numbering, fallback behavior, and batched lookup.

<h3>Confidence Score: 4/5</h3>

The concurrent handle-allocation race should be fixed before merging because it can reject an otherwise valid sign-up.

The availability query and uniquely constrained insertion are separate operations, so simultaneous sign-ups sharing a handle base can select the same candidate and cause one insertion to fail.

**Files Needing Attention:** apps/web/src/lib/auth/server.ts and apps/web/src/lib/auth/handle.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/auth/handle.ts | Introduces testable base and candidate selection logic, but selection does not reserve the chosen handle. |
| apps/web/src/lib/auth/server.ts | Adds the batched database lookup and asynchronous sign-up integration, leaving a race between availability lookup and insertion. |
| apps/web/tests/lib/auth/handle.test.ts | Thoroughly covers sequential generation behavior, although concurrent collision handling is not represented. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as Sign-up A
  participant B as Sign-up B
  participant H as Handle generator
  participant DB as Database
  A->>H: Generate handle for shared base
  B->>H: Generate handle for shared base
  H->>DB: Query candidate handles
  H->>DB: Query candidate handles
  DB-->>H: Base is available
  DB-->>H: Base is available
  H-->>A: Return base
  H-->>B: Return base
  A->>DB: Insert user with base
  DB-->>A: Success
  B->>DB: Insert user with base
  DB-->>B: Unique constraint failure
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fweb%2Fsrc%2Flib%2Fauth%2Fserver.ts%3A89%0A**Handle%20allocation%20races%20insertion**%0A%0AIf%20two%20sign-ups%20with%20the%20same%20slugified%20name%20overlap%2C%20both%20availability%20queries%20can%20select%20the%20same%20free%20handle%20before%20either%20insertion%20completes%2C%20causing%20one%20sign-up%20to%20fail%20on%20the%20unique%20handle%20constraint%20instead%20of%20receiving%20the%20next%20numbered%20handle.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=noveum%2Forbit&pr=267&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/lib/auth/server.ts:89
**Handle allocation races insertion**

If two sign-ups with the same slugified name overlap, both availability queries can select the same free handle before either insertion completes, causing one sign-up to fail on the unique handle constraint instead of receiving the next numbered handle.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): give people a handle they can..."](https://github.com/noveum/orbit/commit/8142bb0f88f54d07ed324f6164950aacb296ddd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51559816)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->