### PR TITLE
fix(issues): show all projects in quick create

### DIFF
--- a/apps/web/src/features/issues/quick-create.tsx
+++ b/apps/web/src/features/issues/quick-create.tsx
@@ -50,8 +50,18 @@ function projectSupportsTeam(project: Project | undefined, teamId: string): bool
   );
 }
 
+function compatibleTeamId(
+  project: Project,
+  currentTeamId: string | null,
+  availableTeamIds: readonly string[],
+): string | null {
+  if (project.teamIds.length === 0) return currentTeamId;
+  if (currentTeamId !== null && project.teamIds.includes(currentTeamId)) return currentTeamId;
+  return availableTeamIds.find((teamId) => project.teamIds.includes(teamId)) ?? null;
+}
+
 function ScopePickers({
-  teamProjects,
+  projects,
   teamCycles,
   projectId,
   estimate,
@@ -60,7 +70,7 @@ function ScopePickers({
   onEstimate,
   onCycle,
 }: {
-  readonly teamProjects: readonly Project[];
+  readonly projects: readonly Project[];
   readonly teamCycles: readonly Cycle[];
   readonly projectId: string | null;
   readonly estimate: number | null;
@@ -76,15 +86,15 @@ function ScopePickers({
         options={[
           {
             id: 'none',
-            label: teamProjects.length === 0 ? 'No projects on this team' : 'No project',
+            label: projects.length === 0 ? 'No projects in this workspace' : 'No project',
           },
-          ...teamProjects.map((project) => ({ id: project.id, label: project.name })),
+          ...projects.map((project) => ({ id: project.id, label: project.name })),
         ]}
         selected={projectId === null ? ['none'] : [projectId]}
         onSelect={(value) => onProject(value === 'none' ? null : value)}
       >
         <button type="button" className={chipClassName} data-testid="quick-create-project">
-          {teamProjects.find((project) => project.id === projectId)?.name ?? 'Project'}
+          {projects.find((project) => project.id === projectId)?.name ?? 'Project'}
         </button>
       </PropertyMenu>
 
@@ -239,15 +249,6 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
 
   const teamStates = statesForTeam(states, teamId);
   const teamLabels = labels.filter((label) => label.teamId === null || label.teamId === teamId);
-  const teamProjects = useMemo(
-    () =>
-      projects.filter(
-        (project) =>
-          project.teamIds.length === 0 || (teamId !== null && project.teamIds.includes(teamId)),
-      ),
-    [projects, teamId],
-  );
-
   const teamCycles = useMemo(
     () => cycles.filter((cycle) => cycle.teamId === teamId),
     [cycles, teamId],
@@ -259,6 +260,29 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
     const selectedProject = projects.find((project) => project.id === projectId);
     if (!projectSupportsTeam(selectedProject, teamId)) setProjectId(null);
   }, [projectId, projects, teamId]);
+
+  const selectProject = (nextProjectId: string | null) => {
+    if (nextProjectId === null) {
+      setProjectId(null);
+      return;
+    }
+    const project = projects.find((entry) => entry.id === nextProjectId);
+    if (project === undefined) return;
+    const nextTeamId = compatibleTeamId(
+      project,
+      teamId,
+      teams.map((team) => team.id),
+    );
+    if (nextTeamId === null) return;
+    if (nextTeamId !== teamId) {
+      setTeamId(nextTeamId);
+      setStateId(null);
+      setEstimate(null);
+      setCycleId(null);
+      setLabelIds([]);
+    }
+    setProjectId(nextProjectId);
+  };
 
   const submit = (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
@@ -451,12 +475,12 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
             </PropertyMenu>
 
             <ScopePickers
-              teamProjects={teamProjects}
+              projects={projects}
               teamCycles={teamCycles}
               projectId={projectId}
               estimate={estimate}
               cycleId={cycleId}
-              onProject={setProjectId}
+              onProject={selectProject}
               onEstimate={setEstimate}
               onCycle={setCycleId}
             />

--- a/apps/web/tests/features/issues/quick-create.test.tsx
+++ b/apps/web/tests/features/issues/quick-create.test.tsx
@@ -114,6 +114,16 @@ function buildWorkspace(): WorkspaceData {
   };
 }
 
+function buildWorkspaceWithDesign(): WorkspaceData {
+  return {
+    ...buildWorkspace(),
+    teams: [
+      { id: 'team_eng', name: 'Engineering', key: 'ENG', icon: 'e', color: '#fff' },
+      { id: 'team_des', name: 'Design', key: 'DES', icon: 'd', color: '#eee' },
+    ],
+  };
+}
+
 const realFetch = globalThis.fetch;
 const realXhr = globalThis.XMLHttpRequest;
 
@@ -378,16 +388,47 @@ describe('attaching a file from the create dialog', () => {
 });
 
 describe('the new issue dialog', () => {
-  it('offers every team and workspace project the chosen team can use', async () => {
+  it('offers every accessible project from every team', async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    workspace = buildWorkspace();
+    workspace = buildWorkspaceWithDesign();
     open();
 
     await user.click(screen.getByTestId('quick-create-project'));
 
     expect(await screen.findByText('API market')).toBeTruthy();
     expect(screen.getByText('Company launch')).toBeTruthy();
-    expect(screen.queryByText('Brand refresh')).toBeNull();
+    expect(screen.getByText('Brand refresh')).toBeTruthy();
+  });
+
+  it('moves the issue to a compatible team when another team project is chosen', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    workspace = buildWorkspaceWithDesign();
+    open();
+
+    await user.type(screen.getByTestId('quick-create-title'), 'Refresh the brand');
+    await user.click(screen.getByRole('button', { name: 'Status' }));
+    await user.click(await screen.findByText('Todo'));
+    await user.click(screen.getByRole('button', { name: 'Labels' }));
+    await user.click(await screen.findByText('Bug'));
+    await user.keyboard('{Escape}');
+    await user.click(screen.getByTestId('quick-create-estimate'));
+    await user.click(await screen.findByText('5 points'));
+    await user.click(screen.getByTestId('quick-create-cycle'));
+    await user.click(await screen.findByText('Sprint 3'));
+    const projectTrigger = screen.getByTestId('quick-create-project');
+    projectTrigger.focus();
+    await user.keyboard('{Enter}Brand{Enter}');
+
+    expect(screen.getByTestId('quick-create-crumb')).toHaveTextContent('DES');
+    await user.click(screen.getByTestId('quick-create-submit'));
+    expect(created.mock.calls[0]?.[0]).toMatchObject({
+      teamId: 'team_des',
+      projectId: 'proj_2',
+      cycleId: null,
+      estimate: null,
+      labelIds: [],
+    });
+    expect(created.mock.calls[0]?.[0]?.['stateId']).toBeUndefined();
   });
 
   it('focuses the title when it opens', () => {
@@ -689,14 +730,14 @@ describe('the new issue dialog', () => {
 });
 
 describe('the pickers when a team owns nothing yet', () => {
-  it('says the team has no projects rather than showing an empty menu', async () => {
+  it('says the workspace has no projects rather than showing an empty menu', async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     workspace = { ...buildWorkspace(), projects: [] };
     open();
 
     await user.click(screen.getByTestId('quick-create-project'));
 
-    expect(await screen.findByText('No projects on this team')).toBeTruthy();
+    expect(await screen.findByText('No projects in this workspace')).toBeTruthy();
   });
 
   it('says the team has no sprints rather than showing an empty menu', async () => {


### PR DESCRIPTION
## What this changes

Quick create now lists every project visible to the current user, regardless of the initially selected issue team. Choosing a project from another team moves the issue to a compatible team and clears fields scoped to the previous team.

## Why

The Projects page showed 13 accessible projects while global quick create filtered them by its default AI team and displayed No projects on this team.

## How you know it works

- Reproduced in production while signed in from the Projects page.
- Added two regressions that failed before the implementation: all accessible projects appear, and keyboard selection of another team project moves the issue safely.
- 39 focused quick create and workspace provider tests pass.
- Lint, comment policy, source bytes, runtime import checks, dependency dedupe, and typecheck pass.
- The full local test phase could not connect to Postgres on port 5434. The shared setup was intentionally left unchanged.

## Checklist

- [ ] bun run verify is green, the local database test phase is unavailable
- [x] Tests added or updated, and they fail without the change
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No any, no non-null assertions
- [x] No external input or schema changes
- [x] Server authorization and project-team validation remain enforced
- [x] No documentation change is required
- [x] No database schema changes

## Anything reviewers should know

Workspace-wide projects keep the current team. Team-scoped projects keep a compatible current team or select the first compatible visible team.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Quick create now displays all projects visible to the user and moves an issue to a compatible team when a cross-team project is selected.
- Replaces team-filtered project options with workspace-wide project options.
- Adds compatible-team selection while clearing fields scoped to the previous team.
- Adds regression coverage for project visibility, keyboard selection, team movement, and scoped-field cleanup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with cross-team project selection and scoped-field cleanup covered by focused regression tests.

The changed selection path chooses a team compatible with the selected project, clears fields tied to the previous team, and preserves the selected project through reconciliation; no concrete blocking or non-blocking defect remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/issues/quick-create.tsx | Expands the project picker to all accessible projects and safely reconciles team-scoped issue fields when project selection changes the team. |
| apps/web/tests/features/issues/quick-create.test.tsx | Adds focused regression coverage for workspace-wide project visibility and keyboard-driven cross-team project selection. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[User selects project] --> B{Workspace-wide project?}
  B -- Yes --> C[Keep current team]
  B -- No --> D{Current team compatible?}
  D -- Yes --> C
  D -- No --> E[Choose first compatible visible team]
  E --> F[Clear prior team-scoped fields]
  C --> G[Set selected project]
  F --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(issues): show all projects in quick ..."](https://github.com/noveum/orbit/commit/05f8d6d50691254cf1c9fba01477c801eeb29caa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51561928)</sub>

<!-- /greptile_comment -->