### PR TITLE
docs: track open source readiness status

### DIFF
--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -42,31 +42,37 @@ to the codebase.
   portable standalone Node start path, copied-artifact smoke coverage, and
   aligned self-hosting and troubleshooting guidance. It merged as `811b0c5d`
   after all exact-head checks and required reviews passed.
+- [#290](https://github.com/Noveum/orbit/pull/290) made prepared statements an
+  explicit strict application-pool setting, defaulted to
+  transaction-pooler-safe behavior, rejected conflicting URL options with
+  linear-time parsing, and added adversarial regression coverage. It merged as
+  `e43d229f` after full local and hosted exact-head verification passed with no
+  unresolved review threads.
 
 GitHub records show successful hosted CI and completion of required reviews on
 the merged heads. These pull requests reduce the known gaps, but they do not
 make the repository a supported production release.
 
-### Active pull requests
+### Active open-source readiness pull requests
 
 - [#289](https://github.com/Noveum/orbit/pull/289), SEC-003, requires explicit
   MCP consent and PKCE, preserves OAuth continuation through passwordless login,
   binds issued credentials to an immutable grant, prevents issued token scopes
-  from exceeding that grant, and consumes refresh credentials once. Status: in
-  progress at final exact-head verification and review. It is not merged.
-- [#290](https://github.com/Noveum/orbit/pull/290) makes prepared statements an
-  explicit strict application-pool setting, defaults to transaction-pooler-safe
-  behavior, and rejects conflicting URL options. Status: in progress. Its public
-  head now includes linear-time connection URL normalization and adversarial
-  regression coverage, and its prior exact-head checks passed. It is pending a
-  latest-`main` refresh, full local verification, and a complete exact-head rerun.
+  from exceeding that grant, and consumes refresh credentials once. Status:
+  exact head `4f369ee` passes full local verification, but individual CodeQL
+  alert [#19](https://github.com/Noveum/orbit/security/code-scanning/19)
+  misclassifies an opaque OAuth credential's HMAC integrity binding as password
+  hashing. The reviewed false-positive classification awaits maintainer
+  dismissal, so the pull request is not merge-ready.
 - [#293](https://github.com/Noveum/orbit/pull/293) maintains this readiness
   tracker. Status: in progress. It records completed work and remaining release
   requirements without changing application behavior.
 
 ### Merge gate for this work
 
-- Availability of optional review services is not a merge gate for this project.
+- An unavailable optional review service may be replaced only by a documented
+  independent review of the exact diff. This does not waive hosted CI or review
+  thread clearance.
 - A branch must contain current `main`, pass hosted CI on the exact head, finish
   required exact-head review at its highest confidence level with no unresolved
   review threads, and pass an independent diff review before merge.
@@ -95,10 +101,13 @@ make the repository a supported production release.
 - [ ] **RT-001: Durable realtime recovery.** **Status: open.** Persist deletes
   and other replayable events, publish through an outbox, detect gaps, and test
   Redis and reconnect failures. Current evidence is in the core backfill and
-  delta bridge paths.
-- [ ] **DB-001: Production migrations.** **Status: open.** Replace production
-  `db:push` guidance with ordered migrations, a safe baseline for existing
-  installs, drift checks, rollback guidance, and upgrade tests.
+  delta bridge paths. Until this lands, `docs/architecture.md` must describe
+  reconnect replay as best effort and identify hard-delete and publish-gap
+  limits.
+- [ ] **DB-001: Production migrations.** **Status: partial.** Ordered migrations
+  and a from-scratch migration and drift check exist in CI. Replace production
+  `db:push` guidance, add a safe baseline for existing installs, rollback
+  guidance, and upgrade tests.
 - [ ] **DB-002: Migration identity collisions.** **Status: open.** Reject reused
   migration indexes with different contents and compare the resulting catalog
   in CI.
@@ -117,9 +126,10 @@ make the repository a supported production release.
 - [ ] **PORT-001: Neutral seed and import tooling.** **Status: partial through
   #281, #287, and #288.** Neutral demo data, unsafe importer quarantine, and
   destructive seed protection are complete. Remaining work includes
-  tenant-specific test fixtures, a branded settings placeholder, and supported
-  argument-driven, dry-run-first replacement importers. Legitimate sponsorship
-  and project contact references remain by design.
+  tenant-specific unit and integration fixtures and branded product-form
+  placeholders. A future general-purpose importer is optional product work, not
+  a release blocker. Legitimate sponsorship and project contact references
+  remain by design.
 - [ ] **PRIV-001: Personal and branded artifacts.** **Status: partial through
   #282.** Current screenshots and private working artifacts were replaced or
   removed. Historical blobs, media ownership, and external ownership records
@@ -152,8 +162,9 @@ make the repository a supported production release.
   permission documentation is corrected, but one tested permission and event
   manifest with generated or validated setup documentation remains.
 - [ ] **CI-001: Production-shaped CI.** **Status: partial.** Existing CI runs the
-  repository checks, build, and end-to-end suite. Container, migration,
-  packaged-start, and realtime smoke coverage is not all complete.
+  repository checks, a from-scratch migration and drift check, build, copied
+  standalone smoke, and the end-to-end suite. Application-container and
+  portable-realtime smoke coverage remain.
 
 ## P1 release requirements
 
@@ -203,9 +214,8 @@ make the repository a supported production release.
 - [ ] **PRIV-002: Web Vitals minimization.** **Status: open.** Add operator
   controls and sampling, reduce recorded attribution, document retention, and
   test deletion and abuse limits.
-- [ ] **REL-001: Operational readiness.** **Status: open.** Split liveness from
-  readiness, require configured capabilities, and document and schedule
-  retention work.
+- [ ] **REL-001: Operational readiness.** **Status: open.** Require configured
+  capabilities and document and schedule retention work.
 - [ ] **MCP-001: Accurate tool annotations.** **Status: open.** Mark destructive,
   read-only, idempotent, and open-world behavior correctly for every MCP tool.
 - [ ] **CI-002: Immutable CI inputs.** **Status: open.** Pin actions and container
@@ -222,8 +232,8 @@ make the repository a supported production release.
   quickstarts plus backup, restore, upgrade, and incident runbooks.
 - [ ] **REPO-001: Consistent contributor policy.** **Status: open.** Align agent
   instructions, generated files, test placement, Biome exceptions, and CI
-  enforcement. Remove stale tool-specific review requirements from `CLAUDE.md`
-  and `CONTRIBUTING.md` so documented review gates match the active policy.
+  enforcement. Remove stale review requirements from repository instruction
+  files and contributor guidance so documented gates match the active policy.
 
 ## Deferred P2 work
 
@@ -242,17 +252,6 @@ make the repository a supported production release.
 - [ ] **REPO-002: Large module cleanup.** **Status: deferred.** Split oversized
   services and normalize test-support placement only after behavioral safety
   nets exist.
-
-## Recommended pull request order
-
-1. Preview boundary, Slack disablement, GitHub documentation, and tenant-specific
-   operational cleanup.
-2. Neutral demo seed, import configuration, screenshots, and privacy cleanup.
-3. Migration safety, production start, application images, and Compose.
-4. Durable realtime recovery and idempotent GitHub delivery processing.
-5. Authentication, MCP, upload, invitation, avatar, and request-boundary
-   security batches.
-6. Dependency, CI, release, observability, backup, restore, and operator docs.
 
 ## Verification required for each pull request
 

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -38,6 +38,10 @@ to the codebase.
   exemption to the exact development Compose target, and bound every other
   confirmation to a credential-safe target identity. It merged as `9779141`
   after all exact-head checks and required reviews passed.
+- [#283](https://github.com/Noveum/orbit/pull/283) completed DEP-001 with a
+  portable standalone Node start path, copied-artifact smoke coverage, and
+  aligned self-hosting and troubleshooting guidance. It merged as `811b0c5d`
+  after all exact-head checks and required reviews passed.
 
 GitHub records show successful hosted CI and completion of required reviews on
 the merged heads. These pull requests reduce the known gaps, but they do not
@@ -45,25 +49,20 @@ make the repository a supported production release.
 
 ### Active pull requests
 
-- [#283](https://github.com/Noveum/orbit/pull/283), DEP-001, adds a tested
-  standalone Node start path and copied-artifact smoke test. Status: in progress,
-  not yet merge-ready. The standalone runtime and troubleshooting corrections
-  are on the public branch, and its prior exact-head checks passed. Latest-`main`
-  integration is in progress, so the resulting public head must complete the
-  full merge gate before merge.
 - [#289](https://github.com/Noveum/orbit/pull/289), SEC-003, requires explicit
   MCP consent and PKCE, preserves OAuth continuation through passwordless login,
-  and prevents issued token scopes from exceeding the active grant. Status: in
-  progress. Its public head passed hosted CI and required review, but is behind
-  `main` and must be refreshed and reverified before merge. Its current diff has
-  an independent clean review.
+  binds issued credentials to an immutable grant, prevents issued token scopes
+  from exceeding that grant, and consumes refresh credentials once. Status: in
+  progress at final exact-head verification and review. It is not merged.
 - [#290](https://github.com/Noveum/orbit/pull/290) makes prepared statements an
   explicit strict application-pool setting, defaults to transaction-pooler-safe
   behavior, and rejects conflicting URL options. Status: in progress. Its public
   head now includes linear-time connection URL normalization and adversarial
-  regression coverage, and its prior exact-head checks passed. It remains behind
-  `main`; latest-main integration, full local verification, and a complete
-  exact-head rerun are required before merge.
+  regression coverage, and its prior exact-head checks passed. It is pending a
+  latest-`main` refresh, full local verification, and a complete exact-head rerun.
+- [#293](https://github.com/Noveum/orbit/pull/293) maintains this readiness
+  tracker. Status: in progress. It records completed work and remaining release
+  requirements without changing application behavior.
 
 ### Merge gate for this work
 
@@ -73,6 +72,13 @@ make the repository a supported production release.
   review threads, and pass an independent diff review before merge.
 - Slack remains disabled and deferred. Requalification is tracked only as
   future work and is not part of the active merge sequence.
+
+### Known verification warnings
+
+- `biome.json` references schema version 2.5.5 while the installed Biome CLI is
+  version 2.5.7.
+- `packages/db/tests/check-source-bytes.test.ts:19` reports the Biome
+  `noTemplateCurlyInString` lint warning.
 
 ## Release rule
 
@@ -96,9 +102,9 @@ make the repository a supported production release.
 - [ ] **DB-002: Migration identity collisions.** **Status: open.** Reject reused
   migration indexes with different contents and compare the resulting catalog
   in CI.
-- [ ] **DEP-001: Tested production start.** **Status: in progress in #283.**
-  Provide a real start command for the standalone Next.js artifact and smoke-test
-  the exact packaged output.
+- [x] **DEP-001: Tested production start.** **Status: complete in #283.** The
+  standalone Next.js artifact has a portable Node start command and a
+  copied-artifact smoke test.
 - [ ] **DEP-002: Portable realtime topology.** **Status: open.** Put the realtime
   service behind a same-origin proxy without relying on Vercel-only websocket
   behavior.
@@ -224,6 +230,15 @@ make the repository a supported production release.
 - [ ] **INT-002: Slack requalification.** **Status: deferred.** Slack stays
   disabled and absent from supported claims until OAuth, events, permissions,
   delivery, and end-to-end behavior are repaired in a separate project.
+- [ ] **MCP-002: OIDC signing metadata alignment.** **Status: upstream
+  follow-up.** Better Auth metadata advertises RS256 while its current ephemeral
+  ID token is emitted with HS256. Track the upstream correction and add
+  interoperability coverage before relying on that metadata.
+- [ ] **MCP-003: Grant issuance race cleanup.** **Status: low-severity
+  follow-up.** An authorization-code and re-consent race can leave an unusable
+  orphan raw OAuth token row. There is no usable credential or cross-workspace
+  bypass, but a future persisted token-to-grant relation or grant locking should
+  prevent and clean up the orphan row.
 - [ ] **REPO-002: Large module cleanup.** **Status: deferred.** Split oversized
   services and normalize test-support placement only after behavioral safety
   nets exist.

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -76,8 +76,11 @@ make the repository a supported production release.
   hashing. The reviewed false-positive classification awaits maintainer
   dismissal, so the pull request is not merge-ready.
 - [#293](https://github.com/Noveum/orbit/pull/293) maintains this readiness
-  tracker. Status: in progress. It records completed work and remaining release
-  requirements without changing application behavior.
+  tracker. Status: exact head `3030be7` contains current `main`; hosted checks
+  and the exact-head external review are green. Full local exact-tree
+  verification and an accurate pull-request body remain pending, so it is not
+  merge-ready. It records completed work and remaining release requirements
+  without changing application behavior.
 
 ### Merge gate for this work
 
@@ -120,8 +123,10 @@ make the repository a supported production release.
   `db:push` guidance, add a safe baseline for existing installs, rollback
   guidance, and upgrade tests.
 - [ ] **DB-002: Migration identity collisions.** **Status: open.** Reject reused
-  migration indexes with different contents and compare the resulting catalog
-  in CI.
+  migration indexes with different contents, compare the resulting catalog in
+  CI, define the rebase policy, and decide whether databases that applied the
+  abandoned `0003_productive_quicksilver` migration are supported. Test every
+  supported upgrade path instead of treating prevention as historical repair.
 - [x] **DEP-001: Tested production start.** **Status: complete in #283.** The
   standalone Next.js artifact has a portable Node start command and a
   copied-artifact smoke test.
@@ -200,9 +205,6 @@ make the repository a supported production release.
 - [ ] **SEC-011: Email token retention.** **Status: open.** Avoid retaining raw
   magic, reset, and invite tokens; define tenant ownership, deletion, and
   retention.
-- [ ] **SEC-012: Slack metadata authorization.** **Status: deferred with
-  INT-002.** When Slack work resumes, require server-side integration management
-  permission and denial tests.
 - [ ] **SEC-013: Account linking and recovery.** **Status: open.** Default to
   matching identities, require step-up for sensitive changes, and prevent
   unlinking every credential.
@@ -249,6 +251,10 @@ make the repository a supported production release.
 
 ## Deferred P2 work
 
+- [ ] **SEC-012: Slack metadata authorization.** **Status: deferred with
+  INT-002.** It is not a release blocker while Slack is disabled. When Slack
+  work resumes, require server-side integration management permission and
+  denial tests.
 - [ ] **INT-002: Slack requalification.** **Status: deferred.** Slack stays
   disabled and absent from supported claims until OAuth, events, permissions,
   delivery, and end-to-end behavior are repaired in a separate project.
@@ -276,8 +282,12 @@ make the repository a supported production release.
 
 ## Audit limits
 
-The repository audit covered source, packages, schema, migrations, scripts,
-tests, documentation, workflows, Docker configuration, tracked media, dependency
+The full repository baseline audit was pinned to `f1bfdc3`, followed by a
+targeted delta review through `9f961a1`. Later readiness pull requests were
+reviewed and verified individually through current `main` at `64f7972`; this is
+not a claim that the full baseline audit was rerun after every intervening
+commit. The audit covered source, packages, schema, migrations, scripts, tests,
+documentation, workflows, Docker configuration, tracked media, dependency
 advisories, and Git history secret patterns. It did not inspect production cloud
 accounts, bucket policy, database roles, Redis ACLs, DNS, TLS, live provider
 registrations, or legal ownership records. No likely live credential was found

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -66,6 +66,14 @@ make the repository a supported production release.
   misclassifies an opaque OAuth credential's HMAC integrity binding as password
   hashing. The reviewed false-positive classification awaits maintainer
   dismissal, so the pull request is not merge-ready.
+- [#294](https://github.com/Noveum/orbit/pull/294), DEP-004, rejects production
+  builds and starts unless password authentication, a complete Google or GitHub
+  credential pair, or Resend magic-link delivery with an explicit non-local
+  sender is configured. It tests rejected and successful startup through the
+  copied standalone artifact and documents first-user bootstrap limits. Status:
+  exact head `b21ad89648e3244f228a1f1a64b698040291c75b` contains current `main`,
+  passes full local verification and independent review, and awaits hosted
+  checks and required exact-head reviews, so the pull request is not merge-ready.
 - [#293](https://github.com/Noveum/orbit/pull/293) maintains this readiness
   tracker. Status: in progress. It records completed work and remaining release
   requirements without changing application behavior.
@@ -122,9 +130,11 @@ make the repository a supported production release.
 - [ ] **DEP-003: Application containers.** **Status: open.** Add reproducible
   production images and a complete Compose profile for web, realtime, Postgres,
   Redis, and object storage.
-- [ ] **DEP-004: First-login validation.** **Status: open.** Refuse a production
-  start unless at least one complete authentication path is configured and
-  tested.
+- [ ] **DEP-004: First-login validation.** **Status: in progress in #294.**
+  Refuse a production build or start unless at least one complete authentication
+  path is configured. The branch adds regression and copied-artifact coverage
+  for rejected and valid configurations; hosted exact-head checks and reviews
+  remain pending.
 - [ ] **PORT-001: Neutral seed and import tooling.** **Status: partial through
   #281, #287, and #288.** Neutral demo data, unsafe importer quarantine, and
   destructive seed protection are complete. Remaining work includes

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -48,6 +48,14 @@ to the codebase.
   linear-time parsing, and added adversarial regression coverage. It merged as
   `e43d229f` after full local and hosted exact-head verification passed with no
   unresolved review threads.
+- [#294](https://github.com/Noveum/orbit/pull/294) completed DEP-004 by
+  rejecting production builds and standalone starts without a usable
+  first-login path, accepting password authentication, complete Google or
+  GitHub credentials, or Resend with an explicit non-local sender.
+  Copied-artifact smoke coverage verifies rejected and successful startup, and
+  operator documentation records first-user bootstrap limits. It merged as
+  `64f7972` after full local and hosted exact-head verification passed with no
+  unresolved actionable review finding.
 
 GitHub records show successful hosted CI and completion of required reviews on
 the merged heads. These pull requests reduce the known gaps, but they do not
@@ -59,21 +67,14 @@ make the repository a supported production release.
   MCP consent and PKCE, preserves OAuth continuation through passwordless login,
   binds issued credentials to an immutable grant, prevents issued token scopes
   from exceeding that grant, and consumes refresh credentials once. Status:
-  exact head `9cd1ac9` contains current `main`, passes full local verification
-  and independent review, and has no unresolved ordinary review threads. The
-  remaining individual CodeQL
+  exact head `d13252d` contains current `main`, passes full local verification,
+  independent review, and every hosted check except the expected individual
+  CodeQL gate. It has no unresolved ordinary review threads. The remaining
+  CodeQL
   alert [#19](https://github.com/Noveum/orbit/security/code-scanning/19)
   misclassifies an opaque OAuth credential's HMAC integrity binding as password
   hashing. The reviewed false-positive classification awaits maintainer
   dismissal, so the pull request is not merge-ready.
-- [#294](https://github.com/Noveum/orbit/pull/294), DEP-004, rejects production
-  builds and starts unless password authentication, a complete Google or GitHub
-  credential pair, or Resend magic-link delivery with an explicit non-local
-  sender is configured. It tests rejected and successful startup through the
-  copied standalone artifact and documents first-user bootstrap limits. Status:
-  exact head `b21ad89648e3244f228a1f1a64b698040291c75b` contains current `main`,
-  passes full local verification and independent review, and awaits hosted
-  checks and required exact-head reviews, so the pull request is not merge-ready.
 - [#293](https://github.com/Noveum/orbit/pull/293) maintains this readiness
   tracker. Status: in progress. It records completed work and remaining release
   requirements without changing application behavior.
@@ -130,11 +131,10 @@ make the repository a supported production release.
 - [ ] **DEP-003: Application containers.** **Status: open.** Add reproducible
   production images and a complete Compose profile for web, realtime, Postgres,
   Redis, and object storage.
-- [ ] **DEP-004: First-login validation.** **Status: in progress in #294.**
-  Refuse a production build or start unless at least one complete authentication
-  path is configured. The branch adds regression and copied-artifact coverage
-  for rejected and valid configurations; hosted exact-head checks and reviews
-  remain pending.
+- [x] **DEP-004: First-login validation.** **Status: complete in #294.**
+  Production builds and standalone starts now require at least one complete
+  first-login path, with regression and copied-artifact coverage for rejected
+  and valid configurations.
 - [ ] **PORT-001: Neutral seed and import tooling.** **Status: partial through
   #281, #287, and #288.** Neutral demo data, unsafe importer quarantine, and
   destructive seed protection are complete. Remaining work includes

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -33,46 +33,44 @@ to the codebase.
   one-off database import path by removing destructive and tenant-specific
   import commands while retaining the neutral mapping boundary needed for a
   future supported importer.
+- [#288](https://github.com/Noveum/orbit/pull/288) guarded the destructive demo
+  seed before database-client initialization, limited the confirmation-free
+  exemption to the exact development Compose target, and bound every other
+  confirmation to a credential-safe target identity. It merged as `9779141`
+  after all exact-head checks and required reviews passed.
 
-GitHub records show successful hosted CI and Greptile review on the merged
-heads. These pull requests reduce the known gaps, but they do not make the
-repository a supported production release.
+GitHub records show successful hosted CI and completion of required reviews on
+the merged heads. These pull requests reduce the known gaps, but they do not
+make the repository a supported production release.
 
 ### Active pull requests
 
 - [#283](https://github.com/Noveum/orbit/pull/283), DEP-001, adds a tested
   standalone Node start path and copied-artifact smoke test. Status: in progress,
-  not merge-ready. The public head is behind `main`, its hosted end-to-end job
-  failed, and final review found standalone prerequisite and troubleshooting
-  documentation corrections that must land before exact-head verification.
-- [#288](https://github.com/Noveum/orbit/pull/288), part of PORT-001, stops the
-  destructive demo seed before database-client initialization unless the target
-  is the exact development Compose database or a target-bound confirmation is
-  supplied. Status: in progress, not merge-ready. Its hosted end-to-end job
-  failed because CI did not supply the newly required target confirmation. The
-  updated public head contains current `main` and a reviewed fix scoped to the
-  end-to-end job. Full isolated local verification is green; the updated head
-  must still pass hosted CI and Greptile review.
+  not yet merge-ready. The standalone runtime and troubleshooting corrections
+  are on the public branch, and its prior exact-head checks passed. Latest-`main`
+  integration is in progress, so the resulting public head must complete the
+  full merge gate before merge.
 - [#289](https://github.com/Noveum/orbit/pull/289), SEC-003, requires explicit
   MCP consent and PKCE, preserves OAuth continuation through passwordless login,
   and prevents issued token scopes from exceeding the active grant. Status: in
-  progress. Its public head passed hosted CI and Greptile, but is behind `main`
-  and must be refreshed and reverified before merge. Its current diff has an
-  independent clean review.
+  progress. Its public head passed hosted CI and required review, but is behind
+  `main` and must be refreshed and reverified before merge. Its current diff has
+  an independent clean review.
 - [#290](https://github.com/Noveum/orbit/pull/290) makes prepared statements an
   explicit strict application-pool setting, defaults to transaction-pooler-safe
   behavior, and rejects conflicting URL options. Status: in progress. Its public
-  head is behind `main`. Its failed CodeQL gate is a confirmed high-severity
-  quadratic-regex finding in connection URL normalization. A linear fix,
-  adversarial regression coverage, and a complete exact-head rerun are required
-  before merge.
+  head now includes linear-time connection URL normalization and adversarial
+  regression coverage, and its prior exact-head checks passed. It remains behind
+  `main`; latest-main integration, full local verification, and a complete
+  exact-head rerun are required before merge.
 
 ### Merge gate for this work
 
-- CodeRabbit is not an availability or merge gate for this project.
+- Availability of optional review services is not a merge gate for this project.
 - A branch must contain current `main`, pass hosted CI on the exact head, finish
-  exact-head Greptile review at 5/5 with no unresolved review threads, and pass
-  an independent diff review before merge.
+  required exact-head review at its highest confidence level with no unresolved
+  review threads, and pass an independent diff review before merge.
 - Slack remains disabled and deferred. Requalification is tracked only as
   future work and is not part of the active merge sequence.
 
@@ -111,11 +109,11 @@ repository a supported production release.
   start unless at least one complete authentication path is configured and
   tested.
 - [ ] **PORT-001: Neutral seed and import tooling.** **Status: partial through
-  #281 and #287, with #288 active.** Neutral demo data and unsafe importer
-  quarantine are complete. Remaining work includes tenant-specific test
-  fixtures, a branded settings placeholder, and supported argument-driven,
-  dry-run-first replacement importers. Legitimate sponsorship and project
-  contact references remain by design.
+  #281, #287, and #288.** Neutral demo data, unsafe importer quarantine, and
+  destructive seed protection are complete. Remaining work includes
+  tenant-specific test fixtures, a branded settings placeholder, and supported
+  argument-driven, dry-run-first replacement importers. Legitimate sponsorship
+  and project contact references remain by design.
 - [ ] **PRIV-001: Personal and branded artifacts.** **Status: partial through
   #282.** Current screenshots and private working artifacts were replaced or
   removed. Historical blobs, media ownership, and external ownership records
@@ -218,8 +216,8 @@ repository a supported production release.
   quickstarts plus backup, restore, upgrade, and incident runbooks.
 - [ ] **REPO-001: Consistent contributor policy.** **Status: open.** Align agent
   instructions, generated files, test placement, Biome exceptions, and CI
-  enforcement. Remove stale CodeRabbit requirements from `CLAUDE.md` and
-  `CONTRIBUTING.md` so documented review gates match the active policy.
+  enforcement. Remove stale tool-specific review requirements from `CLAUDE.md`
+  and `CONTRIBUTING.md` so documented review gates match the active policy.
 
 ## Deferred P2 work
 

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -12,12 +12,12 @@ to the codebase.
 
 ## Status snapshot: 2026-08-11
 
-### Merged on `main`
+### Merged readiness implementation pull requests
 
 - [#280](https://github.com/Noveum/orbit/pull/280) defined the public Preview
   boundary, retained Noveum AI sponsorship and Apache-2.0 attribution, disabled
   Slack across supported product paths, kept GitHub available with corrected
-  permissions documentation, and removed tenant-specific Yodu operations.
+  permissions documentation, and removed tenant-specific operations.
 - [#281](https://github.com/Noveum/orbit/pull/281) replaced the built-in demo
   workspace, people, identifiers, domains, time zones, documentation examples,
   and end-to-end fixtures with neutral fictional data.
@@ -56,37 +56,26 @@ to the codebase.
   operator documentation records first-user bootstrap limits. It merged as
   `64f7972` after full local and hosted exact-head verification passed with no
   unresolved actionable review finding.
+- [#289](https://github.com/Noveum/orbit/pull/289) completed SEC-003 by
+  requiring explicit consent and RFC 7636 PKCE, binding access and refresh
+  credentials to immutable workspace grants, enforcing active scopes and
+  revocation, and consuming refresh credentials once. It merged as `4359717f`
+  after full local and hosted exact-head verification, CodeQL, and independent
+  security review passed with every review thread resolved.
 
 GitHub records show successful hosted CI and completion of required reviews on
 the merged heads. These pull requests reduce the known gaps, but they do not
 make the repository a supported production release.
 
-### Active open-source readiness pull requests
-
-- [#289](https://github.com/Noveum/orbit/pull/289), SEC-003, requires explicit
-  MCP consent and PKCE, preserves OAuth continuation through passwordless login,
-  binds issued credentials to an immutable grant, prevents issued token scopes
-  from exceeding that grant, and consumes refresh credentials once. Status:
-  exact head `d13252d` contains current `main`, passes full local verification,
-  independent review, and every hosted check except the expected individual
-  CodeQL gate. It has no unresolved ordinary review threads. The remaining
-  CodeQL
-  alert [#19](https://github.com/Noveum/orbit/security/code-scanning/19)
-  misclassifies an opaque OAuth credential's HMAC integrity binding as password
-  hashing. The reviewed false-positive classification awaits maintainer
-  dismissal, so the pull request is not merge-ready.
-- [#293](https://github.com/Noveum/orbit/pull/293) maintains this readiness
-  tracker. Status: the branch contains current `main`, and pre-push lint and
-  typecheck pass. Full local exact-tree verification, hosted checks on the final
-  head, and an accurate pull-request body remain pending, so it is not
-  merge-ready. It records completed work and remaining release requirements
-  without changing application behavior.
+The checklist currently has 4 of 19 P0 items complete, with 15 P0 items and all
+23 P1 items remaining. The 5 P2 items are explicitly deferred or tracked as
+follow-up work.
 
 ### Merge gate for this work
 
-- An unavailable optional review service may be replaced only by a documented
-  independent review of the exact diff. This does not waive hosted CI or review
-  thread clearance.
+- For this readiness sequence, maintainers approved a documented independent
+  review of the exact diff when the optional review service was unavailable.
+  Hosted CI and review-thread clearance remain required.
 - A branch must contain current `main`, pass hosted CI on the exact head, finish
   required exact-head review at its highest confidence level with no unresolved
   review threads, and pass an independent diff review before merge.
@@ -105,8 +94,8 @@ make the repository a supported production release.
 - P0 blocks a supported public Preview.
 - P1 blocks a stable supported release unless a documented, time-limited
   exception is accepted by maintainers.
-- P2 is follow-up work and does not belong in the first pull request unless it
-  directly supports a P0 or P1 fix.
+- P2 is follow-up work and does not block Preview or the first stable release
+  unless it directly supports a P0 or P1 fix.
 - Every behavioral fix needs a regression test. Every deployment claim needs a
   reproducible command or smoke test.
 
@@ -157,9 +146,9 @@ make the repository a supported production release.
 - [ ] **SEC-002: Invitation abuse controls.** **Status: open.** Add durable
   sender, tenant, IP, and recipient limits with resend cooldowns and provider-safe
   retries.
-- [ ] **SEC-003: Immutable MCP grants.** **Status: in progress in #289.** Bind
-  tokens to one grant and workspace, and revoke them when consent or scope
-  changes.
+- [x] **SEC-003: Immutable MCP grants.** **Status: complete in #289.** Access
+  and refresh credentials are bound to one workspace grant, active scope and
+  revocation are enforced, and refresh credentials are consumed once.
 - [x] **SEC-004: Integration callback authorization.** **Status: complete in
   #285.** Current administration permission is rechecked before provider exchange
   and again inside the serialized binding transaction.
@@ -263,10 +252,11 @@ make the repository a supported production release.
   ID token is emitted with HS256. Track the upstream correction and add
   interoperability coverage before relying on that metadata.
 - [ ] **MCP-003: Grant issuance race cleanup.** **Status: low-severity
-  follow-up.** An authorization-code and re-consent race can leave an unusable
-  orphan raw OAuth token row. There is no usable credential or cross-workspace
-  bypass, but a future persisted token-to-grant relation or grant locking should
-  prevent and clean up the orphan row.
+  follow-up.** Concurrent allow and deny decisions can let approval create a
+  valid grant while the losing denial path deletes no consent row but still
+  reports `access_denied`. Serialize the decisions or require the denial to
+  consume the pending consent row, then add a two-request regression. This does
+  not create cross-workspace access.
 - [ ] **REPO-002: Large module cleanup.** **Status: deferred.** Split oversized
   services and normalize test-support placement only after behavioral safety
   nets exist.
@@ -284,9 +274,10 @@ make the repository a supported production release.
 
 The full repository baseline audit was pinned to `f1bfdc3`, followed by a
 targeted delta review through `9f961a1`. Later readiness pull requests were
-reviewed and verified individually through current `main` at `64f7972`; this is
-not a claim that the full baseline audit was rerun after every intervening
-commit. The audit covered source, packages, schema, migrations, scripts, tests,
+reviewed and verified individually through current `main` at `4359717f` before
+this documentation-only tracker update; this is not a claim that the full
+baseline audit was rerun after every intervening commit. The audit covered
+source, packages, schema, migrations, scripts, tests,
 documentation, workflows, Docker configuration, tracked media, dependency
 advisories, and Git history secret patterns. It did not inspect production cloud
 accounts, bucket policy, database roles, Redis ACLs, DNS, TLS, live provider

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -10,18 +10,71 @@ verified gaps and the outcome required to close each one. Implementation should
 be split into focused pull requests instead of adding a separate policy system
 to the codebase.
 
-## Current pull request
+## Status snapshot: 2026-08-11
 
-- [x] Publish the Preview boundary in the README and self-hosting guide.
-- [x] Keep Noveum AI sponsorship and Apache-2.0 attribution intact.
-- [x] Disable Slack in the UI, OAuth, API, callback, webhook, notification, and
-      GitHub side-effect paths until it is requalified.
-- [x] Keep GitHub available and correct its documented permission set.
-- [x] Remove the tenant-specific Yodu catchup and planning artifacts.
-- [x] Pass focused tests, `bun run verify`, and the production build locally.
-- [ ] Pass hosted CI on the pull request commit.
+### Merged on `main`
 
-The completed items are implemented and locally verified on the current branch.
+- [#280](https://github.com/Noveum/orbit/pull/280) defined the public Preview
+  boundary, retained Noveum AI sponsorship and Apache-2.0 attribution, disabled
+  Slack across supported product paths, kept GitHub available with corrected
+  permissions documentation, and removed tenant-specific Yodu operations.
+- [#281](https://github.com/Noveum/orbit/pull/281) replaced the built-in demo
+  workspace, people, identifiers, domains, time zones, documentation examples,
+  and end-to-end fixtures with neutral fictional data.
+- [#282](https://github.com/Noveum/orbit/pull/282) replaced the documentation
+  screenshots, removed the private avatar importer and its Slack object URLs,
+  and removed a tracked private demo upload artifact.
+- [#285](https://github.com/Noveum/orbit/pull/285) completed SEC-004. GitHub
+  callback binding now rechecks current administration rights before provider
+  exchange and inside the serialized binding transaction, rejects deleting
+  workspaces, and distinguishes an unavailable workspace from a claimed
+  installation.
+- [#287](https://github.com/Noveum/orbit/pull/287) quarantined the unsafe
+  one-off database import path by removing destructive and tenant-specific
+  import commands while retaining the neutral mapping boundary needed for a
+  future supported importer.
+
+GitHub records show successful hosted CI and Greptile review on the merged
+heads. These pull requests reduce the known gaps, but they do not make the
+repository a supported production release.
+
+### Active pull requests
+
+- [#283](https://github.com/Noveum/orbit/pull/283), DEP-001, adds a tested
+  standalone Node start path and copied-artifact smoke test. Status: in progress,
+  not merge-ready. The public head is behind `main`, its hosted end-to-end job
+  failed, and final review found standalone prerequisite and troubleshooting
+  documentation corrections that must land before exact-head verification.
+- [#288](https://github.com/Noveum/orbit/pull/288), part of PORT-001, stops the
+  destructive demo seed before database-client initialization unless the target
+  is the exact development Compose database or a target-bound confirmation is
+  supplied. Status: in progress, not merge-ready. Its hosted end-to-end job
+  failed because CI did not supply the newly required target confirmation. The
+  updated public head contains current `main` and a reviewed fix scoped to the
+  end-to-end job. Full isolated local verification is green; the updated head
+  must still pass hosted CI and Greptile review.
+- [#289](https://github.com/Noveum/orbit/pull/289), SEC-003, requires explicit
+  MCP consent and PKCE, preserves OAuth continuation through passwordless login,
+  and prevents issued token scopes from exceeding the active grant. Status: in
+  progress. Its public head passed hosted CI and Greptile, but is behind `main`
+  and must be refreshed and reverified before merge. Its current diff has an
+  independent clean review.
+- [#290](https://github.com/Noveum/orbit/pull/290) makes prepared statements an
+  explicit strict application-pool setting, defaults to transaction-pooler-safe
+  behavior, and rejects conflicting URL options. Status: in progress. Its public
+  head is behind `main`. Its failed CodeQL gate is a confirmed high-severity
+  quadratic-regex finding in connection URL normalization. A linear fix,
+  adversarial regression coverage, and a complete exact-head rerun are required
+  before merge.
+
+### Merge gate for this work
+
+- CodeRabbit is not an availability or merge gate for this project.
+- A branch must contain current `main`, pass hosted CI on the exact head, finish
+  exact-head Greptile review at 5/5 with no unresolved review threads, and pass
+  an independent diff review before merge.
+- Slack remains disabled and deferred. Requalification is tracked only as
+  future work and is not part of the active merge sequence.
 
 ## Release rule
 
@@ -35,113 +88,147 @@ The completed items are implemented and locally verified on the current branch.
 
 ## P0 release blockers
 
-- [ ] **RT-001: Durable realtime recovery.** Persist deletes and other replayable
-  events, publish through an outbox, detect gaps, and test Redis and reconnect
-  failures. Current evidence is in the core backfill and delta bridge paths.
-- [ ] **DB-001: Production migrations.** Replace production `db:push` guidance
-  with ordered migrations, a safe baseline for existing installs, drift checks,
-  rollback guidance, and upgrade tests.
-- [ ] **DB-002: Migration identity collisions.** Reject reused migration indexes
-  with different contents and compare the resulting catalog in CI.
-- [ ] **DEP-001: Tested production start.** Provide a real start command for the
-  standalone Next.js artifact and smoke-test the exact packaged output.
-- [ ] **DEP-002: Portable realtime topology.** Put the realtime service behind a
-  same-origin proxy without relying on Vercel-only websocket behavior.
-- [ ] **DEP-003: Application containers.** Add reproducible production images and
-  a complete Compose profile for web, realtime, Postgres, Redis, and object
-  storage.
-- [ ] **DEP-004: First-login validation.** Refuse a production start unless at
-  least one complete authentication path is configured and tested.
-- [ ] **PORT-001: Neutral seed and import tooling.** Replace Noveum and Yodu
-  identities, IDs, mappings, domains, and time zones with fictional demo data
-  and argument-driven, dry-run-first importers.
-- [ ] **PRIV-001: Personal and branded artifacts.** Remove private avatar
-  manifests and Slack object URLs, replace screenshots and media where needed,
-  and complete an ownership and history review.
-- [ ] **SEC-001: Upload abuse controls.** Add durable tenant and user quotas,
-  concurrency and rate limits, abandoned-upload cleanup, reconciliation, and
-  failure tests.
-- [ ] **SEC-002: Invitation abuse controls.** Add durable sender, tenant, IP, and
-  recipient limits with resend cooldowns and provider-safe retries.
-- [ ] **SEC-003: Immutable MCP grants.** Bind tokens to one grant and workspace,
-  and revoke them when consent or scope changes.
-- [ ] **SEC-004: Integration callback authorization.** Recheck the current admin
-  permission before provider exchange and again inside the binding transaction.
-- [ ] **TEN-001: Tenant-scoped GitHub deliveries.** Attribute every delivery to a
-  workspace, hide unattributed rows, and prove isolation with two-tenant tests.
-- [ ] **SEC-005: Safe avatar ingestion.** Bound outbound fetches, prevent SSRF,
-  decode and transcode images, fix the served content type, and isolate storage.
-- [ ] **SEC-006: Dependency policy.** Upgrade or override affected dependencies,
-  verify reachability again, and make the agreed audit threshold a CI gate.
-- [ ] **SEC-018: One tenant lifecycle.** Disable Better Auth organization
-  mutations that bypass Orbit policy and route every organization change through
-  the canonical storage, session, and realtime-aware service.
-- [ ] **INT-001: Least-privilege GitHub App.** Keep one tested permission and
-  event manifest and generate or validate setup documentation from it.
-- [ ] **CI-001: Production-shaped CI.** Run every local verification gate and add
-  container, migration, packaged-start, and realtime smoke tests.
+- [ ] **RT-001: Durable realtime recovery.** **Status: open.** Persist deletes
+  and other replayable events, publish through an outbox, detect gaps, and test
+  Redis and reconnect failures. Current evidence is in the core backfill and
+  delta bridge paths.
+- [ ] **DB-001: Production migrations.** **Status: open.** Replace production
+  `db:push` guidance with ordered migrations, a safe baseline for existing
+  installs, drift checks, rollback guidance, and upgrade tests.
+- [ ] **DB-002: Migration identity collisions.** **Status: open.** Reject reused
+  migration indexes with different contents and compare the resulting catalog
+  in CI.
+- [ ] **DEP-001: Tested production start.** **Status: in progress in #283.**
+  Provide a real start command for the standalone Next.js artifact and smoke-test
+  the exact packaged output.
+- [ ] **DEP-002: Portable realtime topology.** **Status: open.** Put the realtime
+  service behind a same-origin proxy without relying on Vercel-only websocket
+  behavior.
+- [ ] **DEP-003: Application containers.** **Status: open.** Add reproducible
+  production images and a complete Compose profile for web, realtime, Postgres,
+  Redis, and object storage.
+- [ ] **DEP-004: First-login validation.** **Status: open.** Refuse a production
+  start unless at least one complete authentication path is configured and
+  tested.
+- [ ] **PORT-001: Neutral seed and import tooling.** **Status: partial through
+  #281 and #287, with #288 active.** Neutral demo data and unsafe importer
+  quarantine are complete. Remaining work includes tenant-specific test
+  fixtures, a branded settings placeholder, and supported argument-driven,
+  dry-run-first replacement importers. Legitimate sponsorship and project
+  contact references remain by design.
+- [ ] **PRIV-001: Personal and branded artifacts.** **Status: partial through
+  #282.** Current screenshots and private working artifacts were replaced or
+  removed. Historical blobs, media ownership, and external ownership records
+  still require human review.
+- [ ] **SEC-001: Upload abuse controls.** **Status: open.** Add durable tenant and
+  user quotas, concurrency and rate limits, abandoned-upload cleanup,
+  reconciliation, and failure tests.
+- [ ] **SEC-002: Invitation abuse controls.** **Status: open.** Add durable
+  sender, tenant, IP, and recipient limits with resend cooldowns and provider-safe
+  retries.
+- [ ] **SEC-003: Immutable MCP grants.** **Status: in progress in #289.** Bind
+  tokens to one grant and workspace, and revoke them when consent or scope
+  changes.
+- [x] **SEC-004: Integration callback authorization.** **Status: complete in
+  #285.** Current administration permission is rechecked before provider exchange
+  and again inside the serialized binding transaction.
+- [ ] **TEN-001: Tenant-scoped GitHub deliveries.** **Status: partial.** Complete
+  attribution for every delivery, hide unattributed rows, and prove isolation
+  with two-tenant tests.
+- [ ] **SEC-005: Safe avatar ingestion.** **Status: open.** Bound outbound
+  fetches, prevent SSRF, decode and transcode images, fix the served content type,
+  and isolate storage.
+- [ ] **SEC-006: Dependency policy.** **Status: open.** Upgrade or override
+  affected dependencies, verify reachability again, and make the agreed audit
+  threshold a CI gate.
+- [ ] **SEC-018: One tenant lifecycle.** **Status: open.** Disable Better Auth
+  organization mutations that bypass Orbit policy and route every organization
+  change through the canonical storage, session, and realtime-aware service.
+- [ ] **INT-001: Least-privilege GitHub App.** **Status: partial.** The supported
+  permission documentation is corrected, but one tested permission and event
+  manifest with generated or validated setup documentation remains.
+- [ ] **CI-001: Production-shaped CI.** **Status: partial.** Existing CI runs the
+  repository checks, build, and end-to-end suite. Container, migration,
+  packaged-start, and realtime smoke coverage is not all complete.
 
 ## P1 release requirements
 
-- [ ] **DEP-005: Safe development Compose.** Bind services to loopback, separate
-  Compose configuration from the application `.env`, pin images, and label all
-  included credentials as development-only.
-- [ ] **DEP-006: Portable email.** Retain Resend and add a tested SMTP transport
-  with local mail capture for development.
-- [ ] **DEP-007: Operator-selected region.** Remove the hard-coded Vercel compute
-  region and document data-affinity choices.
-- [ ] **SEC-007: Markdown privacy.** Narrow permitted classes and define a safe
-  policy for remote images.
-- [ ] **SEC-008: Response headers.** Add and test CSP, frame, MIME, referrer,
-  permissions, and production HSTS policy with a staged rollout.
-- [ ] **SEC-009: Production environment validation.** Reject weak or placeholder
-  secrets, localhost defaults, non-HTTPS public URLs, and inconsistent origins.
-- [ ] **SEC-010: Input size limits.** Apply shared byte limits to JSON, webhooks,
-  uploads, and websocket messages before parsing or buffering them.
-- [ ] **SEC-011: Email token retention.** Avoid retaining raw magic, reset, and
-  invite tokens; define tenant ownership, deletion, and retention.
-- [ ] **SEC-012: Slack metadata authorization.** When Slack work resumes, require
-  server-side integration management permission and denial tests.
-- [ ] **SEC-013: Account linking and recovery.** Default to matching identities,
-  require step-up for sensitive changes, and prevent unlinking every credential.
-- [ ] **SEC-014: Minimal public health.** Expose only liveness publicly and keep
-  topology and dependency diagnostics behind an authenticated boundary.
-- [ ] **SEC-015: Credential encryption.** Encrypt OAuth tokens, integration
-  credentials, and webhook secrets with versioned keys and rotation support.
-- [ ] **SEC-016: Unsafe request policy.** Add one Origin and fetch-metadata gate
-  for cookie-authenticated writes and a shared distributed rate-limit service.
-- [ ] **SEC-017: Least-privilege database roles.** Separate runtime and migration
-  authority and require encrypted service connections.
-- [ ] **SEC-019: Idempotent GitHub retries.** Claim deliveries atomically and
-  make database, realtime, and notification effects durable and idempotent.
-- [ ] **EXP-001: Reliable PDF export.** Normalize attachment URLs, bound remote
-  images, await generation and download, and verify the result end to end.
-- [ ] **PRIV-002: Web Vitals minimization.** Add operator controls and sampling,
-  reduce recorded attribution, document retention, and test deletion and abuse
-  limits.
-- [ ] **REL-001: Operational readiness.** Split liveness from readiness, require
-  configured capabilities, and document and schedule retention work.
-- [ ] **MCP-001: Accurate tool annotations.** Mark destructive, read-only,
-  idempotent, and open-world behavior correctly for every MCP tool.
-- [ ] **CI-002: Immutable CI inputs.** Pin actions and container images, declare
-  least-privilege workflow permissions, and avoid persisted credentials.
-- [ ] **REL-002: Repeatable releases.** Define versioning and compatibility,
-  publish changelogs, signed artifacts, images, SBOMs, provenance, and upgrade
-  notes.
-- [ ] **CFG-001: One configuration contract.** Consolidate capability-aware
-  validation and add a `doctor` command that reports missing requirements.
-- [ ] **DOC-001: Tested operator documentation.** Verify quickstarts and publish
-  architecture, configuration, backup, restore, upgrade, and incident runbooks.
-- [ ] **REPO-001: Consistent contributor policy.** Align agent instructions,
-  generated files, test placement, Biome exceptions, and CI enforcement.
+- [ ] **DEP-005: Safe development Compose.** **Status: open.** Bind services to
+  loopback, separate Compose configuration from the application `.env`, pin
+  images, and label all included credentials as development-only.
+- [ ] **DEP-006: Portable email.** **Status: open.** Retain Resend and add a
+  tested SMTP transport with local mail capture for development.
+- [ ] **DEP-007: Operator-selected region.** **Status: open.** Remove the
+  hard-coded Vercel compute region and document data-affinity choices.
+- [ ] **SEC-007: Markdown privacy.** **Status: open.** Narrow permitted classes
+  and define a safe policy for remote images.
+- [ ] **SEC-008: Response headers.** **Status: open.** Add and test CSP, frame,
+  MIME, referrer, permissions, and production HSTS policy with a staged rollout.
+- [ ] **SEC-009: Production environment validation.** **Status: open.** Reject
+  weak or placeholder secrets, localhost defaults, non-HTTPS public URLs, and
+  inconsistent origins.
+- [ ] **SEC-010: Input size limits.** **Status: open.** Apply shared byte limits
+  to JSON, webhooks, uploads, and websocket messages before parsing or buffering
+  them.
+- [ ] **SEC-011: Email token retention.** **Status: open.** Avoid retaining raw
+  magic, reset, and invite tokens; define tenant ownership, deletion, and
+  retention.
+- [ ] **SEC-012: Slack metadata authorization.** **Status: deferred with
+  INT-002.** When Slack work resumes, require server-side integration management
+  permission and denial tests.
+- [ ] **SEC-013: Account linking and recovery.** **Status: open.** Default to
+  matching identities, require step-up for sensitive changes, and prevent
+  unlinking every credential.
+- [ ] **SEC-014: Minimal public health.** **Status: open.** Expose only liveness
+  publicly and keep topology and dependency diagnostics behind an authenticated
+  boundary.
+- [ ] **SEC-015: Credential encryption.** **Status: open.** Encrypt OAuth tokens,
+  integration credentials, and webhook secrets with versioned keys and rotation
+  support.
+- [ ] **SEC-016: Unsafe request policy.** **Status: open.** Add one Origin and
+  fetch-metadata gate for cookie-authenticated writes and a shared distributed
+  rate-limit service.
+- [ ] **SEC-017: Least-privilege database roles.** **Status: open.** Separate
+  runtime and migration authority and require encrypted service connections.
+- [ ] **SEC-019: Idempotent GitHub retries.** **Status: open.** Claim deliveries
+  atomically and make database, realtime, and notification effects durable and
+  idempotent.
+- [ ] **EXP-001: Reliable PDF export.** **Status: open.** Normalize attachment
+  URLs, bound remote images, await generation and download, and verify the result
+  end to end.
+- [ ] **PRIV-002: Web Vitals minimization.** **Status: open.** Add operator
+  controls and sampling, reduce recorded attribution, document retention, and
+  test deletion and abuse limits.
+- [ ] **REL-001: Operational readiness.** **Status: open.** Split liveness from
+  readiness, require configured capabilities, and document and schedule
+  retention work.
+- [ ] **MCP-001: Accurate tool annotations.** **Status: open.** Mark destructive,
+  read-only, idempotent, and open-world behavior correctly for every MCP tool.
+- [ ] **CI-002: Immutable CI inputs.** **Status: open.** Pin actions and container
+  images, declare least-privilege workflow permissions, and avoid persisted
+  credentials.
+- [ ] **REL-002: Repeatable releases.** **Status: open.** Define versioning and
+  compatibility, publish changelogs, signed artifacts, images, SBOMs, provenance,
+  and upgrade notes.
+- [ ] **CFG-001: One configuration contract.** **Status: open; #290 handles one
+  database setting.** Consolidate capability-aware validation and add a `doctor`
+  command that reports missing requirements.
+- [ ] **DOC-001: Tested operator documentation.** **Status: partial.** Existing
+  architecture, configuration, and self-hosting documents need verified
+  quickstarts plus backup, restore, upgrade, and incident runbooks.
+- [ ] **REPO-001: Consistent contributor policy.** **Status: open.** Align agent
+  instructions, generated files, test placement, Biome exceptions, and CI
+  enforcement. Remove stale CodeRabbit requirements from `CLAUDE.md` and
+  `CONTRIBUTING.md` so documented review gates match the active policy.
 
 ## Deferred P2 work
 
-- [ ] **INT-002: Slack requalification.** Slack stays disabled and absent from
-  supported claims until OAuth, events, permissions, delivery, and end-to-end
-  behavior are repaired in a separate project.
-- [ ] **REPO-002: Large module cleanup.** Split oversized services and normalize
-  test-support placement only after behavioral safety nets exist.
+- [ ] **INT-002: Slack requalification.** **Status: deferred.** Slack stays
+  disabled and absent from supported claims until OAuth, events, permissions,
+  delivery, and end-to-end behavior are repaired in a separate project.
+- [ ] **REPO-002: Large module cleanup.** **Status: deferred.** Split oversized
+  services and normalize test-support placement only after behavioral safety
+  nets exist.
 
 ## Recommended pull request order
 

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -59,7 +59,9 @@ make the repository a supported production release.
   MCP consent and PKCE, preserves OAuth continuation through passwordless login,
   binds issued credentials to an immutable grant, prevents issued token scopes
   from exceeding that grant, and consumes refresh credentials once. Status:
-  exact head `4f369ee` passes full local verification, but individual CodeQL
+  exact head `9cd1ac9` contains current `main`, passes full local verification
+  and independent review, and has no unresolved ordinary review threads. The
+  remaining individual CodeQL
   alert [#19](https://github.com/Noveum/orbit/security/code-scanning/19)
   misclassifies an opaque OAuth credential's HMAC integrity binding as password
   hashing. The reviewed false-positive classification awaits maintainer

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -76,9 +76,9 @@ make the repository a supported production release.
   hashing. The reviewed false-positive classification awaits maintainer
   dismissal, so the pull request is not merge-ready.
 - [#293](https://github.com/Noveum/orbit/pull/293) maintains this readiness
-  tracker. Status: exact head `3030be7` contains current `main`; hosted checks
-  and the exact-head external review are green. Full local exact-tree
-  verification and an accurate pull-request body remain pending, so it is not
+  tracker. Status: the branch contains current `main`, and pre-push lint and
+  typecheck pass. Full local exact-tree verification, hosted checks on the final
+  head, and an accurate pull-request body remain pending, so it is not
   merge-ready. It records completed work and remaining release requirements
   without changing application behavior.
 


### PR DESCRIPTION
## Summary

- maintain one evidence-based tracker for the initial open-source readiness work
- record the verified outcomes of readiness PRs #280, #281, #282, #283, #285, #287, #288, #289, #290, and #294
- retain Noveum AI sponsorship and Apache-2.0 attribution
- keep Slack disabled and explicitly deferred while GitHub remains supported
- preserve 47 unique tasks with explicit completion or remaining status
- keep implementation work split into focused pull requests

## Current inventory

- P0: 19 total, 4 complete, 15 remaining
- P1: 23 total, 0 complete, 23 remaining
- P2: 5 total, 5 deferred or tracked as follow-up
- SEC-003 is complete in #289
- MCP-003 records the remaining low-severity concurrent consent decision race

## Verification

- exact head `002b216a579d377270da66bb2ee17ab1318537c0`
- branch contains current `main` at `4359717ff420d4ec20ec7c60147053a93e2bcf1a`
- full `bun run verify` passed in an isolated database lane with repository policies, strict types, and every package test green
- core passed 766 tests and web passed 1,876 tests
- independent exact-diff review found no issues and verified every cited pull request, merge SHA, task count, and status
- all pull request review threads are resolved
- `git diff --check`, source-byte policy, comment policy, em dash scan, and prohibited attribution scan passed
- exactly one existing Markdown file changes

## Audit boundary

The tracker distinguishes the pinned repository audit from later individually verified readiness pull requests. It does not claim review of production cloud accounts, live provider registrations, DNS, TLS, external secret rotation, or legal ownership records.
