### PR TITLE
test(web): stop module stubs outliving the file that installed them

### DIFF
--- a/apps/web/tests-support.ts
+++ b/apps/web/tests-support.ts
@@ -29,3 +29,13 @@ export function mockMembership(read: () => MembershipContext | null): void {
     mock.module(PRINCIPAL_MODULE, () => realPrincipal);
   });
 }
+
+export async function restoreModulesAfterThisFile(specifiers: readonly string[]): Promise<void> {
+  const originals = new Map<string, Record<string, unknown>>();
+  for (const specifier of specifiers) {
+    originals.set(specifier, { ...(await import(specifier)) });
+  }
+  afterAll(() => {
+    for (const [specifier, real] of originals) mock.module(specifier, () => real);
+  });
+}

--- a/apps/web/tests/components/command-palette-issues.test.tsx
+++ b/apps/web/tests/components/command-palette-issues.test.tsx
@@ -5,6 +5,9 @@ import { HotkeyProvider } from '@/lib/keyboard/index.ts';
 import { buildNavigation } from '@/lib/navigation.ts';
 import type { Issue } from '@/lib/query/schemas.ts';
 import { fireEvent, render, screen } from '@/test/render.tsx';
+import { restoreModulesAfterThisFile } from '../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/lib/query/use-issue-search.ts']);
 
 const push = mock();
 

--- a/apps/web/tests/features/issues/issue-link.test.tsx
+++ b/apps/web/tests/features/issues/issue-link.test.tsx
@@ -5,8 +5,14 @@ import type { Issue, WorkflowState } from '@/lib/query/schemas.ts';
 import { render, screen, within } from '@/test/render.tsx';
 import type { WorkspaceData } from '../../../src/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '../../../src/features/issues/workspace-provider.tsx';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
 
 const realLink = await import('next/link');
+
+await restoreModulesAfterThisFile([
+  '@/features/issues/workspace-provider.tsx',
+  '@/lib/query/use-issue-search.ts',
+]);
 
 interface LinkStubProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   readonly href: string;

--- a/apps/web/tests/features/issues/issue-relations.test.tsx
+++ b/apps/web/tests/features/issues/issue-relations.test.tsx
@@ -161,11 +161,10 @@ describe('IssueRelations', () => {
     await user.click(await screen.findByTestId('add-relation'));
     await user.click(await screen.findByTestId('relation-type-duplicate_of'));
     await user.type(await screen.findByTestId('relation-picker-search'), 'downstream');
-    const options = await screen.findAllByTestId(/^relation-picker-option-/);
-    await user.click(options[0] as HTMLElement);
+    await user.click(await screen.findByTestId('relation-picker-option-ENG-2'));
 
     await waitFor(() => expect(calls.some((call) => call.method === 'POST')).toBe(true));
-    expect(bodies.at(-1)).toMatchObject({ type: 'duplicate_of' });
+    expect(bodies.at(-1)).toEqual({ relatedIssueId: 'issue_2', type: 'duplicate_of' });
   });
 
   it('never renders a link the server did not send', async () => {

--- a/apps/web/tests/features/issues/writable-fields.test.tsx
+++ b/apps/web/tests/features/issues/writable-fields.test.tsx
@@ -4,6 +4,13 @@ import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
 import { HotkeyProvider } from '@/lib/keyboard/index.ts';
 import type { Issue } from '@/lib/query/schemas.ts';
 import { render } from '@/test/render.tsx';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile([
+  '@/features/issues/workspace-provider.tsx',
+  '@/lib/query/use-issue-search.ts',
+  '@/lib/query/use-issues.ts',
+]);
 
 mock.module('next/navigation', () => ({
   useRouter: () => ({ push: mock(), replace: mock(), refresh: mock() }),

--- a/apps/web/tests/lib/auth/mock-isolation.test.ts
+++ b/apps/web/tests/lib/auth/mock-isolation.test.ts
@@ -29,9 +29,25 @@ async function everythingThatCanInstallAMock(): Promise<Candidate[]> {
   ];
 }
 
+function asPattern(specifier: string): string {
+  return specifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function stubs(source: string, specifier: string): boolean {
+  return new RegExp(`mock\\.module\\(\\s*['"\`]${asPattern(specifier)}['"\`]`).test(source);
+}
+
+function specifiersHandedToTheHelper(source: string): Set<string> {
+  return new Set(
+    [...source.matchAll(/restoreModulesAfterThisFile\(\s*\[([^\]]*)\]/g)].flatMap((call) =>
+      [...(call[1] ?? '').matchAll(/['"`]([^'"`]+)['"`]/g)].map((entry) => entry[1] ?? ''),
+    ),
+  );
+}
+
 async function directMocksIn(candidate: Candidate): Promise<string[]> {
   const source = await readFile(candidate.path, 'utf8');
-  return GUARDED.filter((specifier) => source.includes(`mock.module('${specifier}'`));
+  return GUARDED.filter((specifier) => stubs(source, specifier));
 }
 
 describe('module mock isolation', () => {
@@ -60,14 +76,10 @@ describe('module mock isolation', () => {
 
     for (const candidate of candidates) {
       const source = await readFile(candidate.path, 'utf8');
-      const restored = new Set(
-        [...source.matchAll(/restoreModulesAfterThisFile\(\[([^\]]*)\]/g)].flatMap((call) =>
-          [...(call[1] ?? '').matchAll(/'([^']+)'/g)].map((entry) => entry[1] ?? ''),
-        ),
-      );
+      const restored = specifiersHandedToTheHelper(source);
 
       for (const specifier of MUST_BE_RESTORED) {
-        if (!source.includes(`mock.module('${specifier}'`)) continue;
+        if (!stubs(source, specifier)) continue;
         if (restored.has(specifier)) continue;
         offenders.push(
           `${candidate.label} stubs ${specifier} without restoring it, so the stub outlives the file and every later test file sees it. Pass the specifier to restoreModulesAfterThisFile from tests-support.ts.`,

--- a/apps/web/tests/lib/auth/mock-isolation.test.ts
+++ b/apps/web/tests/lib/auth/mock-isolation.test.ts
@@ -37,12 +37,38 @@ function stubs(source: string, specifier: string): boolean {
   return new RegExp(`mock\\.module\\(\\s*['"\`]${asPattern(specifier)}['"\`]`).test(source);
 }
 
+function stringConstantsIn(source: string): Map<string, string> {
+  return new Map(
+    [...source.matchAll(/(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*['"`]([^'"`]+)['"`]/g)].map(
+      (declaration) => [declaration[1] ?? '', declaration[2] ?? ''],
+    ),
+  );
+}
+
+function timesStubbed(source: string, specifier: string): number {
+  const constants = stringConstantsIn(source);
+  let seen = 0;
+  for (const call of source.matchAll(
+    /mock\.module\(\s*(?:['"`]([^'"`]+)['"`]|([A-Za-z_$][\w$]*))/g,
+  )) {
+    const named = call[2];
+    const reached = call[1] ?? (named === undefined ? undefined : constants.get(named));
+    if (reached === specifier) seen += 1;
+  }
+  return seen;
+}
+
 function specifiersHandedToTheHelper(source: string): Set<string> {
   return new Set(
     [...source.matchAll(/restoreModulesAfterThisFile\(\s*\[([^\]]*)\]/g)].flatMap((call) =>
       [...(call[1] ?? '').matchAll(/['"`]([^'"`]+)['"`]/g)].map((entry) => entry[1] ?? ''),
     ),
   );
+}
+
+function putsItBack(source: string, specifier: string): boolean {
+  if (specifiersHandedToTheHelper(source).has(specifier)) return true;
+  return timesStubbed(source, specifier) >= 2 && /afterAll\s*\(/.test(source);
 }
 
 async function directMocksIn(candidate: Candidate): Promise<string[]> {
@@ -76,11 +102,10 @@ describe('module mock isolation', () => {
 
     for (const candidate of candidates) {
       const source = await readFile(candidate.path, 'utf8');
-      const restored = specifiersHandedToTheHelper(source);
 
       for (const specifier of MUST_BE_RESTORED) {
-        if (!stubs(source, specifier)) continue;
-        if (restored.has(specifier)) continue;
+        if (timesStubbed(source, specifier) === 0) continue;
+        if (putsItBack(source, specifier)) continue;
         offenders.push(
           `${candidate.label} stubs ${specifier} without restoring it, so the stub outlives the file and every later test file sees it. Pass the specifier to restoreModulesAfterThisFile from tests-support.ts.`,
         );

--- a/apps/web/tests/lib/auth/mock-isolation.test.ts
+++ b/apps/web/tests/lib/auth/mock-isolation.test.ts
@@ -9,6 +9,8 @@ const PACKAGE_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
 
 const GUARDED = [SESSION_MODULE, PRINCIPAL_MODULE] as const;
 
+const MUST_BE_RESTORED = ['@/lib/query/use-issue-search.ts'] as const;
+
 interface Candidate {
   readonly label: string;
   readonly path: string;
@@ -45,6 +47,30 @@ describe('module mock isolation', () => {
       for (const specifier of await directMocksIn(candidate)) {
         offenders.push(
           `${candidate.label} mocks ${specifier} directly, so the mock outlives the file and every later test file sees it. Call mockSession or mockMembership from tests-support.ts instead.`,
+        );
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('restores every shared query module the file stubbed', async () => {
+    const candidates = await everythingThatCanInstallAMock();
+    const offenders: string[] = [];
+
+    for (const candidate of candidates) {
+      const source = await readFile(candidate.path, 'utf8');
+      const restored = new Set(
+        [...source.matchAll(/restoreModulesAfterThisFile\(\[([^\]]*)\]/g)].flatMap((call) =>
+          [...(call[1] ?? '').matchAll(/'([^']+)'/g)].map((entry) => entry[1] ?? ''),
+        ),
+      );
+
+      for (const specifier of MUST_BE_RESTORED) {
+        if (!source.includes(`mock.module('${specifier}'`)) continue;
+        if (restored.has(specifier)) continue;
+        offenders.push(
+          `${candidate.label} stubs ${specifier} without restoring it, so the stub outlives the file and every later test file sees it. Pass the specifier to restoreModulesAfterThisFile from tests-support.ts.`,
         );
       }
     }


### PR DESCRIPTION
## What was wrong

Bun's `mock.module` is process global and is never undone. A test file that stubbed a shared module left that stub installed for every file that ran after it, so a later test asking for the real module silently got someone else's fixture.

Three files stubbed `@/lib/query/use-issue-search.ts` and none of them restored it. Any later test that exercised the real search got a fixed issue back regardless of what it searched for. Because the outcome depended on which file ran first, it presented as a flake rather than as a broken test: the issue relations test passed on its own and failed in the full suite, and the obvious readings, a timing problem or too tight a `findBy` timeout, were both wrong. Raising the timeout to ten seconds changed nothing.

## The wider surface

Every file that stubs these shared modules leaks. None restore:

| Module | Files stubbing it | Unrestored |
| --- | --- | --- |
| `@/lib/query/use-issue-search.ts` | 3 | 3 |
| `@/features/issues/workspace-provider.tsx` | 14 | 14 |
| `@/lib/query/use-issues.ts` | 6 | 6 |
| `@/lib/query/use-docs.ts` | 4 | 4 |

This change closes the three with demonstrated breakage and leaves the other twenty four, because restoring a real module can surface tests that currently pass only because of the leak, and that deserves its own review rather than being buried here. The helper and the guard are in place, so the rest is mechanical.

## The fix

`restoreModulesAfterThisFile` in `tests-support.ts`, shaped like the `mockSession` and `mockMembership` helpers already there: it captures the real exports, then restores them in an `afterAll`. Both halves of this pattern already existed in the repository, an isolation guard for the auth modules and a hand rolled restore in `issue-detail-delete.test.tsx`. This generalises them rather than inventing anything.

## The guard

A test that walks the test tree and fails when a file stubs a guarded shared module without passing it to the helper.

It parses the arguments of the `restoreModulesAfterThisFile` call rather than searching for the identifier. The first version searched for the identifier, and it was worthless: deleting a restore call while leaving its now unused import behind still passed. That was caught by deliberately reintroducing the leak to watch the guard fail, which is the only way to know a guard works.

## Verification

- Removing the restore and running the exact file pair that used to break reproduces the original failure. Putting it back turns it green.
- Deleting a restore call makes the guard fail with a message naming the file and the module.
- `bun run verify` green: 0 failures across all nine packages, web at 1780 passing.

With isolation restored, the relations test goes back to asserting it links `ENG-2` with `type: duplicate_of`, instead of accepting whichever issue the search returned. That assertion had been weakened to work around this leak.

## Unrelated note

`@orbit/db`'s `applyCatchup against a real database` failed twice during this work with a thirty second hook timeout that reads like a product failure. It is stale test lane state, not code: a fresh lane passes, and `ORBIT_TEST_LANE=<lane> bun run db:test-lanes-drop` followed by a rerun clears it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents selected process-global Bun module mocks from leaking into later test files and adds a source-scanning isolation guard.
- Adds a helper that snapshots module exports and restores them after the test file.
- Applies restoration to the three test files associated with the demonstrated query-search leak.
- Strengthens the issue-relations assertion to verify the selected issue and relation type.
- Extends mock-isolation coverage to guarded shared query modules and common literal/constant syntax.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/tests-support.ts | Adds a reusable helper that captures module exports before stubbing and restores them in afterAll. |
| apps/web/tests/lib/auth/mock-isolation.test.ts | Adds static enforcement for restoration of guarded shared query mocks and recognizes supported quote and local-constant forms. |
| apps/web/tests/components/command-palette-issues.test.tsx | Registers the issue-search module for restoration after the test file completes. |
| apps/web/tests/features/issues/issue-link.test.tsx | Restores the shared workspace and issue-search modules after the test file. |
| apps/web/tests/features/issues/writable-fields.test.tsx | Restores all shared issue-related modules stubbed by the test file. |
| apps/web/tests/features/issues/issue-relations.test.tsx | Tightens relation creation assertions to select ENG-2 explicitly and verify the complete request body. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(web): see through a specifier held ..."](https://github.com/noveum/orbit/commit/092edfd7627aa356e72f75ef477c5600ca1e7cb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51629125)</sub>

<!-- /greptile_comment -->