### PR TITLE
feat(auth): replace magic links with email OTP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ domain verified in Resend, otherwise every send fails.
 - **Socket lifetime.** A socket never outlives its session. Signing out publishes a session revocation on
   the control channel and the hub closes that connection, and the hub also sweeps the sessions behind every
   open connection on an interval, so an expired or deleted session is dropped even when nothing announced it.
-- **Auth.** better-auth. Passkeys, Google, GitHub, magic link. Email and password is
+- **Auth.** better-auth. Passkeys, Google, GitHub, email OTP. Email and password is
   optional, off unless `ORBIT_PASSWORD_AUTH=true`, hashed with `@node-rs/argon2` (argon2id),
   rate limited, and never a replacement for the passwordless methods.
 - **MCP auth.** OAuth only, no API keys. The web app hosts the OAuth server through the better-auth

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ yourself and never depend on us at all.
 | **MCP server** | AI agents read the board and file work, with your permissions, over OAuth |
 | **Notifications** | In-app inbox, with per-event preferences and quiet hours |
 | **GitHub** | Pull requests linked to the issues they close |
-| **Auth** | Passkeys, Google, GitHub, magic links. Password optional and off by default |
+| **Auth** | Passkeys, Google, GitHub, email OTP. Password optional and off by default |
 | **Roles** | Admin, member, contributor and guest, enforced on the server |
 | **Themes** | Light and dark, both first class |
 
@@ -140,7 +140,7 @@ all of which have free tiers, so a small team can run it for nothing.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FNoveum%2Forbit&root-directory=apps%2Fweb&env=DATABASE_URL,REDIS_URL,BETTER_AUTH_SECRET,BETTER_AUTH_URL,NEXT_PUBLIC_APP_URL,RESEND_API_KEY,EMAIL_FROM&project-name=orbit&repository-name=orbit)
 
-The button prompts for Resend so a fresh deployment can send magic links. You
+The button prompts for Resend so a fresh deployment can send sign-in codes. You
 can instead configure password, Google or GitHub sign-in. Production refuses to
 build or start without one complete method; see [Authentication](docs/configuration.md#authentication).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,7 +44,7 @@ If you self-host, track `main` or a recent tag. There is no backporting.
 
 In scope:
 
-- Authentication and session handling, including passkeys, magic links, OAuth
+- Authentication and session handling, including passkeys, email OTP, OAuth
   and the dev login route.
 - Authorization. Anything that lets a user read or change something their role
   in `packages/shared/src/policy` should not allow, or that crosses a workspace

--- a/apps/web/src/app/api/dev/sign-in/route.ts
+++ b/apps/web/src/app/api/dev/sign-in/route.ts
@@ -1,4 +1,4 @@
-import { db, desc, eq, ilike, schema } from '@orbit/db';
+import { db, eq, schema } from '@orbit/db';
 import { notFound } from '@orbit/shared/errors';
 import { devSignInSchema } from '@orbit/shared/validators';
 import { NextResponse } from 'next/server';
@@ -28,21 +28,11 @@ export async function POST(request: Request): Promise<Response> {
 
     const forwarded = new Headers(request.headers);
     forwarded.set(DEV_LOGIN_HEADER, '1');
-    await auth.api.signInMagicLink({
-      body: { email, callbackURL: '/' },
-      headers: forwarded,
+    const otp = await auth.api.createVerificationOTP({
+      body: { email, type: 'sign-in' },
     });
-
-    const [pending] = await db
-      .select({ identifier: schema.verification.identifier })
-      .from(schema.verification)
-      .where(ilike(schema.verification.value, `%${email}%`))
-      .orderBy(desc(schema.verification.createdAt))
-      .limit(1);
-    if (pending === undefined) throw notFound('Could not mint a dev session.');
-
-    const verified = await auth.api.magicLinkVerify({
-      query: { token: pending.identifier, callbackURL: '/' },
+    const verified = await auth.api.signInEmailOTP({
+      body: { email, otp },
       headers: forwarded,
       asResponse: true,
     });

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -28,7 +28,7 @@ export function GET(): Response {
 ## Links
 
 - [Landing page](${base}/)
-- [Sign in](${absoluteUrl('/login')}) with Google, GitHub, a passkey, or a magic link
+- [Sign in](${absoluteUrl('/login')}) with Google, GitHub, a passkey, or an email code
 - [Source code](https://github.com/Noveum/orbit)
 - [Documentation](https://github.com/Noveum/orbit/tree/main/docs)
 - [Self-hosting guide](https://github.com/Noveum/orbit/blob/main/docs/self-hosting.md)

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -338,6 +338,7 @@ export function LoginForm({
     }
     sendOtp();
   };
+  const emailCodeButtonSubmits = !passwordEnabled || otpSent;
 
   return (
     <div className="flex w-full max-w-[22rem] flex-col gap-5">
@@ -429,19 +430,18 @@ export function LoginForm({
           />
         ) : null}
         <Button
-          type={passwordEnabled && !otpSent ? 'button' : 'submit'}
+          type={emailCodeButtonSubmits ? 'submit' : 'button'}
           variant="secondary"
           size="md"
           block
           disabled={pending !== null || email.length === 0 || (otpSent && otp.length !== 6)}
-          {...(passwordEnabled
-            ? {
+          {...(emailCodeButtonSubmits
+            ? {}
+            : {
                 onClick: () => {
-                  if (otpSent) verifyOtp();
-                  else sendOtp();
+                  sendOtp();
                 },
-              }
-            : {})}
+              })}
         >
           {pending === 'otp-send' || pending === 'otp-verify' ? (
             <Loader2 className="size-4 animate-spin" aria-hidden="true" />

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { signInCodeRequestSchema, signInCodeVerifySchema } from '@orbit/shared/validators';
 import { Fingerprint, KeyRound, Loader2, MailCheck } from 'lucide-react';
 import { type FormEvent, useState } from 'react';
 import { OrbitMark } from '@/components/brand/orbit-logo.tsx';
@@ -291,7 +292,11 @@ export function LoginForm({
 
   const sendOtp = () =>
     withPending('otp-send', async () => {
-      const result = await authClient.emailOtp.sendVerificationOtp({ email, type: 'sign-in' });
+      const input = signInCodeRequestSchema.parse({ email });
+      const result = await authClient.emailOtp.sendVerificationOtp({
+        email: input.email,
+        type: 'sign-in',
+      });
       if (result.error) throw new Error(result.error.message ?? 'Could not send the code.');
       setOtpSent(true);
       toast({
@@ -302,7 +307,8 @@ export function LoginForm({
 
   const verifyOtp = () =>
     withPending('otp-verify', async () => {
-      const result = await authClient.signIn.emailOtp({ email, otp });
+      const input = signInCodeVerifySchema.parse({ email, otp });
+      const result = await authClient.signIn.emailOtp(input);
       if (result.error) throw new Error(result.error.message ?? 'That code is invalid or expired.');
       window.location.assign(callbackUrl);
     });
@@ -322,12 +328,12 @@ export function LoginForm({
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (passwordEnabled) {
-      submitPassword();
-      return;
-    }
     if (otpSent) {
       verifyOtp();
+      return;
+    }
+    if (passwordEnabled) {
+      submitPassword();
       return;
     }
     sendOtp();
@@ -404,7 +410,7 @@ export function LoginForm({
             setOtpSent(false);
           }}
         />
-        {passwordEnabled ? (
+        {passwordEnabled && !otpSent ? (
           <PasswordField
             creatingAccount={creatingAccount}
             value={password}
@@ -413,7 +419,7 @@ export function LoginForm({
             disabled={pending !== null || email.length === 0 || password.length === 0}
           />
         ) : null}
-        {passwordEnabled && !creatingAccount ? (
+        {passwordEnabled && !creatingAccount && !otpSent ? (
           <ForgotPasswordButton
             sending={pending === 'forgot'}
             disabled={pending !== null || email.length === 0}
@@ -423,7 +429,7 @@ export function LoginForm({
           />
         ) : null}
         <Button
-          type={passwordEnabled ? 'button' : 'submit'}
+          type={passwordEnabled && !otpSent ? 'button' : 'submit'}
           variant="secondary"
           size="md"
           block

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -18,7 +18,15 @@ export interface LoginFormProps {
   readonly passwordEnabled?: boolean;
 }
 
-type Pending = 'passkey' | 'google' | 'github' | 'magic-link' | 'password' | 'forgot' | null;
+type Pending =
+  | 'passkey'
+  | 'google'
+  | 'github'
+  | 'otp-send'
+  | 'otp-verify'
+  | 'password'
+  | 'forgot'
+  | null;
 
 function messageOf(error: unknown, fallback: string): string {
   if (error instanceof Error && error.message.length > 0) return error.message;
@@ -145,6 +153,87 @@ function ForgotPasswordButton({
   );
 }
 
+interface OtpFieldsProps {
+  readonly sent: boolean;
+  readonly value: string;
+  readonly pending: boolean;
+  readonly onChange: (value: string) => void;
+  readonly onResend: () => void;
+  readonly onChangeEmail: () => void;
+}
+
+function OtpFields({ sent, value, pending, onChange, onResend, onChangeEmail }: OtpFieldsProps) {
+  if (!sent) return null;
+  return (
+    <>
+      <label htmlFor="login-otp" className="sr-only">
+        Sign in code
+      </label>
+      <Input
+        id="login-otp"
+        type="text"
+        name="otp"
+        inputMode="numeric"
+        autoComplete="one-time-code"
+        required
+        minLength={6}
+        maxLength={6}
+        pattern="[0-9]{6}"
+        placeholder="6-digit code"
+        value={value}
+        onChange={(event) => onChange(event.target.value.replace(/\D/g, '').slice(0, 6))}
+      />
+      <div className="flex items-center justify-between text-xs">
+        <button
+          type="button"
+          className="text-muted underline-offset-2 hover:underline"
+          disabled={pending}
+          onClick={onResend}
+        >
+          Resend code
+        </button>
+        <button
+          type="button"
+          className="text-muted underline-offset-2 hover:underline"
+          disabled={pending}
+          onClick={onChangeEmail}
+        >
+          Use another email
+        </button>
+      </div>
+    </>
+  );
+}
+
+function LoginFooter({
+  passwordEnabled,
+  creatingAccount,
+  onToggleAccount,
+}: {
+  readonly passwordEnabled: boolean;
+  readonly creatingAccount: boolean;
+  readonly onToggleAccount: () => void;
+}) {
+  return (
+    <>
+      {passwordEnabled ? (
+        <button
+          type="button"
+          className="text-center text-muted text-xs underline-offset-2 hover:underline"
+          onClick={onToggleAccount}
+        >
+          {creatingAccount ? 'I already have an account' : 'Create an account with a password'}
+        </button>
+      ) : null}
+      <p className="text-center text-2xs text-faint">
+        {passwordEnabled
+          ? 'Passkeys and email codes still work. Sessions expire after 30 days.'
+          : 'Orbit never asks for a password. Sessions expire after 30 days.'}
+      </p>
+    </>
+  );
+}
+
 export function LoginForm({
   providers,
   callbackUrl = DEFAULT_CALLBACK_URL,
@@ -153,10 +242,11 @@ export function LoginForm({
   const { toast } = useToast();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [otp, setOtp] = useState('');
   const [name, setName] = useState('');
   const [creatingAccount, setCreatingAccount] = useState(false);
   const [pending, setPending] = useState<Pending>(null);
-  const [linkSent, setLinkSent] = useState(false);
+  const [otpSent, setOtpSent] = useState(false);
 
   const withPending = async (kind: Exclude<Pending, null>, run: () => Promise<void>) => {
     setPending(kind);
@@ -199,15 +289,22 @@ export function LoginForm({
       window.location.assign(callbackUrl);
     });
 
-  const sendMagicLink = () =>
-    withPending('magic-link', async () => {
-      const result = await authClient.signIn.magicLink({ email, callbackURL: callbackUrl });
-      if (result.error) throw new Error(result.error.message ?? 'Could not send the link.');
-      setLinkSent(true);
+  const sendOtp = () =>
+    withPending('otp-send', async () => {
+      const result = await authClient.emailOtp.sendVerificationOtp({ email, type: 'sign-in' });
+      if (result.error) throw new Error(result.error.message ?? 'Could not send the code.');
+      setOtpSent(true);
       toast({
         title: 'Check your email',
-        description: `A sign in link is on its way to ${email}.`,
+        description: `A sign in code is on its way to ${email}.`,
       });
+    });
+
+  const verifyOtp = () =>
+    withPending('otp-verify', async () => {
+      const result = await authClient.signIn.emailOtp({ email, otp });
+      if (result.error) throw new Error(result.error.message ?? 'That code is invalid or expired.');
+      window.location.assign(callbackUrl);
     });
 
   const forgotPassword = () =>
@@ -229,7 +326,11 @@ export function LoginForm({
       submitPassword();
       return;
     }
-    sendMagicLink();
+    if (otpSent) {
+      verifyOtp();
+      return;
+    }
+    sendOtp();
   };
 
   return (
@@ -286,7 +387,22 @@ export function LoginForm({
           required
           placeholder="you@company.com"
           value={email}
+          disabled={otpSent}
           onChange={(event) => setEmail(event.target.value)}
+        />
+        <OtpFields
+          sent={otpSent}
+          value={otp}
+          pending={pending !== null}
+          onChange={setOtp}
+          onResend={() => {
+            setOtp('');
+            sendOtp();
+          }}
+          onChangeEmail={() => {
+            setOtp('');
+            setOtpSent(false);
+          }}
         />
         {passwordEnabled ? (
           <PasswordField
@@ -311,42 +427,30 @@ export function LoginForm({
           variant="secondary"
           size="md"
           block
-          disabled={pending !== null || email.length === 0}
+          disabled={pending !== null || email.length === 0 || (otpSent && otp.length !== 6)}
           {...(passwordEnabled
             ? {
                 onClick: () => {
-                  sendMagicLink();
+                  if (otpSent) verifyOtp();
+                  else sendOtp();
                 },
               }
             : {})}
         >
-          {pending === 'magic-link' ? (
+          {pending === 'otp-send' || pending === 'otp-verify' ? (
             <Loader2 className="size-4 animate-spin" aria-hidden="true" />
           ) : (
             <MailCheck className="size-4" aria-hidden="true" />
           )}
-          Email me a link
+          {otpSent ? 'Verify code' : 'Email me a code'}
         </Button>
-        {linkSent ? (
-          <output className="text-center text-success text-xs">Link sent. Check your inbox.</output>
-        ) : null}
       </form>
 
-      {passwordEnabled ? (
-        <button
-          type="button"
-          className="text-center text-muted text-xs underline-offset-2 hover:underline"
-          onClick={() => setCreatingAccount((current) => !current)}
-        >
-          {creatingAccount ? 'I already have an account' : 'Create an account with a password'}
-        </button>
-      ) : null}
-
-      <p className="text-center text-2xs text-faint">
-        {passwordEnabled
-          ? 'Passkeys and links still work. Sessions expire after 30 days.'
-          : 'Orbit never asks for a password. Sessions expire after 30 days.'}
-      </p>
+      <LoginFooter
+        passwordEnabled={passwordEnabled}
+        creatingAccount={creatingAccount}
+        onToggleAccount={() => setCreatingAccount((current) => !current)}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/landing/landing-page.tsx
+++ b/apps/web/src/features/landing/landing-page.tsx
@@ -431,7 +431,7 @@ function Hero() {
           </span>
         </div>
         <p className="landing-rise mt-4 text-xs text-faint" style={{ animationDelay: '250ms' }}>
-          Google, GitHub, passkey, or magic link. No password to invent. Or{' '}
+          Google, GitHub, passkey, or email code. No password to invent. Or{' '}
           <a href={SELF_HOST_HREF} className="underline" target="_blank" rel="noopener noreferrer">
             run the whole thing yourself
           </a>
@@ -845,7 +845,7 @@ function ClosingCta() {
       <div className="relative mx-auto w-full max-w-6xl 2xl:max-w-7xl px-5 py-28 text-center sm:px-8">
         <h2 className="landing-h2">Ready when you are.</h2>
         <p className="landing-lede mx-auto mt-4 max-w-xl text-muted">
-          Sign in with Google, GitHub, a passkey, or a magic link, and bring your team with you. Or
+          Sign in with Google, GitHub, a passkey, or an email code, and bring your team with you. Or
           clone the repository and run it on your own infrastructure.
         </p>
         <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">

--- a/apps/web/src/lib/auth/client.ts
+++ b/apps/web/src/lib/auth/client.ts
@@ -3,9 +3,10 @@
 import { passkeyClient } from '@better-auth/passkey/client';
 import { emailOTPClient, organizationClient } from 'better-auth/client/plugins';
 import { createAuthClient } from 'better-auth/react';
+import { publicAppUrl } from '@/lib/env.ts';
 
 export const authClient = createAuthClient({
-  baseURL: process.env['NEXT_PUBLIC_APP_URL'] ?? 'http://localhost:3000',
+  baseURL: publicAppUrl(),
   plugins: [passkeyClient(), emailOTPClient(), organizationClient()],
 });
 

--- a/apps/web/src/lib/auth/client.ts
+++ b/apps/web/src/lib/auth/client.ts
@@ -1,12 +1,12 @@
 'use client';
 
 import { passkeyClient } from '@better-auth/passkey/client';
-import { magicLinkClient, organizationClient } from 'better-auth/client/plugins';
+import { emailOTPClient, organizationClient } from 'better-auth/client/plugins';
 import { createAuthClient } from 'better-auth/react';
 
 export const authClient = createAuthClient({
   baseURL: process.env['NEXT_PUBLIC_APP_URL'] ?? 'http://localhost:3000',
-  plugins: [passkeyClient(), magicLinkClient(), organizationClient()],
+  plugins: [passkeyClient(), emailOTPClient(), organizationClient()],
 });
 
 export const { signIn, signOut, signUp, useSession } = authClient;

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHmac } from 'node:crypto';
 import { passkey } from '@better-auth/passkey';
 import {
   assertEmailDomainAllowed,
@@ -167,7 +167,10 @@ function assertSignUpAllowed(email: string): void {
 }
 
 function signInCodeIdempotencyKey(email: string, otp: string): string {
-  return `sign-in-code:${createHash('sha256').update(`${email}:${otp}`).digest('hex')}`;
+  const digest = createHmac('sha256', serverEnv().BETTER_AUTH_SECRET)
+    .update(`${email}:${otp}`)
+    .digest('hex');
+  return `sign-in-code:${digest}`;
 }
 
 export const auth = betterAuth({

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { passkey } from '@better-auth/passkey';
 import {
   assertEmailDomainAllowed,
@@ -165,6 +166,10 @@ function assertSignUpAllowed(email: string): void {
   }
 }
 
+function signInCodeIdempotencyKey(email: string, otp: string): string {
+  return `sign-in-code:${createHash('sha256').update(`${email}:${otp}`).digest('hex')}`;
+}
+
 export const auth = betterAuth({
   appName: 'Orbit',
   baseURL: serverEnv().BETTER_AUTH_URL,
@@ -241,7 +246,7 @@ export const auth = betterAuth({
           html: content.html,
           text: content.text,
           template: 'sign-in-code',
-          idempotencyKey: `sign-in-code:${email}:${otp}`,
+          idempotencyKey: signInCodeIdempotencyKey(email, otp),
         });
       },
     }),

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -6,13 +6,13 @@ import {
   publishSessionRevoked,
 } from '@orbit/core';
 import { db, eq, inArray, schema } from '@orbit/db';
-import { inviteEmail, magicLinkEmail, resetPasswordEmail, sendEmail } from '@orbit/services/email';
+import { inviteEmail, resetPasswordEmail, sendEmail, signInCodeEmail } from '@orbit/services/email';
 import { DomainError } from '@orbit/shared/errors';
 import { type BetterAuthPlugin, betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { APIError, createAuthMiddleware, getSessionFromCtx } from 'better-auth/api';
 import { nextCookies } from 'better-auth/next-js';
-import { magicLink, mcp, organization } from 'better-auth/plugins';
+import { emailOTP, mcp, organization } from 'better-auth/plugins';
 import { z } from 'zod';
 import { isDevLoginRequest } from '@/lib/api/dev-login.ts';
 import { mcpServerUrl, serverEnv } from '@/lib/env.ts';
@@ -228,18 +228,20 @@ export const auth = betterAuth({
   plugins: [
     mcpTokenRateLimitProbe(),
     passkey({ rpName: 'Orbit' }),
-    magicLink({
-      sendMagicLink: async ({ email, url, token }, request) => {
-        if (isDevLoginRequest(request)) return;
+    emailOTP({
+      storeOTP: 'hashed',
+      sendVerificationOTP: async ({ email, otp, type }, context) => {
+        if (isDevLoginRequest(context)) return;
+        if (type !== 'sign-in') return;
         assertSignUpAllowed(email);
-        const content = await magicLinkEmail({ url, email });
+        const content = await signInCodeEmail({ code: otp, email });
         await sendEmail(db, {
           to: email,
           subject: content.subject,
           html: content.html,
           text: content.text,
-          template: 'magic-link',
-          idempotencyKey: `magic-link:${token}`,
+          template: 'sign-in-code',
+          idempotencyKey: `sign-in-code:${email}:${otp}`,
         });
       },
     }),

--- a/apps/web/tests/app/api/auth/[...all]/route.test.ts
+++ b/apps/web/tests/app/api/auth/[...all]/route.test.ts
@@ -259,17 +259,11 @@ describe('MCP authorize PKCE boundary', () => {
         });
         verify.headers.set('cookie', cookieHeader(cookies));
         const verified = await authPost(verify);
-        expect(verified.status).toBe(200);
+        expect(verified.status).toBe(302);
         storeResponseCookies(cookies, verified);
-
-        const resume = new Request(callbackUrl ?? '', {
-          headers: { cookie: cookieHeader(cookies) },
-        });
-        const resumedAuthorization = await GET(resume);
-        expect(resumedAuthorization.status).toBe(302);
-        expect(
-          new URL(resumedAuthorization.headers.get('location') ?? '', APP_ORIGIN).pathname,
-        ).toBe('/oauth/authorize');
+        expect(new URL(verified.headers.get('location') ?? '', APP_ORIGIN).pathname).toBe(
+          '/oauth/authorize',
+        );
 
         const records = await db
           .select({ value: schema.verification.value })

--- a/apps/web/tests/app/api/auth/[...all]/route.test.ts
+++ b/apps/web/tests/app/api/auth/[...all]/route.test.ts
@@ -8,7 +8,7 @@ import {
   verifyMcpAccessToken,
 } from '@orbit/core';
 import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test-support';
-import { db, desc, eq, schema } from '@orbit/db';
+import { db, eq, schema } from '@orbit/db';
 import { mcpContinueUrl } from '@/app/(auth)/login/continue-url.ts';
 import { POST as authPost, GET } from '@/app/api/auth/[...all]/route.ts';
 import { DEV_LOGIN_HEADER } from '@/lib/api/dev-login.ts';
@@ -231,37 +231,45 @@ describe('MCP authorize PKCE boundary', () => {
         const callbackUrl = mcpContinueUrl(Object.fromEntries(loginLocation.searchParams));
         expect(callbackUrl).toBeDefined();
 
-        const beginLogin = new Request(`${APP_ORIGIN}/api/auth/sign-in/magic-link`, {
+        const beginLogin = new Request(`${APP_ORIGIN}/api/auth/email-otp/send-verification-otp`, {
           method: 'POST',
           headers: {
             'content-type': 'application/json',
             origin: APP_ORIGIN,
             [DEV_LOGIN_HEADER]: '1',
           },
-          body: JSON.stringify({ email: workspace.adminUser.email, callbackURL: callbackUrl }),
+          body: JSON.stringify({ email: workspace.adminUser.email, type: 'sign-in' }),
         });
         beginLogin.headers.set('cookie', cookieHeader(cookies));
         const loginStarted = await authPost(beginLogin);
         expect(loginStarted.status).toBe(200);
         storeResponseCookies(cookies, loginStarted);
 
-        const [pending] = await db
-          .select({ identifier: schema.verification.identifier })
-          .from(schema.verification)
-          .orderBy(desc(schema.verification.createdAt))
-          .limit(1);
-        if (pending === undefined) throw new Error('the magic link token was not stored');
-        const verifyUrl = new URL(`${APP_ORIGIN}/api/auth/magic-link/verify`);
-        verifyUrl.searchParams.set('token', pending.identifier);
-        verifyUrl.searchParams.set('callbackURL', callbackUrl ?? '');
-        const verify = new Request(verifyUrl);
-        verify.headers.set(DEV_LOGIN_HEADER, '1');
+        const otp = await auth.api.createVerificationOTP({
+          body: { email: workspace.adminUser.email, type: 'sign-in' },
+        });
+        const verify = new Request(`${APP_ORIGIN}/api/auth/sign-in/email-otp`, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            origin: APP_ORIGIN,
+            [DEV_LOGIN_HEADER]: '1',
+          },
+          body: JSON.stringify({ email: workspace.adminUser.email, otp }),
+        });
         verify.headers.set('cookie', cookieHeader(cookies));
-        const verified = await GET(verify);
-        expect(verified.status).toBe(302);
-        expect(new URL(verified.headers.get('location') ?? '', APP_ORIGIN).pathname).toBe(
-          '/oauth/authorize',
-        );
+        const verified = await authPost(verify);
+        expect(verified.status).toBe(200);
+        storeResponseCookies(cookies, verified);
+
+        const resume = new Request(callbackUrl ?? '', {
+          headers: { cookie: cookieHeader(cookies) },
+        });
+        const resumedAuthorization = await GET(resume);
+        expect(resumedAuthorization.status).toBe(302);
+        expect(
+          new URL(resumedAuthorization.headers.get('location') ?? '', APP_ORIGIN).pathname,
+        ).toBe('/oauth/authorize');
 
         const records = await db
           .select({ value: schema.verification.value })

--- a/apps/web/tests/components/auth/login-form.test.tsx
+++ b/apps/web/tests/components/auth/login-form.test.tsx
@@ -5,15 +5,25 @@ import { ToastProvider } from '@/components/ui/toast.tsx';
 import { LoginForm } from '../../../src/components/auth/login-form.tsx';
 
 const requestPasswordReset = mock();
+const sendVerificationOtp = mock();
+const signInEmailOtp = mock();
 
 mock.module('@/lib/auth/client.ts', () => ({
   authClient: {
     requestPasswordReset: (...args: unknown[]) => requestPasswordReset(...args),
+    emailOtp: {
+      sendVerificationOtp: (...args: unknown[]) => sendVerificationOtp(...args),
+    },
+    signIn: {
+      emailOtp: (...args: unknown[]) => signInEmailOtp(...args),
+    },
   },
 }));
 
 beforeEach(() => {
   requestPasswordReset.mockReset();
+  sendVerificationOtp.mockReset();
+  signInEmailOtp.mockReset();
 });
 
 function renderForm(passwordEnabled: boolean) {
@@ -40,7 +50,7 @@ describe('LoginForm', () => {
     expect(password).toHaveAttribute('minlength', '12');
     expect(screen.getByText('Sign in with password')).toBeDefined();
     expect(screen.getByText('Create an account with a password')).toBeDefined();
-    expect(screen.getByText('Email me a link')).toBeDefined();
+    expect(screen.getByText('Email me a code')).toBeDefined();
     expect(screen.getByText('Continue with passkey')).toBeDefined();
   });
 
@@ -66,6 +76,43 @@ describe('LoginForm', () => {
       expect(requestPasswordReset).toHaveBeenCalledWith({
         email: 'ada@orbit.local',
         redirectTo: '/reset-password',
+      });
+    });
+  });
+
+  it('sends a sign in code to the entered email', async () => {
+    sendVerificationOtp.mockResolvedValue({ error: null });
+    const user = userEvent.setup();
+    renderForm(false);
+
+    await user.type(screen.getByLabelText('Email address'), 'ada@orbit.local');
+    await user.click(screen.getByText('Email me a code'));
+
+    await waitFor(() => {
+      expect(sendVerificationOtp).toHaveBeenCalledWith({
+        email: 'ada@orbit.local',
+        type: 'sign-in',
+      });
+    });
+    expect(screen.getByLabelText('Sign in code')).toBeDefined();
+    expect(screen.getByText('Verify code')).toBeDefined();
+  });
+
+  it('signs in with the emailed code', async () => {
+    sendVerificationOtp.mockResolvedValue({ error: null });
+    signInEmailOtp.mockResolvedValue({ error: { message: 'Invalid code' } });
+    const user = userEvent.setup();
+    renderForm(false);
+
+    await user.type(screen.getByLabelText('Email address'), 'ada@orbit.local');
+    await user.click(screen.getByText('Email me a code'));
+    await user.type(await screen.findByLabelText('Sign in code'), '123456');
+    await user.click(screen.getByText('Verify code'));
+
+    await waitFor(() => {
+      expect(signInEmailOtp).toHaveBeenCalledWith({
+        email: 'ada@orbit.local',
+        otp: '123456',
       });
     });
   });

--- a/apps/web/tests/components/auth/login-form.test.tsx
+++ b/apps/web/tests/components/auth/login-form.test.tsx
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
 
 const requestPasswordReset = mock();
 const sendVerificationOtp = mock();
@@ -8,6 +9,8 @@ const signInEmailOtp = mock();
 const toast = mock();
 const originalLocation = window.location;
 const assign = mock();
+
+await restoreModulesAfterThisFile(['@/components/ui/toast.tsx']);
 
 Object.defineProperty(window, 'location', {
   configurable: true,
@@ -150,6 +153,7 @@ describe('LoginForm', () => {
     await waitFor(() => {
       expect(assign).toHaveBeenCalledWith('/my-issues');
     });
+    expect(signInEmailOtp).toHaveBeenCalledTimes(1);
   });
 
   it('verifies the code when Enter is pressed with password auth enabled', async () => {

--- a/apps/web/tests/components/auth/login-form.test.tsx
+++ b/apps/web/tests/components/auth/login-form.test.tsx
@@ -1,12 +1,18 @@
-import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { ToastProvider } from '@/components/ui/toast.tsx';
-import { LoginForm } from '../../../src/components/auth/login-form.tsx';
 
 const requestPasswordReset = mock();
 const sendVerificationOtp = mock();
 const signInEmailOtp = mock();
+const toast = mock();
+const originalLocation = window.location;
+const assign = mock();
+
+Object.defineProperty(window, 'location', {
+  configurable: true,
+  value: { ...window.location, assign },
+});
 
 mock.module('@/lib/auth/client.ts', () => ({
   authClient: {
@@ -20,18 +26,26 @@ mock.module('@/lib/auth/client.ts', () => ({
   },
 }));
 
+mock.module('@/components/ui/toast.tsx', () => ({
+  useToast: () => ({ toast, dismiss: mock() }),
+}));
+
+const { LoginForm } = await import('../../../src/components/auth/login-form.tsx');
+
 beforeEach(() => {
   requestPasswordReset.mockReset();
   sendVerificationOtp.mockReset();
   signInEmailOtp.mockReset();
+  toast.mockReset();
+  assign.mockReset();
+});
+
+afterAll(() => {
+  Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
 });
 
 function renderForm(passwordEnabled: boolean) {
-  render(
-    <ToastProvider>
-      <LoginForm providers={[]} passwordEnabled={passwordEnabled} />
-    </ToastProvider>,
-  );
+  render(<LoginForm providers={[]} passwordEnabled={passwordEnabled} />);
 }
 
 describe('LoginForm', () => {
@@ -98,7 +112,7 @@ describe('LoginForm', () => {
     expect(screen.getByText('Verify code')).toBeDefined();
   });
 
-  it('signs in with the emailed code', async () => {
+  it('shows an error for an invalid emailed code', async () => {
     sendVerificationOtp.mockResolvedValue({ error: null });
     signInEmailOtp.mockResolvedValue({ error: { message: 'Invalid code' } });
     const user = userEvent.setup();
@@ -108,6 +122,46 @@ describe('LoginForm', () => {
     await user.click(screen.getByText('Email me a code'));
     await user.type(await screen.findByLabelText('Sign in code'), '123456');
     await user.click(screen.getByText('Verify code'));
+
+    await waitFor(() => {
+      expect(signInEmailOtp).toHaveBeenCalledWith({
+        email: 'ada@orbit.local',
+        otp: '123456',
+      });
+    });
+    expect(toast).toHaveBeenCalledWith({
+      title: 'Sign in failed',
+      description: 'Invalid code',
+      tone: 'danger',
+    });
+  });
+
+  it('signs in with a valid emailed code', async () => {
+    sendVerificationOtp.mockResolvedValue({ error: null });
+    signInEmailOtp.mockResolvedValue({ error: null });
+    const user = userEvent.setup();
+    renderForm(false);
+
+    await user.type(screen.getByLabelText('Email address'), 'ada@orbit.local');
+    await user.click(screen.getByText('Email me a code'));
+    await user.type(await screen.findByLabelText('Sign in code'), '123456');
+    await user.click(screen.getByText('Verify code'));
+
+    await waitFor(() => {
+      expect(assign).toHaveBeenCalledWith('/my-issues');
+    });
+  });
+
+  it('verifies the code when Enter is pressed with password auth enabled', async () => {
+    sendVerificationOtp.mockResolvedValue({ error: null });
+    signInEmailOtp.mockResolvedValue({ error: { message: 'Invalid code' } });
+    const user = userEvent.setup();
+    renderForm(true);
+
+    await user.type(screen.getByLabelText('Email address'), 'ada@orbit.local');
+    await user.click(screen.getByText('Email me a code'));
+    const code = await screen.findByLabelText('Sign in code');
+    await user.type(code, '123456{Enter}');
 
     await waitFor(() => {
       expect(signInEmailOtp).toHaveBeenCalledWith({

--- a/apps/web/tests/lib/auth/server.test.ts
+++ b/apps/web/tests/lib/auth/server.test.ts
@@ -11,7 +11,7 @@ describe('password authentication', () => {
 
   it('keeps the passwordless methods available', () => {
     expect(auth.options.plugins?.map((plugin) => plugin.id)).toEqual(
-      expect.arrayContaining(['passkey', 'magic-link', 'organization']),
+      expect.arrayContaining(['passkey', 'email-otp', 'organization']),
     );
   });
 

--- a/apps/web/tests/lib/auth/server.test.ts
+++ b/apps/web/tests/lib/auth/server.test.ts
@@ -15,6 +15,11 @@ describe('password authentication', () => {
     );
   });
 
+  it('stores sign in codes as hashes', () => {
+    const plugin = auth.options.plugins?.find((candidate) => candidate.id === 'email-otp');
+    expect(plugin?.options).toMatchObject({ storeOTP: 'hashed' });
+  });
+
   it('exposes the MCP OAuth provider for one-click clients', () => {
     expect(auth.options.plugins?.map((plugin) => plugin.id)).toEqual(
       expect.arrayContaining(['mcp']),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,7 +197,7 @@ One file means an audit is reading one file.
 
 ## Auth
 
-better-auth. Passkeys, Google, GitHub and magic links. Email and password is off
+better-auth. Passkeys, Google, GitHub and email OTP. Email and password is off
 unless `ORBIT_PASSWORD_AUTH=true`, hashed with argon2id, rate limited, and never
 a replacement for the passwordless methods.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,7 +197,7 @@ One file means an audit is reading one file.
 
 ## Auth
 
-better-auth. Passkeys, Google, GitHub and email OTP. Email and password is off
+Orbit uses better-auth. Passkeys, Google, GitHub and email OTP. Email and password is off
 unless `ORBIT_PASSWORD_AUTH=true`, hashed with argon2id, rate limited, and never
 a replacement for the passwordless methods.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,8 +111,8 @@ RESEND_API_KEY=re_xxxxxxxxx
 EMAIL_FROM="Orbit <orbit@example.com>"
 ```
 
-If `EMAIL_FROM` is not on a verified domain every send fails, and the only
-symptom users see is that invites never arrive.
+If `EMAIL_FROM` is not on a verified domain every send fails, and users see
+missing sign-in codes and invitations.
 
 The sender in `.env.example` is local-only. Replace it before relying on Resend
 for production authentication.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ the config next, so leave it unset there.
 
 Orbit uses [better-auth](https://better-auth.com). A production build and server
 start require at least one usable first-login method: password authentication,
-a complete Google or GitHub credential pair, or magic-link delivery through
+a complete Google or GitHub credential pair, or email OTP delivery through
 Resend with an explicit non-local sender. Passkeys work after a user registers
 one, but cannot bootstrap a new installation. Local development is unaffected.
 
@@ -98,7 +98,7 @@ real production sign-in after deployment.
 
 ## Email
 
-Orbit sends through [Resend](https://resend.com) only, for magic links and
+Orbit sends through [Resend](https://resend.com) only, for sign-in codes and
 invites. Event notification email and digests are not currently dispatched.
 
 | Variable | Notes |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,7 +63,7 @@ Open <http://localhost:3000>.
 
 `.env.example` sets `ORBIT_DEV_LOGIN=1`, which puts a list of the seeded users
 on the login screen and signs you in with one click. No email, no password, no
-waiting for a magic link.
+waiting for a sign-in code.
 
 Start as **`alex@orbit.example`**, who is an admin on all three teams and sees
 everything.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -104,7 +104,7 @@ EMAIL_FROM="Orbit <orbit@example.com>"
 ```
 
 `EMAIL_FROM` must be on a domain verified in Resend. If it is not, every send
-fails, and the only symptom anyone sees is that invites never arrive.
+fails, including sign-in codes and invitations.
 
 ## Webhooks out
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -94,7 +94,7 @@ either, both, or neither. See [Configuration](configuration.md#authentication).
 ## Email
 
 Not an integration you connect, but worth listing since it carries invites and
-magic links. Ordinary event notifications are currently in-app only.
+sign-in codes. Ordinary event notifications are currently in-app only.
 
 Orbit sends through [Resend](https://resend.com) only.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,7 @@ The core is done and in daily use.
 - **Realtime everywhere**, scoped so delivery matches read permission.
 - **Command palette and keyboard shortcuts** for every action.
 - **Notifications and an inbox**, with per-event preferences and quiet hours.
-- **Auth**: passkeys, Google, GitHub, magic links, optional password.
+- **Auth**: passkeys, Google, GitHub, email OTP, optional password.
 - **Roles and permissions**: admin, member, contributor, guest.
 - **MCP server** over OAuth, with sixty odd tools and scoped access.
 - **GitHub** pull request linking.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -29,7 +29,7 @@ Both need the same infrastructure plus one complete first-login method.
 | S3-compatible storage | Cloudflare R2 | AWS S3, Backblaze B2, MinIO, Supabase Storage |
 | Transactional email (optional with password or OAuth) | [Resend](https://resend.com) | None. Orbit only supports Resend |
 
-Email is used for magic links and invites. It is optional when password, Google
+Email is used for sign-in codes and invites. It is optional when password, Google
 or GitHub sign-in is configured. Production build and startup refuse to proceed
 when none of those methods can bootstrap the first user.
 
@@ -94,7 +94,7 @@ Create a [Resend](https://resend.com) account, verify a domain, and create an
 API key. `EMAIL_FROM` has to be on the domain you verified. If it is not, every
 send fails and the only symptom is that invites never arrive. You can omit
 Resend when password, Google or GitHub sign-in is configured, but invitations
-and magic links will remain unavailable.
+and email OTP will remain unavailable.
 
 ### 5. Apply the schema
 
@@ -190,7 +190,7 @@ walks through naming it and creating the first team.
 
 The production preflight has already confirmed that at least one first-login
 method is configured. See [Configuration](configuration.md#authentication) for
-Google, GitHub, password authentication, passkeys and magic links.
+Google, GitHub, password authentication, passkeys and email OTP.
 
 Complete one real sign-in before inviting anyone. The preflight cannot validate
 remote OAuth credentials or a Resend domain. Passkeys become available after an
@@ -300,7 +300,7 @@ version:
 | Endless "Reconnecting to live updates" | Standalone Node does not support realtime yet. On Vercel, verify the websocket route and Redis configuration |
 | Live updates never arrive, no banner | `REDIS_URL` is wrong, or Redis is unreachable from the functions |
 | Uploads fail in the browser, server looks fine | Bucket CORS does not allow your origin |
-| Invites and magic links never arrive | `EMAIL_FROM` is not on a domain verified in Resend |
+| Invites and sign-in codes never arrive | `EMAIL_FROM` is not on a domain verified in Resend |
 | Build or startup says a first-login method is required | Configure password auth, a complete Google or GitHub pair, or Resend with a non-local sender |
 | Connection pool exhausted | `DATABASE_URL` points at the direct endpoint instead of the pooler |
 | Sign-in loops back to the login screen | `BETTER_AUTH_URL` does not exactly match the origin you are visiting |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,7 +83,7 @@ bun run db:seed
 on `http://localhost:3000` it has to be exactly that, not `127.0.0.1`, not a
 trailing slash, not `https`.
 
-### Magic links and invites never arrive
+### Sign-in codes and invites never arrive
 
 `EMAIL_FROM` is not on a domain verified in Resend, or `RESEND_API_KEY` is
 missing. Every send fails silently from the user's point of view.

--- a/packages/db/src/seed/data.ts
+++ b/packages/db/src/seed/data.ts
@@ -237,7 +237,7 @@ export const SEED_ISSUES: readonly SeedIssue[] = [
     team: 'ENG',
     title: 'Passkey sign in fails on Safari when no credential is registered',
     description:
-      'Safari throws `NotAllowedError` instead of resolving empty. Catch it and fall back to the magic link field without showing an error.',
+      'Safari throws `NotAllowedError` instead of resolving empty. Catch it and fall back to the email code field without showing an error.',
     state: 'In Progress',
     priority: 1,
     assignee: 'casey',

--- a/packages/services/src/email/templates.tsx
+++ b/packages/services/src/email/templates.tsx
@@ -16,8 +16,8 @@ export interface EmailContent {
   readonly text: string;
 }
 
-export interface MagicLinkProps {
-  readonly url: string;
+export interface SignInCodeProps {
+  readonly code: string;
   readonly email: string;
 }
 
@@ -94,19 +94,26 @@ function Excerpt({ text }: { readonly text: string }) {
   );
 }
 
-export async function magicLinkEmail(props: MagicLinkProps): Promise<EmailContent> {
-  const subject = 'Your Orbit sign in link';
+export async function signInCodeEmail(props: SignInCodeProps): Promise<EmailContent> {
+  const subject = 'Your Orbit sign in code';
   const html = await render(
     <Layout
-      preview="Sign in to Orbit"
+      preview={`${props.code} is your Orbit sign in code`}
       heading="Sign in to Orbit"
-      footer={`This link was requested for ${props.email}. It expires shortly and can be used once.`}
+      footer={`This code was requested for ${props.email}. It expires in five minutes and can be used once.`}
     >
-      <Text style={paragraphStyle}>Click the button below to sign in. No password needed.</Text>
-      <Button href={props.url} style={buttonStyle}>
-        Sign in to Orbit
-      </Button>
-      <LinkLine url={props.url} />
+      <Text style={paragraphStyle}>Enter this code to sign in. No password needed.</Text>
+      <Text
+        style={{
+          ...cardStyle,
+          fontSize: '28px',
+          fontWeight: 700,
+          letterSpacing: '0.2em',
+          textAlign: 'center',
+        }}
+      >
+        {props.code}
+      </Text>
     </Layout>,
   );
   return {
@@ -115,10 +122,10 @@ export async function magicLinkEmail(props: MagicLinkProps): Promise<EmailConten
     text: [
       'Sign in to Orbit',
       '',
-      `Use this link to sign in as ${props.email}:`,
-      props.url,
+      `Use this code to sign in as ${props.email}:`,
+      props.code,
       '',
-      'The link expires shortly and can be used once.',
+      'The code expires in five minutes and can be used once.',
     ].join('\n'),
   };
 }

--- a/packages/services/tests/email/email.test.ts
+++ b/packages/services/tests/email/email.test.ts
@@ -40,7 +40,11 @@ describe('templates', () => {
     expect(content.subject).toBe('Your Orbit sign in code');
     expect(content.html).toContain('123456');
     expect(content.html).toContain('#5A63C8');
+    expect(content.html).toContain('expires in five minutes');
+    expect(content.html).toContain('can be used once');
     expect(content.text).toContain('123456');
+    expect(content.text).toContain('expires in five minutes');
+    expect(content.text).toContain('can be used once');
     expect(content.text).toContain('ada@orbit.local');
   });
 

--- a/packages/services/tests/email/email.test.ts
+++ b/packages/services/tests/email/email.test.ts
@@ -175,7 +175,7 @@ describe('sendEmail idempotency', () => {
           html: '<p>Hello</p>',
           text: 'Hello',
           idempotencyKey: key,
-          template: 'magic-link',
+          template: 'sign-in-code',
         },
         transport,
       );
@@ -183,7 +183,7 @@ describe('sendEmail idempotency', () => {
       expect(record.status).toBe('sent');
       expect(record.providerId).toBe('prov_1');
       expect(record.sentAt).not.toBeNull();
-      expect(record.template).toBe('magic-link');
+      expect(record.template).toBe('sign-in-code');
     });
   });
 
@@ -197,7 +197,7 @@ describe('sendEmail idempotency', () => {
         html: '<p>Hello</p>',
         text: 'Hello',
         idempotencyKey: key,
-        template: 'magic-link',
+        template: 'sign-in-code',
       };
       const first = await sendEmail(tx, message, transport);
       const second = await sendEmail(tx, { ...message, subject: 'Different' }, transport);
@@ -226,7 +226,7 @@ describe('sendEmail idempotency', () => {
             html: '<p>Hello</p>',
             text: 'Hello',
             idempotencyKey: key,
-            template: 'magic-link',
+            template: 'sign-in-code',
           },
           transport,
         ),
@@ -252,7 +252,7 @@ describe('sendEmail idempotency', () => {
             html: '<p>Hello</p>',
             text: 'Hello',
             idempotencyKey: 'k',
-            template: 'magic-link',
+            template: 'sign-in-code',
           },
           new RecordingTransport(),
         ),

--- a/packages/services/tests/email/email.test.ts
+++ b/packages/services/tests/email/email.test.ts
@@ -13,11 +13,11 @@ import {
   inviteAcceptedEmail,
   inviteEmail,
   issueAssignedEmail,
-  magicLinkEmail,
   mentionEmail,
   ResendTransport,
   resetPasswordEmail,
   sendEmail,
+  signInCodeEmail,
 } from '../../src/email/index.ts';
 import { withRollback } from '../../src/test-database.ts';
 
@@ -32,15 +32,15 @@ class RecordingTransport implements EmailTransport {
 }
 
 describe('templates', () => {
-  it('renders the magic link email with the url in html and text', async () => {
-    const content = await magicLinkEmail({
-      url: 'https://orbit.local/auth/magic?token=abc123',
+  it('renders the sign in code in html and text', async () => {
+    const content = await signInCodeEmail({
+      code: '123456',
       email: 'ada@orbit.local',
     });
-    expect(content.subject).toBe('Your Orbit sign in link');
-    expect(content.html).toContain('https://orbit.local/auth/magic?token=abc123');
+    expect(content.subject).toBe('Your Orbit sign in code');
+    expect(content.html).toContain('123456');
     expect(content.html).toContain('#5A63C8');
-    expect(content.text).toContain('https://orbit.local/auth/magic?token=abc123');
+    expect(content.text).toContain('123456');
     expect(content.text).toContain('ada@orbit.local');
   });
 

--- a/packages/shared/src/validators/auth.ts
+++ b/packages/shared/src/validators/auth.ts
@@ -20,3 +20,9 @@ export const setPasswordSchema = z.object({
 export type SetPasswordInput = z.infer<typeof setPasswordSchema>;
 
 export const devSignInSchema = z.object({ email: emailSchema });
+
+export const signInCodeRequestSchema = z.object({ email: emailSchema });
+
+export const signInCodeVerifySchema = signInCodeRequestSchema.extend({
+  otp: z.string().regex(/^\d{6}$/),
+});


### PR DESCRIPTION
Replace Magic Link authentication with secure email OTP sign-in, including the login UI, email template, local dev flow, tests, and documentation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces magic-link authentication with six-digit email OTP sign-in across the web UI, server configuration, development login, email delivery, tests, and documentation.
- Adds OTP request and verification states to the login form.
- Configures Better Auth’s email OTP plugin and a dedicated sign-in-code email template.
- Updates the local development sign-in flow, validation schemas, tests, seed data, and operator documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/auth/login-form.tsx | Implements OTP request and verification states; the revised submit ordering and button wiring resolve the previously reported duplicate and password-flow submissions. |
| apps/web/src/lib/auth/server.ts | Replaces the magic-link integration with Better Auth’s email OTP plugin and sign-in-code delivery. |
| apps/web/src/app/api/dev/sign-in/route.ts | Updates development login to mint and verify an email OTP before forwarding the resulting session cookies. |
| packages/services/src/email/templates.tsx | Adds the transactional email template used to deliver six-digit sign-in codes. |
| packages/shared/src/validators/auth.ts | Adds shared schemas for validating OTP requests and six-digit verification inputs. |
| apps/web/tests/components/auth/login-form.test.tsx | Exercises OTP sending and verification, including submission with password authentication enabled. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  actor User
  participant Login as Login form
  participant Auth as Better Auth
  participant Email as Email service
  User->>Login: Enter email
  Login->>Auth: Request sign-in OTP
  Auth->>Email: Send six-digit code
  Email-->>User: Deliver code
  User->>Login: Submit code
  Login->>Auth: Verify email OTP
  Auth-->>Login: Create session
  Login-->>User: Redirect to callback URL
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/noveum/orbit/commit/323a1fa1c648ecfcb14418a34b3b8fa9d318805b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52474516)</sub>

<!-- /greptile_comment -->