### PR TITLE
fix(issues): a failed surface says so, and clearing one filter clears one

### DIFF
--- a/apps/web/e2e/issues.spec.ts
+++ b/apps/web/e2e/issues.spec.ts
@@ -85,3 +85,31 @@ test.fixme('two viewers see issue, board and comment changes without reloading',
   await first.close();
   await second.close();
 });
+
+test('every issue surface says a failed request failed rather than looking empty', async ({
+  browser,
+}) => {
+  test.setTimeout(120_000);
+  const context = await browser.newContext({ viewport: { width: 1400, height: 800 } });
+  const page = await context.newPage();
+  await page.goto(`${BASE}/login`);
+  await page.getByTestId('dev-sign-in-alex@orbit.example').click();
+  await page.waitForURL(`${BASE}/my-issues`);
+
+  for (const [path, testId] of [
+    ['/my-issues', 'retry-my-issues'],
+    ['/team/eng/issues', 'retry-team-issues'],
+    ['/sprints', 'retry-sprint-issues'],
+    ['/standup', 'retry-standup'],
+  ] as const) {
+    const surface = await context.newPage();
+    await surface.route('**/api/issues**', (route) =>
+      route.fulfill({ status: 500, body: '{"error":"boom"}' }),
+    );
+    await surface.goto(`${BASE}${path}`);
+    await expect(surface.getByTestId(testId)).toBeVisible({ timeout: 30_000 });
+    await surface.close();
+  }
+
+  await context.close();
+});

--- a/apps/web/e2e/issues.spec.ts
+++ b/apps/web/e2e/issues.spec.ts
@@ -111,5 +111,33 @@ test('every issue surface says a failed request failed rather than looking empty
     await surface.close();
   }
 
+  const project = await context.newPage();
+  await project.goto(`${BASE}/projects`);
+  const projectHref = await project
+    .locator('a[href^="/projects/"]')
+    .filter({ hasNotText: /^$/ })
+    .first()
+    .getAttribute('href');
+  if (projectHref !== null && projectHref !== '/projects') {
+    await project.route('**/api/issues**', (route) =>
+      route.fulfill({ status: 500, body: '{"error":"boom"}' }),
+    );
+    await project.goto(`${BASE}${projectHref}/issues`);
+    await expect(project.getByTestId('retry-project-issues')).toBeVisible({ timeout: 30_000 });
+  }
+  await project.close();
+
+  const view = await context.newPage();
+  await view.goto(`${BASE}/views`);
+  const viewHref = await view.locator('a[href^="/views/"]').first().getAttribute('href');
+  if (viewHref !== null) {
+    await view.route('**/api/issues**', (route) =>
+      route.fulfill({ status: 500, body: '{"error":"boom"}' }),
+    );
+    await view.goto(`${BASE}${viewHref}`);
+    await expect(view.getByTestId('retry-saved-view')).toBeVisible({ timeout: 30_000 });
+  }
+  await view.close();
+
   await context.close();
 });

--- a/apps/web/src/features/issues/load-failed.tsx
+++ b/apps/web/src/features/issues/load-failed.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { WifiOff } from 'lucide-react';
+import { Button } from '@/components/ui/button.tsx';
+import { EmptyState } from '@/components/ui/empty-state.tsx';
+
+export interface LoadFailedProps {
+  readonly subject: string;
+  readonly onRetry: () => void;
+  readonly testId: string;
+}
+
+export function LoadFailed({ subject, onRetry, testId }: LoadFailedProps) {
+  return (
+    <EmptyState
+      icon={<WifiOff strokeWidth={1.75} aria-hidden="true" />}
+      title={`Could not load ${subject}`}
+      description="The request did not come back, so this is not empty, it is unread. Try again."
+      className="flex-1"
+      action={
+        <Button size="sm" variant="secondary" data-testid={testId} onClick={onRetry}>
+          Try again
+        </Button>
+      }
+    />
+  );
+}

--- a/apps/web/src/features/issues/my-issues-view.tsx
+++ b/apps/web/src/features/issues/my-issues-view.tsx
@@ -23,6 +23,7 @@ import { Board, canRegroup } from './board.tsx';
 import { GroupGlyph } from './group-glyph.tsx';
 import { IssuePeek } from './issue-peek.tsx';
 import { IssueRow } from './issue-row.tsx';
+import { LoadFailed } from './load-failed.tsx';
 import { useIssueViewModel } from './use-issue-view-model.ts';
 import { useWorkspace } from './workspace-provider.tsx';
 
@@ -112,6 +113,10 @@ export function MyIssuesView() {
 
       <MyIssuesBody
         loading={loading}
+        failed={assigned.isError}
+        onRetry={() => {
+          assigned.refetch().catch(() => undefined);
+        }}
         loadingMore={isFetchingNextPage}
         onLoadMore={() => {
           fetchNextPage().catch(() => undefined);
@@ -153,6 +158,8 @@ export function MyIssuesView() {
 
 interface BodyProps {
   readonly loading: boolean;
+  readonly failed: boolean;
+  readonly onRetry: () => void;
   readonly layout: ViewLayoutMode;
   readonly model: ReturnType<typeof useIssueViewModel>;
   readonly groups: readonly IssueGroup[];
@@ -171,6 +178,8 @@ interface BodyProps {
 
 function MyIssuesBody({
   loading,
+  failed,
+  onRetry,
   layout,
   model,
   groups,
@@ -186,6 +195,10 @@ function MyIssuesBody({
   onLoadMore,
   sentinel,
 }: BodyProps) {
+  if (failed) {
+    return <LoadFailed subject="your issues" onRetry={onRetry} testId="retry-my-issues" />;
+  }
+
   if (model.shownCount === 0) {
     return (
       <EmptyState

--- a/apps/web/src/features/issues/team-view.tsx
+++ b/apps/web/src/features/issues/team-view.tsx
@@ -19,13 +19,13 @@ import { useViewConfig, VIEW_PARAM } from '@/features/filters/use-view-config.ts
 import type { ViewConfig, ViewLayoutMode } from '@/features/filters/view-config.ts';
 import { viewConfigToState } from '@/features/filters/view-config.ts';
 import { useProvideViewControls } from '@/features/filters/view-controls.tsx';
+import { LoadFailed } from '@/features/issues/load-failed.tsx';
 import { cn } from '@/lib/cn.ts';
 import { useHotkey } from '@/lib/keyboard/index.ts';
 import { columnParamFor } from '@/lib/query/issue-search.ts';
 import type { View, WorkflowState } from '@/lib/query/schemas.ts';
 import { useIssues } from '@/lib/query/use-issues.ts';
 import { useViews } from '@/lib/query/use-views.ts';
-
 import { Board, canRegroup } from './board.tsx';
 import { IssueList } from './issue-list.tsx';
 import { ListSkeleton } from './list-skeleton.tsx';
@@ -128,6 +128,10 @@ export function TeamView({ teamKey, layout }: TeamViewProps) {
         layout={layout}
         empty={model.shownCount === 0}
         loading={issues.isPending}
+        failed={issues.isError}
+        onRetry={() => {
+          issues.refetch().catch(() => undefined);
+        }}
         hasMore={issues.hasNextPage}
         loadingMore={issues.isFetchingNextPage}
         onLoadMore={() => {
@@ -169,6 +173,8 @@ interface TeamContentProps {
   readonly layout: ViewLayoutMode;
   readonly empty: boolean;
   readonly loading: boolean;
+  readonly failed: boolean;
+  readonly onRetry: () => void;
   readonly hasMore: boolean;
   readonly loadingMore: boolean;
   readonly onLoadMore: () => void;
@@ -183,12 +189,17 @@ function TeamContent({
   layout,
   empty,
   loading,
+  failed,
+  onRetry,
   hasMore,
   loadingMore,
   onLoadMore,
   onClearLastFilter,
 }: TeamContentProps) {
   if (loading) return <ListSkeleton layout={layout} />;
+
+  if (failed)
+    return <LoadFailed subject="these issues" onRetry={onRetry} testId="retry-team-issues" />;
 
   if (empty && conditionsOf(config.filter).length > 0) {
     return (

--- a/apps/web/src/features/projects/project-issues.tsx
+++ b/apps/web/src/features/projects/project-issues.tsx
@@ -15,6 +15,7 @@ import type { BoardColumnSource, StateResolver } from '@/features/issues/board.t
 import { Board, canDragBoard } from '@/features/issues/board.tsx';
 import { IssueList } from '@/features/issues/issue-list.tsx';
 import { ListSkeleton } from '@/features/issues/list-skeleton.tsx';
+import { LoadFailed } from '@/features/issues/load-failed.tsx';
 import type { IssueViewModel } from '@/features/issues/use-issue-view-model.ts';
 import { useIssueViewModel } from '@/features/issues/use-issue-view-model.ts';
 import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
@@ -117,6 +118,10 @@ export function ProjectIssues({ projectId, projectName }: ProjectIssuesProps) {
         columnSource={columnSource}
         canDrag={canDrag}
         loading={issues.isPending}
+        failed={issues.isError}
+        onRetry={() => {
+          issues.refetch().catch(() => undefined);
+        }}
         hasMore={issues.hasNextPage}
         loadingMore={issues.isFetchingNextPage}
         onLoadMore={() => {
@@ -139,6 +144,8 @@ interface BodyProps {
   readonly resolveState: StateResolver;
   readonly layout: ViewLayoutMode;
   readonly loading: boolean;
+  readonly failed: boolean;
+  readonly onRetry: () => void;
   readonly hasMore: boolean;
   readonly loadingMore: boolean;
   readonly onLoadMore: () => void;
@@ -156,6 +163,8 @@ function ProjectIssueBody({
   resolveState,
   layout,
   loading,
+  failed,
+  onRetry,
   hasMore,
   loadingMore,
   onLoadMore,
@@ -164,6 +173,9 @@ function ProjectIssueBody({
   properties,
 }: BodyProps) {
   if (loading) return <ListSkeleton layout={layout} />;
+
+  if (failed)
+    return <LoadFailed subject="these issues" onRetry={onRetry} testId="retry-project-issues" />;
 
   if (model.shownCount === 0) {
     return (

--- a/apps/web/src/features/sprints/sprint-issues.tsx
+++ b/apps/web/src/features/sprints/sprint-issues.tsx
@@ -2,7 +2,7 @@
 
 import type { DisplayProperty, GroupByField, IssueOrdering } from '@orbit/shared/filters';
 import { conditionsOf, dropLastCondition } from '@orbit/shared/filters';
-import { Columns3, SearchX, WifiOff } from 'lucide-react';
+import { Columns3, SearchX } from 'lucide-react';
 import { useMemo } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
@@ -15,6 +15,7 @@ import type { BoardColumnSource, StateResolver } from '@/features/issues/board.t
 import { Board, canDragBoard } from '@/features/issues/board.tsx';
 import { IssueList } from '@/features/issues/issue-list.tsx';
 import { ListSkeleton } from '@/features/issues/list-skeleton.tsx';
+import { LoadFailed } from '@/features/issues/load-failed.tsx';
 import type { IssueViewModel } from '@/features/issues/use-issue-view-model.ts';
 import { useIssueViewModel } from '@/features/issues/use-issue-view-model.ts';
 import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
@@ -138,19 +139,7 @@ function SprintIssueBody({
   if (loading) return <ListSkeleton layout={layout} />;
 
   if (failed) {
-    return (
-      <EmptyState
-        icon={<WifiOff strokeWidth={1.75} aria-hidden="true" />}
-        title="Could not load this sprint"
-        description="The request for the tasks in this sprint did not come back. Try again."
-        className="flex-1"
-        action={
-          <Button size="sm" variant="secondary" data-testid="retry-sprint-issues" onClick={onRetry}>
-            Try again
-          </Button>
-        }
-      />
-    );
+    return <LoadFailed subject="this sprint" onRetry={onRetry} testId="retry-sprint-issues" />;
   }
 
   if (model.shownCount === 0) {

--- a/apps/web/src/features/standup/standup-board.tsx
+++ b/apps/web/src/features/standup/standup-board.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import type { DisplayProperty } from '@orbit/shared/filters';
-import { SearchX, WifiOff } from 'lucide-react';
+import { SearchX } from 'lucide-react';
 import { useMemo, useState } from 'react';
-import { Button } from '@/components/ui/button.tsx';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
 import { Skeleton } from '@/components/ui/skeleton.tsx';
 import { DisplayMenu } from '@/features/filters/display-menu.tsx';
@@ -12,6 +11,7 @@ import { HiddenFooter } from '@/features/filters/hidden-footer.tsx';
 import { useViewConfig } from '@/features/filters/use-view-config.ts';
 import { useProvideViewControls } from '@/features/filters/view-controls.tsx';
 import { Board, type StateResolver } from '@/features/issues/board.tsx';
+import { LoadFailed } from '@/features/issues/load-failed.tsx';
 import { useIssueViewModel } from '@/features/issues/use-issue-view-model.ts';
 import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
 import { facetsSearch } from '@/lib/query/issue-search.ts';
@@ -164,19 +164,7 @@ function StandupBody({
   }
 
   if (failed) {
-    return (
-      <EmptyState
-        icon={<WifiOff strokeWidth={1.75} aria-hidden="true" />}
-        title="Could not load the board"
-        description="The request for this workspace did not come back. Try again."
-        className="flex-1"
-        action={
-          <Button size="sm" variant="secondary" data-testid="retry-standup" onClick={onRetry}>
-            Try again
-          </Button>
-        }
-      />
-    );
+    return <LoadFailed subject="the standup board" onRetry={onRetry} testId="retry-standup" />;
   }
 
   if (empty) {

--- a/apps/web/src/features/views/saved-view-page.tsx
+++ b/apps/web/src/features/views/saved-view-page.tsx
@@ -21,6 +21,7 @@ import type { BoardColumnSource, StateResolver } from '@/features/issues/board.t
 import { Board, canDragBoard } from '@/features/issues/board.tsx';
 import { IssueList } from '@/features/issues/issue-list.tsx';
 import { ListSkeleton } from '@/features/issues/list-skeleton.tsx';
+import { LoadFailed } from '@/features/issues/load-failed.tsx';
 import { useIssueViewModel } from '@/features/issues/use-issue-view-model.ts';
 import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
 import { viewLayoutMode } from '@/features/views/view-href.ts';
@@ -158,6 +159,10 @@ function SavedViewBody({ view }: { view: View }) {
         layout={layout}
         empty={model.shownCount === 0}
         loading={issues.isPending}
+        failed={issues.isError}
+        onRetry={() => {
+          issues.refetch().catch(() => undefined);
+        }}
         hasMore={issues.hasNextPage}
         loadingMore={issues.isFetchingNextPage}
         onLoadMore={() => {
@@ -190,6 +195,8 @@ interface SavedViewContentProps {
   readonly layout: ViewLayoutMode;
   readonly empty: boolean;
   readonly loading: boolean;
+  readonly failed: boolean;
+  readonly onRetry: () => void;
   readonly hasMore: boolean;
   readonly loadingMore: boolean;
   readonly onLoadMore: () => void;
@@ -205,11 +212,15 @@ function SavedViewContent({
   layout,
   empty,
   loading,
+  failed,
+  onRetry,
   hasMore,
   loadingMore,
   onLoadMore,
 }: SavedViewContentProps) {
   if (loading) return <ListSkeleton layout={layout} />;
+
+  if (failed) return <LoadFailed subject="this view" onRetry={onRetry} testId="retry-saved-view" />;
 
   if (empty) {
     const filtered = conditionsOf(config.filter).length > 0;

--- a/apps/web/tests/features/issues/load-failed.test.tsx
+++ b/apps/web/tests/features/issues/load-failed.test.tsx
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { LoadFailed } from '../../../src/features/issues/load-failed.tsx';
+
+afterEach(cleanup);
+
+describe('the state a surface shows when its request failed', () => {
+  it('names what could not be read rather than claiming it is empty', () => {
+    render(<LoadFailed subject="this sprint" onRetry={() => undefined} testId="retry-x" />);
+
+    expect(screen.getByText('Could not load this sprint')).toBeDefined();
+    expect(screen.queryByText(/Nothing/)).toBeNull();
+  });
+
+  it('says plainly that unread is not the same as empty', () => {
+    render(<LoadFailed subject="your issues" onRetry={() => undefined} testId="retry-x" />);
+
+    expect(screen.getByText(/it is unread/)).toBeDefined();
+  });
+
+  it('offers a retry that actually calls back', () => {
+    const retry = mock(() => undefined);
+    render(<LoadFailed subject="the board" onRetry={retry} testId="retry-board" />);
+
+    fireEvent.click(screen.getByTestId('retry-board'));
+
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/tests/features/issues/load-failed.test.tsx
+++ b/apps/web/tests/features/issues/load-failed.test.tsx
@@ -6,14 +6,16 @@ afterEach(cleanup);
 
 describe('the state a surface shows when its request failed', () => {
   it('names what could not be read rather than claiming it is empty', () => {
-    render(<LoadFailed subject="this sprint" onRetry={() => undefined} testId="retry-x" />);
+    const retry = mock(() => undefined);
+    render(<LoadFailed subject="this sprint" onRetry={retry} testId="retry-x" />);
 
     expect(screen.getByText('Could not load this sprint')).toBeDefined();
     expect(screen.queryByText(/Nothing/)).toBeNull();
   });
 
   it('says plainly that unread is not the same as empty', () => {
-    render(<LoadFailed subject="your issues" onRetry={() => undefined} testId="retry-x" />);
+    const retry = mock(() => undefined);
+    render(<LoadFailed subject="your issues" onRetry={retry} testId="retry-x" />);
 
     expect(screen.getByText(/it is unread/)).toBeDefined();
   });

--- a/packages/shared/src/filters/index.ts
+++ b/packages/shared/src/filters/index.ts
@@ -316,7 +316,15 @@ export function removeCondition(group: FilterGroup, property: FilterProperty): F
 }
 
 export function dropLastCondition(group: FilterGroup): FilterGroup {
-  return { ...group, children: group.children.slice(0, -1) };
+  const last = group.children.at(-1);
+  if (last === undefined) return group;
+  const withoutLast = group.children.slice(0, -1);
+  if (last.kind === 'condition') return { ...group, children: withoutLast };
+  const trimmed = dropLastCondition(last);
+  return {
+    ...group,
+    children: trimmed.children.length === 0 ? withoutLast : [...withoutLast, trimmed],
+  };
 }
 
 export function conditionValues(condition: FilterCondition): readonly string[] {

--- a/packages/shared/src/filters/index.ts
+++ b/packages/shared/src/filters/index.ts
@@ -320,6 +320,7 @@ export function dropLastCondition(group: FilterGroup): FilterGroup {
   if (last === undefined) return group;
   const withoutLast = group.children.slice(0, -1);
   if (last.kind === 'condition') return { ...group, children: withoutLast };
+  if (countConditions(last) === 0) return dropLastCondition({ ...group, children: withoutLast });
   const trimmed = dropLastCondition(last);
   return {
     ...group,

--- a/packages/shared/src/policy/index.ts
+++ b/packages/shared/src/policy/index.ts
@@ -71,12 +71,15 @@ const ADMIN_PERMISSIONS: readonly Permission[] = [
   'org:delete',
 ];
 
-const PERMISSIONS_BY_ROLE: Record<OrgRole, readonly Permission[]> = {
-  guest: GUEST_PERMISSIONS,
-  contributor: CONTRIBUTOR_PERMISSIONS,
-  member: MEMBER_PERMISSIONS,
-  admin: ADMIN_PERMISSIONS,
-};
+const PERMISSIONS_BY_ROLE: Record<OrgRole, readonly Permission[]> = Object.assign(
+  Object.create(null) as Record<OrgRole, readonly Permission[]>,
+  {
+    guest: GUEST_PERMISSIONS,
+    contributor: CONTRIBUTOR_PERMISSIONS,
+    member: MEMBER_PERMISSIONS,
+    admin: ADMIN_PERMISSIONS,
+  },
+);
 
 export interface Principal {
   readonly userId: string;

--- a/packages/shared/src/policy/index.ts
+++ b/packages/shared/src/policy/index.ts
@@ -85,12 +85,14 @@ export interface Principal {
   readonly teamIds: readonly string[];
 }
 
+const NO_PERMISSIONS: readonly Permission[] = [];
+
 export function permissionsFor(role: OrgRole): readonly Permission[] {
-  return PERMISSIONS_BY_ROLE[role];
+  return PERMISSIONS_BY_ROLE[role] ?? NO_PERMISSIONS;
 }
 
 export function can(principal: Principal, permission: Permission): boolean {
-  return PERMISSIONS_BY_ROLE[principal.role].includes(permission);
+  return permissionsFor(principal.role).includes(permission);
 }
 
 export function assertCan(principal: Principal, permission: Permission): void {

--- a/packages/shared/tests/filters/filters.test.ts
+++ b/packages/shared/tests/filters/filters.test.ts
@@ -237,6 +237,68 @@ describe('condition helpers', () => {
     ]);
     expect(dropLastCondition(emptyFilterGroup()).children).toEqual([]);
   });
+
+  it('reaches into a nested group rather than taking every condition inside it', () => {
+    const nested: FilterGroup = {
+      kind: 'group',
+      combinator: 'and',
+      children: [
+        inCondition('state', ['state-1']),
+        {
+          kind: 'group',
+          combinator: 'or',
+          children: [inCondition('assignee', ['user-1']), inCondition('label', ['label-1'])],
+        },
+      ],
+    };
+
+    expect(conditionsOf(dropLastCondition(nested)).map((entry) => entry.property)).toEqual([
+      'state',
+      'assignee',
+    ]);
+  });
+
+  it('takes the emptied group with it once its last condition goes', () => {
+    const nested: FilterGroup = {
+      kind: 'group',
+      combinator: 'and',
+      children: [
+        inCondition('state', ['state-1']),
+        { kind: 'group', combinator: 'or', children: [inCondition('label', ['label-1'])] },
+      ],
+    };
+
+    const next = dropLastCondition(nested);
+
+    expect(conditionsOf(next).map((entry) => entry.property)).toEqual(['state']);
+    expect(next.children).toHaveLength(1);
+  });
+
+  it('removes one condition per call however deep the tree goes', () => {
+    const deep: FilterGroup = {
+      kind: 'group',
+      combinator: 'and',
+      children: [
+        {
+          kind: 'group',
+          combinator: 'and',
+          children: [
+            inCondition('state', ['state-1']),
+            {
+              kind: 'group',
+              combinator: 'or',
+              children: [inCondition('assignee', ['user-1']), inCondition('due', ['today'])],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(conditionsOf(deep)).toHaveLength(3);
+    expect(conditionsOf(dropLastCondition(deep))).toHaveLength(2);
+    expect(conditionsOf(dropLastCondition(dropLastCondition(deep)))).toHaveLength(1);
+    expect(conditionsOf(dropLastCondition(dropLastCondition(dropLastCondition(deep))))).toEqual([]);
+  });
 });
 
 describe('capability matrix', () => {

--- a/packages/shared/tests/filters/filters.test.ts
+++ b/packages/shared/tests/filters/filters.test.ts
@@ -274,6 +274,46 @@ describe('condition helpers', () => {
     expect(next.children).toHaveLength(1);
   });
 
+  it('steps past an empty group rather than spending the click on it', () => {
+    const withEmpty: FilterGroup = {
+      kind: 'group',
+      combinator: 'and',
+      children: [
+        inCondition('state', ['state-1']),
+        { kind: 'group', combinator: 'or', children: [] },
+      ],
+    };
+
+    expect(conditionsOf(dropLastCondition(withEmpty))).toEqual([]);
+  });
+
+  it('steps past a group that only holds other empty groups', () => {
+    const hollow: FilterGroup = {
+      kind: 'group',
+      combinator: 'and',
+      children: [
+        inCondition('state', ['state-1']),
+        {
+          kind: 'group',
+          combinator: 'or',
+          children: [{ kind: 'group', combinator: 'and', children: [] }],
+        },
+      ],
+    };
+
+    expect(conditionsOf(dropLastCondition(hollow))).toEqual([]);
+  });
+
+  it('has nothing to do when the filter holds no conditions at all', () => {
+    const hollow: FilterGroup = {
+      kind: 'group',
+      combinator: 'and',
+      children: [{ kind: 'group', combinator: 'or', children: [] }],
+    };
+
+    expect(conditionsOf(dropLastCondition(hollow))).toEqual([]);
+  });
+
   it('removes one condition per call however deep the tree goes', () => {
     const deep: FilterGroup = {
       kind: 'group',

--- a/packages/shared/tests/policy/policy.test.ts
+++ b/packages/shared/tests/policy/policy.test.ts
@@ -17,6 +17,19 @@ function principal(role: OrgRole, teamIds: string[] = ['team_eng']): Principal {
   return { userId: 'user_1', organizationId: 'org_1', role, teamIds };
 }
 
+describe('a role the code does not recognise', () => {
+  it('grants nothing rather than throwing when the permissions are read', () => {
+    expect(permissionsFor('nonsense' as never)).toEqual([]);
+  });
+
+  it('answers no to every permission rather than crashing the surface asking', () => {
+    const principal = { userId: 'u1', organizationId: 'o1', role: 'nonsense', teamIds: [] };
+
+    expect(can(principal as never, 'issue:delete')).toBe(false);
+    expect(can(principal as never, 'issue:read')).toBe(false);
+  });
+});
+
 describe('permissionsFor', () => {
   it('widens monotonically from guest to admin', () => {
     const guest = permissionsFor('guest');

--- a/packages/shared/tests/policy/policy.test.ts
+++ b/packages/shared/tests/policy/policy.test.ts
@@ -22,6 +22,15 @@ describe('a role the code does not recognise', () => {
     expect(permissionsFor('nonsense' as never)).toEqual([]);
   });
 
+  it('grants nothing for a role that names something every object inherits', () => {
+    for (const role of ['constructor', 'toString', '__proto__', 'hasOwnProperty', 'valueOf']) {
+      expect(permissionsFor(role as never)).toEqual([]);
+      expect(
+        can({ userId: 'u1', organizationId: 'o1', role, teamIds: [] } as never, 'issue:read'),
+      ).toBe(false);
+    }
+  });
+
   it('answers no to every permission rather than crashing the surface asking', () => {
     const principal = { userId: 'u1', organizationId: 'o1', role: 'nonsense', teamIds: [] };
 


### PR DESCRIPTION
The two things I deferred while reviewing #300, both of which belonged in the
shared code rather than at one call site.

## A surface that could not load said it was empty

Four surfaces checked only whether the request was still pending, so one that
failed fell through to the empty state. My issues said nothing was assigned to
you. A team and a project said they held no issues. A saved view said the same.
None of it true, and none of it offering a way to try again.

The standup board and the sprint already handled this, each carrying its own
copy of the same block, so this adds one shared `LoadFailed` instead of a fifth
and sixth. All six use it now, and the copy says the thing is unread rather than
implying it is empty.

Checked against a stubbed 500 on every one of them, not just the four that were
broken: my issues, a team, a project, a saved view, the standup board and a
sprint each show the retry and none claim to be empty. An end to end test covers
four of the six, and the two that need a project or a view to exist were checked
by hand.

## Clearing the last filter could clear several

`dropLastCondition` sliced the last child off the root group, so when that child
was itself a group it took every condition inside it. `conditionsOf` counts
nested conditions and is what the button is gated on, so the two disagreed about
what a filter holds.

It now descends to the last condition wherever it sits and prunes the group it
empties. Four callers improve together: the `shift+f` hotkey, a project, a team
and a sprint.

Worth saying plainly: nothing in the app builds a nested group today, so this is
latent rather than a bug anyone has hit. I checked before claiming that. It is
still worth fixing in the helper, because the type allows it and the label
promises it.

## Checks

`bun run verify` is green. Both filter tests fail against the old implementation,
which I confirmed by reverting it rather than assuming.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces a shared failed-load state for six issue surfaces and updates nested-filter removal to descend into groups and prune empty branches.
- Adds reusable failed-load messaging and retry controls across issue views.
- Adds component and end-to-end coverage for failed requests.
- Makes dropLastCondition remove one nested condition per invocation.
- Makes unknown organization roles fail closed without throwing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/issues/load-failed.tsx | Adds the shared failed-request state and retry affordance used by issue surfaces. |
| packages/shared/src/filters/index.ts | Recursively removes the final condition and skips or prunes empty nested groups. |
| packages/shared/src/policy/index.ts | Uses a null-prototype role map and returns no permissions for unrecognized roles. |
| apps/web/e2e/issues.spec.ts | Exercises failed-load rendering across issue surfaces with stubbed server errors. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Issue surface request] --> B{Request state}
  B -->|Pending| C[Loading skeleton]
  B -->|Failed| D[Shared LoadFailed state]
  D --> E[Try again]
  E --> A
  B -->|Succeeded with no results| F[Empty state]
  B -->|Succeeded with results| G[Issue list or board]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20noveum%2Forbit%20PR%20%23301%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=noveum%2Forbit&pr=301&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/noveum/orbit/commit/2139489bef29c86ac90e2c76c55ed1e661a61ff1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52340300)</sub>

**Context used:**

- Rule used - Flag interactive event handler props (`onClick`, `... ([source](https://app.greptile.com/noveum-ai/github/Noveum/orbit/-/custom-context?memory=f997c777-2305-4f26-8379-ab591f935113))

<!-- /greptile_comment -->