### PR TITLE
Stop one unknown action from discarding a whole delta batch

### DIFF
--- a/packages/realtime-client/src/index.ts
+++ b/packages/realtime-client/src/index.ts
@@ -1,6 +1,7 @@
 import type {
   AuthMessage,
   ClientMessage,
+  DeliveredSyncAction,
   PresenceKind,
   PresenceMessage,
   SyncAction,
@@ -9,6 +10,7 @@ import {
   ORGANIZATION_FORBIDDEN_CLOSE_CODE,
   SESSION_REVOKED_CLOSE_CODE,
   serverMessageSchema,
+  tolerantDeltaMessageSchema,
   UNAUTHORIZED_CLOSE_CODE,
 } from '@orbit/shared/events';
 
@@ -93,8 +95,14 @@ export function createRealtimeClient(options: RealtimeClientOptions): RealtimeCl
     if (reconnected) options.onResume?.(maxSeenSyncId);
   }
 
-  function handleDelta(actions: SyncAction[]): void {
-    for (const action of actions) observe(action.syncId);
+  function handleDelta(delivered: DeliveredSyncAction[]): void {
+    const actions: SyncAction[] = [];
+    for (const entry of delivered) {
+      observe(entry.syncId);
+      if ('unsupported' in entry) continue;
+      actions.push(entry);
+    }
+    if (actions.length === 0) return;
     options.onDelta?.(actions);
   }
 
@@ -111,7 +119,11 @@ export function createRealtimeClient(options: RealtimeClientOptions): RealtimeCl
       return;
     }
     const parsed = serverMessageSchema.safeParse(parsedJson);
-    if (!parsed.success) return;
+    if (!parsed.success) {
+      const tolerated = tolerantDeltaMessageSchema.safeParse(parsedJson);
+      if (tolerated.success) handleDelta(tolerated.data.actions);
+      return;
+    }
     const message = parsed.data;
     if (message.type === 'ready') {
       handleReady();

--- a/packages/realtime-client/tests/index.test.ts
+++ b/packages/realtime-client/tests/index.test.ts
@@ -35,6 +35,10 @@ class FakeWebSocket {
   deliver(message: ServerMessage): void {
     this.onmessage?.({ data: JSON.stringify(message) });
   }
+
+  deliverRaw(message: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(message) });
+  }
 }
 
 function wait(ms: number): Promise<void> {
@@ -64,6 +68,10 @@ function delta(syncId: number): SyncAction {
     actor: { type: 'user', id: 'user_1' },
     at: '2026-01-01T00:00:00.000Z',
   };
+}
+
+function actionOfUnknownModel(syncId: number): Record<string, unknown> {
+  return { ...delta(syncId), model: 'pull_request', modelId: 'pull_request_1' };
 }
 
 const TICKET = 'ticket_1';
@@ -274,6 +282,74 @@ describe('realtime client lifecycle', () => {
 
     expect(presence).toHaveLength(1);
     expect(client.seen()).toBe(0);
+    client.close();
+  });
+});
+
+describe('a delta carrying a model this build does not know', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterEach(() => {
+    FakeWebSocket.instances = [];
+  });
+
+  it('keeps the actions it does understand instead of dropping the batch', async () => {
+    const batches: SyncAction[][] = [];
+    const client = createRealtimeClient({
+      url: 'ws://localhost:3100',
+      fetchTicket: () => Promise.resolve(TICKET),
+      maxBackoffMs: 10,
+      onDelta: (actions) => batches.push([...actions]),
+    });
+
+    const socket = await firstSocket();
+    socket.open();
+    socket.deliver(readyMessage());
+    socket.deliverRaw({
+      type: 'delta',
+      actions: [delta(70), actionOfUnknownModel(71), delta(72)],
+    });
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]?.map((action) => action.syncId)).toEqual([70, 72]);
+    client.close();
+  });
+
+  it('advances the watermark past what it dropped, so resume does not replay it forever', async () => {
+    const client = createRealtimeClient({
+      url: 'ws://localhost:3100',
+      fetchTicket: () => Promise.resolve(TICKET),
+      maxBackoffMs: 10,
+    });
+
+    const socket = await firstSocket();
+    socket.open();
+    socket.deliver(readyMessage());
+    socket.deliverRaw({ type: 'delta', actions: [delta(70), actionOfUnknownModel(71)] });
+
+    expect(client.seen()).toBe(71);
+    client.close();
+  });
+
+  it('reports nothing rather than an empty batch when it understands none of them', async () => {
+    const batches: SyncAction[][] = [];
+    const client = createRealtimeClient({
+      url: 'ws://localhost:3100',
+      fetchTicket: () => Promise.resolve(TICKET),
+      maxBackoffMs: 10,
+      onDelta: (actions) => batches.push([...actions]),
+    });
+
+    const socket = await firstSocket();
+    socket.open();
+    socket.deliver(readyMessage());
+    socket.deliverRaw({ type: 'delta', actions: [actionOfUnknownModel(71)] });
+
+    expect(batches).toHaveLength(0);
+    expect(client.seen()).toBe(71);
     client.close();
   });
 });

--- a/packages/shared/src/events/message.ts
+++ b/packages/shared/src/events/message.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { presenceKindSchema, presenceMessageSchema } from './presence.ts';
-import { syncActionSchema, syncCursorSchema } from './sync.ts';
+import { deliveredSyncActionSchema, syncActionSchema, syncCursorSchema } from './sync.ts';
 
 export const authMessageSchema = z.object({
   type: z.literal('auth'),
@@ -46,3 +46,10 @@ export const serverMessageSchema = z.discriminatedUnion('type', [
 ]);
 
 export type ServerMessage = z.infer<typeof serverMessageSchema>;
+
+export const tolerantDeltaMessageSchema = z.object({
+  type: z.literal('delta'),
+  actions: z.array(deliveredSyncActionSchema).min(1),
+});
+
+export type TolerantDeltaMessage = z.infer<typeof tolerantDeltaMessageSchema>;

--- a/packages/shared/src/events/sync.ts
+++ b/packages/shared/src/events/sync.ts
@@ -48,6 +48,15 @@ export const syncActionSchema = z.object({
   originClientId: originClientIdSchema.optional(),
 });
 
+export const deliveredSyncActionSchema = z.union([
+  syncActionSchema,
+  z
+    .object({ syncId: z.number().int().nonnegative() })
+    .transform((row) => ({ syncId: row.syncId, unsupported: true as const })),
+]);
+
+export type DeliveredSyncAction = z.infer<typeof deliveredSyncActionSchema>;
+
 export type SyncAction = z.infer<typeof syncActionSchema>;
 
 export const syncCursorSchema = z.number().int().nonnegative();


### PR DESCRIPTION
## Why

Three things that are individually reasonable combine into a silent bug.

```
sync.ts:43        model: z.enum(SYNC_MODELS)
message.ts:37     actions: z.array(syncActionSchema).min(1)
index.ts:113-114  const parsed = serverMessageSchema.safeParse(parsedJson);
                  if (!parsed.success) return;
connection.ts:136 this.send({ type: 'delta', actions });
```

The client validates a delta as a single unit, and the hub batches everything arriving inside a flush window into one. So one action naming a model the tab has never heard of fails the whole message, and the tab discards **every action in that batch**, including unrelated issue updates.

Nothing surfaces it. The socket stays open, the tab reports itself connected, and it quietly stops applying some updates until somebody reloads.

The practical consequence is that **adding any value to `SYNC_MODELS` is a breaking change for every tab still running older JavaScript**, and tabs here live for days. That is a trap for the next person rather than a theoretical one: the pull request work needs a `pull_request` model, and shipping it without this would have degraded live sessions with no signal at all.

## Where the tolerance lives

Only in the client, and `ServerMessage` keeps its strict shape.

The first attempt widened the shared delta type to a union of "an action" and "something with a sync id". That works, and it is wrong. It pushes the union onto every consumer, so ten existing tests across `@orbit/realtime` and `@orbit/realtime-server` stopped compiling because they read `modelId` off an action that might now be the opaque branch. That is a lot of noise everywhere to pay for a case only a browser running stale JavaScript can hit, and it makes the server's own types pretend to a doubt it does not have.

So the strict schema stays, and the client gets one more attempt when it fails:

```ts
const parsed = serverMessageSchema.safeParse(parsedJson);
if (!parsed.success) {
  const tolerated = tolerantDeltaMessageSchema.safeParse(parsedJson);
  if (tolerated.success) handleDelta(tolerated.data.actions);
  return;
}
```

A well formed message never takes that path, so the common case pays nothing.

## The watermark still advances

This is the part worth arguing about, because the obvious implementation gets it wrong. It would be natural to observe only the actions that survived. That leaves the cursor parked behind an action the client can never accept, so every reconnect asks for a window starting before it, and that window only grows. The stale tab would go from missing some updates to replaying an ever larger backlog forever.

So `observe` runs for every entry, including dropped ones. Only delivery is filtered.

## An empty batch reports nothing

If every action in a batch turns out to be unsupported, `onDelta` is not called at all rather than called with `[]`. A subscriber that treats any delta as evidence of activity should not be handed a batch carrying none.

## Blast radius

`serverMessageSchema` is parsed in one place in shipped code, `packages/realtime-client/src/index.ts:113`, plus `apps/realtime/src/test-helpers.ts`. The hub constructs messages and never parses them with this schema, so nothing on the server side loosens, and no existing consumer changes.

## Ordering

This has to reach production at least one deploy **before** anything adds a value to `SYNC_MODELS`. A tab that loaded before this ships is still fragile, and only a reload fixes that. Shipping it first is what shrinks the window to nothing.

## Tests

3 new, against the real client with a fake socket.

- a batch of understood, unknown, understood delivers the two understood ones
- the watermark advances past the dropped action
- a batch of nothing but unsupported actions reports no delta at all, and still advances

Verified against `main` rather than against a stash, because the first attempt at that proof was worthless: the fix was already committed, so stashing reverted only the redesign. Restoring the three files from `origin/main` takes the suite from 15 passing to 12 passing and 3 failing.

`bun run verify` green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds client-side tolerance for delta batches containing models unknown to an older browser while preserving the strict shared server-message type.
- Adds a tolerant delta schema whose entries retain their sync IDs when unsupported.
- Filters unsupported actions from delivery while still advancing the resume watermark.
- Adds client tests for mixed and entirely unsupported batches.
- The previously reported broad-fallback defect remains outstanding.

<h3>Confidence Score: 4/5</h3>

The PR does not appear safe to merge until the tolerant fallback is limited to genuinely unsupported models rather than masking every strict action-schema failure.

The syncId-only fallback still accepts actions rejected for unrelated schema violations, and the client advances its resume watermark before discarding them, making those updates silently unrecoverable.

**Files Needing Attention:** packages/shared/src/events/sync.ts and packages/realtime-client/src/index.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/realtime-client/src/index.ts | Adds tolerant parsing and separates watermark observation from action delivery, but consumes the overly broad unsupported classification from the shared schema. |
| packages/shared/src/events/sync.ts | Introduces the tolerant action union; its syncId-only branch still masks strict-schema failures unrelated to unknown models. |
| packages/shared/src/events/message.ts | Adds a separate tolerant delta schema without widening the existing ServerMessage contract. |
| packages/realtime-client/tests/index.test.ts | Covers mixed unknown-model batches, watermark advancement, and suppression of empty delivered batches, but not unrelated strict-schema failures. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Receive WebSocket message] --> B{Strict server message parse}
    B -->|Success| C[Handle typed message]
    B -->|Failure| D{Tolerant delta parse}
    D -->|Failure| E[Discard message]
    D -->|Success| F[Observe every syncId]
    F --> G[Filter unsupported entries]
    G --> H{Supported actions remain?}
    H -->|Yes| I[Invoke onDelta]
    H -->|No| J[Do not notify subscriber]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/noveum/orbit/commit/ad9d605a081d5452edbf0bc596a3b660928dbcab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51572583)</sub>

<!-- /greptile_comment -->