### PR TITLE
docs: deduplicate quick-start

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,23 +25,8 @@ gated behind a plan.
 
 ## The five minute version
 
-```bash
-git clone https://github.com/Noveum/orbit.git
-cd orbit
-bun install
-cp .env.example .env
-bun run infra:up
-bun run db:push && bun run db:test-setup && bun run db:seed
-bun run dev
-```
-
-Open <http://localhost:3000> and sign in as `alex@orbit.example`. The seed loads a
-demo workspace with three teams, seven people, thirty two issues, projects,
-sprints and docs, so there is something to click on immediately.
-
-Full detail, including what each command does and what to do when one fails, is
-in [Getting started](getting-started.md).
-
+The canonical quick start is in [Getting started](getting-started.md). Follow
+that page for the full commands and troubleshooting notes.
 ## What Orbit is
 
 - **Issues** with priorities, labels, states, estimates, assignees and


### PR DESCRIPTION
<!-- Thanks for contributing. Keep this short. The parts reviewers actually read are what changed and how you know it works. -->

## What this changes
<!-- One or two sentences. -->
make [`getting-started.md`](https://github.com/Noveum/orbit/blob/main/docs/getting-started.md) the canonical quick-start and replace duplicated quick-start snippets with pointers
## Why
Reduces documentation drift. This keeps one source of truth for quick-start instructions and makes future edits low-friction. 
<!-- The problem this solves. Link the issue: Closes #123 -->

Closes #222

## How you know it works
pre-push lefthook ran during git push and completed biome check +typescript type check 
<!-- The test you added, the manual check you ran, or both. "A feature is not done until it has a test that would fail if the feature broke." -->

## Screenshots
<img width="831" height="344" alt="image" src="https://github.com/user-attachments/assets/e5817491-ca7f-4ad5-bc88-93044877caa3" />

<!-- Anything visual needs a before and after. Both themes if you touched styling. Delete this section if the change is not visual. -->

## Checklist

- [ ] `bun run verify` is green, all four checks
- [ ] Tests added or updated, and they fail without the change
- [ ] No comments added to code, and no em-dash characters anywhere
- [ ] No `any`, no non-null assertions
- [ ] External input is parsed with a Zod schema from `@orbit/shared`
- [ ] Authorization is enforced on the server through `packages/shared/src/policy`, not only in the UI
- [ ] Docs updated if behaviour, configuration or setup changed
- [ ] Schema changes are pushed to the target database before this ships

## Anything reviewers should know

<!-- Trade-offs you made, alternatives you rejected, parts you are unsure about. Flagging your own doubts speeds review up more than anything else. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes `docs/getting-started.md` the canonical quick-start guide and replaces the duplicated setup commands in the documentation index with a direct pointer.

- Removes duplicated installation and startup instructions from `docs/README.md`.
- Directs readers to the canonical guide for commands and troubleshooting.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/README.md | Replaces the duplicated quick-start block with a concise link to the canonical getting-started guide; the previously reported em-dash violation is absent. |

</details>

<sub>Reviews (7): Last reviewed commit: ["docs: point the docs index at the canoni..."](https://github.com/noveum/orbit/commit/6f422bf9b38597663c78ad1bf86dcf15476bd76c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52925118)</sub>

<!-- /greptile_comment -->