### PR TITLE
fix(docs): render pasted markdown in rich editors

### DIFF
--- a/apps/web/src/features/docs/editor/editor-content.ts
+++ b/apps/web/src/features/docs/editor/editor-content.ts
@@ -1,6 +1,14 @@
 import { renderMarkdown } from '@orbit/services/markdown';
 import { toEditorHtml } from './extensions.ts';
 
+const FORMATTED_MARKDOWN_TAG =
+  /<(?:a|blockquote|br|code|del|details|em|h[1-6]|hr|img|mark|ol|pre|strong|table|u|ul)\b/i;
+
 export function editorHtmlFrom(markdown: string): string {
   return toEditorHtml(renderMarkdown(markdown));
+}
+
+export function markdownPasteHtml(markdown: string): string | null {
+  const html = editorHtmlFrom(markdown);
+  return FORMATTED_MARKDOWN_TAG.test(html) ? html : null;
 }

--- a/apps/web/src/features/docs/editor/rich-text-editor.tsx
+++ b/apps/web/src/features/docs/editor/rich-text-editor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { Editor } from '@tiptap/core';
+import { DOMParser as ProseMirrorDOMParser } from '@tiptap/pm/model';
 import { EditorContent, useEditor } from '@tiptap/react';
 import { Bold, Code, Italic, Link2, MessageSquarePlus, Strikethrough } from 'lucide-react';
 import type { Ref } from 'react';
@@ -20,7 +21,7 @@ import { cn } from '@/lib/cn.ts';
 import type { Member } from '@/lib/query/schemas.ts';
 import { docProseClassName } from '../doc-body.tsx';
 import { findTrigger, matchSlashCommands, type SlashCommand } from './commands.ts';
-import { editorHtmlFrom } from './editor-content.ts';
+import { editorHtmlFrom, markdownPasteHtml } from './editor-content.ts';
 import { EditorToolbar } from './editor-toolbar.tsx';
 import { editorExtensions, type MenuKey, type MenuKeyHandlerRef } from './extensions.ts';
 import { docToMarkdown } from './markdown.ts';
@@ -183,6 +184,17 @@ export function RichTextEditor({
         'aria-label': ariaLabel,
         role: 'textbox',
         'aria-multiline': 'true',
+      },
+      handlePaste: (view, event) => {
+        const clipboard = event.clipboardData;
+        if (clipboard === null || clipboard.files.length > 0) return false;
+        const html = markdownPasteHtml(clipboard.getData('text/plain'));
+        if (html === null) return false;
+        const container = document.createElement('div');
+        container.innerHTML = html;
+        const slice = ProseMirrorDOMParser.fromSchema(view.state.schema).parseSlice(container);
+        view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView());
+        return true;
       },
     },
     onUpdate: ({ editor: instance }) => {

--- a/apps/web/src/features/docs/editor/rich-text-editor.tsx
+++ b/apps/web/src/features/docs/editor/rich-text-editor.tsx
@@ -188,6 +188,7 @@ export function RichTextEditor({
       handlePaste: (view, event) => {
         const clipboard = event.clipboardData;
         if (clipboard === null || clipboard.files.length > 0) return false;
+        if (view.state.selection.$from.parent.type.spec.code === true) return false;
         const html = markdownPasteHtml(clipboard.getData('text/plain'));
         if (html === null) return false;
         const container = document.createElement('div');

--- a/apps/web/tests/features/docs/editor/editor.test.ts
+++ b/apps/web/tests/features/docs/editor/editor.test.ts
@@ -6,6 +6,7 @@ import {
   matchSlashCommands,
   SLASH_COMMANDS,
 } from '../../../../src/features/docs/editor/commands.ts';
+import { markdownPasteHtml } from '../../../../src/features/docs/editor/editor-content.ts';
 import {
   editorExtensions,
   type MenuKey,
@@ -230,5 +231,18 @@ describe('toEditorHtml', () => {
 
     expect(html).not.toMatch(/<p>\s*<\/p>/);
     expect(html).toContain('data-checked="false"');
+  });
+});
+
+describe('markdownPasteHtml', () => {
+  it('recognises rendered markdown formatting', () => {
+    expect(markdownPasteHtml('## Plan')).toContain('<h2>Plan</h2>');
+    expect(markdownPasteHtml('Read **this**')).toContain('<strong>this</strong>');
+    expect(markdownPasteHtml('- [ ] Ship it')).toContain('data-type="taskList"');
+  });
+
+  it('leaves plain text for the native paste handler', () => {
+    expect(markdownPasteHtml('Everything is fine now.')).toBeNull();
+    expect(markdownPasteHtml('snake_case_name stays whole')).toBeNull();
   });
 });

--- a/apps/web/tests/features/docs/editor/rich-text-editor.test.tsx
+++ b/apps/web/tests/features/docs/editor/rich-text-editor.test.tsx
@@ -196,6 +196,22 @@ describe('pasting markdown', () => {
 
     await waitFor(() => expect(onChange.mock.calls.at(-1)?.[0]).toBe('Everything is fine now.'));
   });
+
+  it('keeps pasted markdown literal inside a code block', async () => {
+    const onChange = mock();
+    const editor = await mountEditor({ onChange });
+    const user = userEvent.setup();
+
+    await user.click(editor.view.dom);
+    editor.chain().setCodeBlock().run();
+    await user.paste('**text**');
+
+    await waitFor(() =>
+      expect(editor.view.dom.querySelector('code')?.textContent).toBe('**text**'),
+    );
+    expect(editor.view.dom.querySelector('strong')).toBeNull();
+    expect(onChange.mock.calls.at(-1)?.[0]).toContain('**text**');
+  });
 });
 
 describe('mention menu', () => {

--- a/apps/web/tests/features/docs/editor/rich-text-editor.test.tsx
+++ b/apps/web/tests/features/docs/editor/rich-text-editor.test.tsx
@@ -161,6 +161,43 @@ describe('attaching a file from the slash menu', () => {
   });
 });
 
+describe('pasting markdown', () => {
+  it('inserts formatted blocks and emits canonical markdown', async () => {
+    const onChange = mock();
+    const editor = await mountEditor({ onChange });
+    const source = [
+      '## Plan',
+      '',
+      'Read the **release notes** in [the docs](https://orbit.test/docs).',
+      '',
+      '- [ ] Ship it',
+    ].join('\n');
+
+    const user = userEvent.setup();
+    await user.click(editor.view.dom);
+    await user.paste(source);
+
+    await waitFor(() => expect(onChange.mock.calls.at(-1)?.[0]).toBe(source));
+    expect(editor.view.dom.querySelector('h2')?.textContent).toBe('Plan');
+    expect(editor.view.dom.querySelector('strong')?.textContent).toBe('release notes');
+    expect(editor.view.dom.querySelector('a')?.getAttribute('href')).toBe(
+      'https://orbit.test/docs',
+    );
+    expect(editor.view.dom.querySelector('ul[data-type="taskList"]')).not.toBeNull();
+  });
+
+  it('leaves ordinary pasted text on the native editor path', async () => {
+    const onChange = mock();
+    const editor = await mountEditor({ onChange });
+
+    const user = userEvent.setup();
+    await user.click(editor.view.dom);
+    await user.paste('Everything is fine now.');
+
+    await waitFor(() => expect(onChange.mock.calls.at(-1)?.[0]).toBe('Everything is fine now.'));
+  });
+});
+
 describe('mention menu', () => {
   it('offers members and inserts a handle without leaving a trigger character', async () => {
     const onChange = mock();


### PR DESCRIPTION
Parse formatted Markdown pasted into shared rich editors while preserving ordinary text and file paste behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Markdown-aware paste handling to shared rich-text editors while preserving native handling for ordinary text, files, and code blocks.
- Detects rendered Markdown formatting before intercepting a paste.
- Converts matching Markdown into a ProseMirror slice at the current selection.
- Adds unit and integration coverage for formatted, plain-text, and code-block paste behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/docs/editor/editor-content.ts | Adds a helper that renders pasted Markdown and returns HTML only when formatting-related tags are detected. |
| apps/web/src/features/docs/editor/rich-text-editor.tsx | Adds Markdown-aware paste interception while delegating files, code-block content, and ordinary text to existing behavior. |
| apps/web/tests/features/docs/editor/editor.test.ts | Covers formatted-Markdown detection and plain-text fallback. |
| apps/web/tests/features/docs/editor/rich-text-editor.test.tsx | Covers formatted paste insertion, emitted Markdown, ordinary text, and literal code-block pastes. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Paste event] --> B{Clipboard contains files?}
    B -- Yes --> N[Use native file paste path]
    B -- No --> C{Selection is in code block?}
    C -- Yes --> N2[Use native literal paste path]
    C -- No --> D[Render and sanitize text/plain as Markdown]
    D --> E{Formatted Markdown tag found?}
    E -- No --> N3[Use native text paste path]
    E -- Yes --> F[Parse HTML into ProseMirror slice]
    F --> G[Replace current selection]
    G --> H[Emit canonical Markdown]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(docs): preserve literal pastes in co..."](https://github.com/noveum/orbit/commit/e3028cd3dfe4d33d618a3859cfdb0c08e6990ee5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52234984)</sub>

<!-- /greptile_comment -->