### PR TITLE
fix(issues): save large pasted descriptions

### DIFF
--- a/apps/web/src/features/issues/issue-detail.tsx
+++ b/apps/web/src/features/issues/issue-detail.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ISSUE_DESCRIPTION_MAX_LENGTH } from '@orbit/shared/constants';
 import { Bell, BellOff, Check } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -110,7 +111,11 @@ export function IssueTitle({
   );
 }
 
-function IssueBody({
+function canSaveIssueDescription(description: string): boolean {
+  return description.length <= ISSUE_DESCRIPTION_MAX_LENGTH;
+}
+
+export function IssueBody({
   issue,
   members,
   onCommit,
@@ -137,7 +142,11 @@ function IssueBody({
     },
     [issue.id, toast],
   );
-  const autosave = useAutosave({ value: draft, save: onCommit });
+  const autosave = useAutosave({
+    value: draft,
+    save: onCommit,
+    canSave: canSaveIssueDescription,
+  });
   const flush = autosave.saveNow;
   const settled = autosave.status === 'saved';
   const server = useRef(issue.description);
@@ -161,6 +170,17 @@ function IssueBody({
       onForceSave={flush}
       onBlur={flush}
       onUpload={upload}
+      footer={
+        canSaveIssueDescription(draft) ? undefined : (
+          <p
+            className="mt-2 text-danger text-xs"
+            role="alert"
+            data-testid="issue-description-limit"
+          >
+            Description must be 500,000 characters or fewer.
+          </p>
+        )
+      }
     />
   );
 }

--- a/apps/web/src/lib/api/handler.ts
+++ b/apps/web/src/lib/api/handler.ts
@@ -66,10 +66,29 @@ export async function pageContext(options: ContextOptions = {}): Promise<ApiCont
   return context;
 }
 
+function validationIssues(error: ZodError): {
+  readonly code: string;
+  readonly path: string[];
+  readonly message: string;
+}[] {
+  return error.issues.map((issue) => ({
+    code: issue.code,
+    path: issue.path.map(String),
+    message: issue.message,
+  }));
+}
+
 function toResponse(error: unknown): Response {
   if (error instanceof ZodError) {
+    const issues = validationIssues(error);
     return Response.json(
-      { error: { code: 'validation_failed', message: 'Check the highlighted fields.' } },
+      {
+        error: {
+          code: 'validation_failed',
+          message: issues[0]?.message ?? 'That request contains invalid fields.',
+          details: { issues },
+        },
+      },
       { status: 422 },
     );
   }

--- a/apps/web/tests/app/api/issues/[id]/route.test.ts
+++ b/apps/web/tests/app/api/issues/[id]/route.test.ts
@@ -1,6 +1,8 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { createIssue } from '@orbit/core';
 import { addMember } from '@orbit/core/test-support';
+import { ISSUE_DESCRIPTION_MAX_LENGTH } from '@orbit/shared/constants';
+import { issueEnvelopeSchema } from '@/lib/query/schemas.ts';
 import {
   actorFor,
   buildIssueRoutesWorld,
@@ -38,6 +40,49 @@ describe('PATCH /api/issues/[id]', () => {
 
     expect(response.status).toBe(200);
     expect(issueSchema.parse(await response.json()).issue.dueDate).toBe('2031-03-04');
+  });
+
+  it('stores a large pasted description', async () => {
+    const description = 'x'.repeat(150_000);
+    const response = await issueRoute.PATCH(
+      new Request(`${ISSUES_BASE}/${world.second.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ description }),
+      }),
+      contextFor(world.second.id),
+    );
+
+    expect(response.status).toBe(200);
+    expect(issueEnvelopeSchema.parse(await response.json()).issue.description).toBe(description);
+  });
+
+  it('explains when a description exceeds the request limit', async () => {
+    const response = await issueRoute.PATCH(
+      new Request(`${ISSUES_BASE}/${world.second.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          description: 'x'.repeat(ISSUE_DESCRIPTION_MAX_LENGTH + 1),
+        }),
+      }),
+      contextFor(world.second.id),
+    );
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: 'validation_failed',
+        message: 'Description must be 500,000 characters or fewer.',
+        details: {
+          issues: [
+            {
+              code: 'too_big',
+              path: ['description'],
+              message: 'Description must be 500,000 characters or fewer.',
+            },
+          ],
+        },
+      },
+    });
   });
 
   it('stores a parent the client sends', async () => {

--- a/apps/web/tests/features/issues/issue-description.test.tsx
+++ b/apps/web/tests/features/issues/issue-description.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { ISSUE_DESCRIPTION_MAX_LENGTH } from '@orbit/shared/constants';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ChangeEvent, ReactNode } from 'react';
+import { ToastProvider } from '@/components/ui/toast.tsx';
+import type { Issue } from '@/lib/query/schemas.ts';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+const EDITOR_MODULE = '@/features/docs/editor/rich-text-editor.tsx';
+await restoreModulesAfterThisFile([EDITOR_MODULE]);
+
+mock.module(EDITOR_MODULE, () => ({
+  RichTextEditor: ({
+    value,
+    onChange,
+    onBlur,
+    footer,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    onBlur?: () => void;
+    footer?: ReactNode;
+  }) => (
+    <div>
+      <textarea
+        aria-label="Issue description"
+        value={value}
+        onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onChange(event.target.value)}
+        onBlur={() => onBlur?.()}
+      />
+      {footer}
+    </div>
+  ),
+}));
+
+const { IssueBody } = await import('@/features/issues/issue-detail.tsx');
+
+function issue(): Issue {
+  return { id: 'issue_1', description: '' } as unknown as Issue;
+}
+
+function mountBody(onCommit: (description: string) => Promise<unknown>): void {
+  render(
+    <ToastProvider>
+      <IssueBody issue={issue()} members={[]} onCommit={onCommit} />
+    </ToastProvider>,
+  );
+}
+
+describe('saving an issue description', () => {
+  it('keeps an oversized draft local until it fits the server contract', async () => {
+    const onCommit = mock(async (_description: string) => undefined);
+    mountBody(onCommit);
+    const editor = screen.getByLabelText('Issue description');
+
+    fireEvent.change(editor, {
+      target: { value: 'x'.repeat(ISSUE_DESCRIPTION_MAX_LENGTH + 1) },
+    });
+    fireEvent.blur(editor);
+
+    expect(await screen.findByTestId('issue-description-limit')).toHaveTextContent(
+      '500,000 characters or fewer',
+    );
+    expect(onCommit).not.toHaveBeenCalled();
+
+    const accepted = 'x'.repeat(150_000);
+    fireEvent.change(editor, { target: { value: accepted } });
+    fireEvent.blur(editor);
+
+    await waitFor(() => expect(onCommit).toHaveBeenCalledTimes(1));
+    expect(onCommit.mock.calls[0]?.[0]).toBe(accepted);
+    expect(screen.queryByTestId('issue-description-limit')).toBeNull();
+  });
+});

--- a/apps/web/tests/lib/api/handler.test.ts
+++ b/apps/web/tests/lib/api/handler.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import { forbidden } from '@orbit/shared/errors';
 import { ORIGIN_CLIENT_ID_HEADER, type SyncAction } from '@orbit/shared/events';
+import { z } from 'zod';
 
 const published: SyncAction[][] = [];
 const publishOutcome: { fail: boolean } = { fail: false };
@@ -87,6 +88,25 @@ describe('errorResponse', () => {
     expect(response.status).toBe(403);
     expect(await response.json()).toEqual({
       error: { code: 'forbidden', message: 'You cannot comment on this doc.' },
+    });
+  });
+
+  it('returns the first validation reason and safe field details', async () => {
+    const response = errorResponse(
+      z
+        .object({ description: z.string().max(3, { message: 'Description is too long.' }) })
+        .safeParse({ description: 'long' }).error,
+    );
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: 'validation_failed',
+        message: 'Description is too long.',
+        details: {
+          issues: [{ code: 'too_big', path: ['description'], message: 'Description is too long.' }],
+        },
+      },
     });
   });
 

--- a/packages/mcp-server/src/logger.ts
+++ b/packages/mcp-server/src/logger.ts
@@ -1,3 +1,5 @@
+import { safeErrorFields } from '@orbit/shared/utils';
+
 type LogFields = Record<string, unknown>;
 
 type LogLevel = 'info' | 'warn' | 'error';
@@ -23,6 +25,4 @@ export const logger = {
   error: (message: string, fields?: LogFields): void => write('error', message, fields),
 };
 
-export function errorFields(error: unknown): LogFields {
-  return { error: error instanceof Error ? error.message : String(error) };
-}
+export const errorFields = safeErrorFields;

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -67,6 +67,7 @@ function rpcError(status: number, message: string, headers: Record<string, strin
 
 export interface McpRequestOptions {
   readonly publicUrl: string;
+  readonly dispatch?: ((request: Request) => Promise<Response>) | undefined;
 }
 
 async function dispatch(request: Request): Promise<Response> {
@@ -105,7 +106,7 @@ export async function handleMcpRequest(
   }
 
   try {
-    return await dispatch(request);
+    return await (options.dispatch ?? dispatch)(request);
   } catch (error: unknown) {
     const domain = toDomainError(error);
     const fields = { code: domain.code, ...errorFields(error) };

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -108,7 +108,9 @@ export async function handleMcpRequest(
     return await dispatch(request);
   } catch (error: unknown) {
     const domain = toDomainError(error);
-    logger.error('request failed', { code: domain.code, ...errorFields(error) });
+    const fields = { code: domain.code, ...errorFields(error) };
+    if (domain.status >= 500) logger.error('request failed', fields);
+    else logger.warn('request rejected', fields);
     const safe = domain.status >= 500 ? 'Something went wrong on our side.' : domain.message;
     const headers =
       domain.status === 401 ? { 'WWW-Authenticate': wwwAuthenticate(options.publicUrl) } : {};

--- a/packages/mcp-server/src/tools/issues.ts
+++ b/packages/mcp-server/src/tools/issues.ts
@@ -20,6 +20,7 @@ import {
 import { db, eq, inArray, schema } from '@orbit/db';
 import {
   base64LengthFor,
+  ISSUE_DESCRIPTION_MAX_LENGTH,
   ISSUE_RELATION_TYPES,
   MAX_INLINE_UPLOAD_BYTES,
   STATE_CATEGORIES,
@@ -88,7 +89,11 @@ function registerCreateIssue(server: McpServer, principal: Principal): void {
       inputSchema: {
         team: z.string().min(1).describe('Team key like "ENG", team name, or team id.'),
         title: z.string().min(1).max(255).describe('One line summary of the work.'),
-        description: z.string().max(100_000).optional().describe('Markdown body of the issue.'),
+        description: z
+          .string()
+          .max(ISSUE_DESCRIPTION_MAX_LENGTH)
+          .optional()
+          .describe('Markdown body of the issue.'),
         state: z.string().min(1).optional().describe('Workflow state name or id on that team.'),
         priority: priorityRef.optional(),
         assignee: z
@@ -137,7 +142,11 @@ function registerUpdateIssue(server: McpServer, principal: Principal): void {
       inputSchema: {
         issue: issueRef,
         title: z.string().min(1).max(255).optional(),
-        description: z.string().max(100_000).optional().describe('Replaces the markdown body.'),
+        description: z
+          .string()
+          .max(ISSUE_DESCRIPTION_MAX_LENGTH)
+          .optional()
+          .describe('Replaces the markdown body.'),
         state: z
           .string()
           .min(1)

--- a/packages/mcp-server/tests/auth.test.ts
+++ b/packages/mcp-server/tests/auth.test.ts
@@ -1,8 +1,7 @@
-import { beforeAll, describe, expect, it } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test';
 import { verifyMcpAccessToken } from '@orbit/core';
 import { and, db, eq, schema } from '@orbit/db';
 import { DomainError } from '@orbit/shared/errors';
-import { MCP_PATH } from '../src/server.ts';
 import {
   callMcp,
   connect,
@@ -15,11 +14,28 @@ import {
   type TestWorkspace,
 } from '../src/test-helpers.ts';
 
+const logged = { errors: [] as string[], warnings: [] as string[] };
+const loggerModule = await import('../src/logger.ts');
+mock.module('../src/logger.ts', () => ({
+  ...loggerModule,
+  logger: {
+    info: () => undefined,
+    warn: (message: string) => logged.warnings.push(message),
+    error: (message: string) => logged.errors.push(message),
+  },
+}));
+
+const { handleMcpRequest, MCP_PATH } = await import('../src/server.ts');
+
 let workspace: TestWorkspace;
 
 beforeAll(async () => {
   await resetDatabase();
   workspace = await createWorkspace('Nova');
+});
+
+afterAll(() => {
+  mock.module('../src/logger.ts', () => loggerModule);
 });
 
 async function clientIdOf(token: string): Promise<string> {
@@ -127,12 +143,23 @@ describe('access token verification', () => {
 });
 
 describe('http transport', () => {
-  it('challenges an unauthenticated request with WWW-Authenticate', async () => {
-    const response = await post({});
+  it('challenges an unauthenticated request without reporting an expected rejection as an error', async () => {
+    logged.errors.length = 0;
+    logged.warnings.length = 0;
+    const response = await handleMcpRequest(
+      new Request(`${MCP_TEST_ORIGIN}${MCP_PATH}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+      }),
+      { publicUrl: 'http://localhost:3000' },
+    );
     expect(response.status).toBe(401);
     const challenge = response.headers.get('www-authenticate') ?? '';
     expect(challenge).toContain('Bearer resource_metadata=');
     expect(challenge).toContain('/.well-known/oauth-protected-resource/mcp');
+    expect(logged.errors).toEqual([]);
+    expect(logged.warnings).toEqual(['request rejected']);
     await response.body?.cancel();
   });
 

--- a/packages/mcp-server/tests/auth.test.ts
+++ b/packages/mcp-server/tests/auth.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test';
 import { verifyMcpAccessToken } from '@orbit/core';
 import { and, db, eq, schema } from '@orbit/db';
-import { DomainError } from '@orbit/shared/errors';
+import { DomainError, internal } from '@orbit/shared/errors';
 import {
   callMcp,
   connect,
@@ -160,6 +160,23 @@ describe('http transport', () => {
     expect(challenge).toContain('/.well-known/oauth-protected-resource/mcp');
     expect(logged.errors).toEqual([]);
     expect(logged.warnings).toEqual(['request rejected']);
+    await response.body?.cancel();
+  });
+
+  it('logs an unexpected server failure as an error rather than a warning', async () => {
+    logged.errors.length = 0;
+    logged.warnings.length = 0;
+    const response = await handleMcpRequest(
+      new Request(`${MCP_TEST_ORIGIN}${MCP_PATH}`, { method: 'POST' }),
+      {
+        publicUrl: 'http://localhost:3000',
+        dispatch: () => Promise.reject(internal('Forced server failure.')),
+      },
+    );
+
+    expect(response.status).toBe(500);
+    expect(logged.errors).toEqual(['request failed']);
+    expect(logged.warnings).toEqual([]);
     await response.body?.cancel();
   });
 

--- a/packages/realtime-server/src/logger.ts
+++ b/packages/realtime-server/src/logger.ts
@@ -1,3 +1,5 @@
+import { safeErrorFields } from '@orbit/shared/utils';
+
 type LogFields = Record<string, unknown>;
 
 type LogLevel = 'info' | 'warn' | 'error';
@@ -23,6 +25,4 @@ export const logger = {
   error: (message: string, fields?: LogFields): void => write('error', message, fields),
 };
 
-export function errorFields(error: unknown): LogFields {
-  return { error: error instanceof Error ? error.message : String(error) };
-}
+export const errorFields = safeErrorFields;

--- a/packages/shared/src/constants/issue.ts
+++ b/packages/shared/src/constants/issue.ts
@@ -1,3 +1,5 @@
+export const ISSUE_DESCRIPTION_MAX_LENGTH = 500_000;
+
 export const PRIORITIES = [0, 1, 2, 3, 4] as const;
 export type Priority = (typeof PRIORITIES)[number];
 

--- a/packages/shared/src/utils/error-fields.ts
+++ b/packages/shared/src/utils/error-fields.ts
@@ -1,0 +1,52 @@
+export interface SafeErrorFields extends Record<string, unknown> {
+  readonly error: string;
+  readonly errorName?: string;
+  readonly errorCode?: string;
+}
+
+const URL_CREDENTIALS = /([a-z][a-z0-9+.-]*:\/\/)[^/@\s]+@/gi;
+const EMAIL_ADDRESS = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi;
+const LONG_TOKEN = /\b(?=[a-z0-9_-]*[a-z])(?=[a-z0-9_-]*\d)[a-z0-9_-]{24,}\b/gi;
+const MAX_ERROR_LENGTH = 500;
+
+function safeMessage(message: string): string {
+  if (message.startsWith('Failed query:')) return 'Database query failed.';
+  const firstLine = message.split(/\r?\n/, 1)[0] ?? '';
+  return firstLine
+    .replace(URL_CREDENTIALS, '$1[redacted]@')
+    .replace(EMAIL_ADDRESS, '[redacted-email]')
+    .replace(LONG_TOKEN, '[redacted]')
+    .slice(0, MAX_ERROR_LENGTH);
+}
+
+function errorChain(value: unknown): Error[] {
+  const chain: Error[] = [];
+  const seen = new Set<Error>();
+  let current = value;
+  while (current instanceof Error && !seen.has(current)) {
+    chain.push(current);
+    seen.add(current);
+    current = current.cause;
+  }
+  return chain;
+}
+
+function errorCode(chain: readonly Error[]): string | undefined {
+  for (const error of [...chain].reverse()) {
+    const code = (error as Error & { readonly code?: unknown }).code;
+    if (typeof code === 'string' || typeof code === 'number') return String(code);
+  }
+  return undefined;
+}
+
+export function safeErrorFields(value: unknown): SafeErrorFields {
+  const chain = errorChain(value);
+  const error = chain.at(-1);
+  if (error === undefined) return { error: safeMessage(String(value)) };
+  const code = errorCode(chain);
+  return {
+    error: safeMessage(error.message),
+    errorName: error.name,
+    ...(code === undefined ? {} : { errorCode: code }),
+  };
+}

--- a/packages/shared/src/utils/error-fields.ts
+++ b/packages/shared/src/utils/error-fields.ts
@@ -4,19 +4,128 @@ export interface SafeErrorFields extends Record<string, unknown> {
   readonly errorCode?: string;
 }
 
-const URL_CREDENTIALS = /([a-z][a-z0-9+.-]*:\/\/)[^/@\s]+@/gi;
-const EMAIL_ADDRESS = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi;
-const LONG_TOKEN = /\b(?=[a-z0-9_-]*[a-z])(?=[a-z0-9_-]*\d)[a-z0-9_-]{24,}\b/gi;
 const MAX_ERROR_LENGTH = 500;
+const EMAIL_LOCAL_CHARACTERS = new Set('abcdefghijklmnopqrstuvwxyz0123456789._%+-');
+const EMAIL_DOMAIN_CHARACTERS = new Set('abcdefghijklmnopqrstuvwxyz0123456789.-');
+const TOKEN_CHARACTERS = new Set('abcdefghijklmnopqrstuvwxyz0123456789_-');
+const SCHEME_CHARACTERS = new Set('abcdefghijklmnopqrstuvwxyz0123456789+.-');
+
+function isAsciiLetter(value: string): boolean {
+  return value >= 'a' && value <= 'z';
+}
+
+function replaceUrlCredentials(value: string): string {
+  let result = '';
+  let cursor = 0;
+  while (cursor < value.length) {
+    const schemeEnd = value.indexOf('://', cursor);
+    if (schemeEnd === -1) return result + value.slice(cursor);
+    let schemeStart = schemeEnd;
+    while (
+      schemeStart > cursor &&
+      SCHEME_CHARACTERS.has(value[schemeStart - 1]?.toLowerCase() ?? '')
+    ) {
+      schemeStart -= 1;
+    }
+    const scheme = value.slice(schemeStart, schemeEnd);
+    if (!isAsciiLetter(scheme[0]?.toLowerCase() ?? '')) {
+      result += value.slice(cursor, schemeEnd + 3);
+      cursor = schemeEnd + 3;
+      continue;
+    }
+    const authorityStart = schemeEnd + 3;
+    let authorityEnd = authorityStart;
+    while (authorityEnd < value.length && !'/\\?#\r\n\t '.includes(value[authorityEnd] ?? '')) {
+      authorityEnd += 1;
+    }
+    const at = value.indexOf('@', authorityStart);
+    if (at === -1 || at >= authorityEnd) {
+      result += value.slice(cursor, authorityEnd);
+      cursor = authorityEnd;
+      continue;
+    }
+    result += `${value.slice(cursor, authorityStart)}[redacted]@`;
+    cursor = at + 1;
+  }
+  return result;
+}
+
+function emailAt(
+  value: string,
+  at: number,
+): { readonly start: number; readonly end: number } | null {
+  let start = at;
+  while (start > 0 && EMAIL_LOCAL_CHARACTERS.has(value[start - 1]?.toLowerCase() ?? '')) start -= 1;
+  if (start === at) return null;
+  let end = at + 1;
+  while (end < value.length && EMAIL_DOMAIN_CHARACTERS.has(value[end]?.toLowerCase() ?? ''))
+    end += 1;
+  const domain = value.slice(at + 1, end);
+  const dot = domain.lastIndexOf('.');
+  if (dot <= 0 || domain.length - dot < 3) return null;
+  return { start, end };
+}
+
+function replaceEmails(value: string): string {
+  let result = '';
+  let cursor = 0;
+  while (cursor < value.length) {
+    const at = value.indexOf('@', cursor);
+    if (at === -1) return result + value.slice(cursor);
+    const email = emailAt(value, at);
+    if (email === null) {
+      result += value.slice(cursor, at + 1);
+      cursor = at + 1;
+      continue;
+    }
+    result += `${value.slice(cursor, email.start)}[redacted-email]`;
+    cursor = email.end;
+  }
+  return result;
+}
+
+function sensitiveToken(value: string): boolean {
+  if (value.length < 24) return false;
+  let hasLetter = false;
+  let hasDigit = false;
+  for (const character of value) {
+    if (!TOKEN_CHARACTERS.has(character.toLowerCase())) return false;
+    if (isAsciiLetter(character.toLowerCase())) hasLetter = true;
+    if (character >= '0' && character <= '9') hasDigit = true;
+  }
+  return hasLetter && hasDigit;
+}
+
+function replaceLongTokens(value: string): string {
+  let result = '';
+  let cursor = 0;
+  while (cursor < value.length) {
+    if (!TOKEN_CHARACTERS.has(value[cursor]?.toLowerCase() ?? '')) {
+      result += value[cursor];
+      cursor += 1;
+      continue;
+    }
+    let end = cursor + 1;
+    while (end < value.length && TOKEN_CHARACTERS.has(value[end]?.toLowerCase() ?? '')) end += 1;
+    const token = value.slice(cursor, end);
+    result += sensitiveToken(token) ? '[redacted]' : token;
+    cursor = end;
+  }
+  return result;
+}
 
 function safeMessage(message: string): string {
   if (message.startsWith('Failed query:')) return 'Database query failed.';
-  const firstLine = message.split(/\r?\n/, 1)[0] ?? '';
-  return firstLine
-    .replace(URL_CREDENTIALS, '$1[redacted]@')
-    .replace(EMAIL_ADDRESS, '[redacted-email]')
-    .replace(LONG_TOKEN, '[redacted]')
-    .slice(0, MAX_ERROR_LENGTH);
+  const lineEnd = Math.min(
+    ...[message.indexOf('\r'), message.indexOf('\n'), MAX_ERROR_LENGTH].filter(
+      (index) => index >= 0,
+    ),
+  );
+  const firstLine = message.slice(0, lineEnd);
+  return replaceLongTokens(replaceEmails(replaceUrlCredentials(firstLine))).slice(
+    0,
+    MAX_ERROR_LENGTH,
+  );
 }
 
 function errorChain(value: unknown): Error[] {
@@ -46,7 +155,7 @@ export function safeErrorFields(value: unknown): SafeErrorFields {
   const code = errorCode(chain);
   return {
     error: safeMessage(error.message),
-    errorName: error.name,
-    ...(code === undefined ? {} : { errorCode: code }),
+    errorName: safeMessage(error.name),
+    ...(code === undefined ? {} : { errorCode: safeMessage(code) }),
   };
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -2,6 +2,7 @@ import { v7 as uuidv7 } from 'uuid';
 import { SORT_ORDER_STEP } from '../constants/index.ts';
 
 export * from './doc-anchor.ts';
+export * from './error-fields.ts';
 export * from './highlight.ts';
 
 export function slugify(input: string): string {

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
-import { ISSUE_RELATION_TYPES, PRIORITIES, STATE_CATEGORIES } from '../constants/index.ts';
+import {
+  ISSUE_DESCRIPTION_MAX_LENGTH,
+  ISSUE_RELATION_TYPES,
+  PRIORITIES,
+  STATE_CATEGORIES,
+} from '../constants/index.ts';
 import { filterGroupQuerySchema, ISSUE_ORDERINGS } from '../filters/index.ts';
-import { calendarDateSchema, idSchema, markdownSchema, titleSchema } from './common.ts';
+import { calendarDateSchema, idSchema, titleSchema } from './common.ts';
 
 export function booleanFlag(fallback: boolean) {
   return z
@@ -19,10 +24,14 @@ export const prioritySchema = z
   .int()
   .refine((value): value is (typeof PRIORITIES)[number] => PRIORITIES.includes(value as 0));
 
+export const issueDescriptionSchema = z.string().max(ISSUE_DESCRIPTION_MAX_LENGTH, {
+  message: 'Description must be 500,000 characters or fewer.',
+});
+
 export const issueCreateSchema = z.object({
   teamId: idSchema,
   title: titleSchema,
-  description: markdownSchema.default(''),
+  description: issueDescriptionSchema.default(''),
   stateId: idSchema.optional(),
   priority: prioritySchema.default(0),
   assigneeId: idSchema.nullable().optional(),
@@ -38,7 +47,7 @@ export const issueCreateSchema = z.object({
 export const issueUpdateSchema = z
   .object({
     title: titleSchema,
-    description: markdownSchema,
+    description: issueDescriptionSchema,
     stateId: idSchema,
     priority: prioritySchema,
     assigneeId: idSchema.nullable(),

--- a/packages/shared/tests/utils/error-fields.test.ts
+++ b/packages/shared/tests/utils/error-fields.test.ts
@@ -31,6 +31,19 @@ describe('safeErrorFields', () => {
     );
   });
 
+  it('sanitizes the error name and code as well as the message', () => {
+    const error = Object.assign(new Error('Safe message'), {
+      name: 'person@example.test',
+      code: 'abcdefghijklmnopqrstuvwx1234',
+    });
+
+    expect(safeErrorFields(error)).toEqual({
+      error: 'Safe message',
+      errorName: '[redacted-email]',
+      errorCode: '[redacted]',
+    });
+  });
+
   it('bounds an unknown error before it reaches the platform logger', () => {
     expect(safeErrorFields('x'.repeat(1_000)).error).toHaveLength(500);
   });

--- a/packages/shared/tests/utils/error-fields.test.ts
+++ b/packages/shared/tests/utils/error-fields.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test';
+import { safeErrorFields } from '../../src/utils/error-fields.ts';
+
+describe('safeErrorFields', () => {
+  it('keeps a useful database cause without logging SQL or parameters', () => {
+    const cause = Object.assign(new Error('Connection terminated unexpectedly'), {
+      name: 'PostgresError',
+      code: 'CONNECTION_CLOSED',
+    });
+    const wrapped = new Error(
+      'Failed query: select "id" from "session" where "id" in ($1)\nparams: secret-session-token',
+      { cause },
+    );
+
+    expect(safeErrorFields(wrapped)).toEqual({
+      error: 'Connection terminated unexpectedly',
+      errorName: 'PostgresError',
+      errorCode: 'CONNECTION_CLOSED',
+    });
+  });
+
+  it('redacts credentials, emails and long mixed tokens from a plain error', () => {
+    const fields = safeErrorFields(
+      new Error(
+        'Request postgres://orbit:secret@example.test/db for person@example.test and token abcdefghijklmnopqrstuvwx1234 failed',
+      ),
+    );
+
+    expect(fields.error).toBe(
+      'Request postgres://[redacted]@example.test/db for [redacted-email] and token [redacted] failed',
+    );
+  });
+
+  it('bounds an unknown error before it reaches the platform logger', () => {
+    expect(safeErrorFields('x'.repeat(1_000)).error).toHaveLength(500);
+  });
+});

--- a/packages/shared/tests/validators/validators.test.ts
+++ b/packages/shared/tests/validators/validators.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { ISSUE_DESCRIPTION_MAX_LENGTH } from '../../src/constants/index.ts';
 import {
   bootstrapQuerySchema,
   cycleCreateSchema,
@@ -52,6 +53,17 @@ describe('update schemas never invent values', () => {
     expect(issueUpdateSchema.safeParse({ priority: 9 }).success).toBe(false);
     expect(issueUpdateSchema.safeParse({ title: '' }).success).toBe(false);
     expect(labelUpdateSchema.safeParse({ color: 'red' }).success).toBe(false);
+  });
+});
+
+describe('issue descriptions', () => {
+  it('accepts pasted file contents while keeping a bounded request size', () => {
+    expect(issueUpdateSchema.safeParse({ description: 'x'.repeat(150_000) }).success).toBe(true);
+    expect(
+      issueUpdateSchema.safeParse({
+        description: 'x'.repeat(ISSUE_DESCRIPTION_MAX_LENGTH + 1),
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/packages/shared/tests/validators/validators.test.ts
+++ b/packages/shared/tests/validators/validators.test.ts
@@ -61,6 +61,11 @@ describe('issue descriptions', () => {
     expect(issueUpdateSchema.safeParse({ description: 'x'.repeat(150_000) }).success).toBe(true);
     expect(
       issueUpdateSchema.safeParse({
+        description: 'x'.repeat(ISSUE_DESCRIPTION_MAX_LENGTH),
+      }).success,
+    ).toBe(true);
+    expect(
+      issueUpdateSchema.safeParse({
         description: 'x'.repeat(ISSUE_DESCRIPTION_MAX_LENGTH + 1),
       }).success,
     ).toBe(false);


### PR DESCRIPTION
## What this changes

Issue descriptions now accept up to 500,000 characters, show the real validation reason, and keep an oversized draft local instead of repeatedly sending a rejected autosave. Runtime logs now redact database query text and treat expected MCP authentication rejections as warnings.

## Why

Production recorded twelve 422 responses while NOV-202 was being edited. The existing 100,000 character validator rejected pasted file contents, but the response only said to check highlighted fields. The same log review found transient realtime database failures exposing query text and expected MCP 401 responses counted as errors.

## How you know it works

- Added validator and route tests for a 150,000 character description and the bounded 500,000 character limit.
- Added an editor test proving oversized drafts are blocked locally and save once they fit.
- Added validation response, safe logging, and MCP log-level tests.
- Reproduced a Chromium clipboard upload with the reported 136,226 byte PNG. It uploaded and persisted the `/api/files/` URL.
- Production build completed successfully.
- GitHub CI passes lint, comments, types, migrations, build, unit and integration tests, and Playwright. Local targeted tests and the production build also pass.

## Checklist

- [x] `bun run verify` is green, all four checks
- [x] Tests added or updated, and they fail without the change
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions
- [x] External input is parsed with a Zod schema from `@orbit/shared`
- [x] Authorization is enforced on the server through `packages/shared/src/policy`, not only in the UI
- [x] Docs updated if behaviour, configuration or setup changed
- [x] Schema changes are pushed to the target database before this ships

## Anything reviewers should know

No database schema change is required. The production `description` column is already text. The repository volume used for the initial checkout is mounted read-only, so this branch was created from a fresh writable clone of current `main`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR raises the issue-description limit to 500,000 characters while preventing rejected autosaves, improves validation responses, sanitizes logged errors, and adjusts MCP rejection log levels.
- Shares the description limit across web, MCP, and validation paths.
- Preserves oversized drafts locally until they satisfy the server contract.
- Returns structured validation reasons to API clients.
- Redacts common sensitive values from server error logs.
- Logs expected MCP request rejections as warnings while retaining errors for server failures.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/issues/issue-detail.tsx | Adds client-side autosave gating and an inline limit message for oversized descriptions. |
| apps/web/src/lib/api/handler.ts | Returns the first Zod validation reason and structured issue details for invalid API requests. |
| packages/shared/src/validators/issue.ts | Centralizes the 500,000-character description constraint for issue creation and updates. |
| packages/shared/src/utils/error-fields.ts | Introduces bounded error-field extraction with redaction for query wrappers, credentials, emails, and long tokens. |
| packages/mcp-server/src/server.ts | Separates expected client rejection warnings from unexpected server errors and adds injectable dispatch for testing. |
| packages/mcp-server/src/tools/issues.ts | Aligns MCP create and update tool description limits with the shared server contract. |
| packages/realtime-server/src/logger.ts | Replaces raw error-message logging with the shared sanitized error fields. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User edits issue description] --> B{Length at most 500,000?}
    B -- No --> C[Keep draft locally and show limit]
    C --> B
    B -- Yes --> D[Autosave description]
    D --> E[Server validates request]
    E -- Valid --> F[Persist description]
    E -- Invalid --> G[Return structured validation reason]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20noveum%2Forbit%20PR%20%23303%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=noveum%2Forbit&pr=303&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (2): Last reviewed commit: ["fix(logging): harden error sanitization"](https://github.com/noveum/orbit/commit/d460910635e7ff42d3eb3fb7fc479eda1c9d631b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52837963)</sub>

<!-- /greptile_comment -->