### PR TITLE
fix(inbox): stop the hidden labels and wide markdown breaking the page

### DIFF
--- a/apps/web/e2e/inbox-layout.spec.ts
+++ b/apps/web/e2e/inbox-layout.spec.ts
@@ -1,0 +1,138 @@
+import { type BrowserContext, expect, type Page, test } from '@playwright/test';
+import { createIssue, teamIdByKey } from './api.ts';
+import { BASE } from './base-url.ts';
+
+const WIDE_COMMENT = [
+  'The shared packages diverged, so the patch below has to be applied by hand.',
+  '',
+  '```diff',
+  '--- a/packages/rbac/src/permissions.ts',
+  '+++ b/packages/rbac/src/permissions.ts',
+  '+  { service: "autofix", action: "write", description: "Create or update AutoFix runs and approve or reject a proposed patch" },',
+  '+  { service: "autofix", action: "execute", description: "Run and cancel AutoFix backtests against a recorded incident window" },',
+  '```',
+  '',
+  `An unbroken token no soft wrap can help with: ${'a'.repeat(180)}`,
+].join('\n');
+
+async function signIn(context: BrowserContext, email: string): Promise<Page> {
+  const page = await context.newPage();
+  await page.goto(`${BASE}/login`);
+  await page.getByTestId(`dev-sign-in-${email}`).click();
+  await page.waitForURL(`${BASE}/my-issues`);
+  return page;
+}
+
+async function comment(page: Page, issueId: string, body: string): Promise<void> {
+  await page.evaluate(
+    async ({ url, text }) => {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ body: text, parentId: null }),
+      });
+      if (!response.ok) throw new Error(`${url} answered ${response.status}`);
+    },
+    { url: `/api/comments?issueId=${encodeURIComponent(issueId)}`, text: body },
+  );
+}
+
+interface Overflow {
+  readonly documentY: number;
+  readonly mainY: number;
+  readonly mainX: number;
+}
+
+async function overflowOf(page: Page): Promise<Overflow> {
+  return await page.evaluate(() => {
+    const root = document.documentElement;
+    const main = document.querySelector('main');
+    if (main === null) throw new Error('the shell never rendered a main');
+    return {
+      documentY: root.scrollHeight - root.clientHeight,
+      mainY: main.scrollHeight - main.clientHeight,
+      mainX: main.scrollWidth - main.clientWidth,
+    };
+  });
+}
+
+test('the inbox fills the shell without inventing scroll of its own', async ({ browser }) => {
+  const reading = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const writing = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const reader = await signIn(reading, 'sam@orbit.example');
+  const author = await signIn(writing, 'alex@orbit.example');
+
+  const teamId = await teamIdByKey(reader, 'ENG');
+  const watched = await createIssue(reader, teamId, 'An issue whose comments the reader follows');
+  await comment(author, watched.id, WIDE_COMMENT);
+
+  await reader.goto(`${BASE}/inbox`);
+  await expect(reader.getByTestId('inbox-detail')).toBeVisible();
+
+  const settled = await overflowOf(reader);
+  expect(settled.documentY).toBe(0);
+  expect(settled.mainY).toBe(0);
+  expect(settled.mainX).toBe(0);
+
+  await reading.close();
+  await writing.close();
+});
+
+test('a list longer than the pane never pushes the shell off the page', async ({ browser }) => {
+  const reading = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const writing = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const reader = await signIn(reading, 'sam@orbit.example');
+  const author = await signIn(writing, 'alex@orbit.example');
+
+  const teamId = await teamIdByKey(reader, 'ENG');
+  for (let index = 0; index < 18; index += 1) {
+    const issue = await createIssue(reader, teamId, `A followed issue number ${index}`);
+    await comment(author, issue.id, `Reply number ${index}`);
+  }
+
+  await reader.goto(`${BASE}/inbox`);
+  await expect(reader.getByTestId('inbox-detail')).toBeVisible();
+
+  const list = reader.locator('main ul').first();
+  await expect
+    .poll(async () => await list.evaluate((node) => node.scrollHeight - node.clientHeight))
+    .toBeGreaterThan(0);
+
+  for (const tab of ['All', 'Unread', 'Mentions', 'Pull requests']) {
+    await reader.getByRole('button', { name: tab, exact: true }).click();
+    const measured = await overflowOf(reader);
+    expect(measured.documentY, `${tab} pushed the document`).toBe(0);
+    expect(measured.mainY, `${tab} left dead space under the shell`).toBe(0);
+    expect(measured.mainX, `${tab} pushed the shell sideways`).toBe(0);
+  }
+
+  await reading.close();
+  await writing.close();
+});
+
+test('a code block scrolls inside itself rather than widening the pane', async ({ browser }) => {
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const author = await signIn(context, 'alex@orbit.example');
+
+  const teamId = await teamIdByKey(author, 'ENG');
+  const issue = await createIssue(author, teamId, 'A comment carrying a wide diff');
+  await comment(author, issue.id, WIDE_COMMENT);
+
+  await author.goto(`${BASE}/issue/${issue.identifier}`);
+  const block = author.locator('[data-testid=comment-thread] pre').first();
+  await expect(block).toBeVisible();
+
+  const contained = await block.evaluate((node) => ({
+    scrolls: node.scrollWidth > node.clientWidth,
+    overflowX: getComputedStyle(node).overflowX,
+    withinParent:
+      node.getBoundingClientRect().width <=
+      (node.parentElement?.getBoundingClientRect().width ?? 0) + 1,
+  }));
+  expect(contained.overflowX).toBe('auto');
+  expect(contained.withinParent).toBe(true);
+
+  expect((await overflowOf(author)).mainX).toBe(0);
+
+  await context.close();
+});

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -570,6 +570,10 @@
 }
 
 @layer utilities {
+  .sr-only:not(.not-sr-only) {
+    position: fixed;
+  }
+
   .hairline-b {
     box-shadow: inset 0 -1px 0 0 var(--color-border-hairline);
   }

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -134,7 +134,7 @@ export function AppShell({
           {...(actions === undefined ? {} : { actions })}
         />
         <div className={cn(contentWidthClassName, 'flex min-h-0 flex-1')}>
-          <main className="relative min-h-0 flex-1 overflow-y-auto">{children}</main>
+          <main className="min-h-0 flex-1 overflow-y-auto">{children}</main>
           {panel === undefined || !panelOpen ? null : (
             <aside
               aria-label="Details"

--- a/apps/web/src/features/comments/comment-thread.tsx
+++ b/apps/web/src/features/comments/comment-thread.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu.tsx';
-import { taskListClassName } from '@/features/docs/doc-body.tsx';
+import { proseOverflowClassName, taskListClassName } from '@/features/docs/doc-body.tsx';
 import { useHashScroll } from '@/features/docs/use-hash-scroll.ts';
 import { ActivityEntry } from '@/features/issues/activity-feed.tsx';
 import { cn } from '@/lib/cn.ts';
@@ -202,9 +202,16 @@ export function CommentThread({
 }
 
 const bodyClassName = cn(
-  'prose-orbit break-words text-dense text-text leading-relaxed [&_a]:text-accent [&_code]:rounded-sm [&_code]:bg-surface-2 [&_code]:px-1 [&_p]:my-1',
+  'prose-orbit min-w-0 text-dense text-text leading-relaxed [&_a]:text-accent [&_code]:rounded-sm [&_code]:bg-surface-2 [&_code]:px-1 [&_p]:my-1',
   '[&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-1 [&_ol]:list-decimal [&_ol]:pl-5',
   '[&_li]:my-0.5 [&_li]:pl-1 [&_li::marker]:text-faint [&_li_p]:my-0',
+  '[&_pre]:my-2 [&_pre]:rounded-md [&_pre]:border [&_pre]:border-border [&_pre]:bg-surface-2 [&_pre]:p-3',
+  '[&_pre_code]:bg-transparent [&_pre_code]:p-0',
+  '[&_blockquote]:my-2 [&_blockquote]:border-accent/40 [&_blockquote]:border-l-2 [&_blockquote]:pl-3 [&_blockquote]:text-muted',
+  '[&_[data-table-scroll]]:my-2 [&_[data-table-scroll]]:rounded-md [&_[data-table-scroll]]:border [&_[data-table-scroll]]:border-border',
+  '[&_table]:w-full [&_table]:border-collapse [&_th]:bg-surface-2 [&_th]:text-left [&_th]:font-medium',
+  '[&_th]:px-2 [&_th]:py-1 [&_td]:px-2 [&_td]:py-1 [&_td]:align-top [&_th_p]:my-0 [&_td_p]:my-0',
+  proseOverflowClassName,
   taskListClassName,
 );
 

--- a/apps/web/src/features/docs/doc-body.tsx
+++ b/apps/web/src/features/docs/doc-body.tsx
@@ -16,8 +16,17 @@ export const taskListClassName = cn(
   '[&_input[type=checkbox]]:size-3.5 [&_input[type=checkbox]]:accent-[var(--color-accent)]',
 );
 
+export const proseOverflowClassName = cn(
+  '[overflow-wrap:anywhere]',
+  '[&_pre]:max-w-full [&_pre]:overflow-x-auto [&_pre]:[overflow-wrap:normal]',
+  '[&_pre_code]:[overflow-wrap:normal]',
+  '[&_[data-table-scroll]]:max-w-full [&_[data-table-scroll]]:overflow-x-auto',
+  '[&_img]:h-auto [&_img]:max-w-full [&_video]:h-auto [&_video]:max-w-full',
+);
+
 export const docProseClassName = cn(
-  'prose-orbit max-w-none break-words text-base text-text leading-[1.75]',
+  'prose-orbit max-w-none text-base text-text leading-[1.75]',
+  proseOverflowClassName,
   '[&_h1]:mt-10 [&_h1]:mb-3 [&_h1]:scroll-mt-24 [&_h1]:font-semibold [&_h1]:text-text [&_h1]:text-xl [&_h1]:tracking-tight',
   '[&_h2]:mt-9 [&_h2]:mb-2.5 [&_h2]:scroll-mt-24 [&_h2]:font-semibold [&_h2]:text-lg [&_h2]:text-text [&_h2]:tracking-tight',
   '[&_h3]:mt-7 [&_h3]:mb-2 [&_h3]:scroll-mt-24 [&_h3]:font-medium [&_h3]:text-base [&_h3]:text-text',

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -450,15 +450,15 @@ export function InboxView({
   );
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <header className="flex flex-col gap-3 border-border border-b px-5 py-3">
+    <div className="flex min-h-0 flex-col md:h-full">
+      <header className="flex flex-col gap-2 border-border border-b px-5 py-2">
         {error === null ? null : (
           <p role="alert" className="text-danger text-xs" data-testid="inbox-error">
             {error}
           </p>
         )}
-        <div className="flex items-center justify-between gap-3">
-          <h1 className="flex items-center gap-2 font-semibold text-lg text-text">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+          <h1 className="flex shrink-0 items-center gap-2 font-semibold text-base text-text">
             Inbox
             <Badge tone={unread > 0 ? 'accent' : 'neutral'} data-testid="inbox-unread-count">
               {unread} unread
@@ -469,7 +469,25 @@ export function InboxView({
               </Badge>
             ) : null}
           </h1>
-          <p className="hidden items-center gap-1.5 text-2xs text-faint sm:flex">
+          <nav className="flex items-center gap-1" aria-label="Inbox filters">
+            {TABS.map((entry) => (
+              <button
+                key={entry.id}
+                type="button"
+                onClick={() => selectTab(entry.id)}
+                aria-current={tab === entry.id ? 'true' : undefined}
+                className={cn(
+                  'rounded-md px-2.5 py-1 text-dense transition-colors duration-[var(--duration-fast)]',
+                  tab === entry.id
+                    ? 'bg-surface-2 font-medium text-text'
+                    : 'text-muted hover:bg-surface-2 hover:text-text',
+                )}
+              >
+                {entry.label}
+              </button>
+            ))}
+          </nav>
+          <p className="ml-auto hidden items-center gap-1.5 text-2xs text-faint xl:flex">
             <Kbd keys={['J']} />
             <Kbd keys={['K']} /> move
             <Kbd keys={['U']} /> read
@@ -477,24 +495,6 @@ export function InboxView({
             <Kbd keys={['Backspace']} /> delete
           </p>
         </div>
-        <nav className="flex items-center gap-1" aria-label="Inbox filters">
-          {TABS.map((entry) => (
-            <button
-              key={entry.id}
-              type="button"
-              onClick={() => selectTab(entry.id)}
-              aria-current={tab === entry.id ? 'true' : undefined}
-              className={cn(
-                'rounded-md px-2.5 py-1 text-dense transition-colors duration-[var(--duration-fast)]',
-                tab === entry.id
-                  ? 'bg-surface-2 font-medium text-text'
-                  : 'text-muted hover:bg-surface-2 hover:text-text',
-              )}
-            >
-              {entry.label}
-            </button>
-          ))}
-        </nav>
       </header>
 
       {visible.length === 0 ? (
@@ -506,7 +506,7 @@ export function InboxView({
         />
       ) : (
         <div className="grid min-h-0 flex-1 grid-cols-1 md:grid-cols-[22rem_minmax(0,1fr)]">
-          <ul className="flex min-h-0 flex-col overflow-y-auto border-border border-r">
+          <ul className="flex min-h-0 flex-col border-border md:overflow-y-auto md:border-r">
             {visible.map((row) => {
               const Icon = SOURCE_ICONS[row.type];
               return (


### PR DESCRIPTION
Three faults reported against the inbox after the last change, and the
one cause sitting under two of them.

## Dead space under the shell, but only on the All tab

The tab was the clue. Tailwind's `sr-only` is `position: absolute`, so
each read/unread label on a notification row resolves against the
nearest positioned ancestor and is laid out at its static offset. In a
list long enough to scroll, that offset is far below the fold, and the
label drags the scroll height of whatever box it resolved against out
with it.

The previous change gave `main` a containing block to keep those
labels off the document. That moved the weight onto `main`, which does
scroll, so the phantom became visible: 679px of dead space measured on
a 25 row list, none on the shorter tabs. Same cause, worse place.

`sr-only` is now `position: fixed`, which takes it out of flow so it
extends nothing at all, and `main` goes back to being an ordinary
scroller. The rule spares `not-sr-only` so a focus reveal still works.

## A scrollbar across the pane and content pushed sideways

A comment body carried no rules for the blocks markdown produces. A
diff set the width of everything above it, the column grew to 1077px
inside 494px of room, and because a box that scrolls on one axis may
not stay `visible` on the other, the whole issue pane picked up a
horizontal scrollbar.

Code blocks now scroll inside their own box, long tokens break where
they must, and pictures cap at the width they are given. The rules sit
next to the doc prose so both surfaces answer for the same markdown,
and comment code blocks get the frame docs already had.

Tables were already wrapped in a scroll container by the renderer, so
that container is what gets capped. Turning the table itself into a
block would have cost docs their sticky headers and full width layout.

## Two rows of header, and a cramped list on a phone

The title and the filters share a line now, with the shortcut legend
pushed to the end. The two pane grid also stretched its rows to the
shell on every screen, so on a phone the list became a small scroll
box with the issue stacked under it. It only claims the shell height
where the two pane layout exists; below that the page scrolls as a
single column should.

## Verified

Measured in a real browser, not inferred. Every tab reports zero
document scroll, zero left over under the shell and zero sideways.
`/analytics`, `/my-issues`, `/settings/members`, `/views`, the board,
the issue page and docs all come back clean, and the doc route keeps
its own scrolling. Checked at 1440x900 and at 375x812.

The new `e2e/inbox-layout.spec.ts` covers all three. Both halves were
run against the unfixed code first: the long list test fails without
the `sr-only` rule, and the code block test fails without the prose
rules.

`bun run verify` is green apart from the `@orbit/db` apply-catchup
flake, which fails the same way on `main` with none of this applied.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects inbox and markdown overflow behavior while refining the responsive inbox layout.
- Prevents screen-reader-only notification labels from extending scroll containers.
- Constrains wide code blocks, tables, images, and unbroken markdown text.
- Makes the inbox use independent panes on desktop and natural page scrolling on mobile.
- Adds browser coverage for long inbox lists and wide comment content.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/globals.css | Overrides screen-reader-only positioning to prevent hidden labels from increasing scroll dimensions. |
| apps/web/src/components/layout/app-shell.tsx | Removes the positioned containing block from the main application scroller. |
| apps/web/src/features/comments/comment-thread.tsx | Applies shared overflow containment and complete markdown block styling to comment bodies. |
| apps/web/src/features/docs/doc-body.tsx | Defines reusable overflow rules for prose, code blocks, table wrappers, and media. |
| apps/web/src/features/inbox/inbox-view.tsx | Consolidates the header and limits fixed-height pane scrolling to the desktop layout. |
| apps/web/e2e/inbox-layout.spec.ts | Covers desktop shell overflow, long notification lists, and wide code-block containment. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/noveum/orbit/commit/23cb9cd0faf9e7f47e04c6dc18089ea108419cf6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51922710)</sub>

<!-- /greptile_comment -->