### PR TITLE
feat(inbox): page through an inbox larger than one screenful

### DIFF
--- a/apps/web/src/app/(app)/inbox/page.tsx
+++ b/apps/web/src/app/(app)/inbox/page.tsx
@@ -16,6 +16,7 @@ export default async function InboxPage() {
       items={inbox.items}
       unreadCount={inbox.unreadCount}
       unreadMentions={inbox.unreadMentions}
+      nextCursor={inbox.nextCursor}
       userId={context.principal.userId}
       organizationId={context.principal.organizationId}
       realtimeUrl={configuredRealtimeUrl()}

--- a/apps/web/src/app/api/notifications/route.ts
+++ b/apps/web/src/app/api/notifications/route.ts
@@ -1,0 +1,19 @@
+import { db } from '@orbit/db';
+import { listInbox } from '@orbit/services/notifications';
+import { paginationSchema } from '@orbit/shared/validators';
+import { INBOX_PAGE_SIZE, toInboxItem } from '@/features/inbox/data.ts';
+import { handle, searchParamsOf } from '@/lib/api/handler.ts';
+
+export async function GET(request: Request): Promise<Response> {
+  return await handle(async (principal) => {
+    const query = paginationSchema.parse(searchParamsOf(request));
+    const page = await listInbox(db, {
+      userId: principal.userId,
+      organizationId: principal.organizationId,
+      limit: Math.min(query.limit, INBOX_PAGE_SIZE),
+      ...(query.cursor === undefined ? {} : { cursor: query.cursor }),
+    });
+
+    return { notifications: page.items.map(toInboxItem), nextCursor: page.nextCursor };
+  });
+}

--- a/apps/web/src/features/inbox/data.ts
+++ b/apps/web/src/features/inbox/data.ts
@@ -1,8 +1,10 @@
 import { db } from '@orbit/db';
-import { listInbox, unreadCounters } from '@orbit/services/notifications';
+import { listInbox, type NotificationRecord, unreadCounters } from '@orbit/services/notifications';
 import type { NotificationType } from '@orbit/shared/constants';
 import { NOTIFICATION_TYPES } from '@orbit/shared/constants';
 import type { Principal } from '@orbit/shared/policy';
+
+export const INBOX_PAGE_SIZE = 50;
 
 export interface InboxItem {
   readonly id: string;
@@ -22,10 +24,27 @@ export interface InboxData {
   readonly items: InboxItem[];
   readonly unreadCount: number;
   readonly unreadMentions: number;
+  readonly nextCursor: string | null;
 }
 
 function toType(value: string): NotificationType {
   return NOTIFICATION_TYPES.find((entry) => entry === value) ?? 'subscription_activity';
+}
+
+export function toInboxItem(row: NotificationRecord): InboxItem {
+  return {
+    id: row.id,
+    type: toType(row.type),
+    entityType: row.entityType,
+    entityId: row.entityId,
+    actorName: row.actorName,
+    title: row.title,
+    body: row.body,
+    url: row.url,
+    read: row.readAt !== null,
+    snoozedUntil: row.snoozedUntil?.toISOString() ?? null,
+    createdAt: row.createdAt.toISOString(),
+  };
 }
 
 export async function loadInbox(principal: Principal): Promise<InboxData> {
@@ -33,25 +52,14 @@ export async function loadInbox(principal: Principal): Promise<InboxData> {
     listInbox(db, {
       userId: principal.userId,
       organizationId: principal.organizationId,
-      limit: 50,
+      limit: INBOX_PAGE_SIZE,
     }),
     unreadCounters(db, principal.userId, principal.organizationId),
   ]);
   return {
     unreadCount: counters.total,
     unreadMentions: counters.mentions,
-    items: page.items.map((row) => ({
-      id: row.id,
-      type: toType(row.type),
-      entityType: row.entityType,
-      entityId: row.entityId,
-      actorName: row.actorName,
-      title: row.title,
-      body: row.body,
-      url: row.url,
-      read: row.readAt !== null,
-      snoozedUntil: row.snoozedUntil?.toISOString() ?? null,
-      createdAt: row.createdAt.toISOString(),
-    })),
+    nextCursor: page.nextCursor,
+    items: page.items.map(toInboxItem),
   };
 }

--- a/apps/web/src/features/inbox/inbox-realtime.tsx
+++ b/apps/web/src/features/inbox/inbox-realtime.tsx
@@ -11,6 +11,7 @@ export interface InboxRealtimeProps {
   readonly items: readonly InboxItem[];
   readonly unreadCount: number;
   readonly unreadMentions: number;
+  readonly nextCursor: string | null;
   readonly userId: string;
   readonly organizationId: string;
   readonly realtimeUrl: string;
@@ -22,6 +23,7 @@ export function InboxRealtime({
   items,
   unreadCount,
   unreadMentions,
+  nextCursor,
   userId,
   organizationId,
   realtimeUrl,
@@ -39,6 +41,7 @@ export function InboxRealtime({
         items={items}
         unreadCount={unreadCount}
         unreadMentions={unreadMentions}
+        nextCursor={nextCursor}
         userId={userId}
         canWriteDocs={canWriteDocs}
         canPublishDocs={canPublishDocs}

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -348,6 +348,7 @@ export function InboxView({
   const [mentions, setMentions] = useState(unreadMentions);
   const [cursor, setCursor] = useState<string | null>(nextCursor);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [pagingError, setPagingError] = useState<string | null>(null);
   const inFlight = useRef(false);
   const cursorRef = useRef<string | null>(nextCursor);
   const [tab, setTab] = useState<TabId>('all');
@@ -406,9 +407,9 @@ export function InboxView({
       });
       cursorRef.current = parsed.nextCursor;
       setCursor(parsed.nextCursor);
-      setError(null);
+      setPagingError(null);
     } catch {
-      setError('Could not load older notifications. Check your connection and try again.');
+      setPagingError('Could not load these. Check your connection and try again.');
     } finally {
       inFlight.current = false;
       setLoadingMore(false);
@@ -643,6 +644,15 @@ export function InboxView({
             {cursor === null ? null : (
               <li key="load-more">
                 <LoadMoreRow loading={loadingMore} onReach={loadMore} />
+                {pagingError === null ? null : (
+                  <p
+                    role="alert"
+                    data-testid="inbox-paging-error"
+                    className="px-3 pb-3 text-center text-2xs text-danger"
+                  >
+                    {pagingError}
+                  </p>
+                )}
               </li>
             )}
           </ul>

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -591,7 +591,7 @@ export function InboxView({
         </div>
       </header>
 
-      {visible.length === 0 ? (
+      {visible.length === 0 && cursor === null ? (
         <EmptyState
           icon={<Bell strokeWidth={1.75} aria-hidden="true" />}
           title="Inbox zero"

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -25,7 +25,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import Link from 'next/link';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { z } from 'zod';
 import { Badge } from '@/components/ui/badge.tsx';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
@@ -98,13 +98,36 @@ const notificationDeltaSchema = z.object({
 
 const unreadCountSchema = z.object({ unreadCount: z.number() });
 
+function toNotificationType(value: string): NotificationType {
+  return NOTIFICATION_TYPES.find((entry) => entry === value) ?? 'subscription_activity';
+}
+
+const inboxPageSchema = z.object({
+  notifications: z.array(
+    z.object({
+      id: z.string(),
+      type: z.string(),
+      entityType: z.string().default(''),
+      entityId: z.string().default(''),
+      actorName: z.string(),
+      title: z.string(),
+      body: z.string(),
+      url: z.string(),
+      read: z.boolean(),
+      snoozedUntil: z.string().nullable(),
+      createdAt: z.string(),
+    }),
+  ),
+  nextCursor: z.string().nullable(),
+});
+
 function toInboxItem(data: Record<string, unknown>): InboxItem | null {
   const parsed = notificationDeltaSchema.safeParse(data);
   if (!parsed.success) return null;
   const row = parsed.data;
   return {
     id: row.id,
-    type: NOTIFICATION_TYPES.find((entry) => entry === row.type) ?? 'subscription_activity',
+    type: toNotificationType(row.type),
     entityType: row.entityType,
     entityId: row.entityId,
     actorName: row.actorName,
@@ -168,6 +191,39 @@ export function applyNotificationDeltas(
   return actions
     .filter((action) => action.model === 'notification' && action.originClientId !== tabClientId)
     .reduce(applyOne, { rows, unreadDelta: 0, mentionDelta: 0 });
+}
+
+function LoadMoreRow({
+  loading,
+  onReach,
+}: {
+  readonly loading: boolean;
+  readonly onReach: () => void;
+}) {
+  const reach = useRef(onReach);
+  reach.current = onReach;
+
+  const watch = useCallback((node: HTMLButtonElement | null) => {
+    if (node === null || typeof IntersectionObserver === 'undefined') return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) reach.current();
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <button
+      ref={watch}
+      type="button"
+      onClick={onReach}
+      disabled={loading}
+      data-testid="inbox-load-more"
+      className="w-full px-3 py-3 text-center text-2xs text-faint transition-colors duration-[var(--duration-fast)] hover:text-muted"
+    >
+      {loading ? 'Loading older notifications' : 'Load older notifications'}
+    </button>
+  );
 }
 
 function NotificationBody({
@@ -272,6 +328,7 @@ export interface InboxViewProps {
   readonly items: readonly InboxItem[];
   readonly unreadCount: number;
   readonly unreadMentions: number;
+  readonly nextCursor: string | null;
   readonly userId: string;
   readonly canWriteDocs: boolean;
   readonly canPublishDocs: boolean;
@@ -281,6 +338,7 @@ export function InboxView({
   items,
   unreadCount,
   unreadMentions,
+  nextCursor,
   userId,
   canWriteDocs,
   canPublishDocs,
@@ -288,6 +346,10 @@ export function InboxView({
   const [rows, setRows] = useState<readonly InboxItem[]>(items);
   const [unread, setUnread] = useState(unreadCount);
   const [mentions, setMentions] = useState(unreadMentions);
+  const [cursor, setCursor] = useState<string | null>(nextCursor);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const inFlight = useRef(false);
+  const cursorRef = useRef<string | null>(nextCursor);
   const [tab, setTab] = useState<TabId>('all');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -296,7 +358,9 @@ export function InboxView({
     setRows(items);
     setUnread(unreadCount);
     setMentions(unreadMentions);
-  }, [items, unreadCount, unreadMentions]);
+    setCursor(nextCursor);
+    cursorRef.current = nextCursor;
+  }, [items, unreadCount, unreadMentions, nextCursor]);
 
   useScopeSubscription([scopes.user(userId)]);
   useDeltaHandler(
@@ -321,6 +385,34 @@ export function InboxView({
   );
   const selectedIndex = visible.findIndex((row) => row.id === selectedId);
   const current = visible[selectedIndex === -1 ? 0 : selectedIndex];
+
+  const loadMore = useCallback(async () => {
+    const from = cursorRef.current;
+    if (from === null || inFlight.current) return;
+    inFlight.current = true;
+    setLoadingMore(true);
+    try {
+      const page = await apiRequest<unknown>(
+        `/api/notifications?cursor=${encodeURIComponent(from)}`,
+      );
+      const parsed = inboxPageSchema.parse(page);
+      const older = parsed.notifications.map((row) => ({
+        ...row,
+        type: toNotificationType(row.type),
+      }));
+      setRows((list) => {
+        const known = new Set(list.map((row) => row.id));
+        return [...list, ...older.filter((item) => !known.has(item.id))];
+      });
+      cursorRef.current = parsed.nextCursor;
+      setCursor(parsed.nextCursor);
+    } catch {
+      setError('Could not load older notifications. Check your connection and try again.');
+    } finally {
+      inFlight.current = false;
+      setLoadingMore(false);
+    }
+  }, []);
 
   const leaveDeletedIssue = useCallback(() => {
     if (current === undefined) return;
@@ -547,6 +639,11 @@ export function InboxView({
                 </li>
               );
             })}
+            {cursor === null ? null : (
+              <li key="load-more">
+                <LoadMoreRow loading={loadingMore} onReach={loadMore} />
+              </li>
+            )}
           </ul>
 
           <section className="flex min-h-0 min-w-0 flex-col" data-testid="inbox-detail">

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -406,6 +406,7 @@ export function InboxView({
       });
       cursorRef.current = parsed.nextCursor;
       setCursor(parsed.nextCursor);
+      setError(null);
     } catch {
       setError('Could not load older notifications. Check your connection and try again.');
     } finally {

--- a/apps/web/tests/app/api/notifications/route.test.ts
+++ b/apps/web/tests/app/api/notifications/route.test.ts
@@ -1,0 +1,157 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test-support';
+import { db, schema } from '@orbit/db';
+import { randomUUIDv7 } from '@orbit/shared/utils';
+import { z } from 'zod';
+import { mockSession } from '../../../../tests-support.ts';
+
+let workspace: Workspace;
+
+interface Signed {
+  user: { id: string; name: string; email: string };
+  session: { activeOrganizationId: string };
+}
+
+const signedIn: { value: Signed | null } = { value: null };
+
+mockSession(() => signedIn.value);
+
+const notifications = await import('../../../../src/app/api/notifications/route.ts');
+
+const pageSchema = z.object({
+  notifications: z.array(
+    z.object({
+      id: z.string(),
+      type: z.string(),
+      title: z.string(),
+      url: z.string(),
+      read: z.boolean(),
+      snoozedUntil: z.string().nullable(),
+      createdAt: z.string(),
+    }),
+  ),
+  nextCursor: z.string().nullable(),
+});
+
+function asUser(userId: string): void {
+  signedIn.value = {
+    user: { id: userId, name: 'Reader', email: `${userId}@orbit.test` },
+    session: { activeOrganizationId: workspace.organizationId },
+  };
+}
+
+async function seed(count: number): Promise<void> {
+  await db.insert(schema.notification).values(
+    Array.from({ length: count }, (_, index) => ({
+      id: randomUUIDv7(),
+      organizationId: workspace.organizationId,
+      userId: workspace.admin.userId,
+      type: 'comment_created',
+      actorType: 'user' as const,
+      actorId: workspace.admin.userId,
+      actorName: 'Someone',
+      entityType: 'issue',
+      entityId: `issue_${index}`,
+      title: `Notification ${String(index).padStart(3, '0')}`,
+      body: '',
+      url: `/issue/ENG-${index}`,
+      readAt: null,
+      snoozedUntil: null,
+      deliveredChannels: ['inbox'],
+      syncId: 0,
+      createdAt: new Date(),
+    })),
+  );
+}
+
+async function get(url: string): Promise<Response> {
+  return await notifications.GET(new Request(url));
+}
+
+beforeAll(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace();
+});
+
+beforeEach(async () => {
+  await db.delete(schema.notification);
+  asUser(workspace.admin.userId);
+});
+
+describe('GET /api/notifications', () => {
+  it('hands back a page and the cursor that follows it', async () => {
+    await seed(60);
+
+    const page = pageSchema.parse(await (await get('http://orbit.test/api/notifications')).json());
+
+    expect(page.notifications).toHaveLength(50);
+    expect(page.nextCursor).not.toBeNull();
+  });
+
+  it('says there is nothing after the last page', async () => {
+    await seed(3);
+
+    const page = pageSchema.parse(await (await get('http://orbit.test/api/notifications')).json());
+
+    expect(page.notifications).toHaveLength(3);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it('picks up where the cursor left off, without repeating a row', async () => {
+    await seed(60);
+
+    const first = pageSchema.parse(await (await get('http://orbit.test/api/notifications')).json());
+    const second = pageSchema.parse(
+      await (
+        await get(
+          `http://orbit.test/api/notifications?cursor=${encodeURIComponent(first.nextCursor ?? '')}`,
+        )
+      ).json(),
+    );
+
+    expect(second.notifications).toHaveLength(10);
+    expect(second.nextCursor).toBeNull();
+
+    const ids = [...first.notifications, ...second.notifications].map((row) => row.id);
+    expect(new Set(ids).size).toBe(60);
+  });
+
+  it('refuses to hand out more than a page however large the ask', async () => {
+    await seed(60);
+
+    const page = pageSchema.parse(
+      await (await get('http://orbit.test/api/notifications?limit=200')).json(),
+    );
+
+    expect(page.notifications).toHaveLength(50);
+  });
+
+  it('honours a smaller limit', async () => {
+    await seed(10);
+
+    const page = pageSchema.parse(
+      await (await get('http://orbit.test/api/notifications?limit=4')).json(),
+    );
+
+    expect(page.notifications).toHaveLength(4);
+    expect(page.nextCursor).not.toBeNull();
+  });
+
+  it('turns a row into what the inbox reads, not the raw record', async () => {
+    await seed(1);
+
+    const page = pageSchema.parse(await (await get('http://orbit.test/api/notifications')).json());
+    const row = page.notifications[0];
+
+    expect(row?.read).toBe(false);
+    expect(row?.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(row?.url).toContain('/issue/');
+  });
+
+  it('turns away a reader with no session', async () => {
+    await seed(1);
+    signedIn.value = null;
+
+    expect((await get('http://orbit.test/api/notifications')).status).toBe(401);
+  });
+});

--- a/apps/web/tests/components/keyboard-hints.test.tsx
+++ b/apps/web/tests/components/keyboard-hints.test.tsx
@@ -134,6 +134,7 @@ function Surfaces({ extra }: { readonly extra?: ReactNode }) {
             unreadCount={0}
             unreadMentions={0}
             userId="user_1"
+            nextCursor={null}
             canWriteDocs
             canPublishDocs
           />

--- a/apps/web/tests/features/inbox/inbox-issue.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-issue.test.tsx
@@ -228,6 +228,7 @@ function renderInbox(
               unreadCount={1}
               unreadMentions={0}
               userId="user_1"
+              nextCursor={null}
               canWriteDocs={docAccess.canWriteDocs}
               canPublishDocs={docAccess.canPublishDocs}
             />

--- a/apps/web/tests/features/inbox/inbox-open.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-open.test.tsx
@@ -89,6 +89,7 @@ function renderInbox(items: readonly InboxItem[]) {
           unreadCount={1}
           unreadMentions={1}
           userId="user_1"
+          nextCursor={null}
           canWriteDocs
           canPublishDocs
         />

--- a/apps/web/tests/features/inbox/inbox-pagination.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-pagination.test.tsx
@@ -201,6 +201,25 @@ describe('an inbox with more notifications than one page', () => {
     expect(screen.getAllByRole('button', { name: /Notification n1\b/ })).toHaveLength(1);
   });
 
+  it('clears the complaint once a retry gets through', async () => {
+    const user = userEvent.setup();
+    failNext = true;
+    renderInbox([item('n1')], 'cursor-1');
+
+    await user.click(screen.getByTestId('inbox-load-more'));
+    await waitFor(() => {
+      expect(screen.getByTestId('inbox-error')).toBeInTheDocument();
+    });
+
+    failNext = false;
+    await user.click(screen.getByTestId('inbox-load-more'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Notification n51/ })).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('inbox-error')).toBeNull();
+  });
+
   it('says so when the page cannot be fetched, and keeps the offer open', async () => {
     const user = userEvent.setup();
     failNext = true;

--- a/apps/web/tests/features/inbox/inbox-pagination.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-pagination.test.tsx
@@ -1,0 +1,216 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { InboxItem } from '@/features/inbox/data.ts';
+import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+
+const realtimeReact = { ...(await import('@orbit/realtime-client/react')) };
+mock.module('@orbit/realtime-client/react', () => ({
+  ...realtimeReact,
+  useScopeSubscription: () => undefined,
+  useDeltaHandler: () => undefined,
+}));
+
+const issueDetail = { ...(await import('@/features/issues/issue-detail.tsx')) };
+mock.module('@/features/issues/issue-detail.tsx', () => ({
+  ...issueDetail,
+  IssueDetailView: ({ identifier }: { identifier: string }) => (
+    <div data-testid="issue-detail">{identifier}</div>
+  ),
+}));
+
+afterAll(() => {
+  mock.module('@/features/issues/issue-detail.tsx', () => issueDetail);
+  mock.module('@orbit/realtime-client/react', () => realtimeReact);
+});
+
+const { InboxView } = await import('@/features/inbox/inbox-view.tsx');
+
+function item(id: string, overrides: Partial<InboxItem> = {}): InboxItem {
+  return {
+    id,
+    type: 'comment_created',
+    entityType: 'issue',
+    entityId: 'issue_1',
+    actorName: 'Ada',
+    title: `Notification ${id}`,
+    body: '',
+    url: '/issue/ENG-3',
+    read: true,
+    snoozedUntil: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function olderPage(ids: readonly string[], nextCursor: string | null) {
+  return {
+    notifications: ids.map((id) => ({
+      id,
+      type: 'comment_created',
+      entityType: 'issue',
+      entityId: 'issue_1',
+      actorName: 'Ada',
+      title: `Notification ${id}`,
+      body: '',
+      url: '/issue/ENG-3',
+      read: true,
+      snoozedUntil: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    })),
+    nextCursor,
+  };
+}
+
+const realFetch = globalThis.fetch;
+let requests: string[] = [];
+let pages: Record<string, unknown> = {};
+let failNext = false;
+
+beforeEach(() => {
+  requests = [];
+  failNext = false;
+  pages = { 'cursor-1': olderPage(['n51', 'n52'], null) };
+  globalThis.fetch = mock((url: string) => {
+    const path = String(url);
+    requests.push(path);
+    if (path.startsWith('/api/notifications?')) {
+      if (failNext)
+        return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) });
+      const cursor = new URL(path, 'http://localhost').searchParams.get('cursor') ?? '';
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(pages[cursor] ?? olderPage([], null)),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ unreadCount: 0 }),
+    });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function renderInbox(items: readonly InboxItem[], nextCursor: string | null) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <HotkeyProvider>
+        <InboxView
+          items={items}
+          unreadCount={0}
+          unreadMentions={0}
+          userId="user_1"
+          nextCursor={nextCursor}
+          canWriteDocs
+          canPublishDocs
+        />
+      </HotkeyProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('an inbox with more notifications than one page', () => {
+  it('offers the older ones when the server said there are more', () => {
+    renderInbox([item('n1')], 'cursor-1');
+    expect(screen.getByTestId('inbox-load-more')).toBeInTheDocument();
+  });
+
+  it('says nothing when the first page was the whole inbox', () => {
+    renderInbox([item('n1')], null);
+    expect(screen.queryByTestId('inbox-load-more')).toBeNull();
+  });
+
+  it('appends the next page under the ones already read', async () => {
+    const user = userEvent.setup();
+    renderInbox([item('n1')], 'cursor-1');
+
+    await user.click(screen.getByTestId('inbox-load-more'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Notification n51/ })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /Notification n52/ })).toBeInTheDocument();
+
+    const titles = screen
+      .getAllByRole('button')
+      .map((node) => node.textContent ?? '')
+      .filter((text) => text.includes('Notification'));
+    expect(titles[0]).toContain('Notification n1');
+    expect(titles.at(-1)).toContain('Notification n52');
+  });
+
+  it('asks for the cursor the server handed back', async () => {
+    const user = userEvent.setup();
+    renderInbox([item('n1')], 'cursor-1');
+
+    await user.click(screen.getByTestId('inbox-load-more'));
+
+    await waitFor(() => {
+      expect(requests.some((path) => path.includes('cursor=cursor-1'))).toBe(true);
+    });
+  });
+
+  it('stops offering more once the last page comes back', async () => {
+    const user = userEvent.setup();
+    renderInbox([item('n1')], 'cursor-1');
+
+    await user.click(screen.getByTestId('inbox-load-more'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('inbox-load-more')).toBeNull();
+    });
+  });
+
+  it('keeps paging while the server keeps handing back cursors', async () => {
+    const user = userEvent.setup();
+    pages = {
+      'cursor-1': olderPage(['n51'], 'cursor-2'),
+      'cursor-2': olderPage(['n101'], null),
+    };
+    renderInbox([item('n1')], 'cursor-1');
+
+    await user.click(screen.getByTestId('inbox-load-more'));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Notification n51/ })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('inbox-load-more'));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Notification n101/ })).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('inbox-load-more')).toBeNull();
+  });
+
+  it('never lists the same notification twice when a page overlaps', async () => {
+    const user = userEvent.setup();
+    pages = { 'cursor-1': olderPage(['n1', 'n51'], null) };
+    renderInbox([item('n1')], 'cursor-1');
+
+    await user.click(screen.getByTestId('inbox-load-more'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Notification n51/ })).toBeInTheDocument();
+    });
+    expect(screen.getAllByRole('button', { name: /Notification n1\b/ })).toHaveLength(1);
+  });
+
+  it('says so when the page cannot be fetched, and keeps the offer open', async () => {
+    const user = userEvent.setup();
+    failNext = true;
+    renderInbox([item('n1')], 'cursor-1');
+
+    await user.click(screen.getByTestId('inbox-load-more'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('inbox-error')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('inbox-load-more')).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/features/inbox/inbox-pagination.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-pagination.test.tsx
@@ -238,6 +238,33 @@ describe('an inbox with more notifications than one page', () => {
     expect(screen.getByTestId('inbox-load-more')).toBeInTheDocument();
   });
 
+  it('can still reach older pages when a filter matches nothing loaded yet', async () => {
+    const user = userEvent.setup();
+    pages = { 'cursor-1': olderPage(['n51'], null) };
+    renderInbox([item('n1', { read: true })], 'cursor-1');
+
+    await user.click(screen.getByRole('button', { name: 'Unread' }));
+    expect(screen.queryByRole('button', { name: /Notification n1/ })).toBeNull();
+
+    const offer = screen.getByTestId('inbox-load-more');
+    expect(offer).toBeInTheDocument();
+
+    await user.click(offer);
+    await waitFor(() => {
+      expect(requests.some((path) => path.includes('cursor=cursor-1'))).toBe(true);
+    });
+  });
+
+  it('says inbox zero only when there is nothing left to fetch', async () => {
+    const user = userEvent.setup();
+    renderInbox([item('n1', { read: true })], null);
+
+    await user.click(screen.getByRole('button', { name: 'Unread' }));
+
+    expect(screen.getByText('Inbox zero')).toBeInTheDocument();
+    expect(screen.queryByTestId('inbox-load-more')).toBeNull();
+  });
+
   it('leaves a failed save alone when a page loads, they are separate complaints', async () => {
     const user = userEvent.setup();
     renderInbox([item('n1', { read: false })], 'cursor-1');

--- a/apps/web/tests/features/inbox/inbox-pagination.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-pagination.test.tsx
@@ -67,10 +67,12 @@ const realFetch = globalThis.fetch;
 let requests: string[] = [];
 let pages: Record<string, unknown> = {};
 let failNext = false;
+let failRead = false;
 
 beforeEach(() => {
   requests = [];
   failNext = false;
+  failRead = false;
   pages = { 'cursor-1': olderPage(['n51', 'n52'], null) };
   globalThis.fetch = mock((url: string) => {
     const path = String(url);
@@ -84,6 +86,9 @@ beforeEach(() => {
         status: 200,
         json: () => Promise.resolve(pages[cursor] ?? olderPage([], null)),
       });
+    }
+    if (failRead) {
+      return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) });
     }
     return Promise.resolve({
       ok: true,
@@ -208,7 +213,7 @@ describe('an inbox with more notifications than one page', () => {
 
     await user.click(screen.getByTestId('inbox-load-more'));
     await waitFor(() => {
-      expect(screen.getByTestId('inbox-error')).toBeInTheDocument();
+      expect(screen.getByTestId('inbox-paging-error')).toBeInTheDocument();
     });
 
     failNext = false;
@@ -217,7 +222,7 @@ describe('an inbox with more notifications than one page', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Notification n51/ })).toBeInTheDocument();
     });
-    expect(screen.queryByTestId('inbox-error')).toBeNull();
+    expect(screen.queryByTestId('inbox-paging-error')).toBeNull();
   });
 
   it('says so when the page cannot be fetched, and keeps the offer open', async () => {
@@ -228,8 +233,27 @@ describe('an inbox with more notifications than one page', () => {
     await user.click(screen.getByTestId('inbox-load-more'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('inbox-error')).toBeInTheDocument();
+      expect(screen.getByTestId('inbox-paging-error')).toBeInTheDocument();
     });
     expect(screen.getByTestId('inbox-load-more')).toBeInTheDocument();
+  });
+
+  it('leaves a failed save alone when a page loads, they are separate complaints', async () => {
+    const user = userEvent.setup();
+    renderInbox([item('n1', { read: false })], 'cursor-1');
+
+    failRead = true;
+    await user.click(screen.getByRole('button', { name: /Notification n1/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('inbox-error')).toBeInTheDocument();
+    });
+
+    failRead = false;
+    await user.click(screen.getByTestId('inbox-load-more'));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Notification n51/ })).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('inbox-error')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
The inbox asked for fifty notifications and threw away the cursor the
server handed back. Past fifty, the rest of the inbox was unreachable,
and nothing on the screen admitted it existed.

`listInbox` already paged, so most of this is wiring. A `GET` on
`/api/notifications` returns a page and its cursor, the server
component passes the first cursor down with the first page, and the
list offers the older ones at its end. The offer loads itself when it
scrolls into view, so reading down the list keeps going, and it stays
a real button so a reader who never scrolls it into view, or who is on
a keyboard, can still ask for more. It retires when the server stops
handing back a cursor.

## The one thing that was not wiring

The cursor lives in a ref, not only in state. Two things can ask to
load at the same moment, the observer and a click, and a request that
started against an older cursor would otherwise resolve last and write
that older cursor back, so the offer never retired and the same page
was fetched again. Reading the cursor at call time means the second
caller sees what the first already recorded. There is an in flight
guard too, but on its own it is not enough: it clears before React has
re-rendered, so the next caller would still hold the stale cursor.

## Verified

Against a real inbox of 126 notifications: 50, then 100, then 126,
the offer retires on the last page, and no notification appears twice.
Eight unit tests cover the offer appearing and retiring, the cursor
actually asked for, appending under what is already read, paging more
than once, dropping a duplicate that a shifting page can return, and
saying so without losing the offer when a page fails.

## Elsewhere

Issue lists and the Slack channel picker already page. Three surfaces
still truncate silently, each returning a cursor the client drops:
issue comments and doc comments both stop at fifty, and issue activity
returns an `activityCursor` nothing consumes. They are the same shape
of gap as this one, and each wants its own change since loading older
comments reads from the top of a thread rather than the bottom.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds cursor-based inbox pagination while keeping pagination failures separate from read-state failures.

- Adds an authenticated notifications endpoint that returns bounded pages and continuation cursors.
- Passes the initial cursor through the server and realtime components into the inbox view.
- Appends deduplicated pages through an observable, keyboard-accessible load-more button.
- Adds endpoint and component coverage for cursor progression, retries, deduplication, and independent error lifecycles.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the successful-retry path clears only the pagination complaint, while successful pagination leaves an unrelated failed read-state message intact.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/inbox/inbox-view.tsx | Adds cursor tracking, guarded page loading, deduplicated appends, and a pagination-specific error whose successful retry now clears it without affecting read-state errors. |
| apps/web/src/app/api/notifications/route.ts | Adds an authenticated, page-size-bounded endpoint that maps notification records into the inbox response shape. |
| apps/web/src/features/inbox/data.ts | Exposes the initial continuation cursor and centralizes conversion from notification records to inbox items. |
| apps/web/tests/features/inbox/inbox-pagination.test.tsx | Covers cursor progression, retries, duplicate suppression, filtered empty states, and separation between pagination and read-state errors. |
| apps/web/tests/app/api/notifications/route.test.ts | Covers endpoint pagination, page-size bounds, response conversion, cursor continuation, and authentication. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Page as InboxPage
  participant View as InboxView
  participant API as GET /api/notifications
  participant Service as listInbox
  Page->>Service: Request initial page
  Service-->>Page: Items and nextCursor
  Page->>View: Initial items and cursor
  View->>API: Request page with cursor
  API->>Service: Request bounded next page
  Service-->>API: Older items and nextCursor
  API-->>View: Serialized page
  View->>View: Deduplicate and append items
  alt More pages remain
    View->>View: Retain load-more offer
  else Last page
    View->>View: Retire load-more offer
  end
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(inbox): keep older pages reachable w..."](https://github.com/noveum/orbit/commit/79a20be6360cfdd85be81e9470f83eb4d1a82440) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51948132)</sub>

<!-- /greptile_comment -->