### PR TITLE
fix(issues): keep the issue link picker open

### DIFF
--- a/apps/web/src/features/issues/issue-picker.tsx
+++ b/apps/web/src/features/issues/issue-picker.tsx
@@ -22,6 +22,7 @@ export interface IssuePickerProps {
   readonly excludedIds: readonly string[];
   readonly placeholder?: string;
   readonly testId?: string;
+  readonly header?: ReactNode;
   readonly children: ReactNode;
 }
 
@@ -32,6 +33,7 @@ export function IssuePicker({
   excludedIds,
   placeholder = 'Search issues by title or identifier',
   testId = 'issue-picker',
+  header,
   children,
 }: IssuePickerProps) {
   const [term, setTerm] = useState('');
@@ -48,6 +50,7 @@ export function IssuePicker({
     >
       <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent className="flex w-72 flex-col gap-1 p-2" data-testid={testId}>
+        {header}
         <Input
           autoFocus
           value={term}

--- a/apps/web/src/features/issues/issue-relations.tsx
+++ b/apps/web/src/features/issues/issue-relations.tsx
@@ -7,13 +7,6 @@ import { Link2, X } from 'lucide-react';
 import Link from 'next/link';
 import { useCallback, useState } from 'react';
 import { Button } from '@/components/ui/button.tsx';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu.tsx';
 import { cn } from '@/lib/cn.ts';
 import { revealOnHover, rowHover } from '@/lib/interaction.ts';
 import type { Issue, IssueRelation } from '@/lib/query/schemas.ts';
@@ -45,7 +38,8 @@ export function IssueRelations({ issue }: IssueRelationsProps) {
   const relations = useIssueRelations(issue.id);
   const link = useSetRelation(issue.id);
   const unlink = useRemoveRelation(issue.id);
-  const [pickingType, setPickingType] = useState<IssueRelationType | null>(null);
+  const [picking, setPicking] = useState(false);
+  const [linkType, setLinkType] = useState<IssueRelationType>('blocks');
 
   const refetch = relations.refetch;
   useScopeSubscription([scopes.issue(issue.id)]);
@@ -67,45 +61,38 @@ export function IssueRelations({ issue }: IssueRelationsProps) {
       <div className="flex items-center gap-2">
         <h2 className="text-2xs text-faint uppercase tracking-wide">Links</h2>
         <div className="ml-auto">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button size="sm" variant="ghost" data-testid="add-relation">
-                <Link2 className="size-3.5" aria-hidden="true" />
-                Link issue
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuLabel>Link type</DropdownMenuLabel>
-              {ISSUE_RELATION_TYPES.map((type) => (
-                <DropdownMenuItem
-                  key={type}
-                  data-testid={`relation-type-${type}`}
-                  onSelect={() => setPickingType(type)}
-                >
-                  {RELATION_LABELS[type]}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <IssuePicker
+            open={picking}
+            onOpenChange={setPicking}
+            excludedIds={[issue.id, ...linkedIds]}
+            testId="relation-picker"
+            placeholder="Search for an issue to link"
+            onPick={(picked) => link.mutate({ relatedIssueId: picked.id, type: linkType })}
+            header={
+              <fieldset className="flex flex-wrap gap-1">
+                <legend className="sr-only">Link type</legend>
+                {ISSUE_RELATION_TYPES.map((type) => (
+                  <Button
+                    key={type}
+                    size="sm"
+                    variant={type === linkType ? 'primary' : 'ghost'}
+                    aria-pressed={type === linkType}
+                    data-testid={`relation-type-${type}`}
+                    onClick={() => setLinkType(type)}
+                  >
+                    {RELATION_LABELS[type]}
+                  </Button>
+                ))}
+              </fieldset>
+            }
+          >
+            <Button size="sm" variant="ghost" data-testid="add-relation">
+              <Link2 className="size-3.5" aria-hidden="true" />
+              Link issue
+            </Button>
+          </IssuePicker>
         </div>
       </div>
-
-      <IssuePicker
-        open={pickingType !== null}
-        onOpenChange={(open) => {
-          if (!open) setPickingType(null);
-        }}
-        excludedIds={[issue.id, ...linkedIds]}
-        testId="relation-picker"
-        placeholder="Search for an issue to link"
-        onPick={(picked) => {
-          if (pickingType === null) return;
-          link.mutate({ relatedIssueId: picked.id, type: pickingType });
-          setPickingType(null);
-        }}
-      >
-        <span className="sr-only" data-testid="relation-picker-anchor" />
-      </IssuePicker>
 
       {groups.map((group) => (
         <div key={group.type} className="flex flex-col gap-0.5">

--- a/apps/web/tests/features/issues/issue-relations.test.tsx
+++ b/apps/web/tests/features/issues/issue-relations.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { Issue, IssueRelation } from '@/lib/query/schemas.ts';
 import { render } from '@/test/render.tsx';
 
@@ -67,17 +68,22 @@ interface Call {
 
 const originalFetch = globalThis.fetch;
 const calls: Call[] = [];
+const bodies: unknown[] = [];
 let served: readonly IssueRelation[] = [];
+let searchable: readonly Issue[] = [];
 
 function stubFetch(): void {
   calls.length = 0;
+  bodies.length = 0;
   globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
     const url = String(input);
     const method = init?.method ?? 'GET';
     calls.push({ url, method });
+    if (typeof init?.body === 'string') bodies.push(JSON.parse(init.body));
     if (method === 'DELETE') served = [];
+    const payload = url.includes('/relations') ? { relations: served } : { issues: searchable };
     return Promise.resolve(
-      new Response(JSON.stringify({ relations: served }), {
+      new Response(JSON.stringify(payload), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       }),
@@ -131,6 +137,35 @@ describe('IssueRelations', () => {
     const removal = calls.find((call) => call.method === 'DELETE');
     expect(removal?.url).toContain('relatedIssueId=issue_2');
     expect(removal?.url).toContain('type=blocks');
+  });
+
+  it('holds the search open after a link type is chosen', async () => {
+    served = [];
+    stubFetch();
+    const user = userEvent.setup();
+
+    render(<IssueRelations issue={issue()} />);
+    await user.click(await screen.findByTestId('add-relation'));
+    await user.click(await screen.findByTestId('relation-type-blocked_by'));
+
+    expect(await screen.findByTestId('relation-picker-search')).toBeInTheDocument();
+  });
+
+  it('links the picked issue under the chosen type', async () => {
+    served = [];
+    searchable = [issue({ id: 'issue_2', identifier: 'ENG-2', title: 'Downstream work' })];
+    stubFetch();
+    const user = userEvent.setup();
+
+    render(<IssueRelations issue={issue()} />);
+    await user.click(await screen.findByTestId('add-relation'));
+    await user.click(await screen.findByTestId('relation-type-duplicate_of'));
+    await user.type(await screen.findByTestId('relation-picker-search'), 'downstream');
+    const options = await screen.findAllByTestId(/^relation-picker-option-/);
+    await user.click(options[0] as HTMLElement);
+
+    await waitFor(() => expect(calls.some((call) => call.method === 'POST')).toBe(true));
+    expect(bodies.at(-1)).toMatchObject({ type: 'duplicate_of' });
   });
 
   it('never renders a link the server did not send', async () => {


### PR DESCRIPTION
## What was broken

Opening the link type menu on an issue and choosing a type flashed the issue picker for a moment and then dropped it, so no link could ever be created from the UI. The API, the database writes, the realtime fan out and unlinking were all working. The defect was entirely in how the two menus were composed.

## Root cause

The picker was opened from inside a `DropdownMenuItem` `onSelect`. When the dropdown closes, Radix restores focus to its own trigger button, and that button sits outside the popover that had just opened. The popover's dismissable layer sees focus land outside itself and closes immediately. Opening and dismissal happened in the same tick, which is the flash.

A second defect sat behind it: the popover was anchored to a `sr-only` span, a zero size clipped element, so even if it had survived it had nowhere to position and would have rendered detached from the button.

The mechanism was confirmed rather than assumed. Preventing the dropdown's close auto focus turned the failing test green on its own, which isolates focus restoration as the cause.

## The fix

Rather than suppress the focus restore and leave two nested layers stacked, this collapses the interaction into the single popover pattern the codebase already uses in `sub-issues.tsx` and the parent picker in `issue-properties.tsx`: a real visible button as the popover trigger, one layer, no nesting.

"Link issue" now opens one popover holding the five link types, the search field and the results. Choose a type, search, click an issue. `IssuePicker` gained one optional additive `header` prop; the other two call sites are unchanged.

This also removes a step. The flow used to be menu, type, picker, search, pick.

## Behaviour preserved

All five relation types, the reciprocal write, grouping by type, unlinking, the realtime subscription and the exclusion of already linked issues are unchanged.

## Verification

Beyond the unit tests, this was exercised against the running app. Linking ENG-3 as "Blocked by" wrote both rows (`blocked_by ENG-10 to ENG-3` and the reciprocal `blocks ENG-3 to ENG-10`), unlinking removed both, and the popover positions correctly in light and dark themes.

`bun run verify` is green, including against `main` merged into this branch.

## Tests

Two tests that fail if this regresses:

- the search stays open after a link type is chosen, which is the exact flash
- picking an issue posts the chosen relation type

Note on the second one: it initially passed alone and failed in the full suite. The cause was not timing. `apps/web/tests/features/issues/writable-fields.test.tsx` calls `mock.module('@/lib/query/use-issue-search.ts', ...)`, which in Bun is process global and never restored, so every file running afterwards gets a stubbed search returning a fixed issue. The test now asserts the chosen type reaches the mutation rather than asserting on a specific identifier, which is the behaviour that matters and is immune to the stub. Containing that leak is worth a separate change, since it will keep producing failures that look like flakes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the nested relation-type dropdown and issue popover with a single, visibly anchored issue picker, preventing focus restoration from immediately dismissing the picker.
- Adds an optional header region to `IssuePicker`.
- Moves all relation-type controls into the picker header while preserving the selected type for mutation requests.
- Adds regression coverage for picker visibility and forwarding the selected relation type.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified in the changed interaction.

The picker remains open while selecting a relation type, closes through its existing selection handler after an issue is picked, and forwards the selected relation type to the mutation.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/issues/issue-picker.tsx | Adds an optional header rendered before the search input without changing existing call-site behavior. |
| apps/web/src/features/issues/issue-relations.tsx | Replaces nested menu and popover layers with one controlled picker anchored to the visible Link issue button. |
| apps/web/tests/features/issues/issue-relations.test.tsx | Adds regression tests confirming type selection keeps search available and the selected type reaches the relation mutation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/noveum/orbit/commit/5cdd019ad805eec5f46ec53fce3866d36a359c74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51605927)</sub>

<!-- /greptile_comment -->