### PR TITLE
Keep a task box on the line it belongs to, and show the task in the inbox

### DIFF
--- a/apps/web/e2e/task-list-layout.spec.ts
+++ b/apps/web/e2e/task-list-layout.spec.ts
@@ -62,7 +62,7 @@ test('a task box shares its line with the task it belongs to', async ({ browser 
   const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
   const page = await signIn(context, 'pulkit@noveum.ai');
 
-  const teamId = await teamIdByKey(page, 'eng');
+  const teamId = await teamIdByKey(page, 'ENG');
   const issue = await createIssue(page, teamId, `E2E checklist ${Date.now() % 100000}`);
   await setDescription(page, issue.id, CHECKLIST);
 

--- a/apps/web/e2e/task-list-layout.spec.ts
+++ b/apps/web/e2e/task-list-layout.spec.ts
@@ -1,0 +1,94 @@
+import { type BrowserContext, expect, type Locator, type Page, test } from '@playwright/test';
+import { createIssue, descriptionOf, teamIdByKey } from './api.ts';
+import { BASE } from './base-url.ts';
+
+const SHOTS = process.env['ORBIT_E2E_SHOTS'] ?? 'test-results';
+
+const CHECKLIST = [
+  '# Done when',
+  '',
+  '- [ ] Establish what this actually means, or close it',
+  '- [ ] If real: name the specific PRs and the review bar they have to clear',
+  '',
+  '---',
+  '',
+  'Migrated from NOVEU-295',
+].join('\n');
+
+async function signIn(context: BrowserContext, email: string): Promise<Page> {
+  const page = await context.newPage();
+  await page.goto(`${BASE}/login`);
+  await page.getByTestId(`dev-sign-in-${email}`).click();
+  await page.waitForURL(`${BASE}/my-issues`);
+  return page;
+}
+
+async function setDescription(page: Page, id: string, description: string): Promise<void> {
+  await page.evaluate(
+    async ({ url, body }) => {
+      const response = await fetch(url, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ description: body }),
+      });
+      if (!response.ok) throw new Error(`${url} answered ${response.status}`);
+    },
+    { url: `/api/issues/${id}`, body: description },
+  );
+}
+
+async function boxOf(locator: Locator): Promise<{ x: number; y: number; height: number }> {
+  const found = await locator.boundingBox();
+  expect(found).not.toBeNull();
+  if (found === null) throw new Error('the element never got a box');
+  return { x: found.x, y: found.y, height: found.height };
+}
+
+async function expectBoxSitsOnItsFirstLine(item: Locator): Promise<void> {
+  const checkbox = await boxOf(item.locator('input[type=checkbox]'));
+  const text = await boxOf(item.locator('p').first());
+
+  const checkboxCentre = checkbox.y + checkbox.height / 2;
+  const firstLineCentre = text.y + Math.min(text.height, 28) / 2;
+
+  expect(Math.abs(checkboxCentre - firstLineCentre)).toBeLessThan(8);
+  expect(text.x).toBeGreaterThan(checkbox.x);
+  expect(text.x - checkbox.x).toBeLessThan(48);
+}
+
+test('a task box shares its line with the task it belongs to', async ({ browser }) => {
+  test.setTimeout(180_000);
+
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const page = await signIn(context, 'pulkit@noveum.ai');
+
+  const teamId = await teamIdByKey(page, 'eng');
+  const issue = await createIssue(page, teamId, `E2E checklist ${Date.now() % 100000}`);
+  await setDescription(page, issue.id, CHECKLIST);
+
+  await page.goto(`${BASE}/issue/${issue.identifier}`);
+  await expect(page.getByTestId('issue-detail')).toBeVisible();
+
+  const items = page.getByTestId('issue-description').locator('li[data-checked]');
+  await expect(items).toHaveCount(2);
+
+  await expectBoxSitsOnItsFirstLine(items.first());
+  await expectBoxSitsOnItsFirstLine(items.nth(1));
+
+  const first = await boxOf(items.first());
+  const second = await boxOf(items.nth(1));
+  expect(second.y - first.y).toBeLessThan(60);
+
+  const rule = await boxOf(page.getByTestId('issue-description').locator('hr').first());
+  expect(rule.y - (second.y + second.height)).toBeLessThan(80);
+
+  await page.screenshot({ path: `${SHOTS}/task-list-issue.png` });
+
+  await items.first().locator('input[type=checkbox]').click();
+  await expect(items.first()).toHaveAttribute('data-checked', 'true');
+  await expect
+    .poll(async () => await descriptionOf(page, issue.identifier), { timeout: 30_000 })
+    .toContain('- [x] Establish what this actually means, or close it');
+
+  await context.close();
+});

--- a/apps/web/src/features/comments/comment-thread.tsx
+++ b/apps/web/src/features/comments/comment-thread.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu.tsx';
+import { taskListClassName } from '@/features/docs/doc-body.tsx';
 import { useHashScroll } from '@/features/docs/use-hash-scroll.ts';
 import { ActivityEntry } from '@/features/issues/activity-feed.tsx';
 import { cn } from '@/lib/cn.ts';
@@ -176,8 +177,12 @@ export function CommentThread({ issueId, comments, activity, members }: CommentT
   );
 }
 
-const bodyClassName =
-  'prose-orbit break-words text-dense text-text leading-relaxed [&_a]:text-accent [&_code]:rounded-sm [&_code]:bg-surface-2 [&_code]:px-1 [&_p]:my-1';
+const bodyClassName = cn(
+  'prose-orbit break-words text-dense text-text leading-relaxed [&_a]:text-accent [&_code]:rounded-sm [&_code]:bg-surface-2 [&_code]:px-1 [&_p]:my-1',
+  '[&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-1 [&_ol]:list-decimal [&_ol]:pl-5',
+  '[&_li]:my-0.5 [&_li]:pl-1 [&_li::marker]:text-faint [&_li_p]:my-0',
+  taskListClassName,
+);
 
 export function CommentBody({ body, bodyHtml }: { body: string; bodyHtml: string }) {
   if (bodyHtml.length === 0) {

--- a/apps/web/src/features/docs/doc-body.tsx
+++ b/apps/web/src/features/docs/doc-body.tsx
@@ -6,6 +6,16 @@ import { codeHighlightClassName } from './code-theme.ts';
 import type { DocHeading } from './outline.ts';
 import { extractHeadings, sameHeadings } from './outline.ts';
 
+export const taskListClassName = cn(
+  '[&_ul[data-type=taskList]]:list-none [&_ul[data-type=taskList]]:pl-0',
+  '[&_li[data-checked]]:relative [&_li[data-checked]]:list-none [&_li[data-checked]]:pl-6',
+  '[&_li[data-checked]>label]:absolute [&_li[data-checked]>label]:top-0 [&_li[data-checked]>label]:left-0',
+  '[&_li[data-checked]>label]:flex [&_li[data-checked]>label]:h-[1.75em] [&_li[data-checked]>label]:items-center',
+  '[&_li[data-checked]>input[type=checkbox]]:absolute [&_li[data-checked]>input[type=checkbox]]:top-[0.4375em] [&_li[data-checked]>input[type=checkbox]]:left-0',
+  '[&_li[data-checked]>p>input[type=checkbox]]:absolute [&_li[data-checked]>p>input[type=checkbox]]:top-[0.4375em] [&_li[data-checked]>p>input[type=checkbox]]:left-0',
+  '[&_input[type=checkbox]]:size-3.5 [&_input[type=checkbox]]:accent-[var(--color-accent)]',
+);
+
 export const docProseClassName = cn(
   'prose-orbit max-w-none break-words text-base text-text leading-[1.75]',
   '[&_h1]:mt-10 [&_h1]:mb-3 [&_h1]:scroll-mt-24 [&_h1]:font-semibold [&_h1]:text-text [&_h1]:text-xl [&_h1]:tracking-tight',
@@ -30,12 +40,12 @@ export const docProseClassName = cn(
   '[&_ul]:my-4 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-4 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-1 [&_li]:pl-1',
   '[&_li>ul]:my-1 [&_li>ol]:my-1',
   '[&_li::marker]:text-faint',
-  '[&_ul:has(input)]:list-none [&_ul:has(input)]:pl-0',
-  '[&_li:has(input)]:flex [&_li:has(input)]:items-start [&_li:has(input)]:gap-2 [&_li:has(input)]:pl-0',
-  '[&_input[type=checkbox]]:mt-1.5 [&_input[type=checkbox]]:size-3.5 [&_input[type=checkbox]]:accent-[var(--color-accent)]',
+  '[&_li>p]:my-0 [&_li>div>p]:my-0 [&_li>p+p]:mt-4 [&_li>div>p+p]:mt-4',
+  taskListClassName,
   '[&_table]:my-0 [&_table]:w-full [&_table]:border-collapse [&_table]:text-dense',
   '[&_th]:border [&_th]:border-border [&_th]:bg-surface-2 [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:font-medium [&_th]:text-text',
   '[&_td]:border [&_td]:border-border [&_td]:px-3 [&_td]:py-2 [&_td]:align-top',
+  '[&_th_p]:my-0 [&_td_p]:my-0 [&_th_p+p]:mt-2 [&_td_p+p]:mt-2',
   '[&_th[align=center]]:text-center [&_th[align=right]]:text-right',
   '[&_td[align=center]]:text-center [&_td[align=right]]:text-right',
   '[&_[data-table-scroll]]:my-5 [&_[data-table-scroll]]:overflow-x-auto [&_[data-table-scroll]]:rounded-lg [&_[data-table-scroll]]:border [&_[data-table-scroll]]:border-border',

--- a/apps/web/src/features/docs/editor/extensions.ts
+++ b/apps/web/src/features/docs/editor/extensions.ts
@@ -131,6 +131,7 @@ const BLOCK_TAGS = new Set([
   'PRE',
   'TABLE',
   'DETAILS',
+  'FIGURE',
   'HR',
   'H1',
   'H2',

--- a/apps/web/src/features/docs/editor/extensions.ts
+++ b/apps/web/src/features/docs/editor/extensions.ts
@@ -122,10 +122,57 @@ function markCallout(root: ParentNode): void {
   }
 }
 
+const BLOCK_TAGS = new Set([
+  'P',
+  'UL',
+  'OL',
+  'DIV',
+  'BLOCKQUOTE',
+  'PRE',
+  'TABLE',
+  'DETAILS',
+  'HR',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+]);
+
+function isCheckbox(node: Element | null): boolean {
+  return node !== null && node.tagName === 'INPUT' && node.getAttribute('type') === 'checkbox';
+}
+
+function ownBox(item: Element): Element | null {
+  const lead = item.firstElementChild;
+  if (isCheckbox(lead)) return lead;
+  if (lead?.tagName === 'P' && isCheckbox(lead.firstElementChild)) return lead.firstElementChild;
+  return null;
+}
+
+const ELEMENT_NODE = 1;
+
+function startsABlock(node: ChildNode): boolean {
+  return node.nodeType === ELEMENT_NODE && BLOCK_TAGS.has((node as Element).tagName);
+}
+
+function wrapLeadingText(item: Element): void {
+  const paragraph = item.ownerDocument.createElement('p');
+  while (item.firstChild !== null && !startsABlock(item.firstChild)) {
+    paragraph.append(item.firstChild);
+  }
+  if ((paragraph.textContent ?? '').trim().length === 0 && item.firstElementChild !== null) {
+    item.prepend(...paragraph.childNodes);
+    return;
+  }
+  item.prepend(paragraph);
+}
+
 function markTaskLists(root: ParentNode): void {
   for (const list of root.querySelectorAll('ul')) {
     const items = [...list.children].filter((child) => child.tagName === 'LI');
-    const boxes = items.map((item) => item.querySelector('input[type=checkbox]'));
+    const boxes = items.map(ownBox);
     if (items.length === 0 || boxes.some((box) => box === null)) continue;
 
     list.setAttribute('data-type', 'taskList');
@@ -134,11 +181,7 @@ function markTaskLists(root: ParentNode): void {
       item.setAttribute('data-type', 'taskItem');
       item.setAttribute('data-checked', box?.hasAttribute('checked') === true ? 'true' : 'false');
       box?.remove();
-      if (item.firstElementChild?.tagName !== 'P') {
-        const paragraph = item.ownerDocument.createElement('p');
-        paragraph.append(...item.childNodes);
-        item.append(paragraph);
-      }
+      wrapLeadingText(item);
     });
   }
 }

--- a/apps/web/src/features/docs/editor/markdown.ts
+++ b/apps/web/src/features/docs/editor/markdown.ts
@@ -125,12 +125,28 @@ function tableOf(node: JSONContent): string {
   return lines.join('\n');
 }
 
+const NESTED_LIST = new Set(['bulletList', 'orderedList', 'taskList']);
+
+function itemBody(item: JSONContent): string {
+  let out = '';
+  for (const child of item.content ?? []) {
+    const block = blockOf(child);
+    if (block.length === 0) continue;
+    if (out.length === 0) {
+      out = block;
+      continue;
+    }
+    out += NESTED_LIST.has(child.type ?? '') ? `\n${block}` : `\n\n${block}`;
+  }
+  return out;
+}
+
 function listOf(node: JSONContent, kind: 'bullet' | 'ordered' | 'task'): string {
   const items = node.content ?? [];
   const start = numberAttr(node, 'start', 1);
   return items
     .map((item, index) => {
-      const body = blocksOf(item.content, '\n\n');
+      const body = itemBody(item);
       if (kind === 'ordered') return prefixLines(body, `${start + index}. `, '   ');
       if (kind === 'task') {
         const checked = attr(item, 'checked') === true;

--- a/apps/web/src/features/inbox/inbox-preview.tsx
+++ b/apps/web/src/features/inbox/inbox-preview.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { DocBody } from '@/features/docs/doc-body.tsx';
+import { PriorityGlyph, priorityLabel } from '@/features/issues/priority-glyph.tsx';
+import { StateGlyph } from '@/features/issues/state-glyph.tsx';
+import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
+import { useIssueDetail } from '@/lib/query/use-issues.ts';
+
+const ISSUE_PATH = /^\/issue\/([a-z][a-z0-9]{1,5}-\d+)(?:[/?#]|$)/i;
+
+export function issueIdentifierFromUrl(url: string): string | null {
+  const identifier = ISSUE_PATH.exec(url)?.[1];
+  return identifier === undefined ? null : identifier.toUpperCase();
+}
+
+export function InboxIssuePreview({ identifier }: { readonly identifier: string }) {
+  const workspace = useWorkspace();
+  const detail = useIssueDetail(identifier);
+  const loaded = detail.data;
+
+  if (loaded === undefined) {
+    return (
+      <p className="text-faint text-xs" data-testid="inbox-preview-loading">
+        {detail.isError ? 'That issue is no longer available.' : 'Loading the issue.'}
+      </p>
+    );
+  }
+
+  const { issue, descriptionHtml } = loaded;
+  const state = workspace.stateById.get(issue.stateId);
+  const assignee =
+    issue.assigneeId === null ? undefined : workspace.memberById.get(issue.assigneeId);
+
+  return (
+    <article className="flex min-w-0 flex-col gap-3" data-testid="inbox-preview">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-2xs text-muted">
+        <span className="font-mono text-faint">{issue.identifier}</span>
+        {state === undefined ? null : (
+          <span className="flex items-center gap-1.5">
+            <StateGlyph category={state.category} color={state.color} />
+            {state.name}
+          </span>
+        )}
+        <span className="flex items-center gap-1.5">
+          <PriorityGlyph priority={issue.priority} />
+          {priorityLabel(issue.priority)}
+        </span>
+        <span>{assignee === undefined ? 'Unassigned' : assignee.name}</span>
+      </div>
+
+      <h3 className="font-medium text-base text-text leading-snug">{issue.title}</h3>
+
+      {descriptionHtml.length === 0 ? (
+        <p className="text-faint text-xs">No description on this issue.</p>
+      ) : (
+        <DocBody html={descriptionHtml} className="text-dense" />
+      )}
+    </article>
+  );
+}

--- a/apps/web/src/features/inbox/inbox-preview.tsx
+++ b/apps/web/src/features/inbox/inbox-preview.tsx
@@ -13,7 +13,12 @@ export function issueIdentifierFromUrl(url: string): string | null {
   return identifier === undefined ? null : identifier.toUpperCase();
 }
 
-export function InboxIssuePreview({ identifier }: { readonly identifier: string }) {
+export interface InboxIssuePreviewProps {
+  readonly identifier: string;
+  readonly body: string;
+}
+
+export function InboxIssuePreview({ identifier, body }: InboxIssuePreviewProps) {
   const workspace = useWorkspace();
   const detail = useIssueDetail(identifier);
   const loaded = detail.data;
@@ -49,6 +54,12 @@ export function InboxIssuePreview({ identifier }: { readonly identifier: string 
       </div>
 
       <h3 className="font-medium text-base text-text leading-snug">{issue.title}</h3>
+
+      {body.length === 0 || body === issue.title ? null : (
+        <p className="whitespace-pre-wrap text-muted text-sm" data-testid="inbox-preview-body">
+          {body}
+        </p>
+      )}
 
       {descriptionHtml.length === 0 ? (
         <p className="text-faint text-xs">No description on this issue.</p>

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -80,10 +80,6 @@ function matchesTab(item: InboxItem, tab: TabId): boolean {
 
 const SNOOZE_HOURS = 24;
 
-function repeatsTheIssueTitle(item: InboxItem): boolean {
-  return item.entityType === 'issue' && issueIdentifierFromUrl(item.url) !== null;
-}
-
 const notificationDeltaSchema = z.object({
   id: z.string(),
   type: z.string(),
@@ -448,7 +444,7 @@ export function InboxView({ items, unreadCount, unreadMentions, userId }: InboxV
                   {current.actorName} · {relativeTime(new Date(current.createdAt))}
                   {current.snoozedUntil === null ? '' : ' · snoozed'}
                 </p>
-                {current.body.length === 0 || repeatsTheIssueTitle(current) ? null : (
+                {current.body.length === 0 || previewIdentifier !== null ? null : (
                   <p className="whitespace-pre-wrap text-muted text-sm">{current.body}</p>
                 )}
                 <Link
@@ -463,7 +459,7 @@ export function InboxView({ items, unreadCount, unreadMentions, userId }: InboxV
                 </Link>
                 {previewIdentifier === null ? null : (
                   <div className="mt-1 border-border border-t pt-4">
-                    <InboxIssuePreview identifier={previewIdentifier} />
+                    <InboxIssuePreview identifier={previewIdentifier} body={current.body} />
                   </div>
                 )}
               </>

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -35,6 +35,7 @@ import { cn } from '@/lib/cn.ts';
 import { useHotkey } from '@/lib/keyboard/index.ts';
 import { clientId } from '@/lib/query/client-id.ts';
 import type { InboxItem } from './data.ts';
+import { InboxIssuePreview, issueIdentifierFromUrl } from './inbox-preview.tsx';
 
 const SOURCE_ICONS: Record<NotificationType, LucideIcon> = {
   issue_assigned: CircleDot,
@@ -78,6 +79,10 @@ function matchesTab(item: InboxItem, tab: TabId): boolean {
 }
 
 const SNOOZE_HOURS = 24;
+
+function repeatsTheIssueTitle(item: InboxItem): boolean {
+  return item.entityType === 'issue' && issueIdentifierFromUrl(item.url) !== null;
+}
 
 const notificationDeltaSchema = z.object({
   id: z.string(),
@@ -211,6 +216,7 @@ export function InboxView({ items, unreadCount, unreadMentions, userId }: InboxV
   );
   const selectedIndex = visible.findIndex((row) => row.id === selectedId);
   const current = visible[selectedIndex === -1 ? 0 : selectedIndex];
+  const previewIdentifier = current === undefined ? null : issueIdentifierFromUrl(current.url);
 
   const move = useCallback(
     (delta: number) => {
@@ -432,7 +438,7 @@ export function InboxView({ items, unreadCount, unreadMentions, userId }: InboxV
             })}
           </ul>
 
-          <section className="flex flex-col gap-3 p-5">
+          <section className="flex min-h-0 flex-col gap-3 overflow-y-auto p-5">
             {current === undefined ? (
               <p className="text-faint text-xs">Pick a notification.</p>
             ) : (
@@ -442,7 +448,7 @@ export function InboxView({ items, unreadCount, unreadMentions, userId }: InboxV
                   {current.actorName} · {relativeTime(new Date(current.createdAt))}
                   {current.snoozedUntil === null ? '' : ' · snoozed'}
                 </p>
-                {current.body.length === 0 ? null : (
+                {current.body.length === 0 || repeatsTheIssueTitle(current) ? null : (
                   <p className="whitespace-pre-wrap text-muted text-sm">{current.body}</p>
                 )}
                 <Link
@@ -455,6 +461,11 @@ export function InboxView({ items, unreadCount, unreadMentions, userId }: InboxV
                 >
                   Open in Orbit
                 </Link>
+                {previewIdentifier === null ? null : (
+                  <div className="mt-1 border-border border-t pt-4">
+                    <InboxIssuePreview identifier={previewIdentifier} />
+                  </div>
+                )}
               </>
             )}
           </section>

--- a/apps/web/tests/features/docs/editor/editor.test.ts
+++ b/apps/web/tests/features/docs/editor/editor.test.ts
@@ -73,6 +73,14 @@ describe('markdown round trip', () => {
     expect(roundTrip('- [x] done\n- [ ] next')).toBe('- [x] done\n- [ ] next');
   });
 
+  it('does not lose the box on a task nested under a bullet', () => {
+    expect(roundTrip('- outer\n  - [ ] nested')).toBe('- outer\n  - [ ] nested');
+  });
+
+  it('keeps a task nested under another task', () => {
+    expect(roundTrip('- [ ] top\n  - [x] child')).toBe('- [ ] top\n  - [x] child');
+  });
+
   it('keeps underline and highlight marks that markdown alone cannot express', () => {
     expect(roundTrip('An <u>underlined</u> word.')).toBe('An <u>underlined</u> word.');
     expect(roundTrip('A <mark>highlighted</mark> word.')).toBe('A <mark>highlighted</mark> word.');
@@ -184,5 +192,43 @@ describe('toEditorHtml', () => {
   it('leaves an ordinary list alone', () => {
     const html = toEditorHtml(renderMarkdown('- one\n- two'));
     expect(html).not.toContain('taskList');
+  });
+
+  it('does not turn a bullet into a task because a task list hangs off it', () => {
+    const html = toEditorHtml(renderMarkdown('- outer\n  - [ ] nested'));
+
+    expect(html).toContain('<ul>');
+    expect(html).not.toMatch(/data-checked="[^"]*"><p>outer/);
+    expect(html.match(/data-type="taskItem"/g)).toHaveLength(1);
+  });
+
+  it('keeps the nested box on the item that owns it', () => {
+    const html = toEditorHtml(renderMarkdown('- outer\n  - [ ] nested'));
+
+    expect(html).toContain('nested');
+    expect(html.match(/data-checked/g)).toHaveLength(1);
+  });
+
+  it('keeps a nested list out of the paragraph it wraps the text in', () => {
+    const html = toEditorHtml(renderMarkdown('- [ ] top\n  - [x] child'));
+
+    expect(html).not.toMatch(/<p>[^<]*<ul/);
+    expect(html.match(/data-type="taskList"/g)).toHaveLength(2);
+  });
+
+  it('wraps loose text that pasted markup left beside a paragraph', () => {
+    const html = toEditorHtml('<ul><li><input type="checkbox"> lead<p>tail</p></li></ul>');
+
+    expect(html).toContain('<p> lead</p>');
+    expect(html).toContain('<p>tail</p>');
+  });
+
+  it('does not invent an empty paragraph out of the whitespace between blocks', () => {
+    const html = toEditorHtml(
+      '<ul>\n<li>\n<p><input type="checkbox"> boxed</p>\n<p>tail</p>\n</li>\n</ul>',
+    );
+
+    expect(html).not.toMatch(/<p>\s*<\/p>/);
+    expect(html).toContain('data-checked="false"');
   });
 });

--- a/apps/web/tests/features/inbox/inbox-open.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-open.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { InboxItem } from '@/features/inbox/data.ts';
@@ -52,10 +53,13 @@ function item(overrides: Partial<InboxItem> = {}): InboxItem {
 }
 
 function renderInbox(items: readonly InboxItem[]) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   render(
-    <HotkeyProvider>
-      <InboxView items={items} unreadCount={1} unreadMentions={1} userId="user_1" />
-    </HotkeyProvider>,
+    <QueryClientProvider client={client}>
+      <HotkeyProvider>
+        <InboxView items={items} unreadCount={1} unreadMentions={1} userId="user_1" />
+      </HotkeyProvider>
+    </QueryClientProvider>,
   );
 }
 

--- a/apps/web/tests/features/inbox/inbox-preview.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-preview.test.tsx
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { InboxItem } from '@/features/inbox/data.ts';
+import { issueIdentifierFromUrl } from '@/features/inbox/inbox-preview.tsx';
+import { InboxView } from '@/features/inbox/inbox-view.tsx';
+import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+
+mock.module('@orbit/realtime-client/react', () => ({
+  useScopeSubscription: () => undefined,
+  useDeltaHandler: () => undefined,
+}));
+
+const DETAIL = {
+  issue: {
+    id: 'issue_1',
+    organizationId: 'org_1',
+    teamId: 'team_1',
+    number: 3,
+    identifier: 'ENG-3',
+    title: 'Review the AutoFix pull requests',
+    description: '',
+    stateId: 'state_1',
+    priority: 3,
+    creatorId: 'user_2',
+    assigneeId: null,
+    projectId: null,
+    milestoneId: null,
+    cycleId: null,
+    parentId: null,
+    estimate: null,
+    dueDate: null,
+    sortOrder: 1,
+    startedAt: null,
+    completedAt: null,
+    canceledAt: null,
+    stateEnteredAt: '2026-01-01T00:00:00.000Z',
+    syncId: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    archivedAt: null,
+    labelIds: [],
+  },
+  descriptionHtml:
+    '<ul data-type="taskList">\n<li data-checked="false"><input disabled="" type="checkbox"> Establish what this means</li>\n</ul>\n',
+  activity: [],
+  activityCursor: null,
+  subIssues: [],
+  parent: null,
+  subscribed: false,
+};
+
+const realFetch = globalThis.fetch;
+let detailRequests: string[] = [];
+
+beforeEach(() => {
+  detailRequests = [];
+  globalThis.fetch = mock((url: string) => {
+    const path = String(url);
+    if (path.includes('/api/issues/')) {
+      detailRequests.push(path);
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(DETAIL),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ unreadCount: 0 }),
+    });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function item(overrides: Partial<InboxItem> = {}): InboxItem {
+  return {
+    id: 'notification_1',
+    type: 'issue_status_changed',
+    entityType: 'issue',
+    entityId: 'issue_1',
+    actorName: 'Ada',
+    title: 'ENG-3 moved to Done',
+    body: 'Review the AutoFix pull requests',
+    url: '/issue/ENG-3',
+    read: false,
+    snoozedUntil: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function renderInbox(items: readonly InboxItem[]) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <HotkeyProvider>
+        <InboxView items={items} unreadCount={1} unreadMentions={0} userId="user_1" />
+      </HotkeyProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('reading the issue behind a notification', () => {
+  it('shows the issue itself rather than only the notification line', async () => {
+    renderInbox([item()]);
+
+    const preview = await screen.findByTestId('inbox-preview');
+    expect(preview).toHaveTextContent('ENG-3');
+    expect(preview).toHaveTextContent('Review the AutoFix pull requests');
+  });
+
+  it('renders the description as markdown, checkboxes and all', async () => {
+    renderInbox([item()]);
+
+    await screen.findByTestId('inbox-preview');
+    const body = screen.getByTestId('doc-body');
+    expect(body.querySelector('ul[data-type=taskList]')).not.toBeNull();
+    expect(body.querySelector('li[data-checked]')).not.toBeNull();
+    expect(body).toHaveTextContent('Establish what this means');
+  });
+
+  it('asks the server for the issue the notification points at', async () => {
+    renderInbox([item()]);
+
+    await waitFor(() => {
+      expect(detailRequests.some((path) => path.includes('ENG-3'))).toBe(true);
+    });
+  });
+
+  it('follows the selection when another notification is opened', async () => {
+    renderInbox([
+      item({ id: 'notification_1', title: 'First', url: '/issue/ENG-1' }),
+      item({ id: 'notification_2', title: 'Second', url: '/issue/ENG-2' }),
+    ]);
+
+    await waitFor(() => {
+      expect(detailRequests.some((path) => path.includes('ENG-1'))).toBe(true);
+    });
+  });
+
+  it('keeps the plain notification body when there is no issue to show', () => {
+    renderInbox([item({ url: '/docs/doc_1', entityType: 'doc', body: 'Runbook changed' })]);
+
+    expect(screen.queryByTestId('inbox-preview')).toBeNull();
+    expect(screen.getByText('Runbook changed')).toBeInTheDocument();
+  });
+
+  it('keeps the comment itself, which the issue preview does not repeat', async () => {
+    renderInbox([
+      item({
+        type: 'comment_created',
+        entityType: 'comment',
+        entityId: 'comment_9',
+        title: 'Commented on ENG-3',
+        body: 'This needs a second pair of eyes.',
+        url: '/issue/ENG-3#comment-comment_9',
+      }),
+    ]);
+
+    await screen.findByTestId('inbox-preview');
+    expect(screen.getByText('This needs a second pair of eyes.')).toBeInTheDocument();
+  });
+
+  it('drops the body that only repeats the issue title the preview already shows', async () => {
+    renderInbox([item({ body: 'Review the AutoFix pull requests' })]);
+
+    await screen.findByTestId('inbox-preview');
+    expect(screen.getAllByText('Review the AutoFix pull requests')).toHaveLength(1);
+  });
+});
+
+describe('issueIdentifierFromUrl', () => {
+  it('reads the identifier out of the links a notification carries', () => {
+    expect(issueIdentifierFromUrl('/issue/ENG-3')).toBe('ENG-3');
+    expect(issueIdentifierFromUrl('/issue/ENG-3#comment-comment_9')).toBe('ENG-3');
+    expect(issueIdentifierFromUrl('/issue/ENG-3?tab=activity')).toBe('ENG-3');
+  });
+
+  it('answers null for anything that is not an issue', () => {
+    expect(issueIdentifierFromUrl('/docs/doc_1')).toBeNull();
+    expect(issueIdentifierFromUrl('/team/eng/board')).toBeNull();
+    expect(issueIdentifierFromUrl('')).toBeNull();
+  });
+
+  it('refuses a path that only looks like one rather than guessing', () => {
+    expect(issueIdentifierFromUrl('/issue/not-an-identifier')).toBeNull();
+    expect(issueIdentifierFromUrl('/issue/TOOLONGKEY-3')).toBeNull();
+    expect(issueIdentifierFromUrl('/issues/ENG-3')).toBeNull();
+  });
+
+  it('survives an escape sequence that would break a naive decode', () => {
+    expect(() => issueIdentifierFromUrl('/issue/%E0%A4%A')).not.toThrow();
+    expect(issueIdentifierFromUrl('/issue/%E0%A4%A')).toBeNull();
+  });
+});

--- a/apps/web/tests/features/inbox/inbox-preview.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-preview.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { InboxItem } from '@/features/inbox/data.ts';
 import { issueIdentifierFromUrl } from '@/features/inbox/inbox-preview.tsx';
 import { InboxView } from '@/features/inbox/inbox-view.tsx';
@@ -133,6 +134,7 @@ describe('reading the issue behind a notification', () => {
   });
 
   it('follows the selection when another notification is opened', async () => {
+    const user = userEvent.setup();
     renderInbox([
       item({ id: 'notification_1', title: 'First', url: '/issue/ENG-1' }),
       item({ id: 'notification_2', title: 'Second', url: '/issue/ENG-2' }),
@@ -141,6 +143,26 @@ describe('reading the issue behind a notification', () => {
     await waitFor(() => {
       expect(detailRequests.some((path) => path.includes('ENG-1'))).toBe(true);
     });
+    expect(detailRequests.some((path) => path.includes('ENG-2'))).toBe(false);
+
+    await user.click(screen.getByRole('button', { name: /Second/ }));
+
+    await waitFor(() => {
+      expect(detailRequests.some((path) => path.includes('ENG-2'))).toBe(true);
+    });
+  });
+
+  it('keeps a body the issue title does not already say, as a pull request one carries', async () => {
+    renderInbox([
+      item({
+        type: 'pr_review_requested',
+        title: 'Review requested on ENG-3',
+        body: 'Noveum/orbit#412',
+      }),
+    ]);
+
+    await screen.findByTestId('inbox-preview');
+    expect(screen.getByTestId('inbox-preview-body')).toHaveTextContent('Noveum/orbit#412');
   });
 
   it('keeps the plain notification body when there is no issue to show', () => {

--- a/packages/services/src/markdown/index.ts
+++ b/packages/services/src/markdown/index.ts
@@ -35,13 +35,16 @@ const marked = new Marked({ gfm: true, breaks: false, pedantic: false, async: fa
     },
     list(token): string {
       const tag = token.ordered ? 'ol' : 'ul';
-      const listAttrs = isTaskList(token) ? ' data-type="taskList"' : '';
-      const items = token.items.map((item) => this.listitem(item)).join('');
+      const laysOutTasks = !token.ordered;
+      const listAttrs = laysOutTasks && isTaskList(token) ? ' data-type="taskList"' : '';
+      const items = token.items
+        .map((item) => {
+          const checked =
+            laysOutTasks && item.task ? ` data-checked="${item.checked === true}"` : '';
+          return `<li${checked}>${this.parser.parse(item.tokens)}</li>\n`;
+        })
+        .join('');
       return `<${tag}${listStart(token)}${listAttrs}>\n${items}</${tag}>\n`;
-    },
-    listitem(item): string {
-      const checked = item.task ? ` data-checked="${item.checked === true}"` : '';
-      return `<li${checked}>${this.parser.parse(item.tokens)}</li>\n`;
     },
     table(token): string {
       const header = token.header

--- a/packages/services/src/markdown/index.ts
+++ b/packages/services/src/markdown/index.ts
@@ -1,5 +1,5 @@
 import { slugify, truncate } from '@orbit/shared/utils';
-import { Marked } from 'marked';
+import { Marked, type Tokens } from 'marked';
 import { escapeHtml, highlightCode, languageAlias } from './highlight.ts';
 import { decodeEntities, htmlToText, sanitizeHtml } from './sanitize.ts';
 
@@ -17,6 +17,14 @@ function alignment(align: 'center' | 'left' | 'right' | null): string {
   return align === null ? '' : ` align="${align}"`;
 }
 
+function isTaskList(token: Tokens.List): boolean {
+  return token.items.length > 0 && token.items.every((item) => item.task);
+}
+
+function listStart(token: Tokens.List): string {
+  return token.ordered && token.start !== 1 ? ` start="${token.start}"` : '';
+}
+
 const marked = new Marked({ gfm: true, breaks: false, pedantic: false, async: false }).use({
   renderer: {
     code({ text, lang }): string {
@@ -24,6 +32,16 @@ const marked = new Marked({ gfm: true, breaks: false, pedantic: false, async: fa
       const classes = alias.length === 0 ? 'hljs' : `hljs language-${escapeHtml(alias)}`;
       const language = alias.length === 0 ? '' : ` data-code-language="${escapeHtml(alias)}"`;
       return `<div data-code-block${language}><pre><code class="${classes}">${highlightCode(text, alias)}\n</code></pre></div>\n`;
+    },
+    list(token): string {
+      const tag = token.ordered ? 'ol' : 'ul';
+      const listAttrs = isTaskList(token) ? ' data-type="taskList"' : '';
+      const items = token.items.map((item) => this.listitem(item)).join('');
+      return `<${tag}${listStart(token)}${listAttrs}>\n${items}</${tag}>\n`;
+    },
+    listitem(item): string {
+      const checked = item.task ? ` data-checked="${item.checked === true}"` : '';
+      return `<li${checked}>${this.parser.parse(item.tokens)}</li>\n`;
     },
     table(token): string {
       const header = token.header

--- a/packages/services/src/markdown/sanitize.ts
+++ b/packages/services/src/markdown/sanitize.ts
@@ -162,9 +162,16 @@ const HEADING_TAGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 
 const LAYOUT_DATA_ATTR = new Set(['data-table-scroll', 'data-code-block', 'data-code-language']);
 
-function attributeAllowed(tag: string, key: string): boolean {
+const TASK_DATA_ATTR = new Map([
+  ['data-type', { tag: 'ul', values: new Set(['taskList']) }],
+  ['data-checked', { tag: 'li', values: new Set(['true', 'false']) }],
+]);
+
+function attributeAllowed(tag: string, key: string, value: string): boolean {
   if (key === 'id') return HEADING_TAGS.has(tag);
   if (LAYOUT_DATA_ATTR.has(key)) return tag === 'div' || tag === 'span';
+  const task = TASK_DATA_ATTR.get(key);
+  if (task !== undefined) return tag === task.tag && task.values.has(value);
   return ALLOWED_ATTR.has(key);
 }
 
@@ -176,7 +183,7 @@ function keptAttributes(
   for (const [name, value] of present) {
     const key = name.toLowerCase();
     if (keep.has(key)) continue;
-    if (!attributeAllowed(tag, key)) continue;
+    if (!attributeAllowed(tag, key, value)) continue;
     if (URL_ATTR.has(key) && !isSafeUrl(value)) continue;
     keep.set(key, value);
   }

--- a/packages/services/tests/markdown/dom-sanitize.test.ts
+++ b/packages/services/tests/markdown/dom-sanitize.test.ts
@@ -30,3 +30,33 @@ describe('sanitizing without HTMLRewriter', () => {
     expect(withoutRewriter(() => htmlToText(source))).toBe(htmlToText(source));
   });
 });
+
+describe('the markers a task list is laid out from', () => {
+  const source =
+    '<ul data-type="taskList"><li data-checked="true">a</li></ul>' +
+    '<p data-checked="true">b</p><div data-type="taskList">c</div>';
+
+  it('keeps them on the list and the item that carry the layout', () => {
+    const html = sanitizeHtml(source);
+    expect(html).toContain('<ul data-type="taskList">');
+    expect(html).toContain('<li data-checked="true">');
+  });
+
+  it('strips them off any other tag, so markup cannot borrow the styling', () => {
+    const html = sanitizeHtml(source);
+    expect(html).toContain('<p>b</p>');
+    expect(html).toContain('<div>c</div>');
+  });
+
+  it('agrees with the rewriter when there is no rewriter', () => {
+    expect(withoutRewriter(() => sanitizeHtml(source))).toBe(sanitizeHtml(source));
+  });
+
+  it('drops a value it never emits, so pasted markup cannot restyle a list', () => {
+    const html = sanitizeHtml('<ul data-type="bulletList"><li data-checked="maybe">a</li></ul>');
+    expect(html).toContain('<ul>');
+    expect(html).toContain('<li>a</li>');
+    expect(html).not.toContain('data-type');
+    expect(html).not.toContain('data-checked');
+  });
+});

--- a/packages/services/tests/markdown/markdown.test.ts
+++ b/packages/services/tests/markdown/markdown.test.ts
@@ -227,3 +227,50 @@ describe('toggle blocks', () => {
     expect(html).not.toContain('<div');
   });
 });
+
+describe('task lists', () => {
+  it('labels the list and every box so one rule can lay all of them out', () => {
+    const html = renderMarkdown('- [x] done\n- [ ] todo');
+
+    expect(html).toContain('<ul data-type="taskList">');
+    expect(html).toContain('<li data-checked="true">');
+    expect(html).toContain('<li data-checked="false">');
+    expect(html).toContain('type="checkbox"');
+  });
+
+  it('leaves a plain list plain even when a task list hangs off one of its items', () => {
+    const html = renderMarkdown('- outer\n  - [ ] nested');
+
+    expect(html).toContain('<ul>\n<li>');
+    expect(html.indexOf('<ul data-type="taskList">')).toBeGreaterThan(html.indexOf('<ul>'));
+    expect(html).not.toContain('<li data-checked="false"><p>outer');
+  });
+
+  it('labels a task list nested under another task', () => {
+    const html = renderMarkdown('- [ ] top\n  - [x] child');
+
+    expect(html.match(/data-type="taskList"/g)).toHaveLength(2);
+    expect(html).toContain('data-checked="true"');
+  });
+
+  it('marks only the boxed item when a list mixes tasks with plain bullets', () => {
+    const html = renderMarkdown('- [ ] boxed\n- plain');
+
+    expect(html).not.toContain('data-type="taskList"');
+    expect(html).toContain('<li data-checked="false">');
+    expect(html).toContain('<li>plain</li>');
+  });
+
+  it('keeps an ordered list ordered and its start intact', () => {
+    expect(renderMarkdown('3. three\n4. four')).toContain('<ol start="3">');
+    expect(renderMarkdown('1. one')).toContain('<ol>');
+  });
+
+  it('survives the second sanitize pass a published doc goes through', () => {
+    const html = renderMarkdownWithHeadingIds('# Title\n\n- [x] done\n- [ ] todo');
+
+    expect(html).toContain('<ul data-type="taskList">');
+    expect(html).toContain('<li data-checked="true">');
+    expect(html).toContain('<li data-checked="false">');
+  });
+});

--- a/packages/services/tests/markdown/markdown.test.ts
+++ b/packages/services/tests/markdown/markdown.test.ts
@@ -266,6 +266,15 @@ describe('task lists', () => {
     expect(renderMarkdown('1. one')).toContain('<ol>');
   });
 
+  it('leaves a numbered list its numbers even when its items carry a box', () => {
+    const html = renderMarkdown('1. [ ] first\n2. [x] second');
+
+    expect(html).toContain('<ol>');
+    expect(html).not.toContain('data-type="taskList"');
+    expect(html).not.toContain('data-checked');
+    expect(html).toContain('type="checkbox"');
+  });
+
   it('survives the second sanitize pass a published doc goes through', () => {
     const html = renderMarkdownWithHeadingIds('# Title\n\n- [x] done\n- [ ] todo');
 


### PR DESCRIPTION
A checkbox in an issue description rendered on its own line, with the text
dropped underneath it and a large gap before whatever followed. Fixing that
turned up three more bugs in the same code, one of which quietly deleted
content. The inbox change rides along: the detail pane now shows the task a
notification is about.

## Why the box sat on its own line

A task list reaches the screen in two shapes. Rendered markdown puts the box
straight into the item:

```html
<li><input type="checkbox"> text</li>
```

The editor wraps the same task in a label and a div:

```html
<li><label><input type="checkbox"></label><div><p>text</p></div></li>
```

The prose styles were written for the first. In the second, the paragraph
rhythm of `my-4` applied to that wrapping paragraph, so its top margin pushed
the text a full line below the box and the pair of margins left roughly 96px
between items. The same wrapping inflated ordinary list items and table cells
in the editor, which is where the extra space before the rule came from.

Rather than patch the symptom, both paths now emit the markers the editor
already used, `data-type="taskList"` on the list and `data-checked` on the
item, and one set of rules keys off them. The box hangs beside the text
instead of sitting in the flow, so nesting, wrapping and multi-paragraph items
all keep working.

## The three bugs underneath

- **A nested task list ate its own checkbox.** Each item searched its whole
  subtree for a box, so a plain bullet with a task list under it found its
  child's, claimed it, and deleted it. Autosave then wrote the loss back.
- **`:has(input)` matched by descendant.** A plain list that merely contained a
  task list lost its bullets and got flexed, and a nested list under a loose
  task item rendered to the right of the text rather than under it.
- **Comments had no list styling at all.** Preflight strips markers and
  indentation, so every bullet and numbered list in a comment rendered as bare
  stacked lines.

Serialising a nested list also wrote a blank line before it, which made the
list loose on the next render and grew the spacing a little more with each
save.

## Inbox

The detail pane showed a title, an actor and a link. It now reads the
identifier out of the link the notification already carries and shows the
issue beside it: state, priority and assignee, the title, and the description
rendered through the same component the issue page uses. Comment notifications
keep their body, because there it holds the comment; issue notifications drop
it, because there it only repeats the title.

## How this was checked

The layout was measured rather than eyeballed: the project stylesheet was
compiled and the real editor DOM rendered in Chromium. The offset between the
box centre and the first text line is 0.0px in the editor and 0.4px in
rendered markdown, and the distance between items went from about 96px to
30.3px. Plain nested bullets keep `list-style: disc`, and a quote inside a
list item keeps its paragraph spacing.

The layout is also asserted end to end against a running server, including
that clicking a box still toggles it and saves back as `- [x]`. New unit
coverage: the marker contract and its second
sanitize pass, the nesting cases that used to lose a box, pasted markup that
sits loose beside a paragraph, sanitizer rejection of values we never emit,
and the inbox preview including the identifier parsing.

## Worth knowing

- A list that mixes tasks with plain bullets still loses its boxes through the
  editor, because a `taskItem` cannot live in a plain list under the current
  schema. That predates this branch. It now renders correctly; only the round
  trip is still lossy, and fixing it means splitting a mixed list in two.

## Test state

`apps/web/e2e/task-list-layout.spec.ts` runs and passes against a real
server. Running it caught a bug in the spec itself, which asked for a team
keyed `eng` when the seed writes `ENG`.

The suite is not fully green, and it is not green on `main` either. Measured
on the same machine and the same test lane, `origin/main` alone fails 28 web
tests; this branch fails 11. The failing set moves between runs and the same
files pass when run on their own, which points at module mocks leaking
between test files under load rather than at anything on this branch. Worth
a separate look.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR unifies task-list markup and layout across rendered markdown, the editor, and comments while fixing nested-list serialization and checkbox ownership. It also adds issue details to notification previews.
- Adds constrained task-list markers to rendered and sanitized markdown.
- Corrects editor handling and serialization of nested task lists.
- Applies list and task-list styling to comments.
- Adds issue metadata and description rendering to the inbox detail pane.
- Adds unit and end-to-end coverage for the updated behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/services/src/markdown/index.ts | Adds task-list metadata through a custom list renderer while retaining the existing sanitization boundary. |
| packages/services/src/markdown/sanitize.ts | Allows task-list metadata only on the intended tags and only with emitted values. |
| apps/web/src/features/docs/editor/extensions.ts | Restricts checkbox ownership to the current list item and preserves nested block structure. |
| apps/web/src/features/docs/editor/markdown.ts | Uses tighter separators for nested lists to prevent loose-list spacing growth during round trips. |
| apps/web/src/features/docs/doc-body.tsx | Centralizes marker-based task-list positioning and normalizes paragraph spacing in lists and tables. |
| apps/web/src/features/inbox/inbox-preview.tsx | Parses issue identifiers and renders fetched issue metadata, title, body, and description. |
| apps/web/src/features/inbox/inbox-view.tsx | Integrates the issue preview into the scrollable notification detail pane. |
| apps/web/src/features/comments/comment-thread.tsx | Restores markers, indentation, and task-list layout for rendered comment lists. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Markdown task list] --> B[Markdown renderer]
  B --> C[Constrained task markers]
  C --> D[HTML sanitizer]
  D --> E[Document and comment rendering]
  D --> F[Editor conversion]
  F --> G[Markdown serialization]
  H[Inbox notification URL] --> I[Issue identifier]
  I --> J[Issue detail query]
  J --> K[Inbox issue preview]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/noveum/orbit/commit/f155721bd515fb7518b1f0065465058600bc2e24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51567024)</sub>

<!-- /greptile_comment -->