### PR TITLE
Let an assistant read the files on an issue, not just post them

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -123,7 +123,7 @@ them.
 | `list_labels` | read | Labels |
 | `list_members` | read | Members with their roles |
 | `invite_member` | write | Invite someone |
-| `list_notifications` | read | Your inbox: mentions, assignments, replies and state changes |
+| `list_notifications` | read | Your inbox: mentions, assignments, replies and state changes. Each row resolves its issue, or its doc for a doc mention |
 | `mark_notification_read` | write | Mark your own notifications read |
 
 ### Issues
@@ -143,6 +143,7 @@ them.
 | `archive_issue`, `unarchive_issue`, `delete_issue` | write | |
 | `edit_comment`, `delete_comment` | write | |
 | `list_issue_attachments` | read | Every file attached to an issue or to a comment on it |
+| `list_attachments` | read | Files on one issue, comment, doc or project |
 | `read_attachment` | read | The contents of an attached file |
 | `attach_file` | write | Upload a file and attach it to an issue, a comment, a doc or a project |
 
@@ -152,12 +153,16 @@ An assistant can both send and read files. `attach_file` uploads up to 4MB inlin
 base64 and returns a url and ready made markdown, so a generated report or a chart can
 be posted straight onto the issue it belongs to. `list_issue_attachments` shows what is
 attached to an issue and to every comment on it, and `get_issue` reports the same list,
-so an assistant can tell a file is there without being told. `read_attachment` returns
-the contents: text-like types come back as text, anything else base64, and a large file
-is truncated with `truncated: true` rather than silently cut.
+so an assistant can tell a file is there without being told. `list_attachments` does the
+same for one doc or project. `read_attachment` returns the contents: text-like types come
+back as text, anything else base64, and a large file is truncated with `truncated: true`
+rather than silently cut.
 
-Reads are governed by the issue, not by the file. If you cannot read the issue a file
-hangs off, you cannot list it or read it.
+Reading and writing cover the same four parents, so a file an assistant can post is a
+file it can open again. Reads are governed by the thing the file hangs off, through that
+type's own check: an issue file by the issue, a comment file by its issue, a doc file by
+the doc, a project file by the project. If you cannot read the parent, you cannot list or
+read its files.
 
 ### Projects and milestones
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -142,6 +142,22 @@ them.
 | `set_relation` | write | Blocks, blocked by, relates to, duplicates |
 | `archive_issue`, `unarchive_issue`, `delete_issue` | write | |
 | `edit_comment`, `delete_comment` | write | |
+| `list_issue_attachments` | read | Every file attached to an issue or to a comment on it |
+| `read_attachment` | read | The contents of an attached file |
+| `attach_file` | write | Upload a file and attach it to an issue, a comment, a doc or a project |
+
+### Files
+
+An assistant can both send and read files. `attach_file` uploads up to 4MB inline as
+base64 and returns a url and ready made markdown, so a generated report or a chart can
+be posted straight onto the issue it belongs to. `list_issue_attachments` shows what is
+attached to an issue and to every comment on it, and `get_issue` reports the same list,
+so an assistant can tell a file is there without being told. `read_attachment` returns
+the contents: text-like types come back as text, anything else base64, and a large file
+is truncated with `truncated: true` rather than silently cut.
+
+Reads are governed by the issue, not by the file. If you cannot read the issue a file
+hangs off, you cannot list it or read it.
 
 ### Projects and milestones
 

--- a/packages/core/src/content/attachment-service.ts
+++ b/packages/core/src/content/attachment-service.ts
@@ -19,6 +19,8 @@ import { type Executor, newId, requireRow } from '../internal.ts';
 import { lockOrganization } from '../org/organization-lock.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
+import { getProject } from '../work/project-service.ts';
+import { loadReadableDoc } from './doc-service.ts';
 
 export type AttachmentRecord = typeof schema.attachment.$inferSelect;
 
@@ -292,6 +294,20 @@ async function requireReadableIssue(principal: Principal, issueId: string) {
   return found;
 }
 
+function toIssueAttachment(row: AttachmentRecord): IssueAttachment {
+  return {
+    id: row.id,
+    fileName: row.fileName,
+    contentType: row.contentType,
+    size: row.size,
+    parentType: row.parentType,
+    parentId: row.parentId,
+    uploadedById: row.uploadedById,
+    createdAt: row.createdAt,
+    url: fileUrlFor(row.storageKey),
+  };
+}
+
 export async function listIssueAttachments(
   principal: Principal,
   issueId: string,
@@ -315,17 +331,7 @@ export async function listIssueAttachments(
     .orderBy(asc(schema.attachment.createdAt));
   return rows
     .filter((row) => row.parentType === 'issue' || row.parentType === 'comment')
-    .map((row) => ({
-      id: row.id,
-      fileName: row.fileName,
-      contentType: row.contentType,
-      size: row.size,
-      parentType: row.parentType,
-      parentId: row.parentId,
-      uploadedById: row.uploadedById,
-      createdAt: row.createdAt,
-      url: fileUrlFor(row.storageKey),
-    }));
+    .map(toIssueAttachment);
 }
 
 export interface AttachmentContent {
@@ -342,13 +348,29 @@ export function isTextualContentType(contentType: string): boolean {
   return TEXT_CONTENT_TYPES.test(contentType.toLowerCase());
 }
 
-async function issueIdForAttachment(
+async function assertAttachmentReadable(
   principal: Principal,
   record: AttachmentRecord,
-): Promise<string | null> {
-  if (record.parentType === 'issue') return record.parentId;
-  if (record.parentType === 'comment') return await commentIssueId(principal, record.parentId);
-  return null;
+): Promise<void> {
+  if (record.parentType === 'issue') {
+    await requireReadableIssue(principal, record.parentId);
+    return;
+  }
+  if (record.parentType === 'comment') {
+    const issueId = await commentIssueId(principal, record.parentId);
+    if (issueId === null) throw notFound('That comment does not exist.');
+    await requireReadableIssue(principal, issueId);
+    return;
+  }
+  if (record.parentType === 'doc') {
+    await loadReadableDoc(db, principal, record.parentId);
+    return;
+  }
+  if (record.parentType === 'project') {
+    await getProject(principal, record.parentId);
+    return;
+  }
+  throw notFound('That file does not exist.');
 }
 
 export async function readAttachment(
@@ -358,11 +380,7 @@ export async function readAttachment(
   driver?: StorageDriver,
 ): Promise<AttachmentContent> {
   const record = await findAttachmentForOrganization(principal, attachmentId);
-  const issueId = await issueIdForAttachment(principal, record);
-  if (issueId === null) {
-    throw validationFailed('Only files attached to an issue or a comment can be read.');
-  }
-  await requireReadableIssue(principal, issueId);
+  await assertAttachmentReadable(principal, record);
 
   const store = driver ?? storageDriver();
   const bytes = await store.get(record.storageKey);
@@ -372,17 +390,7 @@ export async function readAttachment(
   const slice = truncated ? bytes.slice(0, maxBytes) : bytes;
   const textual = isTextualContentType(record.contentType);
   return {
-    attachment: {
-      id: record.id,
-      fileName: record.fileName,
-      contentType: record.contentType,
-      size: record.size,
-      parentType: record.parentType,
-      parentId: record.parentId,
-      uploadedById: record.uploadedById,
-      createdAt: record.createdAt,
-      url: fileUrlFor(record.storageKey),
-    },
+    attachment: toIssueAttachment(record),
     encoding: textual ? 'utf8' : 'base64',
     content: textual ? Buffer.from(slice).toString('utf8') : Buffer.from(slice).toString('base64'),
     truncated,
@@ -401,4 +409,29 @@ async function commentIssueId(principal: Principal, commentId: string): Promise<
     )
     .limit(1);
   return comment?.issueId ?? null;
+}
+
+export async function listAttachmentsFor(
+  principal: Principal,
+  parentType: 'issue' | 'comment' | 'doc' | 'project',
+  parentId: string,
+): Promise<IssueAttachment[]> {
+  await assertAttachmentReadable(principal, {
+    parentType,
+    parentId,
+    uploadedById: principal.userId,
+  } as AttachmentRecord);
+  const rows = await db
+    .select()
+    .from(schema.attachment)
+    .where(
+      and(
+        eq(schema.attachment.organizationId, principal.organizationId),
+        eq(schema.attachment.status, 'ready'),
+        eq(schema.attachment.parentType, parentType),
+        eq(schema.attachment.parentId, parentId),
+      ),
+    )
+    .orderBy(asc(schema.attachment.createdAt));
+  return rows.map(toIssueAttachment);
 }

--- a/packages/core/src/content/attachment-service.ts
+++ b/packages/core/src/content/attachment-service.ts
@@ -1,4 +1,4 @@
-import { and, db, eq, schema, type Transaction } from '@orbit/db';
+import { and, asc, db, eq, inArray, isNull, schema, type Transaction } from '@orbit/db';
 import {
   assertUploadParent,
   fileUrlFor,
@@ -12,6 +12,7 @@ import { conflict, notFound, validationFailed } from '@orbit/shared/errors';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
+import { assertCan, assertInTeam, teamScope } from '@orbit/shared/policy';
 import { inlineUploadSchema, uploadRequestSchema } from '@orbit/shared/validators';
 import { principalActor } from '../activity/activity-service.ts';
 import { type Executor, newId, requireRow } from '../internal.ts';
@@ -258,4 +259,146 @@ export async function attachFile(
     if (objectStored && store !== null) await store.delete(key).catch(() => undefined);
     throw error;
   }
+}
+
+export interface IssueAttachment {
+  readonly id: string;
+  readonly fileName: string;
+  readonly contentType: string;
+  readonly size: number;
+  readonly parentType: string;
+  readonly parentId: string;
+  readonly uploadedById: string;
+  readonly createdAt: Date;
+  readonly url: string;
+}
+
+async function requireReadableIssue(principal: Principal, issueId: string) {
+  assertCan(principal, 'issue:read');
+  const [issue] = await db
+    .select({
+      id: schema.issue.id,
+      teamId: schema.issue.teamId,
+      projectId: schema.issue.projectId,
+      organizationId: schema.issue.organizationId,
+    })
+    .from(schema.issue)
+    .where(
+      and(eq(schema.issue.id, issueId), eq(schema.issue.organizationId, principal.organizationId)),
+    )
+    .limit(1);
+  const found = requireRow(issue, 'That issue does not exist.');
+  assertInTeam(principal, teamScope(found));
+  return found;
+}
+
+export async function listIssueAttachments(
+  principal: Principal,
+  issueId: string,
+): Promise<IssueAttachment[]> {
+  await requireReadableIssue(principal, issueId);
+  const commentIds = await db
+    .select({ id: schema.comment.id })
+    .from(schema.comment)
+    .where(and(eq(schema.comment.issueId, issueId), isNull(schema.comment.deletedAt)));
+  const parents = [issueId, ...commentIds.map((row) => row.id)];
+  const rows = await db
+    .select()
+    .from(schema.attachment)
+    .where(
+      and(
+        eq(schema.attachment.organizationId, principal.organizationId),
+        eq(schema.attachment.status, 'ready'),
+        inArray(schema.attachment.parentId, parents),
+      ),
+    )
+    .orderBy(asc(schema.attachment.createdAt));
+  return rows
+    .filter((row) => row.parentType === 'issue' || row.parentType === 'comment')
+    .map((row) => ({
+      id: row.id,
+      fileName: row.fileName,
+      contentType: row.contentType,
+      size: row.size,
+      parentType: row.parentType,
+      parentId: row.parentId,
+      uploadedById: row.uploadedById,
+      createdAt: row.createdAt,
+      url: fileUrlFor(row.storageKey),
+    }));
+}
+
+export interface AttachmentContent {
+  readonly attachment: IssueAttachment;
+  readonly encoding: 'utf8' | 'base64';
+  readonly content: string;
+  readonly truncated: boolean;
+}
+
+const TEXT_CONTENT_TYPES =
+  /^(text\/|application\/(json|xml|yaml|x-yaml|javascript|typescript|sql))/;
+
+export function isTextualContentType(contentType: string): boolean {
+  return TEXT_CONTENT_TYPES.test(contentType.toLowerCase());
+}
+
+async function issueIdForAttachment(
+  principal: Principal,
+  record: AttachmentRecord,
+): Promise<string | null> {
+  if (record.parentType === 'issue') return record.parentId;
+  if (record.parentType === 'comment') return await commentIssueId(principal, record.parentId);
+  return null;
+}
+
+export async function readAttachment(
+  principal: Principal,
+  attachmentId: string,
+  maxBytes: number,
+  driver?: StorageDriver,
+): Promise<AttachmentContent> {
+  const record = await findAttachmentForOrganization(principal, attachmentId);
+  const issueId = await issueIdForAttachment(principal, record);
+  if (issueId === null) {
+    throw validationFailed('Only files attached to an issue or a comment can be read.');
+  }
+  await requireReadableIssue(principal, issueId);
+
+  const store = driver ?? storageDriver();
+  const bytes = await store.get(record.storageKey);
+  if (bytes === null) throw notFound('That file is no longer in storage.');
+
+  const truncated = bytes.byteLength > maxBytes;
+  const slice = truncated ? bytes.slice(0, maxBytes) : bytes;
+  const textual = isTextualContentType(record.contentType);
+  return {
+    attachment: {
+      id: record.id,
+      fileName: record.fileName,
+      contentType: record.contentType,
+      size: record.size,
+      parentType: record.parentType,
+      parentId: record.parentId,
+      uploadedById: record.uploadedById,
+      createdAt: record.createdAt,
+      url: fileUrlFor(record.storageKey),
+    },
+    encoding: textual ? 'utf8' : 'base64',
+    content: textual ? Buffer.from(slice).toString('utf8') : Buffer.from(slice).toString('base64'),
+    truncated,
+  };
+}
+
+async function commentIssueId(principal: Principal, commentId: string): Promise<string | null> {
+  const [comment] = await db
+    .select({ issueId: schema.comment.issueId })
+    .from(schema.comment)
+    .where(
+      and(
+        eq(schema.comment.id, commentId),
+        eq(schema.comment.organizationId, principal.organizationId),
+      ),
+    )
+    .limit(1);
+  return comment?.issueId ?? null;
 }

--- a/packages/core/src/content/attachment-service.ts
+++ b/packages/core/src/content/attachment-service.ts
@@ -373,6 +373,31 @@ async function assertAttachmentReadable(
   throw notFound('That file does not exist.');
 }
 
+function decodeWholeCharacters(bytes: Uint8Array): string {
+  return new TextDecoder('utf-8', { fatal: false, ignoreBOM: false })
+    .decode(bytes.subarray(0, wholeCharacterLength(bytes)))
+    .replace(/\uFFFD+$/, '');
+}
+
+function utf8SequenceLength(byte: number): number {
+  if (byte < 0x80) return 1;
+  if ((byte & 0b1110_0000) === 0b1100_0000) return 2;
+  if ((byte & 0b1111_0000) === 0b1110_0000) return 3;
+  return 4;
+}
+
+function wholeCharacterLength(bytes: Uint8Array): number {
+  const CONTINUATION_LIMIT = 3;
+  for (let back = 0; back <= CONTINUATION_LIMIT && back < bytes.length; back += 1) {
+    const index = bytes.length - 1 - back;
+    const byte = bytes[index] ?? 0;
+    if ((byte & 0b1100_0000) === 0b1000_0000) continue;
+    const needed = index + utf8SequenceLength(byte);
+    return needed <= bytes.length ? bytes.length : index;
+  }
+  return bytes.length;
+}
+
 export async function readAttachment(
   principal: Principal,
   attachmentId: string,
@@ -392,7 +417,7 @@ export async function readAttachment(
   return {
     attachment: toIssueAttachment(record),
     encoding: textual ? 'utf8' : 'base64',
-    content: textual ? Buffer.from(slice).toString('utf8') : Buffer.from(slice).toString('base64'),
+    content: textual ? decodeWholeCharacters(slice) : Buffer.from(slice).toString('base64'),
     truncated,
   };
 }
@@ -405,6 +430,7 @@ async function commentIssueId(principal: Principal, commentId: string): Promise<
       and(
         eq(schema.comment.id, commentId),
         eq(schema.comment.organizationId, principal.organizationId),
+        isNull(schema.comment.deletedAt),
       ),
     )
     .limit(1);

--- a/packages/mcp-server/src/tools/inbox.ts
+++ b/packages/mcp-server/src/tools/inbox.ts
@@ -12,6 +12,32 @@ interface IssueSummary {
   readonly teamKey: string;
 }
 
+interface DocSummary {
+  readonly id: string;
+  readonly title: string;
+}
+
+async function docIdsForComments(commentIds: readonly string[]): Promise<Map<string, string>> {
+  if (commentIds.length === 0) return new Map();
+  const rows = await db
+    .select({ id: schema.docComment.id, docId: schema.docComment.docId })
+    .from(schema.docComment)
+    .where(inArray(schema.docComment.id, [...commentIds]));
+  return new Map(rows.map((row) => [row.id, row.docId]));
+}
+
+async function docSummaries(
+  organizationId: string,
+  docIds: readonly string[],
+): Promise<Map<string, DocSummary>> {
+  if (docIds.length === 0) return new Map();
+  const rows = await db
+    .select({ id: schema.doc.id, title: schema.doc.title })
+    .from(schema.doc)
+    .where(and(eq(schema.doc.organizationId, organizationId), inArray(schema.doc.id, [...docIds])));
+  return new Map(rows.map((row) => [row.id, { id: row.id, title: row.title }]));
+}
+
 async function issueIdsForComments(
   organizationId: string,
   commentIds: readonly string[],
@@ -88,6 +114,18 @@ export function registerInboxTools(server: McpServer, principal: Principal): voi
         .map((item) => item.entityId);
       const byComment = await issueIdsForComments(principal.organizationId, commentIds);
 
+      const docCommentIds = page.items
+        .filter((item) => item.entityType === 'doc_comment')
+        .map((item) => item.entityId);
+      const byDocComment = await docIdsForComments(docCommentIds);
+
+      const docIds = page.items.flatMap((item) => {
+        if (item.entityType === 'doc') return [item.entityId];
+        const resolved = byDocComment.get(item.entityId);
+        return resolved === undefined ? [] : [resolved];
+      });
+      const byDoc = await docSummaries(principal.organizationId, docIds);
+
       const issueIds = page.items.flatMap((item) => {
         if (item.entityType === 'issue') return [item.entityId];
         const resolved = byComment.get(item.entityId);
@@ -99,6 +137,7 @@ export function registerInboxTools(server: McpServer, principal: Principal): voi
         notifications: page.items.map((item) => {
           const issueId =
             item.entityType === 'issue' ? item.entityId : byComment.get(item.entityId);
+          const docId = item.entityType === 'doc' ? item.entityId : byDocComment.get(item.entityId);
           return {
             id: item.id,
             type: item.type,
@@ -110,6 +149,7 @@ export function registerInboxTools(server: McpServer, principal: Principal): voi
             createdAt: item.createdAt.toISOString(),
             read: item.readAt !== null,
             issue: issueId === undefined ? null : (byIssue.get(issueId) ?? null),
+            doc: docId === undefined ? null : (byDoc.get(docId) ?? null),
           };
         }),
         nextCursor: page.nextCursor,

--- a/packages/mcp-server/src/tools/issues.ts
+++ b/packages/mcp-server/src/tools/issues.ts
@@ -5,11 +5,13 @@ import {
   createIssue,
   getIssue,
   listComments,
+  listIssueAttachments,
   listIssueLabels,
   listIssues,
   listLabels,
   listRelatedIssues,
   moveIssue,
+  readAttachment,
   removeRelation,
   setRelation,
   updateIssue,
@@ -277,6 +279,7 @@ function registerGetIssue(server: McpServer, principal: Principal): void {
           description: issue.description,
           labels: await issueLabelNames(principal, issue.id),
           relations: await issueRelationViews(principal, issue.id),
+          attachments: (await listIssueAttachments(principal, issue.id)).map(describeAttachment),
         },
       };
     },
@@ -607,6 +610,86 @@ function registerRemoveRelation(server: McpServer, principal: Principal): void {
   );
 }
 
+const MAX_ATTACHMENT_READ_BYTES = 256 * 1024;
+
+function describeAttachment(file: {
+  id: string;
+  fileName: string;
+  contentType: string;
+  size: number;
+  parentType: string;
+  url: string;
+}) {
+  return {
+    id: file.id,
+    fileName: file.fileName,
+    contentType: file.contentType,
+    size: file.size,
+    attachedTo: file.parentType,
+    url: file.url,
+  };
+}
+
+function registerListIssueAttachments(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'list_issue_attachments',
+      title: 'List the files on an issue',
+      description:
+        'Every file attached to an issue or to a comment on it, oldest first. Call this before you answer a thread that refers to a document, a screenshot or an export, so you work from what was actually attached rather than guessing from the filename.',
+      readOnly: true,
+      inputSchema: {
+        issue: z.string().min(1).describe('Issue identifier like "ENG-42", or an issue id.'),
+      },
+    },
+    async (args) => {
+      const issue = await getIssue(principal, args.issue);
+      const files = await listIssueAttachments(principal, issue.id);
+      return { attachments: files.map(describeAttachment) };
+    },
+  );
+}
+
+function registerReadAttachment(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'read_attachment',
+      title: 'Read an attached file',
+      description:
+        'Return the contents of a file attached to an issue or a comment. Text-like files come back as text; anything else comes back base64 encoded. Large files are truncated, and the response says so.',
+      readOnly: true,
+      inputSchema: {
+        attachment: z
+          .string()
+          .min(1)
+          .describe('Attachment id from list_issue_attachments or get_issue.'),
+        maxBytes: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_ATTACHMENT_READ_BYTES)
+          .optional()
+          .describe(`Stop after this many bytes. Defaults to ${MAX_ATTACHMENT_READ_BYTES}.`),
+      },
+    },
+    async (args) => {
+      const read = await readAttachment(
+        principal,
+        args.attachment,
+        args.maxBytes ?? MAX_ATTACHMENT_READ_BYTES,
+      );
+      return {
+        attachment: describeAttachment(read.attachment),
+        encoding: read.encoding,
+        content: read.content,
+        truncated: read.truncated,
+      };
+    },
+  );
+}
+
 function registerAttachFile(server: McpServer, principal: Principal): void {
   defineTool(
     server,
@@ -698,5 +781,7 @@ export function registerIssueTools(server: McpServer, principal: Principal): voi
   registerSetRelation(server, principal);
   registerRemoveRelation(server, principal);
   registerAttachFile(server, principal);
+  registerListIssueAttachments(server, principal);
+  registerReadAttachment(server, principal);
   registerCopyBranchName(server, principal);
 }

--- a/packages/mcp-server/src/tools/issues.ts
+++ b/packages/mcp-server/src/tools/issues.ts
@@ -4,6 +4,7 @@ import {
   createComment,
   createIssue,
   getIssue,
+  listAttachmentsFor,
   listComments,
   listIssueAttachments,
   listIssueLabels,
@@ -658,7 +659,7 @@ function registerReadAttachment(server: McpServer, principal: Principal): void {
       name: 'read_attachment',
       title: 'Read an attached file',
       description:
-        'Return the contents of a file attached to an issue or a comment. Text-like files come back as text; anything else comes back base64 encoded. Large files are truncated, and the response says so.',
+        'Return the contents of a file attached to an issue, a comment, a doc or a project. Text-like files come back as text; anything else comes back base64 encoded. Large files are truncated, and the response says so.',
       readOnly: true,
       inputSchema: {
         attachment: z
@@ -686,6 +687,34 @@ function registerReadAttachment(server: McpServer, principal: Principal): void {
         content: read.content,
         truncated: read.truncated,
       };
+    },
+  );
+}
+
+function registerListAttachments(server: McpServer, principal: Principal): void {
+  defineTool(
+    server,
+    {
+      name: 'list_attachments',
+      title: 'List the files on anything',
+      description:
+        'Files attached to one issue, comment, doc or project. Use list_issue_attachments for an issue, since that one also covers files attached to its comments. This is for docs and projects.',
+      readOnly: true,
+      inputSchema: {
+        parentType: z
+          .enum(['issue', 'comment', 'doc', 'project'])
+          .describe('What the files hang off.'),
+        parentId: z
+          .string()
+          .min(1)
+          .describe(
+            'Id of the issue, comment, doc or project. Issue identifiers are not accepted.',
+          ),
+      },
+    },
+    async (args) => {
+      const files = await listAttachmentsFor(principal, args.parentType, args.parentId);
+      return { attachments: files.map(describeAttachment) };
     },
   );
 }
@@ -783,5 +812,6 @@ export function registerIssueTools(server: McpServer, principal: Principal): voi
   registerAttachFile(server, principal);
   registerListIssueAttachments(server, principal);
   registerReadAttachment(server, principal);
+  registerListAttachments(server, principal);
   registerCopyBranchName(server, principal);
 }

--- a/packages/mcp-server/tests/tools/inbox.test.ts
+++ b/packages/mcp-server/tests/tools/inbox.test.ts
@@ -133,3 +133,26 @@ describe('mark_notification_read', () => {
     await readOnly.close();
   });
 });
+
+describe('list_notifications on docs', () => {
+  it('resolves the doc for a mention in a doc comment', async () => {
+    const doc = await admin.result('create_doc', { title: 'RBAC permissions', content: 'body' });
+    const docId = (doc['doc'] as { id: string }).id;
+    await admin.result('comment_on_doc', {
+      doc: docId,
+      body: `@${agentHandle} please review this doc against the code.`,
+    });
+
+    const result = await agent.result('list_notifications', { unreadOnly: true });
+    const rows = result['notifications'] as {
+      type: string;
+      issue: unknown;
+      doc: { id: string; title: string } | null;
+    }[];
+    const mention = rows.find((row) => row.doc?.title === 'RBAC permissions');
+
+    expect(mention).toBeDefined();
+    expect(mention?.doc?.id).toBe(docId);
+    expect(mention?.issue).toBeNull();
+  });
+});

--- a/packages/mcp-server/tests/tools/issue-attachments.test.ts
+++ b/packages/mcp-server/tests/tools/issue-attachments.test.ts
@@ -1,0 +1,225 @@
+import { beforeAll, describe, expect, it, mock } from 'bun:test';
+import type { StorageDriver, StoredObject } from '@orbit/services/storage';
+
+const storageModule = await import('@orbit/services/storage');
+
+const objects = new Map<string, { bytes: Uint8Array; contentType: string }>();
+
+const fakeDriver = {
+  name: 's3',
+  createUploadTarget: (key: string, contentType: string, contentLength: number) =>
+    Promise.resolve({
+      key,
+      url: `https://storage.test/${key}`,
+      method: 'PUT',
+      headers: { 'content-type': contentType },
+      maxBytes: contentLength,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    }),
+  put: (key: string, body: Uint8Array, contentType: string) => {
+    objects.set(key, { bytes: body, contentType });
+    return Promise.resolve();
+  },
+  get: (key: string) => Promise.resolve(objects.get(key)?.bytes ?? null),
+  getUrl: () => Promise.reject(new Error('unused')),
+  delete: (key: string) => {
+    objects.delete(key);
+    return Promise.resolve();
+  },
+  stat: (key: string): Promise<StoredObject | null> => {
+    const stored = objects.get(key);
+    return Promise.resolve(
+      stored === undefined
+        ? null
+        : {
+            key,
+            size: stored.bytes.byteLength,
+            contentType: stored.contentType,
+            updatedAt: new Date(),
+          },
+    );
+  },
+} as unknown as StorageDriver;
+
+mock.module('@orbit/services/storage', () => ({
+  ...storageModule,
+  storageDriver: () => fakeDriver,
+}));
+
+const {
+  addMember,
+  connect,
+  createWorkspace,
+  errorPayload,
+  mintToken,
+  resetDatabase,
+}: typeof import('../../src/test-helpers.ts') = await import('../../src/test-helpers.ts');
+
+type TestClient = Awaited<ReturnType<typeof connect>>;
+type TestWorkspace = Awaited<ReturnType<typeof createWorkspace>>;
+
+const REPORT = '# Weekly report\n\nRevenue is up.\n';
+
+let workspace: TestWorkspace;
+let admin: TestClient;
+let issueId: string;
+let issueIdentifier: string;
+let commentId: string;
+let issueAttachmentId: string;
+let commentAttachmentId: string;
+let binaryAttachmentId: string;
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  admin = await connect(await mintToken(workspace.organizationId, workspace.adminUser.id));
+
+  const created = await admin.result('create_issue', {
+    team: workspace.teamKey,
+    title: 'Ship the weekly report',
+  });
+  const issue = created['issue'] as { id: string; identifier: string };
+  issueId = issue.id;
+  issueIdentifier = issue.identifier;
+
+  const commented = await admin.result('add_comment', {
+    issue: issueIdentifier,
+    body: 'Numbers attached.',
+  });
+  commentId = (commented['comment'] as { id: string }).id;
+
+  const onIssue = await admin.result('attach_file', {
+    parentType: 'issue',
+    parentId: issueId,
+    fileName: 'report.md',
+    contentType: 'text/markdown',
+    content: Buffer.from(REPORT, 'utf8').toString('base64'),
+  });
+  issueAttachmentId = (onIssue['attachment'] as { id: string }).id;
+
+  const onComment = await admin.result('attach_file', {
+    parentType: 'comment',
+    parentId: commentId,
+    fileName: 'numbers.csv',
+    contentType: 'text/csv',
+    content: Buffer.from('a,b\n1,2\n', 'utf8').toString('base64'),
+  });
+  commentAttachmentId = (onComment['attachment'] as { id: string }).id;
+
+  const binary = await admin.result('attach_file', {
+    parentType: 'issue',
+    parentId: issueId,
+    fileName: 'chart.png',
+    contentType: 'image/png',
+    content: Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'),
+  });
+  binaryAttachmentId = (binary['attachment'] as { id: string }).id;
+});
+
+describe('list_issue_attachments', () => {
+  it('returns files attached to the issue and to its comments', async () => {
+    const result = await admin.result('list_issue_attachments', { issue: issueIdentifier });
+    const files = result['attachments'] as { fileName: string; attachedTo: string }[];
+
+    expect(files.map((file) => file.fileName).sort()).toEqual([
+      'chart.png',
+      'numbers.csv',
+      'report.md',
+    ]);
+    expect(files.find((file) => file.fileName === 'numbers.csv')?.attachedTo).toBe('comment');
+    expect(files.find((file) => file.fileName === 'report.md')?.attachedTo).toBe('issue');
+  });
+
+  it('is empty for an issue with nothing attached', async () => {
+    const other = await admin.result('create_issue', {
+      team: workspace.teamKey,
+      title: 'Nothing attached here',
+    });
+    const result = await admin.result('list_issue_attachments', {
+      issue: (other['issue'] as { identifier: string }).identifier,
+    });
+    expect(result['attachments']).toEqual([]);
+  });
+});
+
+describe('get_issue', () => {
+  it('reports what is attached, so an agent knows a file exists', async () => {
+    const result = await admin.result('get_issue', { issue: issueIdentifier });
+    const issue = result['issue'] as { attachments: { fileName: string }[] };
+    expect(issue.attachments.map((file) => file.fileName).sort()).toEqual([
+      'chart.png',
+      'numbers.csv',
+      'report.md',
+    ]);
+  });
+});
+
+describe('read_attachment', () => {
+  it('returns a text file as text', async () => {
+    const result = await admin.result('read_attachment', { attachment: issueAttachmentId });
+    expect(result['encoding']).toBe('utf8');
+    expect(result['content']).toBe(REPORT);
+    expect(result['truncated']).toBe(false);
+  });
+
+  it('reads a file attached to a comment', async () => {
+    const result = await admin.result('read_attachment', { attachment: commentAttachmentId });
+    expect(result['content']).toBe('a,b\n1,2\n');
+  });
+
+  it('returns a binary file base64 encoded', async () => {
+    const result = await admin.result('read_attachment', { attachment: binaryAttachmentId });
+    expect(result['encoding']).toBe('base64');
+    expect(
+      Buffer.from(result['content'] as string, 'base64')
+        .subarray(1, 4)
+        .toString(),
+    ).toBe('PNG');
+  });
+
+  it('truncates and says so', async () => {
+    const result = await admin.result('read_attachment', {
+      attachment: issueAttachmentId,
+      maxBytes: 5,
+    });
+    expect(result['truncated']).toBe(true);
+    expect(result['content']).toBe(REPORT.slice(0, 5));
+  });
+
+  it('refuses an attachment from another workspace', async () => {
+    const other = await createWorkspace('Rival');
+    const outsider = await connect(await mintToken(other.organizationId, other.adminUser.id));
+    const result = await outsider.call('read_attachment', { attachment: issueAttachmentId });
+    expect(result.isError).toBe(true);
+    expect(errorPayload(result).code).toBe('not_found');
+    await outsider.close();
+  });
+
+  it('refuses a member who is not on the issue team', async () => {
+    const created = await admin.result('create_team', { name: 'Secrets', key: 'SEC' });
+    const team = created['team'] as { key: string };
+    const secret = await admin.result('create_issue', {
+      team: team.key,
+      title: 'Board pack',
+    });
+    const secretIssue = secret['issue'] as { id: string; identifier: string };
+    const stored = await admin.result('attach_file', {
+      parentType: 'issue',
+      parentId: secretIssue.id,
+      fileName: 'board-pack.md',
+      contentType: 'text/markdown',
+      content: Buffer.from('confidential', 'utf8').toString('base64'),
+    });
+    const secretAttachmentId = (stored['attachment'] as { id: string }).id;
+
+    const outsider = await addMember(workspace, 'contributor', 'Otto Outsider');
+    const client = await connect(await mintToken(workspace.organizationId, outsider.user.id));
+
+    const listed = await client.call('list_issue_attachments', { issue: secretIssue.identifier });
+    expect(listed.isError).toBe(true);
+    const read = await client.call('read_attachment', { attachment: secretAttachmentId });
+    expect(read.isError).toBe(true);
+
+    await client.close();
+  });
+});

--- a/packages/mcp-server/tests/tools/issue-attachments.test.ts
+++ b/packages/mcp-server/tests/tools/issue-attachments.test.ts
@@ -269,3 +269,54 @@ describe('files on docs and projects', () => {
     expect(read['content']).toBe('phase,week\n1,3\n');
   });
 });
+
+describe('greptile findings', () => {
+  it('never splits a multi-byte character when truncating', async () => {
+    const emoji = 'héllo wörld 🌍 done';
+    const stored = await admin.result('attach_file', {
+      parentType: 'issue',
+      parentId: issueId,
+      fileName: 'utf8.md',
+      contentType: 'text/markdown',
+      content: Buffer.from(emoji, 'utf8').toString('base64'),
+    });
+    const id = (stored['attachment'] as { id: string }).id;
+
+    const full = Buffer.from(emoji, 'utf8');
+    for (let cut = 1; cut < full.byteLength; cut += 1) {
+      const result = await admin.result('read_attachment', { attachment: id, maxBytes: cut });
+      const text = result['content'] as string;
+      expect(text).not.toContain('�');
+      expect(emoji.startsWith(text)).toBe(true);
+    }
+  });
+
+  it('stops reading a file whose comment was deleted', async () => {
+    const commented = await admin.result('add_comment', {
+      issue: issueIdentifier,
+      body: 'Temporary, with a file.',
+    });
+    const doomedCommentId = (commented['comment'] as { id: string }).id;
+    const stored = await admin.result('attach_file', {
+      parentType: 'comment',
+      parentId: doomedCommentId,
+      fileName: 'secret.md',
+      contentType: 'text/markdown',
+      content: Buffer.from('should not survive', 'utf8').toString('base64'),
+    });
+    const id = (stored['attachment'] as { id: string }).id;
+
+    expect((await admin.result('read_attachment', { attachment: id }))['content']).toBe(
+      'should not survive',
+    );
+
+    await admin.result('delete_comment', { commentId: doomedCommentId });
+
+    const afterList = await admin.result('list_issue_attachments', { issue: issueIdentifier });
+    const names = (afterList['attachments'] as { fileName: string }[]).map((f) => f.fileName);
+    expect(names).not.toContain('secret.md');
+
+    const afterRead = await admin.call('read_attachment', { attachment: id });
+    expect(afterRead.isError).toBe(true);
+  });
+});

--- a/packages/mcp-server/tests/tools/issue-attachments.test.ts
+++ b/packages/mcp-server/tests/tools/issue-attachments.test.ts
@@ -223,3 +223,49 @@ describe('read_attachment', () => {
     await client.close();
   });
 });
+
+describe('files on docs and projects', () => {
+  it('lists and reads a file attached to a doc', async () => {
+    const doc = await admin.result('create_doc', { title: 'Spec', content: 'body' });
+    const docId = (doc['doc'] as { id: string }).id;
+    const stored = await admin.result('attach_file', {
+      parentType: 'doc',
+      parentId: docId,
+      fileName: 'spec.md',
+      contentType: 'text/markdown',
+      content: Buffer.from('the spec', 'utf8').toString('base64'),
+    });
+    const attachmentId = (stored['attachment'] as { id: string }).id;
+
+    const listed = await admin.result('list_attachments', {
+      parentType: 'doc',
+      parentId: docId,
+    });
+    expect((listed['attachments'] as { fileName: string }[])[0]?.fileName).toBe('spec.md');
+
+    const read = await admin.result('read_attachment', { attachment: attachmentId });
+    expect(read['content']).toBe('the spec');
+  });
+
+  it('lists and reads a file attached to a project', async () => {
+    const project = await admin.result('create_project', { name: 'Launch' });
+    const projectId = (project['project'] as { id: string }).id;
+    const stored = await admin.result('attach_file', {
+      parentType: 'project',
+      parentId: projectId,
+      fileName: 'plan.csv',
+      contentType: 'text/csv',
+      content: Buffer.from('phase,week\n1,3\n', 'utf8').toString('base64'),
+    });
+    const attachmentId = (stored['attachment'] as { id: string }).id;
+
+    const listed = await admin.result('list_attachments', {
+      parentType: 'project',
+      parentId: projectId,
+    });
+    expect((listed['attachments'] as { fileName: string }[])[0]?.fileName).toBe('plan.csv');
+
+    const read = await admin.result('read_attachment', { attachment: attachmentId });
+    expect(read['content']).toBe('phase,week\n1,3\n');
+  });
+});

--- a/packages/services/src/storage/s3.ts
+++ b/packages/services/src/storage/s3.ts
@@ -421,6 +421,20 @@ export class S3StorageDriver implements StorageDriver {
     );
   }
 
+  async get(key: string): Promise<Uint8Array | null> {
+    assertSafeKey(key);
+    try {
+      const client = await this.client();
+      const object = await client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key }));
+      const body = object.Body;
+      if (body === undefined) return null;
+      return await body.transformToByteArray();
+    } catch (error) {
+      if (isNotFound(error)) return null;
+      throw internal('Could not read that file from storage.', error);
+    }
+  }
+
   async delete(key: string): Promise<void> {
     assertSafeKey(key);
     const client = await this.client();

--- a/packages/services/src/storage/types.ts
+++ b/packages/services/src/storage/types.ts
@@ -38,6 +38,7 @@ export interface StorageDriver {
   ): Promise<UploadTarget>;
   put(key: string, body: Uint8Array, contentType: string): Promise<void>;
   getUrl(key: string, expiresInSeconds: number, options?: DownloadOptions): Promise<string>;
+  get(key: string): Promise<Uint8Array | null>;
   delete(key: string): Promise<void>;
   summarizePrefix(prefix: string): Promise<StoragePrefixSummary>;
   deletePrefix(prefix: string): Promise<void>;


### PR DESCRIPTION
`attach_file` has existed since the start, so an assistant could upload a report and link it. It could **not see a single file anybody else attached**. `get_issue` returned no attachments, no tool listed them, and none returned their contents. A thread saying "see the attached spec" was unreadable: the assistant could not tell the file was there, let alone open it.

Found while checking what the Orbit integration could actually do for yodu's agents. I attached a generated markdown file through `attach_file` (worked), then called `get_issue` on the same issue and got nothing back about it.

## What changes

- **`list_issue_attachments`** returns everything hanging off an issue and off every comment on it, oldest first.
- **`read_attachment`** returns the contents. Text-like types come back as text, anything else base64. A large file is truncated with `truncated: true` rather than silently cut, default 256KB.
- **`get_issue`** now reports the attachment list, the way it already reports labels and relations, so an assistant learns a file exists without having to ask.
- **`StorageDriver.get()`** is new. The S3 implementation already imported `GetObjectCommand` for presigning, so this is the same command with the body read.

## Authorization

Reads are governed by the issue the file hangs off, not by the file. Both tools resolve a comment attachment back to its issue, then go through the same `assertCan(principal, 'issue:read')` and team check that `listComments` already uses. A file is exactly as readable as the issue it belongs to and no more.

Two tests cover that boundary: an attachment in another workspace comes back `not_found`, and a workspace member who is not on the issue's team is refused with `forbidden: You are not a member of that team`.

## Testing

Nine cases in `packages/mcp-server/tests/tools/issue-attachments.test.ts`: listing across issue and comment parents, an empty issue, `get_issue` reporting the list, text read, comment-attachment read, binary as base64, truncation, and the two authorization boundaries.

mcp-server 186 pass, core 760 pass, repo typecheck clean, comment policy and byte check clean. The one remaining repo lint warning is pre-existing in `packages/db/tests/check-source-bytes.test.ts` and untouched here.

## Also

`attach_file` was never documented. All three tools and a short section on how files work are now in `docs/mcp.md`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds authorized discovery and reading of files attached to issues, comments, documents, and projects, while also enriching issue and notification responses.
- Adds attachment listing and content-reading tools, including bounded reads, binary encoding, and UTF-8-safe truncation.
- Applies parent-resource authorization and hides attachments belonging to deleted comments.
- Implements object retrieval in the storage interface and S3 driver.
- Documents the attachment tools and adds authorization, content, truncation, and lifecycle coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/content/attachment-service.ts | Adds parent-authorized attachment listing and reading; the prior UTF-8 truncation and deleted-comment readability issues are resolved. |
| packages/mcp-server/src/tools/issues.ts | Registers attachment discovery and reading tools and exposes issue attachments through get_issue. |
| packages/services/src/storage/s3.ts | Adds S3 object retrieval with not-found handling and normalized storage errors. |
| packages/mcp-server/src/tools/inbox.ts | Enriches document-related notifications with document identifiers and titles. |
| packages/mcp-server/tests/tools/issue-attachments.test.ts | Covers listing, reading, authorization, encoding, truncation boundaries, and deleted-comment behavior. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(mcp): keep truncated text valid, and..."](https://github.com/noveum/orbit/commit/016e64af205d807e957b390da6ac9aa2c7d4e03c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51860170)</sub>

<!-- /greptile_comment -->