### PR TITLE
fix(issues): line up the link type buttons

### DIFF
--- a/apps/web/src/features/issues/issue-relations.tsx
+++ b/apps/web/src/features/issues/issue-relations.tsx
@@ -21,6 +21,8 @@ export const RELATION_LABELS: Record<IssueRelationType, string> = {
   duplicated_by: 'Duplicated by',
 };
 
+const LAST_TYPE_FILLS_ITS_ROW = ISSUE_RELATION_TYPES.length % 2 === 1;
+
 export function groupRelations(
   relations: readonly IssueRelation[],
 ): { type: IssueRelationType; entries: readonly IssueRelation[] }[] {
@@ -69,9 +71,9 @@ export function IssueRelations({ issue }: IssueRelationsProps) {
             placeholder="Search for an issue to link"
             onPick={(picked) => link.mutate({ relatedIssueId: picked.id, type: linkType })}
             header={
-              <fieldset className="flex flex-wrap gap-1">
+              <fieldset className="grid grid-cols-2 gap-1">
                 <legend className="sr-only">Link type</legend>
-                {ISSUE_RELATION_TYPES.map((type) => (
+                {ISSUE_RELATION_TYPES.map((type, index) => (
                   <Button
                     key={type}
                     size="sm"
@@ -79,6 +81,11 @@ export function IssueRelations({ issue }: IssueRelationsProps) {
                     aria-pressed={type === linkType}
                     data-testid={`relation-type-${type}`}
                     onClick={() => setLinkType(type)}
+                    className={cn(
+                      LAST_TYPE_FILLS_ITS_ROW &&
+                        index === ISSUE_RELATION_TYPES.length - 1 &&
+                        'col-span-2',
+                    )}
                   >
                     {RELATION_LABELS[type]}
                   </Button>


### PR DESCRIPTION
## What was wrong

The five link type buttons sat in a `flex flex-wrap` container. With labels of five different widths they wrapped into a ragged three then two, with the second row ending short and the whole block reading as an accident rather than a layout.

## The fix

The container becomes `grid grid-cols-2`, so every button gets an identical column and the rows line up. With an odd number of types the last one spans the full row instead of leaving a hole beside it.

Both the column count and the span are derived from `ISSUE_RELATION_TYPES` rather than hardcoded, so adding a sixth relation type later fills the grid correctly with no change here.

Nothing else moves. Same buttons, same labels, same selected state, same test ids, same behaviour.

## Verification

Checked in the running app in both light and dark themes: even columns, no ragged edge, and "Duplicated by" fills its own row.

`bun run verify` green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the wrapping relation-type button layout with a two-column grid and makes the final button span both columns when the relation-type count is odd.

- Derives the odd-item layout behavior from `ISSUE_RELATION_TYPES.length`.
- Preserves the existing controls, selection behavior, and test identifiers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or repository-rule issues identified.

The conditional span follows the same two-column invariant as the grid, the current relation list and labels render within the available container, and the new class composition uses an existing valid utility.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/issues/issue-relations.tsx | Converts the relation selector to an evenly aligned grid with correct handling for an odd final item; no actionable issue was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(issues): line up the link type butto..."](https://github.com/noveum/orbit/commit/578ea2bb9ac85ccc8f840f2097a928d34f232b81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51617445)</sub>

<!-- /greptile_comment -->