### PR TITLE
Say a repository is untracked instead of blaming branch naming

### DIFF
--- a/apps/web/src/features/pulls/data.ts
+++ b/apps/web/src/features/pulls/data.ts
@@ -16,7 +16,33 @@ export interface PullRequestRow {
   readonly updatedAt: string;
 }
 
-export type GithubReach = 'not_installed' | 'suspended' | 'no_repositories' | 'connected';
+export type GithubReach =
+  | 'not_installed'
+  | 'suspended'
+  | 'no_repositories'
+  | 'repositories_untracked'
+  | 'connected';
+
+async function reachableButUntracked(
+  organizationId: string,
+  watched: ReadonlySet<string>,
+): Promise<boolean> {
+  const visible = await db
+    .select({ repositoryId: schema.githubRepository.repositoryId })
+    .from(schema.githubRepository)
+    .innerJoin(
+      schema.githubInstallation,
+      eq(schema.githubInstallation.id, schema.githubRepository.installationRowId),
+    )
+    .where(
+      and(
+        eq(schema.githubRepository.organizationId, organizationId),
+        eq(schema.githubRepository.archived, false),
+        eq(schema.githubInstallation.status, 'active'),
+      ),
+    );
+  return visible.some((row) => !watched.has(row.repositoryId));
+}
 
 export async function githubReach(principal: Principal): Promise<GithubReach> {
   const [installations, tracked] = await Promise.all([
@@ -28,7 +54,10 @@ export async function githubReach(principal: Principal): Promise<GithubReach> {
       .from(schema.githubInstallation)
       .where(eq(schema.githubInstallation.organizationId, principal.organizationId)),
     db
-      .select({ integrationId: schema.githubRepositorySync.integrationId })
+      .select({
+        integrationId: schema.githubRepositorySync.integrationId,
+        repositoryId: schema.githubRepositorySync.repositoryId,
+      })
       .from(schema.githubRepositorySync)
       .where(
         and(
@@ -44,7 +73,14 @@ export async function githubReach(principal: Principal): Promise<GithubReach> {
     installations.filter((row) => row.status === 'active').map((row) => row.integrationId),
   );
   if (active.size === 0) return 'suspended';
-  return tracked.some((row) => active.has(row.integrationId)) ? 'connected' : 'no_repositories';
+
+  const reachable = tracked.filter((row) => active.has(row.integrationId));
+  if (reachable.length === 0) return 'no_repositories';
+
+  const watched = new Set(reachable.map((row) => row.repositoryId));
+  return (await reachableButUntracked(principal.organizationId, watched))
+    ? 'repositories_untracked'
+    : 'connected';
 }
 
 export async function loadPullRequests(principal: Principal): Promise<PullRequestRow[]> {

--- a/apps/web/src/features/pulls/pulls-view.tsx
+++ b/apps/web/src/features/pulls/pulls-view.tsx
@@ -21,6 +21,55 @@ export interface PullsViewProps {
   readonly canManageIntegrations: boolean;
 }
 
+interface ReachCopy {
+  readonly title: string;
+  readonly admin: string;
+  readonly member: string;
+  readonly action: string;
+}
+
+const REACH_COPY: Record<GithubReach, ReachCopy> = {
+  not_installed: {
+    title: 'GitHub is not connected yet',
+    admin:
+      'Connect GitHub, pick the repositories to track, and pull requests naming an issue show up here.',
+    member: 'A workspace admin needs to connect GitHub before pull requests can appear here.',
+    action: 'Connect GitHub',
+  },
+  suspended: {
+    title: 'The GitHub installation is suspended',
+    admin:
+      'GitHub is refusing to send anything while the installation is suspended. Lift it in the GitHub App settings, then pull requests naming an issue show up here.',
+    member:
+      'GitHub is refusing to send anything while the installation is suspended. A workspace admin has to lift it on GitHub.',
+    action: 'Open integrations',
+  },
+  no_repositories: {
+    title: 'No repository is being tracked',
+    admin:
+      'GitHub is connected but no repository is switched on yet. Pick the ones this workspace should track.',
+    member:
+      'GitHub is connected but no repository is switched on yet. A workspace admin picks which ones to track.',
+    action: 'Pick repositories',
+  },
+  repositories_untracked: {
+    title: 'Some repositories are not tracked yet',
+    admin:
+      'GitHub can see repositories this workspace never switched on. A pull request from one of them is dropped on arrival, and GitHub reports the delivery as accepted, so nothing looks wrong on either side. Switch the ones you work in on.',
+    member:
+      'GitHub can see repositories this workspace never switched on, and pull requests from them are dropped on arrival. A workspace admin picks which ones to track.',
+    action: 'Track repositories',
+  },
+  connected: {
+    title: 'No pull requests linked to your issues',
+    admin:
+      'Orbit links a pull request when its branch or title names an issue, like ENG-42. Copy branch name on an issue gives you one that matches.',
+    member:
+      'Orbit links a pull request when its branch or title names an issue, like ENG-42. Copy branch name on an issue gives you one that matches.',
+    action: 'Open integrations',
+  },
+};
+
 export function PullsEmptyState({
   reach,
   canManageIntegrations,
@@ -28,75 +77,21 @@ export function PullsEmptyState({
   readonly reach: GithubReach;
   readonly canManageIntegrations: boolean;
 }) {
-  const icon = <GitPullRequest strokeWidth={1.75} aria-hidden="true" />;
-  const settingsAction = (label: string) =>
-    canManageIntegrations ? (
-      <Button asChild variant="primary">
-        <Link href="/settings/integrations" data-testid="pulls-connect-github">
-          {label}
-        </Link>
-      </Button>
-    ) : undefined;
-
-  if (reach === 'not_installed') {
-    return (
-      <EmptyState
-        icon={icon}
-        title="GitHub is not connected yet"
-        description={
-          canManageIntegrations
-            ? 'Connect GitHub, pick the repositories to track, and pull requests naming an issue show up here.'
-            : 'A workspace admin needs to connect GitHub before pull requests can appear here.'
-        }
-        {...(settingsAction('Connect GitHub') === undefined
-          ? {}
-          : { action: settingsAction('Connect GitHub') })}
-        className="flex-1"
-      />
-    );
-  }
-
-  if (reach === 'suspended') {
-    return (
-      <EmptyState
-        icon={icon}
-        title="The GitHub installation is suspended"
-        description={
-          canManageIntegrations
-            ? 'GitHub is refusing to send anything while the installation is suspended. Lift it in the GitHub App settings, then pull requests naming an issue show up here.'
-            : 'GitHub is refusing to send anything while the installation is suspended. A workspace admin has to lift it on GitHub.'
-        }
-        {...(settingsAction('Open integrations') === undefined
-          ? {}
-          : { action: settingsAction('Open integrations') })}
-        className="flex-1"
-      />
-    );
-  }
-
-  if (reach === 'no_repositories') {
-    return (
-      <EmptyState
-        icon={icon}
-        title="No repository is being tracked"
-        description={
-          canManageIntegrations
-            ? 'GitHub is connected but no repository is switched on yet. Pick the ones this workspace should track.'
-            : 'GitHub is connected but no repository is switched on yet. A workspace admin picks which ones to track.'
-        }
-        {...(settingsAction('Pick repositories') === undefined
-          ? {}
-          : { action: settingsAction('Pick repositories') })}
-        className="flex-1"
-      />
-    );
-  }
+  const copy = REACH_COPY[reach];
+  const action = canManageIntegrations ? (
+    <Button asChild variant="primary">
+      <Link href="/settings/integrations" data-testid="pulls-connect-github">
+        {copy.action}
+      </Link>
+    </Button>
+  ) : undefined;
 
   return (
     <EmptyState
-      icon={icon}
-      title="No pull requests linked to your issues"
-      description="Orbit links a pull request when its branch or title names an issue, like ENG-42. Copy branch name on an issue gives you one that matches."
+      icon={<GitPullRequest strokeWidth={1.75} aria-hidden="true" />}
+      title={copy.title}
+      description={canManageIntegrations ? copy.admin : copy.member}
+      {...(action === undefined ? {} : { action })}
       className="flex-1"
     />
   );

--- a/apps/web/src/features/pulls/pulls-view.tsx
+++ b/apps/web/src/features/pulls/pulls-view.tsx
@@ -53,12 +53,12 @@ const REACH_COPY: Record<GithubReach, ReachCopy> = {
     action: 'Pick repositories',
   },
   repositories_untracked: {
-    title: 'Some repositories are not tracked yet',
+    title: 'No pull requests linked to your issues',
     admin:
-      'GitHub can see repositories this workspace never switched on. A pull request from one of them is dropped on arrival, and GitHub reports the delivery as accepted, so nothing looks wrong on either side. Switch the ones you work in on.',
+      'Two things have to be true. The branch or title has to name an issue, like ENG-42, and the repository has to be tracked here. GitHub can see repositories this workspace has not switched on, and a pull request from one of those is dropped on arrival while GitHub still reports the delivery as accepted, so nothing looks wrong on either side.',
     member:
-      'GitHub can see repositories this workspace never switched on, and pull requests from them are dropped on arrival. A workspace admin picks which ones to track.',
-    action: 'Track repositories',
+      'Two things have to be true. The branch or title has to name an issue, like ENG-42, and the repository has to be tracked here. GitHub can see repositories this workspace has not switched on, and pull requests from those are dropped on arrival. A workspace admin picks which ones to track.',
+    action: 'Check tracked repositories',
   },
   connected: {
     title: 'No pull requests linked to your issues',

--- a/apps/web/tests/features/pulls/github-reach.test.ts
+++ b/apps/web/tests/features/pulls/github-reach.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test-support';
-import { db, schema } from '@orbit/db';
+import { db, eq, schema } from '@orbit/db';
 import { randomUUIDv7 } from '@orbit/shared/utils';
 import { githubReach } from '../../../src/features/pulls/data.ts';
 
@@ -35,15 +35,41 @@ async function installation(status: 'active' | 'suspended'): Promise<string> {
   return integrationId;
 }
 
-async function repository(integrationId: string, enabled = true): Promise<void> {
+async function repository(
+  integrationId: string,
+  enabled = true,
+  repositoryId = `${Math.floor(Math.random() * 100000)}`,
+): Promise<string> {
   await db.insert(schema.githubRepositorySync).values({
     id: `repo_${randomUUIDv7()}`,
     organizationId: workspace.organizationId,
     integrationId,
     teamId: workspace.teamId,
-    repositoryId: `${Math.floor(Math.random() * 100000)}`,
+    repositoryId,
     repositoryName: 'noveum/orbit',
     enabled,
+  });
+  return repositoryId;
+}
+
+async function catalogued(
+  integrationId: string,
+  repositoryId: string,
+  archived = false,
+): Promise<void> {
+  const [row] = await db
+    .select({ id: schema.githubInstallation.id })
+    .from(schema.githubInstallation)
+    .where(eq(schema.githubInstallation.integrationId, integrationId))
+    .limit(1);
+  if (row === undefined) throw new Error('that integration has no installation row');
+  await db.insert(schema.githubRepository).values({
+    id: `ghr_${randomUUIDv7()}`,
+    organizationId: workspace.organizationId,
+    installationRowId: row.id,
+    repositoryId,
+    fullName: `noveum/repo-${repositoryId}`,
+    archived,
   });
 }
 
@@ -105,6 +131,49 @@ describe('githubReach', () => {
     await installation('active');
     const suspended = await installation('suspended');
     await repository(suspended);
+
+    expect(await githubReach(workspace.admin)).toBe('no_repositories');
+  });
+
+  it('reports untracked repositories when the app can see one nobody switched on', async () => {
+    const integrationId = await installation('active');
+    const tracked = await repository(integrationId);
+    await catalogued(integrationId, tracked);
+    await catalogued(integrationId, 'seen-but-never-switched-on');
+
+    expect(await githubReach(workspace.admin)).toBe('repositories_untracked');
+  });
+
+  it('stays connected when every repository the app can see is tracked', async () => {
+    const integrationId = await installation('active');
+    const tracked = await repository(integrationId);
+    await catalogued(integrationId, tracked);
+
+    expect(await githubReach(workspace.admin)).toBe('connected');
+  });
+
+  it('does not nag about an archived repository, which will never open a pull request', async () => {
+    const integrationId = await installation('active');
+    const tracked = await repository(integrationId);
+    await catalogued(integrationId, tracked);
+    await catalogued(integrationId, 'long-since-archived', true);
+
+    expect(await githubReach(workspace.admin)).toBe('connected');
+  });
+
+  it('does not nag about a repository only a suspended installation can see', async () => {
+    const active = await installation('active');
+    const suspended = await installation('suspended');
+    const tracked = await repository(active);
+    await catalogued(active, tracked);
+    await catalogued(suspended, 'visible-only-while-suspended');
+
+    expect(await githubReach(workspace.admin)).toBe('connected');
+  });
+
+  it('keeps reporting no repositories rather than untracked when nothing is switched on at all', async () => {
+    const integrationId = await installation('active');
+    await catalogued(integrationId, 'seen-but-never-switched-on');
 
     expect(await githubReach(workspace.admin)).toBe('no_repositories');
   });

--- a/apps/web/tests/features/pulls/pulls-view.test.tsx
+++ b/apps/web/tests/features/pulls/pulls-view.test.tsx
@@ -80,11 +80,44 @@ describe('the empty pull request page explaining itself', () => {
     expect(screen.queryByText('No repository is being tracked')).not.toBeInTheDocument();
   });
 
-  it('says what makes a pull request link once a repository is tracked', () => {
+  it('says what makes a pull request link once every repository is tracked', () => {
     render(<PullsView pulls={[]} userId="user_1" reach="connected" canManageIntegrations />);
 
     expect(screen.getByText('No pull requests linked to your issues')).toBeInTheDocument();
     expect(screen.getByText(/branch or title names an issue/)).toBeInTheDocument();
+  });
+
+  it('offers the route to integrations even when naming is the only thing left to fix', () => {
+    render(<PullsView pulls={[]} userId="user_1" reach="connected" canManageIntegrations />);
+
+    expect(screen.getByTestId('pulls-connect-github')).toHaveAttribute(
+      'href',
+      '/settings/integrations',
+    );
+  });
+
+  it('blames the untracked repository rather than branch naming when one exists', () => {
+    render(
+      <PullsView pulls={[]} userId="user_1" reach="repositories_untracked" canManageIntegrations />,
+    );
+
+    expect(screen.getByText('Some repositories are not tracked yet')).toBeInTheDocument();
+    expect(screen.getByText(/GitHub reports the delivery as accepted/)).toBeInTheDocument();
+    expect(screen.queryByText(/branch or title names an issue/)).not.toBeInTheDocument();
+    expect(screen.getByTestId('pulls-connect-github')).toBeInTheDocument();
+  });
+
+  it('tells a member who cannot track repositories to ask an admin', () => {
+    render(
+      <PullsView
+        pulls={[]}
+        userId="user_1"
+        reach="repositories_untracked"
+        canManageIntegrations={false}
+      />,
+    );
+
+    expect(screen.getByText(/workspace admin picks which ones to track/)).toBeInTheDocument();
     expect(screen.queryByTestId('pulls-connect-github')).not.toBeInTheDocument();
   });
 

--- a/apps/web/tests/features/pulls/pulls-view.test.tsx
+++ b/apps/web/tests/features/pulls/pulls-view.test.tsx
@@ -96,14 +96,13 @@ describe('the empty pull request page explaining itself', () => {
     );
   });
 
-  it('blames the untracked repository rather than branch naming when one exists', () => {
+  it('names the untracked repository as well as naming, never one instead of the other', () => {
     render(
       <PullsView pulls={[]} userId="user_1" reach="repositories_untracked" canManageIntegrations />,
     );
 
-    expect(screen.getByText('Some repositories are not tracked yet')).toBeInTheDocument();
-    expect(screen.getByText(/GitHub reports the delivery as accepted/)).toBeInTheDocument();
-    expect(screen.queryByText(/branch or title names an issue/)).not.toBeInTheDocument();
+    expect(screen.getByText(/has to name an issue/)).toBeInTheDocument();
+    expect(screen.getByText(/reports the delivery as accepted/)).toBeInTheDocument();
     expect(screen.getByTestId('pulls-connect-github')).toBeInTheDocument();
   });
 
@@ -119,6 +118,16 @@ describe('the empty pull request page explaining itself', () => {
 
     expect(screen.getByText(/workspace admin picks which ones to track/)).toBeInTheDocument();
     expect(screen.queryByTestId('pulls-connect-github')).not.toBeInTheDocument();
+  });
+
+  it('never asserts naming is the only remaining cause while a repository is untracked', () => {
+    render(
+      <PullsView pulls={[]} userId="user_1" reach="repositories_untracked" canManageIntegrations />,
+    );
+
+    expect(
+      screen.queryByText(/Copy branch name on an issue gives you one that matches/),
+    ).toBeNull();
   });
 
   it('sends a member who cannot manage integrations to an admin rather than a dead end', () => {


### PR DESCRIPTION
## Why

The pull requests page told an admin, with confidence, that no branch names an issue. It could not know that. The workspace it was rendering for had `Noveum/orbit` connected to GitHub but never tracked in Orbit, so every `pull_request` delivery for it was answered like this:

```
{"ok":true,"actions":0,"ignored":"repository_not_connected"}
```

GitHub recorded a 200 for all of them. Nothing looked wrong from either side, and the page pointed at branch naming, which was the wrong thing to go and fix.

## The mistake in `githubReach`

It asks an org-wide question:

```ts
return tracked.some((row) => active.has(row.integrationId)) ? 'connected' : 'no_repositories';
```

Any one enabled repository sync row sharing an active installation returns `connected`. Three unrelated repositories were associated, so the workspace looked healthy while the repository actually being worked in was invisible to the check. The signal that mattered, "GitHub can see repositories nobody switched on", was never computed.

## What changes

A new reach state sits between `connected` and `no_repositories`:

| Reach | Meaning |
| --- | --- |
| `no_repositories` | nothing is switched on at all |
| `repositories_untracked` | something is switched on, but GitHub can also see repositories that are not |
| `connected` | everything GitHub can see is tracked, so naming really is the remaining variable |

Its copy says the part that was missing: a delivery from an untracked repository is dropped on arrival and GitHub reports it as accepted.

Two exclusions, so the state means something. An archived repository and one only a suspended installation can see are both left out, because neither will ever open a pull request and nagging about them would train people to ignore the state.

The empty state also always offers the route to `/settings/integrations`. The previous final branch omitted the action entirely, so an admin who reached the page had nowhere to go.

`PullsEmptyState` became a lookup rather than a chain of conditionals. Adding a fifth branch to the chain crossed the cognitive complexity limit, and the copy for five states reads better as a table than as nested returns.

## Cost

One extra indexed query, and only on the path that was about to return `connected`. Every other reach state returns before it.

## Tests

9 new. 5 against a real database on `githubReach`, of which 3 are false positive guards: an archived repository, a repository only a suspended installation can see, and the case where nothing is tracked at all must all stay off the new state. 4 on the empty state, covering the new copy, the admin action, and the member who cannot act on it.

Checked that they fail without the change: reverting the two source files takes 24 passing to 20 passing and 4 failing, and the 4 are exactly the ones asserting new behaviour.

`bun run verify` green.

## Not in this PR

Associating a repository does not backfill the pull requests that already exist, because `applyGithubEvent` is the only writer of `git_link` and the webhook route is its only caller. A workspace that fixes its association sees the page fill up from the next event, not immediately. That is worth its own issue rather than a change here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR distinguishes repositories visible to active GitHub installations but not tracked by Orbit, replacing misleading branch-naming guidance with an actionable repository-tracking state.
- Adds `repositories_untracked` reach detection while excluding archived repositories and suspended installations.
- Refactors empty-state copy into a typed lookup and consistently offers eligible administrators an integrations action.
- Adds database-backed reach tests and rendering tests for the new guidance and permissions behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/pulls/data.ts | Adds organization-scoped catalogue comparison and the new repository-reach classification without leaving the previously raised catalogue-consistency concern outstanding. |
| apps/web/src/features/pulls/pulls-view.tsx | Centralizes typed empty-state content and renders state-appropriate descriptions and administrator actions. |
| apps/web/tests/features/pulls/github-reach.test.ts | Covers untracked, fully tracked, archived, suspended-installation, and no-tracked-repository reach scenarios. |
| apps/web/tests/features/pulls/pulls-view.test.tsx | Verifies the revised guidance, integrations link, and member-versus-administrator behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Evaluate GitHub installations] --> B{Any installations?}
  B -- No --> C[not_installed]
  B -- Yes --> D{Any active installation?}
  D -- No --> E[suspended]
  D -- Yes --> F{Any tracked repository on an active installation?}
  F -- No --> G[no_repositories]
  F -- Yes --> H{Active non-archived visible repository is untracked?}
  H -- Yes --> I[repositories_untracked]
  H -- No --> J[connected]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/noveum/orbit/commit/5316507f2c53db70c45115dae606028ea3cdd031) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51562871)</sub>

<!-- /greptile_comment -->