### PR TITLE
feat(docs): render mermaid diagrams in documents

### DIFF
--- a/apps/web/e2e/doc-mermaid.spec.ts
+++ b/apps/web/e2e/doc-mermaid.spec.ts
@@ -1,0 +1,88 @@
+import { type BrowserContext, expect, type Page, test } from '@playwright/test';
+import { BASE } from './base-url.ts';
+
+const CONTENT = [
+  '## Diagrams',
+  '',
+  '```mermaid',
+  'graph TD',
+  '  A[Client mutation] --> B[Route handler]',
+  '  B --> C[(Postgres)]',
+  '```',
+  '',
+  '```mermaid',
+  'graph TD',
+  '  A["<img src=x onerror=alert(1)>"] --> B["<script>alert(2)</script>"]',
+  '```',
+  '',
+  '```mermaid',
+  'graph TD',
+  '  A[Start --> B]]]',
+  '```',
+  '',
+].join('\n');
+
+async function signIn(context: BrowserContext, email: string): Promise<Page> {
+  const page = await context.newPage();
+  await page.goto(`${BASE}/login`);
+  await page.getByTestId(`dev-sign-in-${email}`).click();
+  await page.waitForURL(`${BASE}/my-issues`);
+  return page;
+}
+
+test('a mermaid fence is drawn as a diagram, sanitised, and falls back to its source', async ({
+  browser,
+}) => {
+  test.setTimeout(180_000);
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const author = await signIn(context, 'alex@orbit.example');
+
+  const created = await author.evaluate(async (content) => {
+    const response = await fetch('/api/docs', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ title: 'Diagram spec', content, visibility: 'workspace' }),
+    });
+    if (!response.ok) throw new Error(`create answered ${response.status}`);
+    return (await response.json()) as { doc: { id: string } };
+  }, CONTENT);
+
+  const shared = await author.evaluate(async (id) => {
+    const response = await fetch(`/api/docs/${id}/share`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ visibility: 'public' }),
+    });
+    if (!response.ok) throw new Error(`share answered ${response.status}`);
+    return (await response.json()) as { publishUrl: string };
+  }, created.doc.id);
+
+  const reader = await context.newPage();
+  await reader.goto(shared.publishUrl);
+
+  const blocks = reader.locator('[data-mermaid]');
+  await expect(blocks).toHaveCount(3);
+  await expect(blocks.nth(0).locator('svg')).toBeVisible();
+  await expect(blocks.nth(0)).toHaveAttribute('data-mermaid-view', 'diagram');
+
+  await expect(blocks.nth(2)).toHaveAttribute('data-mermaid-view', 'source');
+  await expect(blocks.nth(2)).toContainText('This diagram could not be drawn.');
+  await expect(blocks.nth(2)).toContainText('graph TD');
+
+  const unsafe = await reader.evaluate(() => {
+    const drawn = [...document.querySelectorAll('[data-mermaid-canvas]')];
+    return {
+      scripts: drawn.filter((node) => node.querySelector('script') !== null).length,
+      handlers: drawn.filter((node) => node.innerHTML.includes('onerror')).length,
+      images: drawn.filter((node) => node.querySelector('img') !== null).length,
+    };
+  });
+  expect(unsafe).toEqual({ scripts: 0, handlers: 0, images: 0 });
+
+  await blocks.nth(0).hover();
+  await blocks.nth(0).locator('[data-mermaid-toggle]').click();
+  await expect(blocks.nth(0)).toHaveAttribute('data-mermaid-view', 'source');
+  await expect(blocks.nth(0)).toContainText('graph TD');
+
+  await context.close();
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -62,6 +62,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "dompurify": "3.4.13",
     "html-to-pdfmake": "2.5.33",
     "idb-keyval": "^6.3.0",
     "lowlight": "^3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -66,6 +66,7 @@
     "idb-keyval": "^6.3.0",
     "lowlight": "^3",
     "lucide-react": "^1.28.0",
+    "mermaid": "^11.16.1",
     "motion": "^12.43.0",
     "next": "^16.3.0",
     "next-themes": "^0.4.6",

--- a/apps/web/src/features/docs/doc-body.tsx
+++ b/apps/web/src/features/docs/doc-body.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { useTheme } from 'next-themes';
 import { useEffect, useMemo, useRef } from 'react';
 import { cn } from '@/lib/cn.ts';
 import { codeHighlightClassName } from './code-theme.ts';
+import { drawDiagrams, mermaidClassName } from './mermaid.ts';
 import type { DocHeading } from './outline.ts';
 import { extractHeadings, sameHeadings } from './outline.ts';
 
@@ -69,6 +71,7 @@ export const docProseClassName = cn(
   '[&_figure]:my-5 [&_figcaption]:mt-1.5 [&_figcaption]:text-2xs [&_figcaption]:text-faint',
   '[&_img]:my-5 [&_img]:max-w-full [&_img]:rounded-lg [&_img]:border [&_img]:border-border',
   codeHighlightClassName,
+  mermaidClassName,
 );
 
 export interface DocBodyProps {
@@ -112,6 +115,7 @@ export function DocBody({ html, onHeadings, className }: DocBodyProps) {
   const notify = useRef(onHeadings);
   const previous = useRef<DocHeading[]>([]);
   const root = useRef<HTMLDivElement | null>(null);
+  const { resolvedTheme } = useTheme();
   notify.current = onHeadings;
 
   const headings = useMemo(() => extractHeadings(html), [html]);
@@ -126,6 +130,12 @@ export function DocBody({ html, onHeadings, className }: DocBodyProps) {
   useEffect(() => {
     if (root.current !== null) addCodeCopyButtons(root.current);
   });
+
+  useEffect(() => {
+    const node = root.current;
+    if (node === null || html.length === 0) return;
+    drawDiagrams(node, resolvedTheme === 'dark' ? 'dark' : 'light').catch(() => undefined);
+  }, [html, resolvedTheme]);
 
   return (
     <div

--- a/apps/web/src/features/docs/editor/code-block-view.tsx
+++ b/apps/web/src/features/docs/editor/code-block-view.tsx
@@ -30,7 +30,9 @@ export function useDiagram(source: string, theme: string): { svg: string | null;
           setNote(drawn === null ? DIAGRAM_FAILED : '');
         })
         .catch(() => {
-          if (live) setNote(DIAGRAM_FAILED);
+          if (!live) return;
+          setSvg(null);
+          setNote(DIAGRAM_FAILED);
         });
     }, PREVIEW_DEBOUNCE_MS);
 

--- a/apps/web/src/features/docs/editor/code-block-view.tsx
+++ b/apps/web/src/features/docs/editor/code-block-view.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { MERMAID_LANGUAGE } from '@orbit/services/markdown';
+import type { NodeViewProps } from '@tiptap/react';
+import { NodeViewContent, NodeViewWrapper } from '@tiptap/react';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+import { cn } from '@/lib/cn.ts';
+import { DIAGRAM_FAILED, renderDiagram } from '../mermaid.ts';
+
+export const PREVIEW_DEBOUNCE_MS = 300;
+export const EMPTY_DIAGRAM = 'Write mermaid below and the diagram appears here.';
+
+export function useDiagram(source: string, theme: string): { svg: string | null; note: string } {
+  const [svg, setSvg] = useState<string | null>(null);
+  const [note, setNote] = useState(EMPTY_DIAGRAM);
+
+  useEffect(() => {
+    if (source.trim().length === 0) {
+      setSvg(null);
+      setNote(EMPTY_DIAGRAM);
+      return;
+    }
+    let live = true;
+    const timer = setTimeout(() => {
+      renderDiagram(source, theme, document)
+        .then((drawn) => {
+          if (!live) return;
+          setSvg(drawn);
+          setNote(drawn === null ? DIAGRAM_FAILED : '');
+        })
+        .catch(() => {
+          if (live) setNote(DIAGRAM_FAILED);
+        });
+    }, PREVIEW_DEBOUNCE_MS);
+
+    return () => {
+      live = false;
+      clearTimeout(timer);
+    };
+  }, [source, theme]);
+
+  return { svg, note };
+}
+
+function DiagramPreview({ source }: { readonly source: string }) {
+  const { resolvedTheme } = useTheme();
+  const { svg, note } = useDiagram(source, resolvedTheme === 'dark' ? 'dark' : 'light');
+
+  return (
+    <div
+      contentEditable={false}
+      data-testid="mermaid-preview"
+      className={cn(
+        'mb-2 flex min-h-24 items-center justify-center overflow-x-auto rounded-lg',
+        'border border-border bg-surface px-4 py-5',
+        '[&_svg]:h-auto [&_svg]:max-w-full',
+      )}
+    >
+      {svg === null ? (
+        <p className={cn('m-0 text-2xs', note === DIAGRAM_FAILED ? 'text-danger' : 'text-faint')}>
+          {note}
+        </p>
+      ) : (
+        <div
+          role="img"
+          aria-label="Diagram preview"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: mermaid sanitizes its own output at the strict security level
+          dangerouslySetInnerHTML={{ __html: svg }}
+        />
+      )}
+    </div>
+  );
+}
+
+export function CodeBlockView({ node }: NodeViewProps) {
+  const language = typeof node.attrs['language'] === 'string' ? node.attrs['language'] : '';
+  const drawsDiagram = language === MERMAID_LANGUAGE;
+
+  return (
+    <NodeViewWrapper
+      data-code-view=""
+      data-language={language}
+      className={cn('relative', drawsDiagram && 'my-5')}
+    >
+      {drawsDiagram ? <DiagramPreview source={node.textContent} /> : null}
+      <pre className={drawsDiagram ? 'my-0' : undefined}>
+        <NodeViewContent<'code'>
+          as="code"
+          className={language.length === 0 ? 'hljs' : `hljs language-${language}`}
+        />
+      </pre>
+      {drawsDiagram ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute right-3 bottom-3 font-mono text-2xs text-faint"
+        >
+          {MERMAID_LANGUAGE}
+        </span>
+      ) : null}
+    </NodeViewWrapper>
+  );
+}

--- a/apps/web/src/features/docs/editor/commands.ts
+++ b/apps/web/src/features/docs/editor/commands.ts
@@ -1,3 +1,4 @@
+import { MERMAID_LANGUAGE } from '@orbit/services/markdown';
 import type { Editor } from '@tiptap/core';
 import {
   ChevronRight,
@@ -14,6 +15,7 @@ import {
   Quote,
   Table2,
   TriangleAlert,
+  Workflow,
 } from 'lucide-react';
 import { CALLOUT_LABEL } from './markdown.ts';
 
@@ -45,6 +47,8 @@ function callout(tone: 'note' | 'tip' | 'warning' | 'danger', icon: typeof Info)
     },
   };
 }
+
+export const STARTER_DIAGRAM = ['graph TD', '  A[Start] --> B[Ship]'].join('\n');
 
 export const SLASH_COMMANDS: readonly SlashCommand[] = [
   {
@@ -95,6 +99,23 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
     hint: 'Syntax highlighted',
     icon: Code2,
     run: (editor) => editor.chain().focus().toggleCodeBlock().run(),
+  },
+  {
+    id: 'diagram',
+    label: 'Diagram',
+    hint: 'Mermaid',
+    keywords: ['mermaid', 'flowchart', 'graph', 'sequence', 'chart'],
+    icon: Workflow,
+    run: (editor) =>
+      editor
+        .chain()
+        .focus()
+        .insertContent({
+          type: 'codeBlock',
+          attrs: { language: MERMAID_LANGUAGE },
+          content: [{ type: 'text', text: STARTER_DIAGRAM }],
+        })
+        .run(),
   },
   {
     id: 'quote',

--- a/apps/web/src/features/docs/editor/extensions.ts
+++ b/apps/web/src/features/docs/editor/extensions.ts
@@ -5,8 +5,10 @@ import Image from '@tiptap/extension-image';
 import { TaskItem, TaskList } from '@tiptap/extension-list';
 import { TableKit } from '@tiptap/extension-table';
 import { Placeholder } from '@tiptap/extensions';
+import { ReactNodeViewRenderer } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { common, createLowlight } from 'lowlight';
+import { CodeBlockView } from './code-block-view.tsx';
 import { calloutToneOf } from './markdown.ts';
 
 export const MENU_KEYS = ['ArrowDown', 'ArrowUp', 'Enter', 'Tab', 'Escape'] as const;
@@ -84,6 +86,12 @@ export const MenuKeymap = Extension.create<{ handler: MenuKeyHandlerRef | null }
 
 const lowlight = createLowlight(common);
 
+const CodeBlock = CodeBlockLowlight.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(CodeBlockView);
+  },
+});
+
 export function editorExtensions(handler: MenuKeyHandlerRef, placeholder = '') {
   return [
     Placeholder.configure({ placeholder, emptyEditorClass: 'orbit-editor-empty' }),
@@ -93,7 +101,7 @@ export function editorExtensions(handler: MenuKeyHandlerRef, placeholder = '') {
       heading: { levels: [1, 2, 3, 4, 5, 6] },
     }),
     Highlight,
-    CodeBlockLowlight.configure({ lowlight, defaultLanguage: 'ts' }),
+    CodeBlock.configure({ lowlight, defaultLanguage: 'ts' }),
     TaskList,
     TaskItem.configure({ nested: true }),
     TableKit.configure({ table: { resizable: false } }),

--- a/apps/web/src/features/docs/mermaid.ts
+++ b/apps/web/src/features/docs/mermaid.ts
@@ -1,3 +1,4 @@
+import purify from 'dompurify';
 import type { MermaidConfig } from 'mermaid';
 import { cn } from '@/lib/cn.ts';
 
@@ -58,6 +59,7 @@ export function mermaidConfig(styles: CSSStyleDeclaration, dark: boolean): Merma
     theme: 'base',
     darkMode: dark,
     fontFamily: token(styles, '--font-sans', 'system-ui, sans-serif'),
+    htmlLabels: false,
     flowchart: { useMaxWidth: true, htmlLabels: false, curve: 'basis' },
     sequence: { useMaxWidth: true },
     gantt: { useMaxWidth: true },
@@ -178,6 +180,10 @@ function failInto(block: HTMLElement): void {
   noteOf(block, DIAGRAM_FAILED);
 }
 
+export function safeSvg(svg: string): string {
+  return purify.sanitize(svg, { ADD_ATTR: ['transform-origin'] });
+}
+
 export interface MermaidRenderer {
   initialize(config: MermaidConfig): void;
   render(id: string, source: string): Promise<{ svg: string }>;
@@ -202,7 +208,7 @@ async function drawOne(
   const id = `orbit-mermaid-${sequence}`;
   try {
     const { svg } = await mermaid.render(id, source);
-    return svg;
+    return safeSvg(svg);
   } catch {
     return null;
   } finally {

--- a/apps/web/src/features/docs/mermaid.ts
+++ b/apps/web/src/features/docs/mermaid.ts
@@ -9,7 +9,7 @@ export const SHOW_DIAGRAM_LABEL = 'Show the diagram';
 export const DIAGRAM_FAILED = 'This diagram could not be drawn.';
 
 export const mermaidClassName = cn(
-  '[&_[data-mermaid]]:group/mermaid [&_[data-mermaid]]:relative [&_[data-mermaid]]:my-5',
+  '[&_[data-mermaid]]:relative [&_[data-mermaid]]:my-5',
   '[&_[data-mermaid]]:rounded-lg [&_[data-mermaid]]:border [&_[data-mermaid]]:border-border [&_[data-mermaid]]:bg-surface-2',
   '[&_[data-mermaid][data-mermaid-view=diagram]_pre]:hidden',
   '[&_[data-mermaid]_pre]:my-0 [&_[data-mermaid]_pre]:rounded-lg [&_[data-mermaid]_pre]:border-0 [&_[data-mermaid]_pre]:bg-transparent',
@@ -24,7 +24,9 @@ export const mermaidClassName = cn(
   '[&_[data-mermaid-toggle]]:bg-surface [&_[data-mermaid-toggle]]:px-1.5 [&_[data-mermaid-toggle]]:py-0.5',
   '[&_[data-mermaid-toggle]]:text-2xs [&_[data-mermaid-toggle]]:text-muted',
   '[&_[data-mermaid-toggle]]:opacity-0 [&_[data-mermaid-toggle]]:transition-opacity [&_[data-mermaid-toggle]]:duration-[var(--duration-fast)]',
-  'group-hover/mermaid:[&_[data-mermaid-toggle]]:opacity-100 focus-visible:[&_[data-mermaid-toggle]]:opacity-100',
+  '[&_[data-mermaid]:hover_[data-mermaid-toggle]]:opacity-100',
+  '[&_[data-mermaid]:focus-within_[data-mermaid-toggle]]:opacity-100',
+  '[&_[data-mermaid][data-mermaid-view=source]_[data-mermaid-toggle]]:opacity-100',
   'motion-reduce:[&_[data-mermaid-toggle]]:transition-none',
 );
 
@@ -99,6 +101,7 @@ export function mermaidConfig(styles: CSSStyleDeclaration, dark: boolean): Merma
       pie5: link,
       pie6: danger,
       pieStrokeColor: surfaceTwo,
+      pieOuterStrokeColor: border,
       pieTitleTextColor: text,
       pieSectionTextColor: surface,
       pieLegendTextColor: text,

--- a/apps/web/src/features/docs/mermaid.ts
+++ b/apps/web/src/features/docs/mermaid.ts
@@ -8,6 +8,7 @@ export const SOURCE_VIEW = 'source';
 export const SHOW_SOURCE_LABEL = 'Show the diagram source';
 export const SHOW_DIAGRAM_LABEL = 'Show the diagram';
 export const DIAGRAM_FAILED = 'This diagram could not be drawn.';
+export const DIAGRAM_UNAVAILABLE = 'The diagram renderer could not be loaded.';
 
 export const mermaidClassName = cn(
   '[&_[data-mermaid]]:relative [&_[data-mermaid]]:my-5',
@@ -173,11 +174,11 @@ function drawInto(block: HTMLElement, svg: string, source: string): void {
   }
 }
 
-function failInto(block: HTMLElement): void {
+function failInto(block: HTMLElement, message = DIAGRAM_FAILED): void {
   block.querySelector('[data-mermaid-canvas]')?.remove();
   block.querySelector('[data-mermaid-toggle]')?.remove();
   block.setAttribute('data-mermaid-view', SOURCE_VIEW);
-  noteOf(block, DIAGRAM_FAILED);
+  noteOf(block, message);
 }
 
 export function safeSvg(svg: string): string {
@@ -229,6 +230,8 @@ export async function renderDiagram(
   return drawOne(mermaid, text, document);
 }
 
+let pass = 0;
+
 export async function drawDiagrams(
   root: HTMLElement,
   theme: string,
@@ -238,15 +241,26 @@ export async function drawDiagrams(
     (block) => block.getAttribute('data-mermaid-drawn') !== theme,
   );
   if (blocks.length === 0) return;
+  for (const block of blocks) block.setAttribute('data-mermaid-drawn', theme);
 
+  pass += 1;
+  const mine = pass;
   const document = root.ownerDocument;
-  const mermaid = await renderer();
+
+  let mermaid: MermaidRenderer;
+  try {
+    mermaid = await renderer();
+  } catch {
+    if (mine === pass) for (const block of blocks) failInto(block, DIAGRAM_UNAVAILABLE);
+    return;
+  }
+  if (mine !== pass) return;
   configure(mermaid, theme, document);
 
   for (const block of blocks) {
     const source = sourceOf(block).trim();
-    block.setAttribute('data-mermaid-drawn', theme);
     const svg = source.length === 0 ? null : await drawOne(mermaid, source, document);
+    if (mine !== pass) return;
     if (svg === null) {
       failInto(block);
       continue;

--- a/apps/web/src/features/docs/mermaid.ts
+++ b/apps/web/src/features/docs/mermaid.ts
@@ -185,6 +185,41 @@ async function load(): Promise<MermaidRenderer> {
   return module.default as unknown as MermaidRenderer;
 }
 
+function configure(mermaid: MermaidRenderer, theme: string, document: Document): void {
+  const styles = document.defaultView?.getComputedStyle(document.documentElement);
+  if (styles !== undefined) mermaid.initialize(mermaidConfig(styles, theme === 'dark'));
+}
+
+async function drawOne(
+  mermaid: MermaidRenderer,
+  source: string,
+  document: Document,
+): Promise<string | null> {
+  sequence += 1;
+  const id = `orbit-mermaid-${sequence}`;
+  try {
+    const { svg } = await mermaid.render(id, source);
+    return svg;
+  } catch {
+    return null;
+  } finally {
+    document.getElementById(`d${id}`)?.remove();
+  }
+}
+
+export async function renderDiagram(
+  source: string,
+  theme: string,
+  document: Document,
+  renderer: () => Promise<MermaidRenderer> = load,
+): Promise<string | null> {
+  const text = source.trim();
+  if (text.length === 0) return null;
+  const mermaid = await renderer();
+  configure(mermaid, theme, document);
+  return drawOne(mermaid, text, document);
+}
+
 export async function drawDiagrams(
   root: HTMLElement,
   theme: string,
@@ -195,27 +230,18 @@ export async function drawDiagrams(
   );
   if (blocks.length === 0) return;
 
+  const document = root.ownerDocument;
   const mermaid = await renderer();
-  const window = root.ownerDocument.defaultView;
-  const styles = window?.getComputedStyle(root.ownerDocument.documentElement);
-  if (styles !== undefined) mermaid.initialize(mermaidConfig(styles, theme === 'dark'));
+  configure(mermaid, theme, document);
 
   for (const block of blocks) {
     const source = sourceOf(block).trim();
     block.setAttribute('data-mermaid-drawn', theme);
-    if (source.length === 0) {
+    const svg = source.length === 0 ? null : await drawOne(mermaid, source, document);
+    if (svg === null) {
       failInto(block);
       continue;
     }
-    sequence += 1;
-    const id = `orbit-mermaid-${sequence}`;
-    try {
-      const { svg } = await mermaid.render(id, source);
-      drawInto(block, svg, source);
-    } catch {
-      failInto(block);
-    } finally {
-      root.ownerDocument.getElementById(`d${id}`)?.remove();
-    }
+    drawInto(block, svg, source);
   }
 }

--- a/apps/web/src/features/docs/mermaid.ts
+++ b/apps/web/src/features/docs/mermaid.ts
@@ -1,0 +1,221 @@
+import type { MermaidConfig } from 'mermaid';
+import { cn } from '@/lib/cn.ts';
+
+export const MERMAID_BLOCK = '[data-mermaid]';
+export const DIAGRAM_VIEW = 'diagram';
+export const SOURCE_VIEW = 'source';
+export const SHOW_SOURCE_LABEL = 'Show the diagram source';
+export const SHOW_DIAGRAM_LABEL = 'Show the diagram';
+export const DIAGRAM_FAILED = 'This diagram could not be drawn.';
+
+export const mermaidClassName = cn(
+  '[&_[data-mermaid]]:group/mermaid [&_[data-mermaid]]:relative [&_[data-mermaid]]:my-5',
+  '[&_[data-mermaid]]:rounded-lg [&_[data-mermaid]]:border [&_[data-mermaid]]:border-border [&_[data-mermaid]]:bg-surface-2',
+  '[&_[data-mermaid][data-mermaid-view=diagram]_pre]:hidden',
+  '[&_[data-mermaid]_pre]:my-0 [&_[data-mermaid]_pre]:rounded-lg [&_[data-mermaid]_pre]:border-0 [&_[data-mermaid]_pre]:bg-transparent',
+  '[&_[data-mermaid-canvas]]:flex [&_[data-mermaid-canvas]]:justify-center [&_[data-mermaid-canvas]]:overflow-x-auto',
+  '[&_[data-mermaid-canvas]]:px-4 [&_[data-mermaid-canvas]]:py-6',
+  '[&_[data-mermaid-canvas]_svg]:h-auto [&_[data-mermaid-canvas]_svg]:max-w-full',
+  '[&_[data-mermaid][data-mermaid-view=source]_[data-mermaid-canvas]]:hidden',
+  '[&_[data-mermaid-note]]:m-0 [&_[data-mermaid-note]]:border-border [&_[data-mermaid-note]]:border-b',
+  '[&_[data-mermaid-note]]:px-4 [&_[data-mermaid-note]]:py-2 [&_[data-mermaid-note]]:text-2xs [&_[data-mermaid-note]]:text-danger',
+  '[&_[data-mermaid-toggle]]:absolute [&_[data-mermaid-toggle]]:top-2 [&_[data-mermaid-toggle]]:right-2',
+  '[&_[data-mermaid-toggle]]:cursor-pointer [&_[data-mermaid-toggle]]:rounded-sm [&_[data-mermaid-toggle]]:border [&_[data-mermaid-toggle]]:border-border',
+  '[&_[data-mermaid-toggle]]:bg-surface [&_[data-mermaid-toggle]]:px-1.5 [&_[data-mermaid-toggle]]:py-0.5',
+  '[&_[data-mermaid-toggle]]:text-2xs [&_[data-mermaid-toggle]]:text-muted',
+  '[&_[data-mermaid-toggle]]:opacity-0 [&_[data-mermaid-toggle]]:transition-opacity [&_[data-mermaid-toggle]]:duration-[var(--duration-fast)]',
+  'group-hover/mermaid:[&_[data-mermaid-toggle]]:opacity-100 focus-visible:[&_[data-mermaid-toggle]]:opacity-100',
+  'motion-reduce:[&_[data-mermaid-toggle]]:transition-none',
+);
+
+function token(styles: CSSStyleDeclaration, name: string, fallback: string): string {
+  const value = styles.getPropertyValue(name).trim();
+  return value.length === 0 ? fallback : value;
+}
+
+export function mermaidConfig(styles: CSSStyleDeclaration, dark: boolean): MermaidConfig {
+  const surface = token(styles, '--orbit-surface', dark ? '#16181d' : '#ffffff');
+  const surfaceTwo = token(styles, '--orbit-surface-2', dark ? '#1c1f26' : '#eef0f3');
+  const surfaceThree = token(styles, '--orbit-surface-3', dark ? '#22262e' : '#e9ebef');
+  const border = token(styles, '--orbit-border', dark ? '#2f343d' : '#d8dbe1');
+  const borderStrong = token(styles, '--orbit-border-strong', dark ? '#414852' : '#c2c6ce');
+  const text = token(styles, '--orbit-text', dark ? '#e6e8ee' : '#1c1f27');
+  const muted = token(styles, '--orbit-muted', dark ? '#9aa0ad' : '#4b5060');
+  const accent = token(styles, '--orbit-accent', '#4d57bd');
+  const accentSoft = token(styles, '--orbit-accent-soft', dark ? '#242741' : '#e6e8fa');
+  const success = token(styles, '--orbit-success', '#12724c');
+  const warning = token(styles, '--orbit-warning', '#96570c');
+  const danger = token(styles, '--orbit-danger', '#ba3237');
+  const merged = token(styles, '--orbit-merged', '#6c3fc7');
+  const link = token(styles, '--orbit-link', '#2f5fd1');
+
+  return {
+    startOnLoad: false,
+    securityLevel: 'strict',
+    suppressErrorRendering: true,
+    theme: 'base',
+    darkMode: dark,
+    fontFamily: token(styles, '--font-sans', 'system-ui, sans-serif'),
+    flowchart: { useMaxWidth: true, htmlLabels: false, curve: 'basis' },
+    sequence: { useMaxWidth: true },
+    gantt: { useMaxWidth: true },
+    themeVariables: {
+      background: surfaceTwo,
+      fontSize: '14px',
+      primaryColor: accentSoft,
+      primaryTextColor: text,
+      primaryBorderColor: accent,
+      secondaryColor: surfaceThree,
+      secondaryTextColor: text,
+      secondaryBorderColor: borderStrong,
+      tertiaryColor: surface,
+      tertiaryTextColor: text,
+      tertiaryBorderColor: border,
+      mainBkg: accentSoft,
+      nodeBorder: accent,
+      nodeTextColor: text,
+      textColor: text,
+      titleColor: text,
+      lineColor: borderStrong,
+      edgeLabelBackground: surface,
+      clusterBkg: surface,
+      clusterBorder: border,
+      noteBkgColor: surfaceThree,
+      noteTextColor: text,
+      noteBorderColor: border,
+      actorBkg: accentSoft,
+      actorBorder: accent,
+      actorTextColor: text,
+      labelBoxBkgColor: surface,
+      labelBoxBorderColor: border,
+      labelTextColor: text,
+      altBackground: surface,
+      signalColor: muted,
+      signalTextColor: text,
+      pie1: accent,
+      pie2: success,
+      pie3: warning,
+      pie4: merged,
+      pie5: link,
+      pie6: danger,
+      pieStrokeColor: surfaceTwo,
+      pieTitleTextColor: text,
+      pieSectionTextColor: surface,
+      pieLegendTextColor: text,
+      git0: accent,
+      git1: success,
+      git2: warning,
+      git3: merged,
+      git4: link,
+      git5: danger,
+      gitBranchLabel0: text,
+    },
+  };
+}
+
+function toggleButton(document: Document, view: string): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.setAttribute('data-mermaid-toggle', '');
+  applyView(button, view);
+  button.addEventListener('click', () => {
+    const block = button.closest<HTMLElement>(MERMAID_BLOCK);
+    if (block === null) return;
+    const next =
+      block.getAttribute('data-mermaid-view') === DIAGRAM_VIEW ? SOURCE_VIEW : DIAGRAM_VIEW;
+    block.setAttribute('data-mermaid-view', next);
+    applyView(button, next);
+  });
+  return button;
+}
+
+function applyView(button: HTMLButtonElement, view: string): void {
+  const showsDiagram = view === DIAGRAM_VIEW;
+  button.textContent = showsDiagram ? 'Source' : 'Diagram';
+  button.setAttribute('aria-label', showsDiagram ? SHOW_SOURCE_LABEL : SHOW_DIAGRAM_LABEL);
+}
+
+function noteOf(block: HTMLElement, message: string): void {
+  const existing = block.querySelector('[data-mermaid-note]');
+  if (existing !== null) existing.remove();
+  const note = block.ownerDocument.createElement('p');
+  note.setAttribute('data-mermaid-note', '');
+  note.textContent = message;
+  block.prepend(note);
+}
+
+function sourceOf(block: HTMLElement): string {
+  return block.querySelector('code')?.textContent ?? '';
+}
+
+let sequence = 0;
+
+function drawInto(block: HTMLElement, svg: string, source: string): void {
+  const document = block.ownerDocument;
+  block.querySelector('[data-mermaid-note]')?.remove();
+  let canvas = block.querySelector<HTMLElement>('[data-mermaid-canvas]');
+  if (canvas === null) {
+    canvas = document.createElement('div');
+    canvas.setAttribute('data-mermaid-canvas', '');
+    block.prepend(canvas);
+  }
+  canvas.setAttribute('role', 'img');
+  canvas.setAttribute('aria-label', `Diagram: ${source.split('\n')[0] ?? ''}`.trim());
+  canvas.innerHTML = svg;
+  block.setAttribute('data-mermaid-view', DIAGRAM_VIEW);
+  if (block.querySelector('[data-mermaid-toggle]') === null) {
+    block.append(toggleButton(document, DIAGRAM_VIEW));
+  }
+}
+
+function failInto(block: HTMLElement): void {
+  block.querySelector('[data-mermaid-canvas]')?.remove();
+  block.querySelector('[data-mermaid-toggle]')?.remove();
+  block.setAttribute('data-mermaid-view', SOURCE_VIEW);
+  noteOf(block, DIAGRAM_FAILED);
+}
+
+export interface MermaidRenderer {
+  initialize(config: MermaidConfig): void;
+  render(id: string, source: string): Promise<{ svg: string }>;
+}
+
+async function load(): Promise<MermaidRenderer> {
+  const module = await import('mermaid');
+  return module.default as unknown as MermaidRenderer;
+}
+
+export async function drawDiagrams(
+  root: HTMLElement,
+  theme: string,
+  renderer: () => Promise<MermaidRenderer> = load,
+): Promise<void> {
+  const blocks = [...root.querySelectorAll<HTMLElement>(MERMAID_BLOCK)].filter(
+    (block) => block.getAttribute('data-mermaid-drawn') !== theme,
+  );
+  if (blocks.length === 0) return;
+
+  const mermaid = await renderer();
+  const window = root.ownerDocument.defaultView;
+  const styles = window?.getComputedStyle(root.ownerDocument.documentElement);
+  if (styles !== undefined) mermaid.initialize(mermaidConfig(styles, theme === 'dark'));
+
+  for (const block of blocks) {
+    const source = sourceOf(block).trim();
+    block.setAttribute('data-mermaid-drawn', theme);
+    if (source.length === 0) {
+      failInto(block);
+      continue;
+    }
+    sequence += 1;
+    const id = `orbit-mermaid-${sequence}`;
+    try {
+      const { svg } = await mermaid.render(id, source);
+      drawInto(block, svg, source);
+    } catch {
+      failInto(block);
+    } finally {
+      root.ownerDocument.getElementById(`d${id}`)?.remove();
+    }
+  }
+}

--- a/apps/web/tests/features/docs/doc-mermaid.test.tsx
+++ b/apps/web/tests/features/docs/doc-mermaid.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { DocBody, docProseClassName } from '@/features/docs/doc-body.tsx';
 import {
   DIAGRAM_FAILED,
+  DIAGRAM_UNAVAILABLE,
   drawDiagrams,
   type MermaidRenderer,
   mermaidConfig,
@@ -105,6 +106,28 @@ describe('a mermaid diagram in a doc', () => {
 
     await user.click(toggle);
     expect(host.querySelector('[data-mermaid]')?.getAttribute('data-mermaid-view')).toBe('diagram');
+  });
+
+  it('says so when the renderer itself never loads, rather than going quiet', async () => {
+    const host = blockFrom(DIAGRAM);
+
+    await drawDiagrams(host, 'light', () => Promise.reject(new Error('chunk gone')));
+
+    const block = host.querySelector('[data-mermaid]');
+    expect(block?.textContent).toContain(DIAGRAM_UNAVAILABLE);
+    expect(block?.getAttribute('data-mermaid-view')).toBe('source');
+  });
+
+  it('lets the newer pass win when a theme flips mid draw', async () => {
+    const host = blockFrom(DIAGRAM);
+    const light = fakeMermaid('<svg><g data-testid="light-hint"></g></svg>');
+    const dark = fakeMermaid('<svg><g data-testid="dark-hint"></g></svg>');
+
+    const slow = drawDiagrams(host, 'light', () => Promise.resolve(light.renderer));
+    await drawDiagrams(host, 'dark', () => Promise.resolve(dark.renderer));
+    await slow;
+
+    expect(host.querySelector('[data-mermaid-canvas]')?.innerHTML).toContain('dark-hint');
   });
 
   it('leaves a document without a diagram alone', async () => {

--- a/apps/web/tests/features/docs/doc-mermaid.test.tsx
+++ b/apps/web/tests/features/docs/doc-mermaid.test.tsx
@@ -147,3 +147,14 @@ describe('the diagram palette', () => {
     expect(light.startOnLoad).toBe(false);
   });
 });
+
+describe('the diagram chrome', () => {
+  it('reveals the toggle on hover and keeps it visible while the source is showing', () => {
+    expect(docProseClassName).toContain(
+      '[&_[data-mermaid]:hover_[data-mermaid-toggle]]:opacity-100',
+    );
+    expect(docProseClassName).toContain(
+      '[&_[data-mermaid][data-mermaid-view=source]_[data-mermaid-toggle]]:opacity-100',
+    );
+  });
+});

--- a/apps/web/tests/features/docs/doc-mermaid.test.tsx
+++ b/apps/web/tests/features/docs/doc-mermaid.test.tsx
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { renderMarkdown } from '@orbit/services/markdown';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DocBody, docProseClassName } from '@/features/docs/doc-body.tsx';
+import {
+  DIAGRAM_FAILED,
+  drawDiagrams,
+  type MermaidRenderer,
+  mermaidConfig,
+  SHOW_DIAGRAM_LABEL,
+  SHOW_SOURCE_LABEL,
+} from '@/features/docs/mermaid.ts';
+
+afterEach(cleanup);
+
+const DIAGRAM = ['```mermaid', 'graph TD', '  A[Start] --> B[Ship]', '```'].join('\n');
+
+function blockFrom(markdown: string): HTMLElement {
+  const host = document.createElement('div');
+  host.innerHTML = renderMarkdown(markdown);
+  document.body.append(host);
+  return host;
+}
+
+function fakeMermaid(svg: string): { renderer: MermaidRenderer; calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    renderer: {
+      initialize: () => undefined,
+      render: (_id: string, source: string) => {
+        calls.push(source);
+        if (source.includes('boom')) return Promise.reject(new Error('bad syntax'));
+        return Promise.resolve({ svg });
+      },
+    },
+  };
+}
+
+const SVG = '<svg role="graphics-document"><g></g></svg>';
+
+describe('a mermaid diagram in a doc', () => {
+  it('draws the fence into the block and keeps the source for the fallback', async () => {
+    const host = blockFrom(DIAGRAM);
+    const { renderer, calls } = fakeMermaid(SVG);
+
+    await drawDiagrams(host, 'light', () => Promise.resolve(renderer));
+
+    expect(calls[0]).toContain('graph TD');
+    const block = host.querySelector('[data-mermaid]');
+    expect(block?.getAttribute('data-mermaid-view')).toBe('diagram');
+    expect(block?.querySelector('[data-mermaid-canvas] svg')).not.toBeNull();
+    expect(block?.querySelector('code')?.textContent).toContain('graph TD');
+  });
+
+  it('falls back to the source with a note when the diagram will not parse', async () => {
+    const host = blockFrom('```mermaid\nboom boom\n```');
+    const { renderer } = fakeMermaid(SVG);
+
+    await drawDiagrams(host, 'light', () => Promise.resolve(renderer));
+
+    const block = host.querySelector('[data-mermaid]');
+    expect(block?.getAttribute('data-mermaid-view')).toBe('source');
+    expect(block?.querySelector('[data-mermaid-canvas]')).toBeNull();
+    expect(block?.textContent).toContain(DIAGRAM_FAILED);
+    expect(block?.textContent).toContain('boom boom');
+  });
+
+  it('draws each block once, however often the reader re renders', async () => {
+    const host = blockFrom(DIAGRAM);
+    const { renderer, calls } = fakeMermaid(SVG);
+
+    await drawDiagrams(host, 'light', () => Promise.resolve(renderer));
+    await drawDiagrams(host, 'light', () => Promise.resolve(renderer));
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it('draws again when the theme flips, because the colours are baked into the svg', async () => {
+    const host = blockFrom(DIAGRAM);
+    const { renderer, calls } = fakeMermaid(SVG);
+
+    await drawDiagrams(host, 'light', () => Promise.resolve(renderer));
+    await drawDiagrams(host, 'dark', () => Promise.resolve(renderer));
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it('offers a toggle between the diagram and the source it came from', async () => {
+    const user = userEvent.setup();
+    const host = blockFrom(DIAGRAM);
+    const { renderer } = fakeMermaid(SVG);
+
+    await drawDiagrams(host, 'light', () => Promise.resolve(renderer));
+
+    const toggle = host.querySelector<HTMLButtonElement>('[data-mermaid-toggle]');
+    expect(toggle?.getAttribute('aria-label')).toBe(SHOW_SOURCE_LABEL);
+    if (toggle === null) throw new Error('no toggle');
+
+    await user.click(toggle);
+    expect(host.querySelector('[data-mermaid]')?.getAttribute('data-mermaid-view')).toBe('source');
+    expect(toggle.getAttribute('aria-label')).toBe(SHOW_DIAGRAM_LABEL);
+
+    await user.click(toggle);
+    expect(host.querySelector('[data-mermaid]')?.getAttribute('data-mermaid-view')).toBe('diagram');
+  });
+
+  it('leaves a document without a diagram alone', async () => {
+    const host = blockFrom('```ts\nconst a = 1;\n```');
+    const { renderer, calls } = fakeMermaid(SVG);
+
+    await drawDiagrams(host, 'light', () => Promise.resolve(renderer));
+
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('the reader', () => {
+  it('renders a mermaid fence as its own block rather than a highlighted code block', async () => {
+    render(<DocBody html={renderMarkdown(DIAGRAM)} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('doc-body').querySelector('[data-mermaid]')).not.toBeNull();
+    });
+    expect(screen.getByTestId('doc-body').querySelector('[data-code-block]')).toBeNull();
+  });
+
+  it('hides the source once a diagram is drawn', () => {
+    expect(docProseClassName).toContain('[&_[data-mermaid][data-mermaid-view=diagram]_pre]:hidden');
+  });
+});
+
+describe('the diagram palette', () => {
+  it('takes its colours from the theme tokens, so light and dark both look at home', () => {
+    const styles = {
+      getPropertyValue: (name: string) => (name === '--orbit-accent' ? '#4d57bd' : ''),
+    } as unknown as CSSStyleDeclaration;
+
+    const light = mermaidConfig(styles, false);
+    const dark = mermaidConfig(styles, true);
+
+    expect(light.themeVariables?.['primaryBorderColor']).toBe('#4d57bd');
+    expect(light.themeVariables?.['textColor']).not.toBe(dark.themeVariables?.['textColor']);
+    expect(dark.darkMode).toBe(true);
+    expect(light.securityLevel).toBe('strict');
+    expect(light.startOnLoad).toBe(false);
+  });
+});

--- a/apps/web/tests/features/docs/doc-mermaid.test.tsx
+++ b/apps/web/tests/features/docs/doc-mermaid.test.tsx
@@ -10,6 +10,7 @@ import {
   mermaidConfig,
   SHOW_DIAGRAM_LABEL,
   SHOW_SOURCE_LABEL,
+  safeSvg,
 } from '@/features/docs/mermaid.ts';
 
 afterEach(cleanup);
@@ -38,7 +39,7 @@ function fakeMermaid(svg: string): { renderer: MermaidRenderer; calls: string[] 
   };
 }
 
-const SVG = '<svg role="graphics-document"><g></g></svg>';
+const SVG = '<svg role="graphics-document"><g data-testid="graphics-hint"></g></svg>';
 
 describe('a mermaid diagram in a doc', () => {
   it('draws the fence into the block and keeps the source for the fallback', async () => {
@@ -50,7 +51,7 @@ describe('a mermaid diagram in a doc', () => {
     expect(calls[0]).toContain('graph TD');
     const block = host.querySelector('[data-mermaid]');
     expect(block?.getAttribute('data-mermaid-view')).toBe('diagram');
-    expect(block?.querySelector('[data-mermaid-canvas] svg')).not.toBeNull();
+    expect(block?.querySelector('[data-mermaid-canvas]')?.innerHTML).toContain('graphics-hint');
     expect(block?.querySelector('code')?.textContent).toContain('graph TD');
   });
 
@@ -128,6 +129,19 @@ describe('the reader', () => {
 
   it('hides the source once a diagram is drawn', () => {
     expect(docProseClassName).toContain('[&_[data-mermaid][data-mermaid-view=diagram]_pre]:hidden');
+  });
+});
+
+describe('the drawn markup', () => {
+  it('goes through the sanitiser on its way to the page', () => {
+    expect(safeSvg('<g><text>hi</text></g>')).toContain('hi');
+  });
+
+  it('asks mermaid for plain svg labels, because the sanitiser drops foreign objects', () => {
+    const styles = { getPropertyValue: () => '' } as unknown as CSSStyleDeclaration;
+
+    expect(mermaidConfig(styles, false).htmlLabels).toBe(false);
+    expect(mermaidConfig(styles, false).flowchart?.htmlLabels).toBe(false);
   });
 });
 

--- a/apps/web/tests/features/docs/editor/mermaid-block.test.tsx
+++ b/apps/web/tests/features/docs/editor/mermaid-block.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Editor } from '@tiptap/core';
+import { useState } from 'react';
+import { STARTER_DIAGRAM } from '@/features/docs/editor/commands.ts';
+import { editorHtmlFrom } from '@/features/docs/editor/editor-content.ts';
+import { docToMarkdown } from '@/features/docs/editor/markdown.ts';
+import { RichTextEditor } from '@/features/docs/editor/rich-text-editor.tsx';
+
+const DIAGRAM = ['```mermaid', 'graph TD', '  A[Start] --> B[Ship]', '```'].join('\n');
+
+function Harness({
+  initial = '',
+  onChange = mock(),
+  onReady,
+}: {
+  initial?: string;
+  onChange?: (value: string) => void;
+  onReady: (editor: Editor) => void;
+}) {
+  const [value, setValue] = useState(initial);
+  return (
+    <RichTextEditor
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange(next);
+      }}
+      ariaLabel="Body"
+      testId="rich"
+      onReady={onReady}
+    />
+  );
+}
+
+function mountEditor(props: Partial<Parameters<typeof Harness>[0]> = {}): Promise<Editor> {
+  return new Promise((resolve) => {
+    render(<Harness onReady={resolve} {...props} />);
+  });
+}
+
+describe('a mermaid block in the rich editor', () => {
+  it('opens a diagram fence as a code block that still knows its language', async () => {
+    const editor = await mountEditor({ initial: DIAGRAM });
+
+    await waitFor(() => {
+      const block = editor.state.doc.firstChild;
+      expect(block?.type.name).toBe('codeBlock');
+      expect(block?.attrs['language']).toBe('mermaid');
+    });
+  });
+
+  it('writes the fence back out unchanged, so the document round trips', async () => {
+    const editor = await mountEditor({ initial: DIAGRAM });
+
+    await waitFor(() => expect(editor.state.doc.firstChild?.type.name).toBe('codeBlock'));
+    expect(docToMarkdown(editor.getJSON()).trim()).toBe(DIAGRAM);
+  });
+
+  it('shows a preview beside the source only for a diagram, not for other code', async () => {
+    await mountEditor({ initial: DIAGRAM });
+    expect(await screen.findByTestId('mermaid-preview')).toBeInTheDocument();
+
+    const other = render(<Harness initial={'```ts\nconst a = 1;\n```'} onReady={mock()} />);
+    await waitFor(() => expect(other.container.querySelector('pre')).not.toBeNull());
+    expect(other.container.querySelector('[data-testid=mermaid-preview]')).toBeNull();
+  });
+
+  it('drops a starter diagram in from the slash menu', async () => {
+    const onChange = mock();
+    const editor = await mountEditor({ onChange });
+    editor.chain().focus().insertContent('/diagram').run();
+
+    await screen.findByTestId('slash-diagram');
+    await userEvent.setup().click(screen.getByTestId('slash-diagram'));
+
+    await waitFor(() => expect(onChange.mock.calls.at(-1)?.[0]).toContain('```mermaid'));
+    expect(onChange.mock.calls.at(-1)?.[0]).toContain(STARTER_DIAGRAM);
+  });
+
+  it('is reachable by the words people search for', async () => {
+    const editor = await mountEditor();
+    editor.chain().focus().insertContent('/mermaid').run();
+
+    expect(await screen.findByTestId('slash-diagram')).toBeInTheDocument();
+  });
+});
+
+describe('the html the editor opens with', () => {
+  it('keeps a mermaid fence as a pre and code pair the editor can parse', () => {
+    const html = editorHtmlFrom(DIAGRAM);
+
+    expect(html).toContain('language-mermaid');
+    expect(html).toContain('<pre>');
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,7 @@
         "idb-keyval": "^6.3.0",
         "lowlight": "^3",
         "lucide-react": "^1.28.0",
+        "mermaid": "^11.16.1",
         "motion": "^12.43.0",
         "next": "^16.3.0",
         "next-themes": "^0.4.6",
@@ -263,6 +264,8 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
     "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.26", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-CGznePoL+1oWCSzqmkvlYMpWQEZohPR3LntjKXXfVH+oh6Kd8d+yHLkjpiAGwPIHAxFe4OAq3aKfRnv/wqWIyA=="],
 
     "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1103.0", "", { "dependencies": { "@aws-sdk/checksums": "^3.1000.26", "@aws-sdk/core": "^3.977.6", "@aws-sdk/credential-provider-node": "^3.972.78", "@aws-sdk/middleware-sdk-s3": "^3.972.72", "@aws-sdk/signature-v4-multi-region": "^3.996.43", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-FO7SB2vLhZRN3lBHVhMhRm3YKSHK8e917qjB8LMEEhU69cQ0Ahd/OMyezu+KqNANqEtyxfSnFVvYt81x6ZKGZA=="],
@@ -348,6 +351,10 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.7", "", { "os": "win32", "cpu": "x64" }, "sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
 
@@ -493,6 +500,10 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.4", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw=="],
+
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
@@ -596,6 +607,8 @@
     "@lezer/yaml": ["@lezer/yaml@1.0.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.4.0" } }, "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw=="],
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.3", "", {}, "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
@@ -965,6 +978,70 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.1", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.4", "", {}, "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
     "@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
 
     "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
@@ -977,6 +1054,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
@@ -984,6 +1063,8 @@
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@vercel/cli-config": ["@vercel/cli-config@0.2.2", "", { "dependencies": { "xdg-app-paths": "5", "zod": "4.1.11" } }, "sha512-kAy35eymNzRBfmcqEViVQge0KJ59FYEKsPqGNCSJQ7M9HTuFGWd3qPcZos1A5cZpAWRBdiYe82Bcz9P7pIZvUQ=="],
 
@@ -1055,6 +1136,8 @@
 
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
@@ -1064,6 +1147,8 @@
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
 
     "crelt": ["crelt@1.0.7", "", {}, "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA=="],
 
@@ -1079,11 +1164,87 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cytoscape": ["cytoscape@3.34.1", "", {}, "sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
@@ -1107,6 +1268,8 @@
 
     "domhandler": ["domhandler@6.0.1", "", { "dependencies": { "domelementtype": "^3.0.0" } }, "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg=="],
 
+    "dompurify": ["dompurify@3.4.13", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ=="],
+
     "domutils": ["domutils@4.0.2", "", { "dependencies": { "dom-serializer": "^3.0.0", "domelementtype": "^3.0.0", "domhandler": "^6.0.0" } }, "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA=="],
 
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
@@ -1128,6 +1291,8 @@
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -1181,6 +1346,8 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
     "happy-dom": ["happy-dom@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
@@ -1209,9 +1376,13 @@
 
     "idb-keyval": ["idb-keyval@6.3.0", "", {}, "sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow=="],
 
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "ioredis": ["ioredis@6.0.0", "", { "dependencies": { "@ioredis/commands": "2.0.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "standard-as-callback": "2.1.0" } }, "sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w=="],
 
@@ -1237,7 +1408,13 @@
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
     "kysely": ["kysely@0.29.4", "", {}, "sha512-y5mVgQNkMbs1eK9Xyc0pmNdabN2wHhRYY/5r4W5HrUT1rYCEPeVNSj1RUJeSDKT3U0p+mXCvLgkrFuIafYI6BA=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
 
@@ -1293,6 +1470,8 @@
 
     "linkifyjs": ["linkifyjs@4.3.3", "", {}, "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg=="],
 
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
     "lowlight": ["lowlight@3.3.0", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.0.0", "highlight.js": "~11.11.0" } }, "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ=="],
 
     "lucide-react": ["lucide-react@1.28.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg=="],
@@ -1310,6 +1489,8 @@
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
+    "mermaid": ["mermaid@11.16.1", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -1355,11 +1536,15 @@
 
     "os-paths": ["os-paths@4.4.0", "", {}, "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg=="],
 
+    "package-manager-detector": ["package-manager-detector@1.8.0", "", {}, "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A=="],
+
     "pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
 
     "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -1396,6 +1581,10 @@
     "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "png-js": ["png-js@1.1.0", "", { "dependencies": { "browserify-zlib": "^0.2.0" } }, "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "postal-mime": ["postal-mime@2.7.5", "", {}, "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA=="],
 
@@ -1481,11 +1670,17 @@
 
     "restructure": ["restructure@3.0.2", "", {}, "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rope-sequence": ["rope-sequence@1.3.4", "", {}, "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="],
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -1543,6 +1738,8 @@
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
@@ -1551,7 +1748,11 @@
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
+    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
+
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -1673,6 +1874,16 @@
 
     "cmdk/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.8", "", { "dependencies": { "@radix-ui/react-slot": "1.3.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-DOlK1BdcIeYYUcFkSYFka4v1h95XTov93b0jCgW1EEiZuIhdwHY2NlE1teLIh+p0uBsuZI5A+voay+iVWpprfA=="],
 
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-dsv/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
     "dom-serializer/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
     "domhandler/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
@@ -1694,6 +1905,8 @@
     "htmlparser2/domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "next/postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
@@ -1778,6 +1991,12 @@
     "cmdk/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rDiah9wvtqihWtWz02XreeRKIxt2EJF8y5D9rtY9l5A2zxePAtcPiOMpDugNRw5bFHz+1/8viVoc7ZVKiJknCw=="],
 
     "cmdk/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.1", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-compose-refs": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Bu/aAQHFFh6/QAvXAeUMurJ9fbW0JUIqlojU/yBXZ7cAVqy75Y7JYYyuCr9zLNF0p4WWoJYV54CTUIf4l7FzTw=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
     "domutils/dom-serializer/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -84,6 +84,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "dompurify": "3.4.13",
         "html-to-pdfmake": "2.5.33",
         "idb-keyval": "^6.3.0",
         "lowlight": "^3",

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -174,6 +174,8 @@ rather than in a separate tool.
   workspace.
 - Commentable, and searchable alongside issues from the command palette.
 - Optionally bound to a path in a repository, so a doc can mirror a file.
+- A fenced `mermaid` block is drawn as a diagram, in the theme's own colours,
+  with the source one click away. The rich editor previews it as you type.
 
 Specs, runbooks, meeting notes and architecture decisions are the things that
 end up here.

--- a/packages/services/src/markdown/index.ts
+++ b/packages/services/src/markdown/index.ts
@@ -7,6 +7,8 @@ export { extractIssueIdentifiers, extractMentions } from '@orbit/shared/utils';
 export { highlightCode, languageAlias } from './highlight.ts';
 export { decodeEntities, htmlToText, sanitizeHtml } from './sanitize.ts';
 
+export const MERMAID_LANGUAGE = 'mermaid';
+
 const UNSAFE_URL = /^\s*(javascript|vbscript|file|data):/i;
 const BLOCK_END = /<\/(p|h[1-6]|li|blockquote|pre|tr|table|ul|ol)>/gi;
 const IMAGE_KEYS = ['tokens', 'items', 'rows', 'header', 'cells'] as const;
@@ -29,6 +31,9 @@ const marked = new Marked({ gfm: true, breaks: false, pedantic: false, async: fa
   renderer: {
     code({ text, lang }): string {
       const alias = languageAlias(lang ?? '');
+      if (alias === MERMAID_LANGUAGE) {
+        return `<div data-mermaid><pre><code class="language-${MERMAID_LANGUAGE}">${escapeHtml(text)}\n</code></pre></div>\n`;
+      }
       const classes = alias.length === 0 ? 'hljs' : `hljs language-${escapeHtml(alias)}`;
       const language = alias.length === 0 ? '' : ` data-code-language="${escapeHtml(alias)}"`;
       return `<div data-code-block${language}><pre><code class="${classes}">${highlightCode(text, alias)}\n</code></pre></div>\n`;

--- a/packages/services/src/markdown/sanitize.ts
+++ b/packages/services/src/markdown/sanitize.ts
@@ -160,7 +160,12 @@ function isSafeUrl(raw: string): boolean {
 
 const HEADING_TAGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 
-const LAYOUT_DATA_ATTR = new Set(['data-table-scroll', 'data-code-block', 'data-code-language']);
+const LAYOUT_DATA_ATTR = new Set([
+  'data-table-scroll',
+  'data-code-block',
+  'data-code-language',
+  'data-mermaid',
+]);
 
 const TASK_DATA_ATTR = new Map([
   ['data-type', { tag: 'ul', values: new Set(['taskList']) }],

--- a/packages/services/tests/markdown/mermaid.test.ts
+++ b/packages/services/tests/markdown/mermaid.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+import { renderMarkdown, renderPlainText } from '../../src/markdown/index.ts';
+
+const DIAGRAM = ['```mermaid', 'graph TD', '  A[Start] --> B{Ship?}', '```'].join('\n');
+
+describe('mermaid fences', () => {
+  it('marks the block so the reader can draw it and keeps the source readable', () => {
+    const html = renderMarkdown(DIAGRAM);
+
+    expect(html).toContain('<div data-mermaid');
+    expect(html).toContain('<code class="language-mermaid">');
+    expect(html).toContain('graph TD');
+    expect(html).not.toContain('data-code-block');
+    expect(html).not.toContain('hljs');
+  });
+
+  it('survives sanitising, because the marker is what the client looks for', () => {
+    expect(renderMarkdown(DIAGRAM)).toContain('data-mermaid');
+  });
+
+  it('escapes the diagram source instead of trusting it as markup', () => {
+    const html = renderMarkdown('```mermaid\ngraph TD\n  A["<img src=x onerror=alert(1)>"]\n```');
+
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  it('accepts the language however the fence spelled it', () => {
+    expect(renderMarkdown('```Mermaid\ngraph TD\n```')).toContain('data-mermaid');
+    expect(renderMarkdown('```mermaid render\ngraph TD\n```')).toContain('data-mermaid');
+  });
+
+  it('leaves every other language on the highlighted path', () => {
+    const html = renderMarkdown('```ts\nconst a = 1;\n```');
+
+    expect(html).toContain('data-code-block');
+    expect(html).not.toContain('data-mermaid');
+  });
+
+  it('reads back as its own source in plain text, so search and summaries stay honest', () => {
+    expect(renderPlainText(DIAGRAM)).toContain('graph TD');
+  });
+});


### PR DESCRIPTION
Fenced `mermaid` blocks are drawn as diagrams in the reader, the published page and the rich editor, themed from the app's own tokens.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Mermaid diagram rendering to document reading, publishing, and rich editing, with application-token theming and sanitized SVG output.
- Converts fenced `mermaid` blocks into dedicated renderable markup while retaining source fallback.
- Adds reader controls, editor previews, failure messaging, and light/dark theme rendering.
- Adds unit and end-to-end coverage for rendering, sanitization, source toggling, invalid syntax, and renderer load failures.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/services/src/markdown/sanitize.ts | Extends sanitized document markup to preserve the dedicated Mermaid block structure needed by client rendering. |
| packages/services/src/markdown/index.ts | Converts Mermaid fences into renderable document blocks while retaining their source code. |
| apps/web/src/features/docs/mermaid.ts | Implements themed Mermaid loading, sanitized SVG rendering, source fallback, toggling, and explicit renderer failure states. |
| apps/web/src/features/docs/doc-body.tsx | Integrates Mermaid drawing into document-body lifecycle and theme changes; the previously reported silent renderer-load failure is now handled inside the renderer. |
| apps/web/src/features/docs/editor/code-block-view.tsx | Adds a debounced live preview for Mermaid code blocks while keeping their editable source. |
| apps/web/src/features/docs/editor/extensions.ts | Registers the custom code-block node view used for Mermaid previews. |
| apps/web/src/features/docs/editor/commands.ts | Adds a slash command that inserts a valid starter Mermaid diagram. |
| apps/web/e2e/doc-mermaid.spec.ts | Covers published rendering, sanitization, invalid-source fallback, and source toggling end to end. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Fenced Mermaid block] --> B[Markdown conversion]
  B --> C[Document reader or published page]
  B --> D[Rich editor]
  C --> E[Load Mermaid renderer]
  D --> E
  E --> F{Render succeeds?}
  F -- Yes --> G[Sanitize SVG]
  G --> H[Display themed diagram]
  F -- No --> I[Display source and failure note]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(docs): drive a diagram end to end i..."](https://github.com/noveum/orbit/commit/9ae63087678c70c8f195102a024f909f911be13e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53295248)</sub>

<!-- /greptile_comment -->