### PR TITLE
feat(sprints): a real sprint board, browsable history, and sane defaults for a new task

### DIFF
--- a/apps/web/src/app/(app)/sprints/all/page.tsx
+++ b/apps/web/src/app/(app)/sprints/all/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { listSprintIndex } from '@/features/sprints/data.ts';
+import { SprintIndex } from '@/features/sprints/sprint-index.tsx';
+import { pageContext } from '@/lib/api/handler.ts';
+import { cn } from '@/lib/cn.ts';
+import { rowHover } from '@/lib/interaction.ts';
+
+export const metadata: Metadata = { title: 'All sprints' };
+
+interface PageProps {
+  readonly searchParams: Promise<{ page?: string }>;
+}
+
+const PAGE_NUMBER = /^[1-9][0-9]{0,6}$/;
+
+export default async function AllSprintsPage({ searchParams }: PageProps) {
+  const { principal } = await pageContext();
+  const { page: wanted } = await searchParams;
+  const page = await listSprintIndex(
+    principal,
+    wanted !== undefined && PAGE_NUMBER.test(wanted) ? Number(wanted) : 1,
+  );
+
+  return (
+    <div className="flex flex-col gap-4 px-6 py-6">
+      <div className="flex items-center justify-between">
+        <h2 className="font-medium text-base text-text">All sprints</h2>
+        <Link
+          href="/sprints"
+          data-testid="sprint-index-back"
+          className={cn(
+            'rounded-md px-2 py-1 text-muted text-xs outline-none',
+            'focus-visible:ring-2 focus-visible:ring-accent',
+            rowHover,
+          )}
+        >
+          Back to the current sprint
+        </Link>
+      </div>
+      <SprintIndex page={page} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/sprints/page.tsx
+++ b/apps/web/src/app/(app)/sprints/page.tsx
@@ -1,6 +1,7 @@
 import { can } from '@orbit/shared/policy';
 import { RefreshCcw } from 'lucide-react';
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
 import { CycleAnalytics, CycleBoard, CycleIssueList } from '@/features/sprints/cycle-board.tsx';
 import {
@@ -16,6 +17,8 @@ import { SprintHistory } from '@/features/sprints/sprint-history.tsx';
 import { SprintSchedule } from '@/features/sprints/sprint-schedule.tsx';
 import { parseSprintTab, SprintTabs } from '@/features/sprints/sprint-tabs.tsx';
 import { pageContext } from '@/lib/api/handler.ts';
+import { cn } from '@/lib/cn.ts';
+import { rowHover } from '@/lib/interaction.ts';
 
 export const metadata: Metadata = { title: 'Sprints' };
 
@@ -80,7 +83,20 @@ export default async function SprintsPage({ searchParams }: PageProps) {
       <SprintSchedule upcoming={upcoming} canManage={canManage} running={running !== null} />
 
       <section className="flex flex-col gap-2">
-        <h3 className="font-medium text-dense text-text">Past sprints</h3>
+        <div className="flex items-center justify-between">
+          <h3 className="font-medium text-dense text-text">Past sprints</h3>
+          <Link
+            href="/sprints/all"
+            data-testid="sprint-browse-all"
+            className={cn(
+              'rounded-md px-2 py-1 text-muted text-xs outline-none',
+              'focus-visible:ring-2 focus-visible:ring-accent',
+              rowHover,
+            )}
+          >
+            Browse every sprint
+          </Link>
+        </div>
         <SprintHistory sprints={past} />
       </section>
     </div>

--- a/apps/web/src/app/(app)/sprints/page.tsx
+++ b/apps/web/src/app/(app)/sprints/page.tsx
@@ -2,7 +2,7 @@ import { can } from '@orbit/shared/policy';
 import { RefreshCcw } from 'lucide-react';
 import type { Metadata } from 'next';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
-import { CycleAnalytics, CycleIssueList } from '@/features/sprints/cycle-board.tsx';
+import { CycleAnalytics, CycleBoard, CycleIssueList } from '@/features/sprints/cycle-board.tsx';
 import {
   getActiveCycleView,
   getSprintView,
@@ -65,15 +65,15 @@ export default async function SprintsPage({ searchParams }: PageProps) {
               {outcome.rolledOver > 0 ? `, ${outcome.rolledOver} rolled into the next sprint` : ''}.
             </p>
           )}
-          <SprintTabs base={base} active={active} available={['board', 'insights']} />
-          {active === 'insights' ? (
-            <CycleAnalytics cycle={sprint} />
-          ) : (
+          <SprintTabs base={base} active={active} available={['board', 'list', 'insights']} />
+          {active === 'insights' ? <CycleAnalytics cycle={sprint} /> : null}
+          {active === 'board' ? <CycleBoard cycle={sprint} /> : null}
+          {active === 'list' ? (
             <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
               <CycleIssueList cycle={sprint} />
               <CycleAnalytics cycle={sprint} />
             </div>
-          )}
+          ) : null}
         </>
       )}
 

--- a/apps/web/src/features/sprints/cycle-board.tsx
+++ b/apps/web/src/features/sprints/cycle-board.tsx
@@ -219,6 +219,61 @@ export function CycleAnalytics({ cycle }: { readonly cycle: CycleView }) {
   );
 }
 
+export function CycleBoard({ cycle }: { readonly cycle: CycleView }) {
+  if (cycle.groups.length === 0) {
+    return <p className="text-faint text-xs">Nothing in this sprint yet.</p>;
+  }
+
+  return (
+    <div className="-mx-1 overflow-x-auto px-1 pb-2" data-testid="sprint-board">
+      <div className="flex items-start gap-3">
+        {cycle.groups.map((group) => (
+          <section
+            key={group.stateId}
+            data-testid={`sprint-column-${group.stateId}`}
+            className="flex w-72 shrink-0 flex-col gap-2 rounded-lg bg-subtle/40 p-2"
+          >
+            <header className="flex items-center gap-2 px-1">
+              <span
+                className="size-2 shrink-0 rounded-full"
+                style={{ backgroundColor: group.color }}
+                aria-hidden="true"
+              />
+              <h3 className="min-w-0 flex-1 truncate font-medium text-dense text-text">
+                {group.name}
+              </h3>
+              <span className="text-2xs text-faint tabular">{group.issues.length}</span>
+            </header>
+            <ul className="flex flex-col gap-1.5">
+              {group.issues.map((issue) => (
+                <li key={issue.id}>
+                  <Link
+                    href={`/issue/${issue.identifier}`}
+                    data-testid={`sprint-card-${issue.identifier}`}
+                    className={cn(
+                      'flex flex-col gap-1.5 rounded-md border border-border bg-surface p-2.5 outline-none',
+                      'focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset',
+                      rowHover,
+                    )}
+                  >
+                    <span className="line-clamp-2 text-dense text-text">{issue.title}</span>
+                    <span className="flex items-center gap-2">
+                      <span className="flex-1 text-2xs text-faint tabular">{issue.identifier}</span>
+                      {issue.assignee === null ? null : (
+                        <Avatar name={issue.assignee.name} src={issue.assignee.image} size="xs" />
+                      )}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function CycleIssueList({ cycle }: { readonly cycle: CycleView }) {
   return (
     <div className="flex flex-col gap-5">

--- a/apps/web/src/features/sprints/cycle-board.tsx
+++ b/apps/web/src/features/sprints/cycle-board.tsx
@@ -24,7 +24,9 @@ function Tally({
         </span>
       </span>
       {points === null ? null : (
-        <span className="text-2xs text-muted tabular">{points} points</span>
+        <span className="text-2xs text-muted tabular">
+          {points} {points === 1 ? 'point' : 'points'}
+        </span>
       )}
       <span className="text-2xs text-faint uppercase">{label}</span>
     </div>
@@ -183,7 +185,10 @@ export function CycleAnalytics({ cycle }: { readonly cycle: CycleView }) {
             title="Issues in triage or backlog states sit in the sprint but count towards nothing until they move to Todo."
           >
             {progress.uncommitted.issues} {progress.uncommitted.issues === 1 ? 'task' : 'tasks'}{' '}
-            uncommitted, {progress.uncommitted.points} points not counted
+            uncommitted
+            {progress.uncommitted.points === 0
+              ? ''
+              : `, ${progress.uncommitted.points} points not counted`}
           </p>
         )}
         <ScopeChanges progress={progress} />

--- a/apps/web/src/features/sprints/cycle-board.tsx
+++ b/apps/web/src/features/sprints/cycle-board.tsx
@@ -6,10 +6,26 @@ import { rowHover } from '@/lib/interaction.ts';
 import { buildBurnUp, burnUpMetric } from './burn-up.ts';
 import type { AssigneeTally, CycleView, StateGroup } from './data.ts';
 
-function Tally({ label, value }: { readonly label: string; readonly value: number }) {
+function Tally({
+  label,
+  issues,
+  points,
+}: {
+  readonly label: string;
+  readonly issues: number;
+  readonly points: number | null;
+}) {
   return (
     <div className="flex flex-col">
-      <span className="font-medium text-lg text-text tabular">{value}</span>
+      <span className="font-medium text-lg text-text tabular">
+        {issues}
+        <span className="ml-1 font-normal text-2xs text-muted">
+          {issues === 1 ? 'task' : 'tasks'}
+        </span>
+      </span>
+      {points === null ? null : (
+        <span className="text-2xs text-muted tabular">{points} points</span>
+      )}
       <span className="text-2xs text-faint uppercase">{label}</span>
     </div>
   );
@@ -139,9 +155,21 @@ export function CycleAnalytics({ cycle }: { readonly cycle: CycleView }) {
     <aside className="flex flex-col gap-5 rounded-lg border border-border p-4">
       <div className="flex flex-col gap-1.5">
         <div className="grid grid-cols-3 gap-2 text-center">
-          <Tally label="Scope" value={progress.scope} />
-          <Tally label="Started" value={progress.started} />
-          <Tally label="Completed" value={progress.completed} />
+          <Tally
+            label="Scope"
+            issues={progress.scope}
+            points={progress.estimated === 0 ? null : progress.points.scope}
+          />
+          <Tally
+            label="Started"
+            issues={progress.started}
+            points={progress.estimated === 0 ? null : progress.points.started}
+          />
+          <Tally
+            label="Completed"
+            issues={progress.completed}
+            points={progress.estimated === 0 ? null : progress.points.completed}
+          />
         </div>
         {progress.estimated === 0 ? null : (
           <p data-testid="sprint-points" className="text-center text-2xs text-muted tabular">
@@ -154,8 +182,8 @@ export function CycleAnalytics({ cycle }: { readonly cycle: CycleView }) {
             className="text-center text-2xs text-faint tabular"
             title="Issues in triage or backlog states sit in the sprint but count towards nothing until they move to Todo."
           >
-            {progress.uncommitted.issues} uncommitted, {progress.uncommitted.points} points not
-            counted
+            {progress.uncommitted.issues} {progress.uncommitted.issues === 1 ? 'task' : 'tasks'}{' '}
+            uncommitted, {progress.uncommitted.points} points not counted
           </p>
         )}
         <ScopeChanges progress={progress} />

--- a/apps/web/src/features/sprints/data.ts
+++ b/apps/web/src/features/sprints/data.ts
@@ -269,7 +269,7 @@ export interface SprintIndexEntry {
   readonly number: number;
   readonly startsAt: string;
   readonly endsAt: string;
-  readonly state: 'running' | 'upcoming' | 'finished';
+  readonly state: 'running' | 'upcoming' | 'finished' | 'overdue';
   readonly issues: number;
 }
 
@@ -286,7 +286,8 @@ function sprintState(
 ): SprintIndexEntry['state'] {
   if (cycle.completedAt !== null) return 'finished';
   if (cycle.startsAt > now) return 'upcoming';
-  return 'running';
+  if (cycle.endsAt > now) return 'running';
+  return 'overdue';
 }
 
 export async function listSprintIndex(

--- a/apps/web/src/features/sprints/data.ts
+++ b/apps/web/src/features/sprints/data.ts
@@ -3,13 +3,14 @@ import {
   type CycleProgress,
   cycleProgress,
   getCycleByNumber,
+  pageOfCycles,
   pastCycles,
   type RecordedOutcome,
   sprintOutcome,
   sprintOutcomes,
   upcomingCycles,
 } from '@orbit/core';
-import { and, asc, db, eq, isNull, schema } from '@orbit/db';
+import { and, asc, count, db, eq, inArray, isNull, schema } from '@orbit/db';
 import type { StateCategory } from '@orbit/shared/constants';
 import { STATE_CATEGORIES, STATE_CATEGORY_ORDER } from '@orbit/shared/constants';
 import type { Principal } from '@orbit/shared/policy';
@@ -260,6 +261,72 @@ export async function listPastSprintViews(
     completedAt: (cycle.completedAt ?? cycle.endsAt).toISOString(),
     outcome: outcomes[index] ?? null,
   }));
+}
+
+export interface SprintIndexEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly number: number;
+  readonly startsAt: string;
+  readonly endsAt: string;
+  readonly state: 'running' | 'upcoming' | 'finished';
+  readonly issues: number;
+}
+
+export interface SprintIndexPage {
+  readonly sprints: SprintIndexEntry[];
+  readonly total: number;
+  readonly page: number;
+  readonly pageCount: number;
+}
+
+function sprintState(
+  cycle: { completedAt: Date | null; startsAt: Date; endsAt: Date },
+  now: Date,
+): SprintIndexEntry['state'] {
+  if (cycle.completedAt !== null) return 'finished';
+  if (cycle.startsAt > now) return 'upcoming';
+  if (cycle.endsAt > now) return 'running';
+  return 'finished';
+}
+
+export async function listSprintIndex(
+  principal: Principal,
+  page: number,
+  now: Date = new Date(),
+): Promise<SprintIndexPage> {
+  const { cycles, total, page: current, pageCount } = await pageOfCycles(principal, { page });
+  if (cycles.length === 0) return { sprints: [], total, page: current, pageCount };
+
+  const counts = await db
+    .select({ cycleId: schema.issue.cycleId, total: count() })
+    .from(schema.issue)
+    .where(
+      and(
+        inArray(
+          schema.issue.cycleId,
+          cycles.map((cycle) => cycle.id),
+        ),
+        isNull(schema.issue.archivedAt),
+      ),
+    )
+    .groupBy(schema.issue.cycleId);
+  const byCycle = new Map(counts.map((row) => [row.cycleId, row.total]));
+
+  return {
+    total,
+    page: current,
+    pageCount,
+    sprints: cycles.map((cycle) => ({
+      id: cycle.id,
+      name: sprintLabel(cycle),
+      number: cycle.number,
+      startsAt: cycle.startsAt.toISOString(),
+      endsAt: cycle.endsAt.toISOString(),
+      state: sprintState(cycle, now),
+      issues: byCycle.get(cycle.id) ?? 0,
+    })),
+  };
 }
 
 export async function getSprintView(

--- a/apps/web/src/features/sprints/data.ts
+++ b/apps/web/src/features/sprints/data.ts
@@ -286,8 +286,7 @@ function sprintState(
 ): SprintIndexEntry['state'] {
   if (cycle.completedAt !== null) return 'finished';
   if (cycle.startsAt > now) return 'upcoming';
-  if (cycle.endsAt > now) return 'running';
-  return 'finished';
+  return 'running';
 }
 
 export async function listSprintIndex(

--- a/apps/web/src/features/sprints/sprint-index.tsx
+++ b/apps/web/src/features/sprints/sprint-index.tsx
@@ -1,0 +1,111 @@
+import Link from 'next/link';
+import { cn } from '@/lib/cn.ts';
+import { rowHover } from '@/lib/interaction.ts';
+import type { SprintIndexEntry, SprintIndexPage } from './data.ts';
+
+const STATE_LABEL: Record<SprintIndexEntry['state'], string> = {
+  running: 'Running',
+  upcoming: 'Upcoming',
+  finished: 'Finished',
+};
+
+const STATE_TONE: Record<SprintIndexEntry['state'], string> = {
+  running: 'bg-accent/15 text-accent',
+  upcoming: 'bg-subtle text-muted',
+  finished: 'bg-subtle text-faint',
+};
+
+function span(startsAt: string, endsAt: string): string {
+  const format = new Intl.DateTimeFormat('en', { day: 'numeric', month: 'short' });
+  return `${format.format(new Date(startsAt))} to ${format.format(new Date(endsAt))}`;
+}
+
+export function SprintIndex({ page }: { readonly page: SprintIndexPage }) {
+  if (page.sprints.length === 0) {
+    return <p className="text-faint text-xs">No sprints yet.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <ul className="flex flex-col rounded-lg border border-border" data-testid="sprint-index">
+        {page.sprints.map((sprint) => (
+          <li key={sprint.id} className="border-border border-b last:border-b-0">
+            <Link
+              href={`/sprints?sprint=${sprint.number}`}
+              data-testid={`sprint-index-${sprint.number}`}
+              className={cn(
+                'flex items-center gap-3 px-3 py-2 outline-none',
+                'focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset',
+                rowHover,
+              )}
+            >
+              <span className="min-w-0 flex-1 truncate text-dense text-text">{sprint.name}</span>
+              <span
+                className={cn('shrink-0 rounded px-1.5 py-0.5 text-2xs', STATE_TONE[sprint.state])}
+              >
+                {STATE_LABEL[sprint.state]}
+              </span>
+              <span className="w-40 shrink-0 text-right text-2xs text-faint tabular">
+                {span(sprint.startsAt, sprint.endsAt)}
+              </span>
+              <span className="w-20 shrink-0 text-right text-2xs text-muted tabular">
+                {sprint.issues} {sprint.issues === 1 ? 'task' : 'tasks'}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      {page.pageCount === 1 ? null : (
+        <nav className="flex items-center justify-between" aria-label="Sprint pages">
+          <PageLink page={page.page - 1} disabled={page.page <= 1} testId="sprint-index-previous">
+            Previous
+          </PageLink>
+          <span className="text-2xs text-faint tabular">
+            Page {page.page} of {page.pageCount}, {page.total} sprints
+          </span>
+          <PageLink
+            page={page.page + 1}
+            disabled={page.page >= page.pageCount}
+            testId="sprint-index-next"
+          >
+            Next
+          </PageLink>
+        </nav>
+      )}
+    </div>
+  );
+}
+
+function PageLink({
+  page,
+  disabled,
+  testId,
+  children,
+}: {
+  readonly page: number;
+  readonly disabled: boolean;
+  readonly testId: string;
+  readonly children: string;
+}) {
+  if (disabled) {
+    return (
+      <span className="rounded-md px-2 py-1 text-2xs text-faint" data-testid={testId}>
+        {children}
+      </span>
+    );
+  }
+  return (
+    <Link
+      href={`/sprints/all?page=${page}`}
+      data-testid={testId}
+      className={cn(
+        'rounded-md px-2 py-1 text-2xs text-muted outline-none',
+        'focus-visible:ring-2 focus-visible:ring-accent',
+        rowHover,
+      )}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/apps/web/src/features/sprints/sprint-index.tsx
+++ b/apps/web/src/features/sprints/sprint-index.tsx
@@ -6,12 +6,14 @@ import type { SprintIndexEntry, SprintIndexPage } from './data.ts';
 const STATE_LABEL: Record<SprintIndexEntry['state'], string> = {
   running: 'Running',
   upcoming: 'Upcoming',
+  overdue: 'Past its end date',
   finished: 'Finished',
 };
 
 const STATE_TONE: Record<SprintIndexEntry['state'], string> = {
   running: 'bg-accent/15 text-accent',
   upcoming: 'bg-subtle text-muted',
+  overdue: 'bg-warning/15 text-warning',
   finished: 'bg-subtle text-faint',
 };
 

--- a/apps/web/tests/features/sprints/cycle-board-columns.test.tsx
+++ b/apps/web/tests/features/sprints/cycle-board-columns.test.tsx
@@ -45,11 +45,26 @@ describe('the sprint board', () => {
     expect(within(todo).queryByTestId('sprint-card-ENG-44')).toBeNull();
   });
 
-  it('counts what each column holds', () => {
+  it('counts what each column holds in its own header', () => {
     render(<CycleBoard cycle={cycle} />);
 
-    expect(screen.getByTestId('sprint-column-state_todo').textContent).toContain('2');
-    expect(screen.getByTestId('sprint-column-state_done').textContent).toContain('1');
+    const todo = screen.getByTestId('sprint-column-state_todo');
+    const done = screen.getByTestId('sprint-column-state_done');
+
+    expect(within(todo).getByRole('banner').textContent).toBe('Todo2');
+    expect(within(done).getByRole('banner').textContent).toBe('Done1');
+  });
+
+  it('stands the columns side by side rather than stacking them', () => {
+    render(<CycleBoard cycle={cycle} />);
+
+    const todo = screen.getByTestId('sprint-column-state_todo');
+    const row = todo.parentElement;
+
+    expect(row?.className).toContain('flex');
+    expect(row?.className).not.toContain('flex-col');
+    expect(todo.className).toContain('shrink-0');
+    expect(todo.className).toMatch(/\bw-\d/);
   });
 
   it('opens the issue page from a card, with a focus ring for the keyboard', () => {

--- a/apps/web/tests/features/sprints/cycle-board-columns.test.tsx
+++ b/apps/web/tests/features/sprints/cycle-board-columns.test.tsx
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { CycleBoard } from '../../../src/features/sprints/cycle-board.tsx';
+import type { CycleView } from '../../../src/features/sprints/data.ts';
+
+function cycleWith(groups: unknown): CycleView {
+  return { id: 'cycle_1', name: 'Sprint 4', groups, assignees: [] } as unknown as CycleView;
+}
+
+const cycle = cycleWith([
+  {
+    stateId: 'state_todo',
+    name: 'Todo',
+    color: '#8b8b8b',
+    issues: [
+      { id: 'issue_1', identifier: 'ENG-42', title: 'Ship the planner', assignee: null },
+      {
+        id: 'issue_2',
+        identifier: 'ENG-43',
+        title: 'Wire the tiles',
+        assignee: { id: 'member_1', name: 'Ada Lovelace', image: null },
+      },
+    ],
+  },
+  {
+    stateId: 'state_done',
+    name: 'Done',
+    color: '#5b8def',
+    issues: [{ id: 'issue_3', identifier: 'ENG-44', title: 'Land the merge', assignee: null }],
+  },
+]);
+
+afterEach(cleanup);
+
+describe('the sprint board', () => {
+  it('lays the states out as columns rather than one stacked list', () => {
+    render(<CycleBoard cycle={cycle} />);
+
+    const todo = screen.getByTestId('sprint-column-state_todo');
+    const done = screen.getByTestId('sprint-column-state_done');
+
+    expect(within(todo).getByTestId('sprint-card-ENG-42')).toBeDefined();
+    expect(within(todo).getByTestId('sprint-card-ENG-43')).toBeDefined();
+    expect(within(done).getByTestId('sprint-card-ENG-44')).toBeDefined();
+    expect(within(todo).queryByTestId('sprint-card-ENG-44')).toBeNull();
+  });
+
+  it('counts what each column holds', () => {
+    render(<CycleBoard cycle={cycle} />);
+
+    expect(screen.getByTestId('sprint-column-state_todo').textContent).toContain('2');
+    expect(screen.getByTestId('sprint-column-state_done').textContent).toContain('1');
+  });
+
+  it('opens the issue page from a card, with a focus ring for the keyboard', () => {
+    render(<CycleBoard cycle={cycle} />);
+
+    const card = screen.getByTestId('sprint-card-ENG-42');
+    expect(card.tagName).toBe('A');
+    expect(card.getAttribute('href')).toBe('/issue/ENG-42');
+    expect(card.className).toContain('focus-visible:ring');
+  });
+
+  it('carries the assignee onto the card and leaves it off an unassigned one', () => {
+    render(<CycleBoard cycle={cycle} />);
+
+    const assigned = screen.getByTestId('sprint-card-ENG-43');
+    expect(within(assigned).getByRole('img', { name: 'Ada Lovelace' })).toBeDefined();
+    expect(within(screen.getByTestId('sprint-card-ENG-42')).queryByRole('img')).toBeNull();
+  });
+
+  it('lets a wide board scroll on its own instead of pushing the page sideways', () => {
+    render(<CycleBoard cycle={cycle} />);
+
+    expect(screen.getByTestId('sprint-board').className).toContain('overflow-x-auto');
+  });
+
+  it('says so plainly when the sprint holds nothing', () => {
+    render(<CycleBoard cycle={cycleWith([])} />);
+
+    expect(screen.queryByTestId('sprint-board')).toBeNull();
+    expect(screen.getByText('Nothing in this sprint yet.')).toBeDefined();
+  });
+});

--- a/apps/web/tests/features/sprints/sprint-index-data.test.ts
+++ b/apps/web/tests/features/sprints/sprint-index-data.test.ts
@@ -45,9 +45,14 @@ describe('listSprintIndex', () => {
     expect((await entryFor(later.number))?.state).toBe('upcoming');
   });
 
-  it('calls a sprint finished once it has been closed, not merely because its dates passed', async () => {
+  it('calls a sprint past its end date overdue rather than running or finished', async () => {
     const overdue = await sprint(-40, -20);
-    expect((await entryFor(overdue.number))?.state).toBe('running');
+
+    expect((await entryFor(overdue.number))?.state).toBe('overdue');
+  });
+
+  it('calls a sprint finished only once it has been closed', async () => {
+    const overdue = await sprint(-40, -20);
 
     await db
       .update(schema.cycle)
@@ -55,6 +60,17 @@ describe('listSprintIndex', () => {
       .where(eq(schema.cycle.id, overdue.id));
 
     expect((await entryFor(overdue.number))?.state).toBe('finished');
+  });
+
+  it('never calls two sprints running at once', async () => {
+    await sprint(-40, -20);
+    await sprint(30, 44);
+
+    const page = await listSprintIndex(workspace.admin, 1);
+    const running = page.sprints.filter((row) => row.state === 'running');
+
+    expect(running).toHaveLength(1);
+    expect(running[0]?.number).toBe((await activeCycle(workspace.admin))?.number);
   });
 
   it('counts the live issues each sprint holds and leaves archived ones out', async () => {

--- a/apps/web/tests/features/sprints/sprint-index-data.test.ts
+++ b/apps/web/tests/features/sprints/sprint-index-data.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { activeCycle, createCycle, createIssue } from '@orbit/core';
+import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test-support';
+import { db, eq, schema } from '@orbit/db';
+import { listSprintIndex } from '../../../src/features/sprints/data.ts';
+
+const DAY = 86_400_000;
+let workspace: Workspace;
+let base: number;
+
+beforeEach(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  base = Date.now();
+});
+
+function at(days: number): Date {
+  return new Date(base + days * DAY);
+}
+
+async function sprint(startDay: number, endDay: number) {
+  const { cycle } = await createCycle(workspace.admin, {
+    startsAt: at(startDay),
+    endsAt: at(endDay),
+  });
+  return cycle;
+}
+
+async function entryFor(number: number) {
+  const page = await listSprintIndex(workspace.admin, 1);
+  return page.sprints.find((row) => row.number === number);
+}
+
+describe('listSprintIndex', () => {
+  it('calls the sprint covering today running', async () => {
+    const running = await activeCycle(workspace.admin);
+    if (running === undefined) throw new Error('the workspace opens with a sprint');
+
+    expect((await entryFor(running.number))?.state).toBe('running');
+  });
+
+  it('calls a sprint that has not started yet upcoming', async () => {
+    const later = await sprint(30, 44);
+
+    expect((await entryFor(later.number))?.state).toBe('upcoming');
+  });
+
+  it('calls a sprint finished once it has been closed, not merely because its dates passed', async () => {
+    const overdue = await sprint(-40, -20);
+    expect((await entryFor(overdue.number))?.state).toBe('running');
+
+    await db
+      .update(schema.cycle)
+      .set({ completedAt: new Date() })
+      .where(eq(schema.cycle.id, overdue.id));
+
+    expect((await entryFor(overdue.number))?.state).toBe('finished');
+  });
+
+  it('counts the live issues each sprint holds and leaves archived ones out', async () => {
+    const current = await activeCycle(workspace.admin);
+    if (current === undefined) throw new Error('the workspace opens with a sprint');
+    const kept = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Counted',
+      cycleId: current.id,
+    });
+    const gone = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Archived',
+      cycleId: current.id,
+    });
+    await db
+      .update(schema.issue)
+      .set({ archivedAt: new Date() })
+      .where(eq(schema.issue.id, gone.issue.id));
+
+    const entry = await entryFor(current.number);
+
+    expect(entry?.issues).toBe(1);
+    expect(kept.issue.cycleId).toBe(current.id);
+  });
+
+  it('reports a sprint holding nothing as zero rather than dropping it', async () => {
+    const empty = await sprint(30, 44);
+
+    expect((await entryFor(empty.number))?.issues).toBe(0);
+  });
+
+  it('pages newest first and reports the totals the pager needs', async () => {
+    for (let index = 0; index < 4; index += 1) await sprint(index * 20 + 30, index * 20 + 44);
+
+    const page = await listSprintIndex(workspace.admin, 1);
+
+    expect(page.total).toBeGreaterThanOrEqual(5);
+    expect(page.page).toBe(1);
+    expect(page.pageCount).toBeGreaterThanOrEqual(1);
+    const starts = page.sprints.map((row) => Date.parse(row.startsAt));
+    expect([...starts].sort((left, right) => right - left)).toEqual(starts);
+  });
+
+  it('answers an empty page without touching the issue table', async () => {
+    const page = await listSprintIndex(workspace.admin, 99);
+
+    expect(page.sprints.every((row) => row.issues >= 0)).toBe(true);
+  });
+});

--- a/apps/web/tests/features/sprints/sprint-index.test.tsx
+++ b/apps/web/tests/features/sprints/sprint-index.test.tsx
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { SprintIndexPage } from '../../../src/features/sprints/data.ts';
+import { SprintIndex } from '../../../src/features/sprints/sprint-index.tsx';
+
+function pageWith(overrides: Partial<SprintIndexPage> = {}): SprintIndexPage {
+  return {
+    total: 3,
+    page: 1,
+    pageCount: 1,
+    sprints: [
+      {
+        id: 'cycle_3',
+        name: 'Sprint 3',
+        number: 3,
+        startsAt: '2026-08-11T00:00:00.000Z',
+        endsAt: '2026-08-25T00:00:00.000Z',
+        state: 'running',
+        issues: 12,
+      },
+      {
+        id: 'cycle_2',
+        name: 'Sprint 2',
+        number: 2,
+        startsAt: '2026-07-28T00:00:00.000Z',
+        endsAt: '2026-08-11T00:00:00.000Z',
+        state: 'finished',
+        issues: 1,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+describe('the sprint index', () => {
+  it('opens any sprint by its number', () => {
+    render(<SprintIndex page={pageWith()} />);
+
+    const row = screen.getByTestId('sprint-index-3');
+    expect(row.getAttribute('href')).toBe('/sprints?sprint=3');
+  });
+
+  it('says which sprint is running and how much each one holds', () => {
+    render(<SprintIndex page={pageWith()} />);
+
+    expect(screen.getByTestId('sprint-index-3').textContent).toContain('Running');
+    expect(screen.getByTestId('sprint-index-3').textContent).toContain('12 tasks');
+    expect(screen.getByTestId('sprint-index-2').textContent).toContain('Finished');
+    expect(screen.getByTestId('sprint-index-2').textContent).toContain('1 task');
+  });
+
+  it('hides the pager when everything fits on one page', () => {
+    render(<SprintIndex page={pageWith()} />);
+
+    expect(screen.queryByTestId('sprint-index-next')).toBeNull();
+  });
+
+  it('pages through a workspace with hundreds of sprints', () => {
+    render(<SprintIndex page={pageWith({ total: 240, page: 4, pageCount: 10 })} />);
+
+    expect(screen.getByTestId('sprint-index-next').getAttribute('href')).toBe(
+      '/sprints/all?page=5',
+    );
+    expect(screen.getByTestId('sprint-index-previous').getAttribute('href')).toBe(
+      '/sprints/all?page=3',
+    );
+    expect(screen.getByText(/Page 4 of 10, 240 sprints/)).toBeDefined();
+  });
+
+  it('leaves the edges of the range unclickable rather than pointing off the end', () => {
+    render(<SprintIndex page={pageWith({ total: 60, page: 1, pageCount: 3 })} />);
+    expect(screen.getByTestId('sprint-index-previous').tagName).toBe('SPAN');
+
+    cleanup();
+    render(<SprintIndex page={pageWith({ total: 60, page: 3, pageCount: 3 })} />);
+    expect(screen.getByTestId('sprint-index-next').tagName).toBe('SPAN');
+  });
+
+  it('says so plainly when there are no sprints at all', () => {
+    render(<SprintIndex page={pageWith({ sprints: [], total: 0 })} />);
+
+    expect(screen.queryByTestId('sprint-index')).toBeNull();
+    expect(screen.getByText('No sprints yet.')).toBeDefined();
+  });
+});

--- a/packages/core/src/work/cycle-service.ts
+++ b/packages/core/src/work/cycle-service.ts
@@ -481,6 +481,35 @@ export async function listCycles(principal: Principal): Promise<CycleRow[]> {
     .orderBy(asc(schema.cycle.number));
 }
 
+export const SPRINT_PAGE_SIZE = 25;
+
+export async function pageOfCycles(
+  principal: Principal,
+  options: { page?: number; pageSize?: number } = {},
+): Promise<{ cycles: CycleRow[]; total: number; page: number; pageCount: number }> {
+  assertCan(principal, 'issue:read');
+  const pageSize = Math.min(Math.max(options.pageSize ?? SPRINT_PAGE_SIZE, 1), 100);
+  const belongs = and(
+    eq(schema.cycle.organizationId, principal.organizationId),
+    isNull(schema.cycle.archivedAt),
+  );
+
+  const [counted] = await db.select({ total: count() }).from(schema.cycle).where(belongs);
+  const total = counted?.total ?? 0;
+  const pageCount = Math.max(Math.ceil(total / pageSize), 1);
+  const page = Math.min(Math.max(options.page ?? 1, 1), pageCount);
+
+  const cycles = await db
+    .select()
+    .from(schema.cycle)
+    .where(belongs)
+    .orderBy(desc(schema.cycle.startsAt))
+    .limit(pageSize)
+    .offset((page - 1) * pageSize);
+
+  return { cycles, total, page, pageCount };
+}
+
 export async function getCycle(principal: Principal, cycleId: string): Promise<CycleRow> {
   assertCan(principal, 'issue:read');
   const [row] = await db

--- a/packages/core/src/work/cycle-service.ts
+++ b/packages/core/src/work/cycle-service.ts
@@ -483,12 +483,17 @@ export async function listCycles(principal: Principal): Promise<CycleRow[]> {
 
 export const SPRINT_PAGE_SIZE = 25;
 
+function whole(value: number | undefined, fallback: number, most: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.min(Math.max(Math.trunc(value), 1), most);
+}
+
 export async function pageOfCycles(
   principal: Principal,
   options: { page?: number; pageSize?: number } = {},
 ): Promise<{ cycles: CycleRow[]; total: number; page: number; pageCount: number }> {
   assertCan(principal, 'issue:read');
-  const pageSize = Math.min(Math.max(options.pageSize ?? SPRINT_PAGE_SIZE, 1), 100);
+  const pageSize = whole(options.pageSize, SPRINT_PAGE_SIZE, 100);
   const belongs = and(
     eq(schema.cycle.organizationId, principal.organizationId),
     isNull(schema.cycle.archivedAt),
@@ -497,7 +502,7 @@ export async function pageOfCycles(
   const [counted] = await db.select({ total: count() }).from(schema.cycle).where(belongs);
   const total = counted?.total ?? 0;
   const pageCount = Math.max(Math.ceil(total / pageSize), 1);
-  const page = Math.min(Math.max(options.page ?? 1, 1), pageCount);
+  const page = Math.min(whole(options.page, 1, pageCount), pageCount);
 
   const cycles = await db
     .select()

--- a/packages/core/src/work/issue-service.ts
+++ b/packages/core/src/work/issue-service.ts
@@ -728,7 +728,8 @@ export async function createIssue(principal: Principal, input: unknown): Promise
     if (state.teamId !== team.id) {
       throw validationFailed('That status belongs to another team.');
     }
-    await assertMemberOfWorkspace(tx, principal.organizationId, parsed.assigneeId);
+    const assigneeId = parsed.assigneeId === undefined ? principal.userId : parsed.assigneeId;
+    await assertMemberOfWorkspace(tx, principal.organizationId, assigneeId);
     await assertAssignableToTeam(tx, principal.organizationId, team.id, {
       cycleId: parsed.cycleId,
       projectId: parsed.projectId,
@@ -755,7 +756,7 @@ export async function createIssue(principal: Principal, input: unknown): Promise
         stateId: state.id,
         priority: parsed.priority,
         creatorId: principal.userId,
-        assigneeId: parsed.assigneeId,
+        assigneeId,
         projectId: parsed.projectId,
         milestoneId: parsed.milestoneId,
         cycleId: parsed.cycleId,
@@ -770,7 +771,7 @@ export async function createIssue(principal: Principal, input: unknown): Promise
     const issue = requireRow(created, 'The issue could not be created.');
 
     await replaceLabels(tx, issue.id, parsed.labelIds);
-    await subscribeUsers(tx, issue.id, [principal.userId, parsed.assigneeId], syncId);
+    await subscribeUsers(tx, issue.id, [principal.userId, assigneeId], syncId);
     await appendActivities(tx, [
       {
         organizationId: principal.organizationId,

--- a/packages/core/src/work/workflow-state-service.ts
+++ b/packages/core/src/work/workflow-state-service.ts
@@ -169,6 +169,8 @@ export async function initialStateFor(
   executor: Executor,
   teamId: string,
 ): Promise<WorkflowStateRow> {
+  const triage = await defaultStateFor(executor, teamId, 'triage');
+  if (triage !== undefined) return triage;
   const unstarted = await defaultStateFor(executor, teamId, 'unstarted');
   if (unstarted !== undefined) return unstarted;
   const backlog = await defaultStateFor(executor, teamId, 'backlog');

--- a/packages/core/tests/activity/activity-service.test.ts
+++ b/packages/core/tests/activity/activity-service.test.ts
@@ -92,7 +92,7 @@ describe('listActivity', () => {
     expect(rows.every((row) => row.actorName.length > 0)).toBe(true);
     expect(rows.map(describeActivity)).toEqual([
       'created the issue',
-      'moved from Todo to In Progress',
+      'moved from Triage to In Progress',
     ]);
   });
 });

--- a/packages/core/tests/work/board-groups.test.ts
+++ b/packages/core/tests/work/board-groups.test.ts
@@ -22,11 +22,12 @@ beforeEach(async () => {
   states = workspace.states.map((state) => ({ id: state.id, name: state.name }));
 });
 
-async function newIssue(title: string, stateId?: string) {
+async function newIssue(title: string, stateId?: string, overrides: Record<string, unknown> = {}) {
   const { issue } = await createIssue(workspace.admin, {
     teamId,
     title,
     ...(stateId === undefined ? {} : { stateId }),
+    ...overrides,
   });
   return issue;
 }
@@ -82,7 +83,7 @@ describe('listBoardGroups', () => {
   it('groups by assignee when asked, keeping the unassigned column', async () => {
     const mine = await newIssue('Mine');
     await updateIssue(workspace.admin, mine.id, { assigneeId: workspace.admin.userId });
-    await newIssue('Nobody');
+    await newIssue('Nobody', undefined, { assigneeId: null });
 
     const page = await listBoardGroups(workspace.admin, { teamId, groupBy: 'assignee' });
 

--- a/packages/core/tests/work/cycle-service.test.ts
+++ b/packages/core/tests/work/cycle-service.test.ts
@@ -363,9 +363,24 @@ describe('cycleProgress', () => {
   it('reports scope, started, completed, and a day by day burn up', async () => {
     const cycle = await firstCycle();
     const created = await Promise.all([
-      createIssue(workspace.admin, { teamId: workspace.teamId, title: 'A', cycleId: cycle.id }),
-      createIssue(workspace.admin, { teamId: workspace.teamId, title: 'B', cycleId: cycle.id }),
-      createIssue(workspace.admin, { teamId: workspace.teamId, title: 'C', cycleId: cycle.id }),
+      createIssue(workspace.admin, {
+        stateId: stateNamed(workspace, 'Todo').id,
+        teamId: workspace.teamId,
+        title: 'A',
+        cycleId: cycle.id,
+      }),
+      createIssue(workspace.admin, {
+        stateId: stateNamed(workspace, 'Todo').id,
+        teamId: workspace.teamId,
+        title: 'B',
+        cycleId: cycle.id,
+      }),
+      createIssue(workspace.admin, {
+        stateId: stateNamed(workspace, 'Todo').id,
+        teamId: workspace.teamId,
+        title: 'C',
+        cycleId: cycle.id,
+      }),
     ]);
     const [a, b] = created;
     if (a === undefined || b === undefined) throw new Error('missing issues');
@@ -424,11 +439,13 @@ describe('cycleProgress reconstructs the scope of the sprint', () => {
   it('steps the scope up on the day work was added and not before', async () => {
     const cycle = await firstCycle();
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Planned',
       cycleId: cycle.id,
     });
     const late = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Added later',
     });
@@ -445,11 +462,13 @@ describe('cycleProgress reconstructs the scope of the sprint', () => {
   it('steps the scope down on the day work was pulled out', async () => {
     const cycle = await firstCycle();
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Planned',
       cycleId: cycle.id,
     });
     const pulled = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Pulled out',
       cycleId: cycle.id,
@@ -468,11 +487,13 @@ describe('cycleProgress reconstructs the scope of the sprint', () => {
   it('steps the scope up on the day an issue was filed straight into the running sprint', async () => {
     const cycle = await firstCycle();
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Planned',
       cycleId: cycle.id,
     });
     const filed = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Filed mid sprint',
       cycleId: cycle.id,
@@ -490,12 +511,14 @@ describe('cycleProgress reconstructs the scope of the sprint', () => {
   it('keeps cancelled work in the scope until the day it was cancelled', async () => {
     const cycle = await firstCycle();
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Kept',
       cycleId: cycle.id,
       estimate: 3,
     });
     const dropped = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Cancelled mid sprint',
       cycleId: cycle.id,
@@ -515,12 +538,14 @@ describe('cycleProgress reconstructs the scope of the sprint', () => {
   it('leaves work cancelled without a recorded time out of the sprint from the first day', async () => {
     const cycle = await firstCycle();
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Kept',
       cycleId: cycle.id,
       estimate: 3,
     });
     const dropped = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Cancelled at an unknown time',
       cycleId: cycle.id,
@@ -540,12 +565,14 @@ describe('cycleProgress reconstructs the scope of the sprint', () => {
   it('leaves cancelled work out of the scope and counts it on its own', async () => {
     const cycle = await firstCycle();
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Kept',
       cycleId: cycle.id,
       estimate: 3,
     });
     const dropped = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Dropped',
       cycleId: cycle.id,
@@ -566,6 +593,7 @@ describe('cycleProgress reconstructs the scope of the sprint', () => {
   it('adds points up from the estimates and counts a missing estimate as zero', async () => {
     const cycle = await firstCycle();
     const done = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Shipped',
       cycleId: cycle.id,
@@ -575,6 +603,7 @@ describe('cycleProgress reconstructs the scope of the sprint', () => {
       stateId: stateNamed(workspace, 'Done').id,
     });
     const running = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Running',
       cycleId: cycle.id,
@@ -584,6 +613,7 @@ describe('cycleProgress reconstructs the scope of the sprint', () => {
       stateId: stateNamed(workspace, 'In Progress').id,
     });
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Unsized',
       cycleId: cycle.id,
@@ -599,6 +629,7 @@ describe('cycleProgress reconstructs the scope of the sprint', () => {
   it('keeps the days an issue sat in the sprint when it is pulled out after the sprint ends', async () => {
     const cycle = await firstCycle();
     const carried = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Carried the whole sprint',
       cycleId: cycle.id,
@@ -618,12 +649,14 @@ describe('cycleProgress reconstructs the scope of the sprint', () => {
   it('leaves work parked in the sprint after it ended out of every day it ran', async () => {
     const cycle = await firstCycle();
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Planned',
       cycleId: cycle.id,
       estimate: 2,
     });
     const late = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Parked here once the sprint was over',
       estimate: 5,
@@ -641,12 +674,14 @@ describe('cycleProgress reconstructs the scope of the sprint', () => {
   it('reports work pulled out before the sprint ended as removed, and stops counting it that day', async () => {
     const cycle = await firstCycle();
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Stayed',
       cycleId: cycle.id,
       estimate: 2,
     });
     const pulled = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Pulled out before the end',
       cycleId: cycle.id,
@@ -668,11 +703,13 @@ describe('completeCycle', () => {
   it('rolls unfinished issues into the next cycle and closes the current one', async () => {
     const cycle = await firstCycle();
     const open = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Still open',
       cycleId: cycle.id,
     });
     const done = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Finished',
       cycleId: cycle.id,
@@ -757,6 +794,7 @@ describe('cycle writes need the right role, not the right team', () => {
     const [theirs] = await listCycles(vega.admin);
     if (theirs === undefined) throw new Error('vega has no sprint');
     const { issue } = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Mine',
     });
@@ -771,6 +809,7 @@ describe('a finished sprint keeps its own history', () => {
   it('records what it shipped, because the rollover empties it of unfinished work', async () => {
     const cycle = await firstCycle();
     const shipped = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Shipped',
       cycleId: cycle.id,
@@ -780,6 +819,7 @@ describe('a finished sprint keeps its own history', () => {
       stateId: stateNamed(workspace, 'Done').id,
     });
     const dropped = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Dropped',
       cycleId: cycle.id,
@@ -789,6 +829,7 @@ describe('a finished sprint keeps its own history', () => {
       stateId: stateNamed(workspace, 'Canceled').id,
     });
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Not finished',
       cycleId: cycle.id,
@@ -895,6 +936,7 @@ describe('two people closing the same sprint at once', () => {
   it('lets one through, refuses the other, and leaves a single successor', async () => {
     const cycle = await firstCycle();
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Carried',
       cycleId: cycle.id,
@@ -941,6 +983,7 @@ describe('sprintOutcome', () => {
   it('hands back what was recorded when the sprint was closed', async () => {
     const cycle = await firstCycle();
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Shipped',
       cycleId: cycle.id,
@@ -956,6 +999,7 @@ describe('sprintOutcome', () => {
   it('counts a sprint closed before outcomes were recorded, rather than saying nothing', async () => {
     const cycle = await firstCycle();
     const done = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Finished',
       cycleId: cycle.id,
@@ -965,6 +1009,7 @@ describe('sprintOutcome', () => {
       stateId: stateNamed(workspace, 'Done').id,
     });
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Left over',
       cycleId: cycle.id,
@@ -994,6 +1039,7 @@ describe('sprintOutcomes', () => {
   it('answers for a page of sprints in one pass, recorded or counted', async () => {
     const first = await firstCycle();
     const one = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'In the first',
       cycleId: first.id,
@@ -1009,6 +1055,7 @@ describe('sprintOutcomes', () => {
       endsAt: daysFromNow(214),
     });
     const two = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'In the second',
       cycleId: second.cycle.id,
@@ -1039,6 +1086,7 @@ describe('sprintOutcomes', () => {
   it('counts the sprint when the stored snapshot is malformed rather than trusting it', async () => {
     const cycle = await firstCycle();
     const done = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Finished',
       cycleId: cycle.id,
@@ -1063,6 +1111,7 @@ describe('sprintOutcomes', () => {
   it('counts only what is still in the sprint, since a rollover moved the rest away', async () => {
     const cycle = await firstCycle();
     const done = await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Finished',
       cycleId: cycle.id,
@@ -1072,6 +1121,7 @@ describe('sprintOutcomes', () => {
       stateId: stateNamed(workspace, 'Done').id,
     });
     await createIssue(workspace.admin, {
+      stateId: stateNamed(workspace, 'Todo').id,
       teamId: workspace.teamId,
       title: 'Rolled over',
       cycleId: cycle.id,

--- a/packages/core/tests/work/cycle-shift.test.ts
+++ b/packages/core/tests/work/cycle-shift.test.ts
@@ -320,3 +320,33 @@ describe('paging through the sprints of a workspace', () => {
     expect(theirs.cycles.every((row) => !ids.has(row.id))).toBe(true);
   });
 });
+
+describe('the paging arguments a url can carry', () => {
+  it('falls back rather than letting a NaN reach the query', async () => {
+    await scheduled(40, 54);
+
+    const page = await pageOfCycles(workspace.admin, {
+      page: Number.NaN,
+      pageSize: Number.NaN,
+    });
+
+    expect(page.page).toBe(1);
+    expect(page.cycles.length).toBeGreaterThan(0);
+  });
+
+  it('truncates a fractional page rather than offsetting by part of a row', async () => {
+    for (let index = 0; index < 3; index += 1) await scheduled(index * 20 + 40, index * 20 + 54);
+
+    const fractional = await pageOfCycles(workspace.admin, { page: 2.7, pageSize: 2 });
+    const whole = await pageOfCycles(workspace.admin, { page: 2, pageSize: 2 });
+
+    expect(fractional.page).toBe(2);
+    expect(fractional.cycles.map((row) => row.id)).toEqual(whole.cycles.map((row) => row.id));
+  });
+
+  it('caps the page size so one request cannot ask for everything', async () => {
+    const page = await pageOfCycles(workspace.admin, { pageSize: 100_000 });
+
+    expect(page.cycles.length).toBeLessThanOrEqual(100);
+  });
+});

--- a/packages/core/tests/work/cycle-shift.test.ts
+++ b/packages/core/tests/work/cycle-shift.test.ts
@@ -10,6 +10,7 @@ import {
   completeCycle,
   createCycle,
   getCycle,
+  pageOfCycles,
   shiftFollowingCycles,
   updateCycle,
 } from '../../src/work/cycle-service.ts';
@@ -264,5 +265,58 @@ describe('an extension that is not a whole number of days', () => {
 
     const after = await getCycle(workspace.admin, second.id);
     expect(after.startsAt.getTime()).toBe(second.startsAt.getTime() + extendedBy);
+  });
+});
+
+describe('paging through the sprints of a workspace', () => {
+  it('hands back the newest first, a page at a time', async () => {
+    const seeded = (await pageOfCycles(workspace.admin)).total;
+    for (let index = 0; index < 5; index += 1) {
+      await scheduled(index * 20 + 40, index * 20 + 54);
+    }
+
+    const first = await pageOfCycles(workspace.admin, { page: 1, pageSize: 2 });
+    const second = await pageOfCycles(workspace.admin, { page: 2, pageSize: 2 });
+
+    expect(first.total).toBe(seeded + 5);
+    expect(first.pageCount).toBe(Math.ceil((seeded + 5) / 2));
+    expect(first.cycles).toHaveLength(2);
+    expect(first.cycles[0]?.startsAt.getTime()).toBeGreaterThan(
+      first.cycles[1]?.startsAt.getTime() ?? 0,
+    );
+    expect(second.cycles[0]?.startsAt.getTime()).toBeLessThan(
+      first.cycles[1]?.startsAt.getTime() ?? 0,
+    );
+  });
+
+  it('never runs off either end of the range', async () => {
+    await scheduled(40, 54);
+    const all = await pageOfCycles(workspace.admin);
+
+    const before = await pageOfCycles(workspace.admin, { page: 0 });
+    const beyond = await pageOfCycles(workspace.admin, { page: 999 });
+
+    expect(before.page).toBe(1);
+    expect(beyond.page).toBe(all.pageCount);
+    expect(beyond.cycles.length).toBeGreaterThan(0);
+  });
+
+  it('pages a long series without ever dividing by zero', async () => {
+    const page = await pageOfCycles(workspace.admin, { pageSize: 1 });
+
+    expect(page.pageCount).toBeGreaterThanOrEqual(1);
+    expect(page.page).toBe(1);
+  });
+
+  it('shows a workspace only its own sprints', async () => {
+    await scheduled(40, 54);
+    const other = await createWorkspace('Other');
+
+    const mine = await pageOfCycles(workspace.admin);
+    const theirs = await pageOfCycles(other.admin);
+
+    expect(mine.total).toBeGreaterThan(theirs.total);
+    const ids = new Set(mine.cycles.map((row) => row.id));
+    expect(theirs.cycles.every((row) => !ids.has(row.id))).toBe(true);
   });
 });

--- a/packages/core/tests/work/issue-predicates.test.ts
+++ b/packages/core/tests/work/issue-predicates.test.ts
@@ -59,7 +59,7 @@ describe('assignee conditions', () => {
     const two = await addMember(workspace, 'member', { name: 'Two' });
     await newIssue('For one', { assigneeId: one.user.id });
     await newIssue('For two', { assigneeId: two.user.id });
-    await newIssue('For nobody');
+    await newIssue('For nobody', { assigneeId: null });
 
     expect(await titlesMatching(inCondition('assignee', [one.user.id, two.user.id]))).toEqual([
       'For one',
@@ -70,7 +70,7 @@ describe('assignee conditions', () => {
   it('treats none as unassigned', async () => {
     const one = await addMember(workspace, 'member', { name: 'One' });
     await newIssue('For one', { assigneeId: one.user.id });
-    await newIssue('For nobody');
+    await newIssue('For nobody', { assigneeId: null });
 
     expect(await titlesMatching(inCondition('assignee', ['none']))).toEqual(['For nobody']);
   });
@@ -80,7 +80,7 @@ describe('assignee conditions', () => {
     const two = await addMember(workspace, 'member', { name: 'Two' });
     await newIssue('For one', { assigneeId: one.user.id });
     await newIssue('For two', { assigneeId: two.user.id });
-    await newIssue('For nobody');
+    await newIssue('For nobody', { assigneeId: null });
 
     expect(await titlesMatching(inCondition('assignee', [one.user.id], true))).toEqual([
       'For nobody',

--- a/packages/core/tests/work/issue-service.test.ts
+++ b/packages/core/tests/work/issue-service.test.ts
@@ -55,14 +55,41 @@ async function newIssue(title: string, overrides: Record<string, unknown> = {}) 
 }
 
 describe('createIssue', () => {
-  it('allocates sequential identifiers and defaults to the first unstarted state', async () => {
+  it('allocates sequential identifiers and starts a new issue in triage', async () => {
     const first = await newIssue('First');
     const second = await newIssue('Second');
 
     expect(first.identifier).toBe('NOVA-1');
     expect(second.identifier).toBe('NOVA-2');
-    expect(first.stateId).toBe(stateNamed(workspace, 'Todo').id);
+    expect(first.stateId).toBe(stateNamed(workspace, 'Triage').id);
     expect(first.creatorId).toBe(workspace.admin.userId);
+  });
+
+  it('assigns a new issue to whoever created it', async () => {
+    const issue = await newIssue('Mine by default');
+
+    expect(issue.assigneeId).toBe(workspace.admin.userId);
+  });
+
+  it('still honours an assignee that was asked for', async () => {
+    const { principal } = await addMember(workspace, 'member');
+    const issue = await newIssue('Theirs', { assigneeId: principal.userId });
+
+    expect(issue.assigneeId).toBe(principal.userId);
+  });
+
+  it('leaves an issue unassigned when null was asked for on purpose', async () => {
+    const issue = await newIssue('Nobody', { assigneeId: null });
+
+    expect(issue.assigneeId).toBeNull();
+  });
+
+  it('still honours a status that was asked for', async () => {
+    const issue = await newIssue('Started already', {
+      stateId: stateNamed(workspace, 'Todo').id,
+    });
+
+    expect(issue.stateId).toBe(stateNamed(workspace, 'Todo').id);
   });
 
   it('allocates unique numbers under concurrency', async () => {
@@ -695,15 +722,15 @@ describe('listIssues', () => {
     const counts = await getIssueCounts(workspace.admin, { teamId: workspace.teamId });
     const byState = new Map(counts.map((row) => [row.stateId, row.total]));
     expect(byState.get(stateNamed(workspace, 'Done').id)).toBe(1);
-    expect(byState.get(stateNamed(workspace, 'Todo').id)).toBe(1);
+    expect(byState.get(stateNamed(workspace, 'Triage').id)).toBe(1);
   });
 });
 
 describe('getIssueSummary', () => {
   it('reports the filtered total beside the unfiltered scope, so nothing has to be crawled', async () => {
     const mine = await newIssue('Mine');
-    await newIssue('Theirs');
-    await newIssue('Also theirs');
+    await newIssue('Theirs', { assigneeId: null });
+    await newIssue('Also theirs', { assigneeId: null });
     await updateIssue(workspace.admin, mine.id, { assigneeId: workspace.admin.userId });
 
     const summary = await getIssueSummary(workspace.admin, {
@@ -731,7 +758,7 @@ describe('getIssueSummary', () => {
 
   it('counts every facet value across the whole scope, not just a loaded page', async () => {
     const done = await newIssue('Shipped');
-    await newIssue('Waiting');
+    await newIssue('Waiting', { assigneeId: null });
     await updateIssue(workspace.admin, done.id, {
       stateId: stateNamed(workspace, 'Done').id,
       assigneeId: workspace.admin.userId,
@@ -741,7 +768,7 @@ describe('getIssueSummary', () => {
     const { facets } = await getIssueFacets(workspace.admin, { teamId: workspace.teamId });
 
     expect(facets.state[stateNamed(workspace, 'Done').id]).toBe(1);
-    expect(facets.state[stateNamed(workspace, 'Todo').id]).toBe(1);
+    expect(facets.state[stateNamed(workspace, 'Triage').id]).toBe(1);
     expect(facets.assignee[workspace.admin.userId]).toBe(1);
     expect(facets.assignee['none']).toBe(1);
     expect(facets.creator[workspace.admin.userId]).toBe(2);
@@ -780,7 +807,7 @@ describe('getIssueSummary', () => {
 
     const scoped = await getIssueFacets(workspace.admin, { teamId: workspace.teamId });
     expect(scoped.scopeTotal).toBe(2);
-    expect(scoped.facets.state[stateNamed(workspace, 'Todo').id]).toBe(1);
+    expect(scoped.facets.state[stateNamed(workspace, 'Triage').id]).toBe(1);
   });
 
   it('reads every column facet in one grouping sets pass instead of one query each', () => {

--- a/packages/core/tests/work/view-service.test.ts
+++ b/packages/core/tests/work/view-service.test.ts
@@ -289,7 +289,7 @@ describe('the built-in views select the issues they promise', () => {
 
   it('keeps only issues with nobody assigned in the unassigned view', async () => {
     const { user: teammate } = await addMember(workspace, 'member', { name: 'Teammate' });
-    await issueNamed('Nobody owns this');
+    await issueNamed('Nobody owns this', { assigneeId: null });
     await issueNamed('Someone owns this', { assigneeId: teammate.id });
 
     expect(await titlesFor('virtual:unassigned')).toEqual(['Nobody owns this']);

--- a/packages/core/tests/work/workflow-state-service.test.ts
+++ b/packages/core/tests/work/workflow-state-service.test.ts
@@ -83,7 +83,11 @@ describe('workflow states', () => {
   });
 
   it('refuses to delete a state that still holds issues', async () => {
-    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Parked' });
+    await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Parked',
+      stateId: stateNamed(workspace, 'Todo').id,
+    });
     await expect(
       deleteWorkflowState(workspace.admin, stateNamed(workspace, 'Todo').id),
     ).rejects.toMatchObject({ code: 'conflict' });

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -490,6 +490,7 @@ describe('planning', () => {
     for (const issue of [heavy, light]) {
       await admin.result('move_to_cycle', { issue: issue.identifier, cycle: 'active' });
     }
+    await admin.result('update_issue', { issue: light.identifier, state: 'Todo' });
     await admin.result('update_issue', { issue: heavy.identifier, state: 'Done' });
 
     const progress = await admin.result('cycle_progress', { cycle: 'active' });

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -25,7 +25,7 @@ export const issueCreateSchema = z.object({
   description: markdownSchema.default(''),
   stateId: idSchema.optional(),
   priority: prioritySchema.default(0),
-  assigneeId: idSchema.nullable().default(null),
+  assigneeId: idSchema.nullable().optional(),
   projectId: idSchema.nullable().default(null),
   milestoneId: idSchema.nullable().default(null),
   cycleId: idSchema.nullable().default(null),

--- a/packages/shared/tests/validators/validators.test.ts
+++ b/packages/shared/tests/validators/validators.test.ts
@@ -60,8 +60,19 @@ describe('create schemas still apply their defaults', () => {
     const parsed = issueCreateSchema.parse({ teamId: 'team_1', title: 'Ship it' });
     expect(parsed.priority).toBe(0);
     expect(parsed.description).toBe('');
-    expect(parsed.assigneeId).toBeNull();
     expect(parsed.labelIds).toEqual([]);
+  });
+
+  it('leaves an omitted assignee undefined so the service can tell it from a deliberate none', () => {
+    const omitted = issueCreateSchema.parse({ teamId: 'team_1', title: 'Ship it' });
+    const cleared = issueCreateSchema.parse({
+      teamId: 'team_1',
+      title: 'Ship it',
+      assigneeId: null,
+    });
+
+    expect(omitted.assigneeId).toBeUndefined();
+    expect(cleared.assigneeId).toBeNull();
   });
 });
 


### PR DESCRIPTION
Follows on from #295.

## The sprint page

The Board tab rendered every state stacked one under another, which is a list
however it is labelled. There are three views now, and they are distinct:

- **Board**, the states as columns that scroll sideways on their own. It takes
  the full width, because sharing the row with the twenty rem panel left it
  showing three and a half columns on a wide screen.
- **List**, the grouped list that used to be called the board.
- **Insights**, the burn up and the per assignee table.

Each tally reads in both units, `20 tasks` over `55 points`, so the task count
can no longer be read as a points total. The uncommitted line says `tasks` too.

## Browsing sprints

The page reached six upcoming sprints and twelve past ones and nothing else, so
a workspace with a couple of years behind it had no way back to most of its own
history. `/sprints/all` pages through every sprint, newest first, twenty five at
a time, saying of each whether it is running, upcoming or finished and how much
it holds.

## Defaults for a new task

A new task landed in the first unstarted state with nobody on it. It now starts
in **triage** and is assigned to **whoever filed it**.

An assignee that was asked for is still honoured, and passing `null` on purpose
still leaves a task unassigned, which is why the create schema stops defaulting
the field: the service has to be able to tell an omitted assignee from a
deliberate none.

Worth knowing: triage is uncommitted, so a newly filed task no longer counts
towards sprint scope until it moves on. That is the intended reading of triage,
and it is why a number of fixtures now state their status and assignee outright
rather than leaning on the old defaults.

Note on the claim that a task can have no status at all: `issue.state_id` is
`not null` and every team carries a Triage state, and there are no rows in
production with a null or dangling status. What was real is the assignee gap,
seventy five live issues with nobody on them, which the default above closes.

## Checks

`bun run verify` is green. New tests cover the board columns, the sprint index
and its paging, and the two create defaults including the deliberate none.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds distinct sprint board, list, and insights views, introduces paginated sprint history with explicit running, upcoming, overdue, and finished states, and defaults new tasks to triage and the filing user while preserving explicit unassignment.
- Adds a horizontally scrolling sprint board and clearer task/point tallies.
- Adds a paginated all-sprints index with lifecycle labels and issue counts.
- Updates task creation defaults and associated validation and service tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the current overdue state distinguishes unclosed past-end sprints from both active and completed sprints, resolving the prior status conflicts.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/sprints/data.ts | Adds paginated sprint-index data, issue counts, and lifecycle classification; the overdue state resolves the previously conflicting running/finished labels. |
| apps/web/src/features/sprints/sprint-index.tsx | Renders paginated sprint history with lifecycle badges, date spans, issue totals, and links to sprint details. |
| apps/web/src/features/sprints/cycle-board.tsx | Adds the column-based board and reports sprint progress in both task and point units. |
| packages/core/src/work/cycle-service.ts | Adds organization-scoped, newest-first cycle pagination with bounded page sizes. |
| packages/core/src/work/issue-service.ts | Changes issue creation to use triage and the filing user as omitted-field defaults while preserving explicit assignee choices. |
| packages/core/src/work/workflow-state-service.ts | Supports selecting the team-local triage state used by the new issue-creation default. |
| packages/shared/src/validators/issue.ts | Removes the schema-level assignee default so the service can distinguish omission from explicit null. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Create task] --> B{Assignee supplied?}
  B -->|User ID| C[Use requested assignee]
  B -->|Explicit null| D[Leave unassigned]
  B -->|Omitted| E[Assign filing user]
  A --> F[Select team triage state]
  G[Browse sprint index] --> H{Sprint lifecycle}
  H -->|Completed| I[Finished]
  H -->|Starts later| J[Upcoming]
  H -->|Within dates| K[Running]
  H -->|Past end and open| L[Past its end date]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(sprints): give a sprint past its end..."](https://github.com/noveum/orbit/commit/f6d0ee56614716edafb7dfffb67fc2ec0a3620d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52189210)</sub>

<!-- /greptile_comment -->