### PR TITLE
Give people a handle they can be mentioned by

### DIFF
--- a/apps/web/src/lib/auth/handle.ts
+++ b/apps/web/src/lib/auth/handle.ts
@@ -1,0 +1,28 @@
+import { randomUUID } from 'node:crypto';
+import { slugify } from '@orbit/shared/utils';
+
+const NUMBERED_CANDIDATES = 20;
+
+export function handleBaseFor(email: string, name: string): string {
+  return slugify(name) || slugify(email.split('@')[0] ?? '') || 'member';
+}
+
+function candidatesFor(base: string): string[] {
+  const numbered = Array.from(
+    { length: NUMBERED_CANDIDATES - 1 },
+    (_unused, index) => `${base}-${index + 2}`,
+  );
+  return [base, ...numbered];
+}
+
+export async function uniqueHandleFor(
+  email: string,
+  name: string,
+  taken: (candidates: readonly string[]) => Promise<Set<string>>,
+): Promise<string> {
+  const base = handleBaseFor(email, name);
+  const candidates = candidatesFor(base);
+  const used = await taken(candidates);
+  const free = candidates.find((candidate) => !used.has(candidate));
+  return free ?? `${base}-${randomUUID().replaceAll('-', '').slice(0, 10)}`;
+}

--- a/apps/web/src/lib/auth/handle.ts
+++ b/apps/web/src/lib/auth/handle.ts
@@ -1,15 +1,15 @@
 import { randomUUID } from 'node:crypto';
 import { slugify } from '@orbit/shared/utils';
 
-const NUMBERED_CANDIDATES = 20;
+export const HANDLE_CANDIDATES = 20;
 
 export function handleBaseFor(email: string, name: string): string {
   return slugify(name) || slugify(email.split('@')[0] ?? '') || 'member';
 }
 
-function candidatesFor(base: string): string[] {
+export function candidatesFor(base: string): string[] {
   const numbered = Array.from(
-    { length: NUMBERED_CANDIDATES - 1 },
+    { length: HANDLE_CANDIDATES - 1 },
     (_unused, index) => `${base}-${index + 2}`,
   );
   return [base, ...numbered];

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { passkey } from '@better-auth/passkey';
 import {
   assertEmailDomainAllowed,
@@ -6,10 +5,9 @@ import {
   isExternalImageUrl,
   publishSessionRevoked,
 } from '@orbit/core';
-import { db, eq, schema } from '@orbit/db';
+import { db, eq, inArray, schema } from '@orbit/db';
 import { inviteEmail, magicLinkEmail, resetPasswordEmail, sendEmail } from '@orbit/services/email';
 import { DomainError } from '@orbit/shared/errors';
-import { slugify } from '@orbit/shared/utils';
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { APIError, createAuthMiddleware, getSessionFromCtx } from 'better-auth/api';
@@ -18,6 +16,7 @@ import { magicLink, mcp, organization } from 'better-auth/plugins';
 import { z } from 'zod';
 import { isDevLoginRequest } from '@/lib/api/dev-login.ts';
 import { mcpServerUrl, serverEnv } from '@/lib/env.ts';
+import { uniqueHandleFor } from './handle.ts';
 import { hashPassword, verifyPassword } from './password.ts';
 
 export const MCP_SCOPES = [
@@ -83,9 +82,16 @@ export const passwordAuthEnabled: boolean = serverEnv().ORBIT_PASSWORD_AUTH;
 const SIGN_IN_ATTEMPTS_PER_MINUTE = 5;
 const SIGN_UP_ATTEMPTS_PER_HOUR = 5;
 
-function handleFor(email: string, name: string): string {
-  const base = slugify(name) || slugify(email.split('@')[0] ?? '') || 'member';
-  return `${base}-${randomUUID().replaceAll('-', '').slice(0, 10)}`;
+async function takenHandles(candidates: readonly string[]): Promise<Set<string>> {
+  const rows = await db
+    .select({ handle: schema.user.handle })
+    .from(schema.user)
+    .where(inArray(schema.user.handle, [...candidates]));
+  return new Set(rows.map((row) => row.handle));
+}
+
+function handleFor(email: string, name: string): Promise<string> {
+  return uniqueHandleFor(email, name, takenHandles);
 }
 
 function emailAndPassword() {
@@ -178,11 +184,9 @@ export const auth = betterAuth({
   databaseHooks: {
     user: {
       create: {
-        before: (user) => {
+        before: async (user) => {
           assertSignUpAllowed(user.email);
-          return Promise.resolve({
-            data: { ...user, handle: handleFor(user.email, user.name) },
-          });
+          return { data: { ...user, handle: await handleFor(user.email, user.name) } };
         },
         after: async (user) => {
           const image = user.image ?? null;

--- a/apps/web/tests/lib/auth/handle.test.ts
+++ b/apps/web/tests/lib/auth/handle.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'bun:test';
+import { handleBaseFor, uniqueHandleFor } from '../../../src/lib/auth/handle.ts';
+
+function nothingTaken(): Promise<Set<string>> {
+  return Promise.resolve(new Set<string>());
+}
+
+function alreadyTaken(...handles: string[]): () => Promise<Set<string>> {
+  return () => Promise.resolve(new Set(handles));
+}
+
+describe('handleBaseFor', () => {
+  it('prefers the name', () => {
+    expect(handleBaseFor('hey@yodu.ai', 'Yodu AI')).toBe('yodu-ai');
+  });
+
+  it('falls back to the email local part when there is no name', () => {
+    expect(handleBaseFor('hey@yodu.ai', '')).toBe('hey');
+  });
+
+  it('falls back to member when neither slugifies', () => {
+    expect(handleBaseFor('!!!@example.com', '???')).toBe('member');
+  });
+});
+
+describe('uniqueHandleFor', () => {
+  it('gives a clean handle when nothing is taken', async () => {
+    expect(await uniqueHandleFor('hey@yodu.ai', 'Yodu AI', nothingTaken)).toBe('yodu-ai');
+  });
+
+  it('does not append a suffix to the first person with a name', async () => {
+    const handle = await uniqueHandleFor('ada@example.com', 'Ada Lovelace', nothingTaken);
+    expect(handle).toBe('ada-lovelace');
+    expect(handle).not.toMatch(/-[0-9a-f]{10}$/);
+  });
+
+  it('numbers the second person with the same name', async () => {
+    expect(
+      await uniqueHandleFor('ada2@example.com', 'Ada Lovelace', alreadyTaken('ada-lovelace')),
+    ).toBe('ada-lovelace-2');
+  });
+
+  it('keeps counting past the first collision', async () => {
+    const taken = alreadyTaken('ada-lovelace', 'ada-lovelace-2', 'ada-lovelace-3');
+    expect(await uniqueHandleFor('ada4@example.com', 'Ada Lovelace', taken)).toBe('ada-lovelace-4');
+  });
+
+  it('falls back to a random suffix when every numbered candidate is taken', async () => {
+    const crowded = Array.from({ length: 40 }, (_, index) =>
+      index === 0 ? 'ada-lovelace' : `ada-lovelace-${index + 1}`,
+    );
+    const handle = await uniqueHandleFor(
+      'ada@example.com',
+      'Ada Lovelace',
+      alreadyTaken(...crowded),
+    );
+    expect(handle).toMatch(/^ada-lovelace-[0-9a-f]{10}$/);
+  });
+
+  it('asks about every candidate in one call', async () => {
+    const calls: string[][] = [];
+    await uniqueHandleFor('ada@example.com', 'Ada Lovelace', (candidates) => {
+      calls.push([...candidates]);
+      return Promise.resolve(new Set<string>());
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[0]).toBe('ada-lovelace');
+    expect(calls[0]?.[1]).toBe('ada-lovelace-2');
+  });
+});

--- a/apps/web/tests/lib/auth/handle.test.ts
+++ b/apps/web/tests/lib/auth/handle.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'bun:test';
-import { handleBaseFor, uniqueHandleFor } from '../../../src/lib/auth/handle.ts';
+import {
+  candidatesFor,
+  HANDLE_CANDIDATES,
+  handleBaseFor,
+  uniqueHandleFor,
+} from '../../../src/lib/auth/handle.ts';
 
 function nothingTaken(): Promise<Set<string>> {
   return Promise.resolve(new Set<string>());
@@ -66,5 +71,26 @@ describe('uniqueHandleFor', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]?.[0]).toBe('ada-lovelace');
     expect(calls[0]?.[1]).toBe('ada-lovelace-2');
+  });
+});
+
+describe('candidate set', () => {
+  it('is HANDLE_CANDIDATES entries: the base plus numbered variants', () => {
+    const candidates = candidatesFor('ada-lovelace');
+    expect(candidates).toHaveLength(HANDLE_CANDIDATES);
+    expect(candidates[0]).toBe('ada-lovelace');
+    expect(candidates[1]).toBe('ada-lovelace-2');
+    expect(candidates.at(-1)).toBe(`ada-lovelace-${HANDLE_CANDIDATES}`);
+  });
+
+  it('falls back to a random suffix only once every candidate is taken', async () => {
+    const candidates = candidatesFor('ada-lovelace');
+    const handle = await uniqueHandleFor(
+      'ada@example.com',
+      'Ada Lovelace',
+      async () => new Set(candidates),
+    );
+    expect(candidates).not.toContain(handle);
+    expect(handle).toMatch(/^ada-lovelace-[0-9a-f]{10}$/);
   });
 });


### PR DESCRIPTION
Reopens the fix from #267, which was closed on the understanding that `handleFor` used a user ID rather than a random string. It doesn't. There are two functions with that name, and the one that runs at sign-up still appends ten random characters unconditionally on `main` today:

```ts
// apps/web/src/lib/auth/server.ts
function handleFor(email: string, name: string): string {
  const base = slugify(name) || slugify(email.split('@')[0] ?? '') || 'member';
  return `${base}-${randomUUID().replaceAll('-', '').slice(0, 10)}`;
}
```

The other one, `packages/db/src/import/plane-mapping.ts`, takes a `taken` set and already does clean base-plus-numbering. That is the good one, and it is almost certainly the one that was looked at. It only runs on import, which is why imported accounts have usable handles and everyone who signed up does not.

Handles are how mentions resolve, so in practice nobody who signed up could be @-mentioned. An account invited as `hey@yodu.ai` came out as `hey-3402a5fa15`, which no colleague is going to type.

## What changes

The base handle stands on its own. A real collision takes `ada-lovelace-2`, then `-3`, and the random suffix survives only as a last resort once twenty numbered candidates are gone. All candidates are checked in one query.

Generation moves to `apps/web/src/lib/auth/handle.ts` so it can be tested without standing up auth: the caller passes in the "which of these are taken" lookup, and the sign-up hook supplies the database one.

Existing accounts are not touched. Anyone already carrying a random suffix can change it in profile settings, which already validates uniqueness.

## The race, and why it is not fixed here

The previous review flagged that the availability query and the insert are separate operations, so two simultaneous sign-ups sharing a base can both select the same free handle and one insert then fails on the unique constraint. That is correct, and it is inherent to a Better Auth `user.create.before` hook: the hook returns the row it wants inserted, so there is no insert error to catch and retry from.

I have deliberately not restructured the hook to fix it, because the trade is lopsided. Today **every** sign-up gets an unusable handle, with certainty. After this, a sign-up can fail only when two people with the same slugified name submit within the same instant, and that failure is retryable. Trading a universal defect for a rare retryable one is worth doing on its own; fixing the race properly means assigning the handle after insert and living with a window where it is wrong, which is a bigger change than this bug warrants.

Worth its own issue if it ever actually bites.

## Testing

Nine cases in `apps/web/tests/lib/auth/handle.test.ts` covering the name and email bases, the `member` fallback, first-come clean handles, numbering on collision, and the random-suffix last resort.

Verified by mutation rather than asserted: restoring the unconditional suffix fails **4 of the 9**, with the file hash checked before and after to prove the mutation actually applied and was reverted.

`bun run typecheck` passes. `bun run lint` is clean. The two failures in `tests/lib/auth/sign-out.test.ts` are realtime socket tests that need a live database and fail identically on `main`, so they are not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces unconditional random handle suffixes with a batched availability lookup that prefers clean handles and then numbered alternatives. The previously reported minimum-length mismatch remains in the current implementation.
- Extracts handle generation into a separately testable module.
- Queries all clean and numbered candidates in one database operation.
- Adds tests for base selection, collisions, numbering, and random fallback.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until generated handles satisfy the mention parser’s minimum length.

A signup whose name or email local part slugifies to one character still persists that value as the handle, while mention extraction only recognizes handles containing at least two characters.

**Files Needing Attention:** apps/web/src/lib/auth/handle.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/auth/handle.ts | Introduces clean and numbered handle generation, but still permits one-character handles that cannot be resolved by mention extraction. |
| apps/web/src/lib/auth/server.ts | Connects asynchronous uniqueness lookup to the user creation hook and persists the selected handle directly. |
| apps/web/tests/lib/auth/handle.test.ts | Covers generation and collision behavior but does not cover the outstanding one-character handle case. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(auth): name the handle-candidate con..."](https://github.com/noveum/orbit/commit/62d5ca9172590c4ae579b3586eb1692aa4b967bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51625841)</sub>

<!-- /greptile_comment -->