### PR TITLE
feat(docs): make a mermaid diagram legible, and openable in a viewer

### DIFF
--- a/apps/web/e2e/doc-mermaid.spec.ts
+++ b/apps/web/e2e/doc-mermaid.spec.ts
@@ -20,6 +20,19 @@ const CONTENT = [
   '  A[Start --> B]]]',
   '```',
   '',
+  '```mermaid',
+  'graph LR',
+  '  U[Users and SDKs] --> CF[Cloudflare DNS<br/>authoritative]',
+  '  CF --> CFR[CloudFront distribution<br/>plus WAF]',
+  '  CFR --> ALB[Load balancer<br/>tls termination]',
+  '  ALB --> ING[Ingress controller<br/>9 host rules]',
+  '  ING --> SVC[Service mesh sidecar<br/>mutual tls]',
+  '  SVC --> APP[traces app<br/>eu west and us east]',
+  '  APP --> Q[Ingest queue<br/>partitioned by workspace]',
+  '  Q --> W[Rollup workers<br/>five minute windows]',
+  '  style CFR fill:#e8f0fe',
+  '```',
+  '',
 ].join('\n');
 
 async function signIn(context: BrowserContext, email: string): Promise<Page> {
@@ -61,7 +74,7 @@ test('a mermaid fence is drawn as a diagram, sanitised, and falls back to its so
   await reader.goto(shared.publishUrl);
 
   const blocks = reader.locator('[data-mermaid]');
-  await expect(blocks).toHaveCount(3);
+  await expect(blocks).toHaveCount(4);
   await expect(blocks.nth(0).locator('svg')).toBeVisible();
   await expect(blocks.nth(0)).toHaveAttribute('data-mermaid-view', 'diagram');
 
@@ -78,6 +91,31 @@ test('a mermaid fence is drawn as a diagram, sanitised, and falls back to its so
     };
   });
   expect(unsafe).toEqual({ scripts: 0, handlers: 0, images: 0 });
+
+  const wide = blocks.nth(3);
+  await expect(wide.locator('svg')).toBeVisible();
+  const scale = await wide.evaluate((block) => {
+    const canvas = block.querySelector('[data-mermaid-canvas]');
+    const svg = canvas?.querySelector('svg');
+    return {
+      natural: Math.round(svg?.getBoundingClientRect().width ?? 0),
+      column: canvas?.clientWidth ?? 0,
+      squeezed: block.hasAttribute('data-mermaid-fit'),
+    };
+  });
+  expect(scale.squeezed).toBe(false);
+  expect(scale.natural).toBeGreaterThan(scale.column);
+  await expect(wide.locator('[data-mermaid-scale]')).toHaveCount(1);
+
+  const ink = await wide.evaluate((block) => {
+    const pale = [...block.querySelectorAll('.node')].find((node) => {
+      const fill = getComputedStyle(node.querySelector('rect, polygon, path') as Element).fill;
+      return fill === 'rgb(232, 240, 254)';
+    });
+    const label = pale?.querySelector('text, tspan');
+    return label === null || label === undefined ? null : getComputedStyle(label).fill;
+  });
+  expect(ink).toBe('rgb(16, 19, 26)');
 
   await blocks.nth(0).hover();
   await blocks.nth(0).locator('[data-mermaid-toggle]').click();

--- a/apps/web/e2e/doc-mermaid.spec.ts
+++ b/apps/web/e2e/doc-mermaid.spec.ts
@@ -117,8 +117,23 @@ test('a mermaid fence is drawn as a diagram, sanitised, and falls back to its so
   });
   expect(ink).toBe('rgb(16, 19, 26)');
 
+  await wide.hover();
+  await wide.locator('[data-mermaid-expand]').click();
+  const viewer = reader.getByTestId('diagram-viewer');
+  await expect(viewer).toBeVisible();
+  await expect(viewer.getByTestId('diagram-viewport').locator('svg').first()).toBeVisible();
+
+  const opensAt = await reader.getByTestId('diagram-zoom').textContent();
+  await viewer.getByLabel('Zoom in').click();
+  await expect(reader.getByTestId('diagram-zoom')).not.toHaveText(opensAt ?? '');
+  await viewer.getByLabel('Fit the diagram to the viewer').click();
+  await expect(reader.getByTestId('diagram-zoom')).toHaveText(opensAt ?? '');
+
+  await reader.keyboard.press('Escape');
+  await expect(viewer).toHaveCount(0);
+
   await blocks.nth(0).hover();
-  await blocks.nth(0).locator('[data-mermaid-toggle]').click();
+  await blocks.nth(0).locator('[data-mermaid-view-toggle]').click();
   await expect(blocks.nth(0)).toHaveAttribute('data-mermaid-view', 'source');
   await expect(blocks.nth(0)).toContainText('graph TD');
 

--- a/apps/web/e2e/doc-mermaid.spec.ts
+++ b/apps/web/e2e/doc-mermaid.spec.ts
@@ -33,6 +33,13 @@ const CONTENT = [
   '  style CFR fill:#e8f0fe',
   '```',
   '',
+  '```mermaid',
+  'graph LR',
+  '  A[Route handler] --> B[(Postgres)]',
+  '  B --> C[Redis fan out]',
+  '  C --> D[Subscribed clients]',
+  '```',
+  '',
 ].join('\n');
 
 async function signIn(context: BrowserContext, email: string): Promise<Page> {
@@ -74,7 +81,7 @@ test('a mermaid fence is drawn as a diagram, sanitised, and falls back to its so
   await reader.goto(shared.publishUrl);
 
   const blocks = reader.locator('[data-mermaid]');
-  await expect(blocks).toHaveCount(4);
+  await expect(blocks).toHaveCount(5);
   await expect(blocks.nth(0).locator('svg')).toBeVisible();
   await expect(blocks.nth(0)).toHaveAttribute('data-mermaid-view', 'diagram');
 
@@ -116,6 +123,13 @@ test('a mermaid fence is drawn as a diagram, sanitised, and falls back to its so
     return label === null || label === undefined ? null : getComputedStyle(label).fill;
   });
   expect(ink).toBe('rgb(16, 19, 26)');
+
+  const midsize = blocks.nth(4);
+  await expect(midsize).toHaveAttribute('data-mermaid-fit', '');
+  await reader.setViewportSize({ width: 520, height: 900 });
+  await expect(midsize).not.toHaveAttribute('data-mermaid-fit', '');
+  await reader.setViewportSize({ width: 1440, height: 900 });
+  await expect(midsize).toHaveAttribute('data-mermaid-fit', '');
 
   await wide.hover();
   await wide.locator('[data-mermaid-expand]').click();

--- a/apps/web/src/features/docs/diagram-viewer.tsx
+++ b/apps/web/src/features/docs/diagram-viewer.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  RotateCcw,
+  ZoomIn,
+  ZoomOut,
+} from 'lucide-react';
+import {
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog.tsx';
+import { cn } from '@/lib/cn.ts';
+import { inkLabels, naturalWidth } from './mermaid.ts';
+
+export const MIN_SCALE = 0.2;
+export const MAX_SCALE = 6;
+export const SCALE_STEP = 1.25;
+export const PAN_STEP = 80;
+export const VIEWER_PADDING = 96;
+
+export interface Placement {
+  readonly scale: number;
+  readonly x: number;
+  readonly y: number;
+}
+
+export const RESET: Placement = { scale: 1, x: 0, y: 0 };
+
+export function clampScale(scale: number): number {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale));
+}
+
+export function scaleToFit(natural: number, available: number): number {
+  if (natural <= 0 || available <= 0) return 1;
+  return clampScale(Math.min(1, available / natural));
+}
+
+export interface DiagramViewerProps {
+  readonly svg: string | null;
+  readonly label: string;
+  readonly onClose: () => void;
+}
+
+export function DiagramViewer({ svg, label, onClose }: DiagramViewerProps) {
+  const viewport = useRef<HTMLDivElement | null>(null);
+  const dragging = useRef<{ x: number; y: number } | null>(null);
+  const touched = useRef(false);
+  const [placement, setPlacement] = useState<Placement>(RESET);
+
+  const fitView = useCallback(() => {
+    const node = viewport.current;
+    const drawn = node?.querySelector('svg') ?? null;
+    if (node === null || drawn === null) return;
+    touched.current = false;
+    setPlacement({
+      ...RESET,
+      scale: scaleToFit(naturalWidth(drawn), node.clientWidth - VIEWER_PADDING),
+    });
+  }, []);
+
+  useEffect(() => {
+    if (svg === null) return;
+    const frame = requestAnimationFrame(() => {
+      const node = viewport.current;
+      if (node === null) return;
+      inkLabels(node);
+      fitView();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [svg, fitView]);
+
+  useEffect(() => {
+    const node = viewport.current;
+    if (svg === null || node === null || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(() => {
+      if (!touched.current) fitView();
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [svg, fitView]);
+
+  const zoom = useCallback((factor: number) => {
+    touched.current = true;
+    setPlacement((current) => ({ ...current, scale: clampScale(current.scale * factor) }));
+  }, []);
+
+  const pan = useCallback((dx: number, dy: number) => {
+    touched.current = true;
+    setPlacement((current) => ({ ...current, x: current.x + dx, y: current.y + dy }));
+  }, []);
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const moves: Record<string, () => void> = {
+      ArrowUp: () => pan(0, PAN_STEP),
+      ArrowDown: () => pan(0, -PAN_STEP),
+      ArrowLeft: () => pan(PAN_STEP, 0),
+      ArrowRight: () => pan(-PAN_STEP, 0),
+      '+': () => zoom(SCALE_STEP),
+      '=': () => zoom(SCALE_STEP),
+      '-': () => zoom(1 / SCALE_STEP),
+      '0': fitView,
+    };
+    const move = moves[event.key];
+    if (move === undefined) return;
+    event.preventDefault();
+    move();
+  };
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if ((event.target as HTMLElement).closest('button') !== null) return;
+    dragging.current = { x: event.clientX - placement.x, y: event.clientY - placement.y };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const from = dragging.current;
+    if (from === null) return;
+    touched.current = true;
+    setPlacement((current) => ({
+      ...current,
+      x: event.clientX - from.x,
+      y: event.clientY - from.y,
+    }));
+  };
+
+  const onPointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (dragging.current === null) return;
+    dragging.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  return (
+    <Dialog
+      open={svg !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent
+        data-testid="diagram-viewer"
+        onKeyDown={onKeyDown}
+        className="flex h-[calc(100dvh-3rem)] w-[calc(100vw-3rem)] max-w-none flex-col overflow-hidden p-0"
+      >
+        <DialogTitle className="border-border border-b px-4 py-2.5 font-medium text-dense text-text">
+          {label}
+        </DialogTitle>
+
+        <div
+          ref={viewport}
+          data-testid="diagram-viewport"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          onWheel={(event) => zoom(event.deltaY < 0 ? SCALE_STEP : 1 / SCALE_STEP)}
+          className={cn(
+            'relative min-h-0 flex-1 cursor-grab touch-none overflow-hidden bg-surface-2',
+            'active:cursor-grabbing',
+          )}
+        >
+          <div
+            className={cn(
+              'absolute inset-0 flex items-center justify-center',
+              '[&_svg]:h-auto [&_svg]:max-w-none',
+            )}
+            style={{
+              transform: `translate(${placement.x}px, ${placement.y}px) scale(${placement.scale})`,
+            }}
+          >
+            {svg === null ? null : (
+              <div
+                role="img"
+                aria-label={label}
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: the drawn svg is sanitised in renderDiagram
+                dangerouslySetInnerHTML={{ __html: svg }}
+              />
+            )}
+          </div>
+
+          <div className="absolute right-4 bottom-4 grid grid-cols-3 gap-1">
+            <span />
+            <ViewerButton label="Pan up" icon={ChevronUp} onPress={() => pan(0, PAN_STEP)} />
+            <ViewerButton label="Zoom in" icon={ZoomIn} onPress={() => zoom(SCALE_STEP)} />
+            <ViewerButton label="Pan left" icon={ChevronLeft} onPress={() => pan(PAN_STEP, 0)} />
+            <ViewerButton
+              label="Fit the diagram to the viewer"
+              icon={RotateCcw}
+              onPress={fitView}
+            />
+            <ViewerButton label="Pan right" icon={ChevronRight} onPress={() => pan(-PAN_STEP, 0)} />
+            <span />
+            <ViewerButton label="Pan down" icon={ChevronDown} onPress={() => pan(0, -PAN_STEP)} />
+            <ViewerButton label="Zoom out" icon={ZoomOut} onPress={() => zoom(1 / SCALE_STEP)} />
+          </div>
+
+          <p
+            data-testid="diagram-zoom"
+            className="absolute bottom-4 left-4 m-0 rounded-sm border border-border bg-surface px-2 py-1 text-2xs text-muted tabular-nums"
+          >
+            {Math.round(placement.scale * 100)}%
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ViewerButton({
+  label,
+  icon: Icon,
+  onPress,
+}: {
+  readonly label: string;
+  readonly icon: typeof ZoomIn;
+  readonly onPress: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onPress}
+      className={cn(
+        'flex size-8 items-center justify-center rounded-md border border-border bg-surface text-muted',
+        'transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)]',
+        'hover:bg-surface-3 hover:text-text motion-reduce:transition-none',
+      )}
+    >
+      <Icon className="size-4" aria-hidden="true" />
+    </button>
+  );
+}

--- a/apps/web/src/features/docs/doc-body.tsx
+++ b/apps/web/src/features/docs/doc-body.tsx
@@ -1,10 +1,16 @@
 'use client';
 
 import { useTheme } from 'next-themes';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@/lib/cn.ts';
 import { codeHighlightClassName } from './code-theme.ts';
-import { drawDiagrams, mermaidClassName } from './mermaid.ts';
+import { DiagramViewer } from './diagram-viewer.tsx';
+import {
+  DIAGRAM_OPEN_EVENT,
+  type DiagramOpenDetail,
+  drawDiagrams,
+  mermaidClassName,
+} from './mermaid.ts';
 import type { DocHeading } from './outline.ts';
 import { extractHeadings, sameHeadings } from './outline.ts';
 
@@ -116,6 +122,7 @@ export function DocBody({ html, onHeadings, className }: DocBodyProps) {
   const previous = useRef<DocHeading[]>([]);
   const root = useRef<HTMLDivElement | null>(null);
   const { resolvedTheme } = useTheme();
+  const [opened, setOpened] = useState<DiagramOpenDetail | null>(null);
   notify.current = onHeadings;
 
   const headings = useMemo(() => extractHeadings(html), [html]);
@@ -137,13 +144,28 @@ export function DocBody({ html, onHeadings, className }: DocBodyProps) {
     drawDiagrams(node, resolvedTheme === 'dark' ? 'dark' : 'light').catch(() => undefined);
   }, [html, resolvedTheme]);
 
+  useEffect(() => {
+    const node = root.current;
+    if (node === null) return;
+    const open = (event: Event) => setOpened((event as CustomEvent<DiagramOpenDetail>).detail);
+    node.addEventListener(DIAGRAM_OPEN_EVENT, open);
+    return () => node.removeEventListener(DIAGRAM_OPEN_EVENT, open);
+  }, []);
+
   return (
-    <div
-      ref={root}
-      data-testid="doc-body"
-      className={cn(docProseClassName, className)}
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: markdown is sanitized by @orbit/services/markdown
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
+    <>
+      <div
+        ref={root}
+        data-testid="doc-body"
+        className={cn(docProseClassName, className)}
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: markdown is sanitized by @orbit/services/markdown
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+      <DiagramViewer
+        svg={opened?.svg ?? null}
+        label={opened?.label ?? 'Diagram'}
+        onClose={() => setOpened(null)}
+      />
+    </>
   );
 }

--- a/apps/web/src/features/docs/editor/code-block-view.tsx
+++ b/apps/web/src/features/docs/editor/code-block-view.tsx
@@ -3,9 +3,11 @@
 import { MERMAID_LANGUAGE } from '@orbit/services/markdown';
 import type { NodeViewProps } from '@tiptap/react';
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react';
+import { Maximize2 } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/cn.ts';
+import { DiagramViewer } from '../diagram-viewer.tsx';
 import {
   DIAGRAM_FAILED,
   fitsTheColumn,
@@ -57,6 +59,7 @@ function DiagramPreview({ source }: { readonly source: string }) {
   const { svg, note } = useDiagram(source, resolvedTheme === 'dark' ? 'dark' : 'light');
   const canvas = useRef<HTMLDivElement | null>(null);
   const [fits, setFits] = useState(false);
+  const [opened, setOpened] = useState<string | null>(null);
 
   useEffect(() => {
     const node = canvas.current;
@@ -72,11 +75,28 @@ function DiagramPreview({ source }: { readonly source: string }) {
       contentEditable={false}
       data-testid="mermaid-preview"
       className={cn(
-        'mb-2 min-h-24 overflow-x-auto rounded-lg border border-border bg-surface px-4 py-5',
+        'group/preview relative mb-2 min-h-24 overflow-x-auto rounded-lg border border-border bg-surface px-4 py-5',
         '[&_svg]:mx-auto [&_svg]:block [&_svg]:h-auto',
         fits ? '[&_svg]:max-w-full' : '[&_svg]:max-w-none',
       )}
     >
+      {svg === null ? null : (
+        <button
+          type="button"
+          aria-label="Open the diagram in a viewer"
+          data-testid="mermaid-preview-expand"
+          onClick={() => setOpened(svg)}
+          className={cn(
+            'absolute top-2 right-2 z-10 flex size-7 items-center justify-center rounded-sm',
+            'border border-border bg-surface text-muted opacity-0',
+            'transition-opacity duration-[var(--duration-fast)] ease-[var(--ease-standard)]',
+            'group-hover/preview:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none',
+          )}
+        >
+          <Maximize2 className="size-3.5" aria-hidden="true" />
+        </button>
+      )}
+      <DiagramViewer svg={opened} label="Diagram" onClose={() => setOpened(null)} />
       {svg === null ? (
         <p className={cn('m-0 text-2xs', note === DIAGRAM_FAILED ? 'text-danger' : 'text-faint')}>
           {note}

--- a/apps/web/src/features/docs/editor/code-block-view.tsx
+++ b/apps/web/src/features/docs/editor/code-block-view.tsx
@@ -66,7 +66,14 @@ function DiagramPreview({ source }: { readonly source: string }) {
     const drawn = svg === null ? null : (node?.querySelector('svg') ?? null);
     if (node === null || drawn === null) return;
     inkLabels(node);
-    setFits(fitsTheColumn(naturalWidth(drawn), node.clientWidth - PREVIEW_PADDING));
+
+    const decide = () =>
+      setFits(fitsTheColumn(naturalWidth(drawn), node.clientWidth - PREVIEW_PADDING));
+    decide();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(decide);
+    observer.observe(node);
+    return () => observer.disconnect();
   }, [svg]);
 
   return (

--- a/apps/web/src/features/docs/editor/code-block-view.tsx
+++ b/apps/web/src/features/docs/editor/code-block-view.tsx
@@ -4,11 +4,18 @@ import { MERMAID_LANGUAGE } from '@orbit/services/markdown';
 import type { NodeViewProps } from '@tiptap/react';
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react';
 import { useTheme } from 'next-themes';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/cn.ts';
-import { DIAGRAM_FAILED, renderDiagram } from '../mermaid.ts';
+import {
+  DIAGRAM_FAILED,
+  fitsTheColumn,
+  inkLabels,
+  naturalWidth,
+  renderDiagram,
+} from '../mermaid.ts';
 
 export const PREVIEW_DEBOUNCE_MS = 300;
+export const PREVIEW_PADDING = 32;
 export const EMPTY_DIAGRAM = 'Write mermaid below and the diagram appears here.';
 
 export function useDiagram(source: string, theme: string): { svg: string | null; note: string } {
@@ -48,15 +55,26 @@ export function useDiagram(source: string, theme: string): { svg: string | null;
 function DiagramPreview({ source }: { readonly source: string }) {
   const { resolvedTheme } = useTheme();
   const { svg, note } = useDiagram(source, resolvedTheme === 'dark' ? 'dark' : 'light');
+  const canvas = useRef<HTMLDivElement | null>(null);
+  const [fits, setFits] = useState(false);
+
+  useEffect(() => {
+    const node = canvas.current;
+    const drawn = svg === null ? null : (node?.querySelector('svg') ?? null);
+    if (node === null || drawn === null) return;
+    inkLabels(node);
+    setFits(fitsTheColumn(naturalWidth(drawn), node.clientWidth - PREVIEW_PADDING));
+  }, [svg]);
 
   return (
     <div
+      ref={canvas}
       contentEditable={false}
       data-testid="mermaid-preview"
       className={cn(
-        'mb-2 flex min-h-24 items-center justify-center overflow-x-auto rounded-lg',
-        'border border-border bg-surface px-4 py-5',
-        '[&_svg]:h-auto [&_svg]:max-w-full',
+        'mb-2 min-h-24 overflow-x-auto rounded-lg border border-border bg-surface px-4 py-5',
+        '[&_svg]:mx-auto [&_svg]:block [&_svg]:h-auto',
+        fits ? '[&_svg]:max-w-full' : '[&_svg]:max-w-none',
       )}
     >
       {svg === null ? (
@@ -67,7 +85,7 @@ function DiagramPreview({ source }: { readonly source: string }) {
         <div
           role="img"
           aria-label="Diagram preview"
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: mermaid sanitizes its own output at the strict security level
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: the drawn svg is sanitised in renderDiagram
           dangerouslySetInnerHTML={{ __html: svg }}
         />
       )}

--- a/apps/web/src/features/docs/mermaid.ts
+++ b/apps/web/src/features/docs/mermaid.ts
@@ -9,19 +9,27 @@ export const SHOW_SOURCE_LABEL = 'Show the diagram source';
 export const SHOW_DIAGRAM_LABEL = 'Show the diagram';
 export const DIAGRAM_FAILED = 'This diagram could not be drawn.';
 export const DIAGRAM_UNAVAILABLE = 'The diagram renderer could not be loaded.';
+export const FIT_LABEL = 'Fit the diagram to the page';
+export const ACTUAL_LABEL = 'Show the diagram at its own size';
+export const LEGIBLE_SCALE = 0.75;
+export const DARK_INK = '#10131a';
+export const LIGHT_INK = '#f4f5f7';
+export const PALE_FILL = 0.55;
 
 export const mermaidClassName = cn(
   '[&_[data-mermaid]]:relative [&_[data-mermaid]]:my-5',
   '[&_[data-mermaid]]:rounded-lg [&_[data-mermaid]]:border [&_[data-mermaid]]:border-border [&_[data-mermaid]]:bg-surface-2',
   '[&_[data-mermaid][data-mermaid-view=diagram]_pre]:hidden',
   '[&_[data-mermaid]_pre]:my-0 [&_[data-mermaid]_pre]:rounded-lg [&_[data-mermaid]_pre]:border-0 [&_[data-mermaid]_pre]:bg-transparent',
-  '[&_[data-mermaid-canvas]]:flex [&_[data-mermaid-canvas]]:justify-center [&_[data-mermaid-canvas]]:overflow-x-auto',
-  '[&_[data-mermaid-canvas]]:px-4 [&_[data-mermaid-canvas]]:py-6',
-  '[&_[data-mermaid-canvas]_svg]:h-auto [&_[data-mermaid-canvas]_svg]:max-w-full',
+  '[&_[data-mermaid-canvas]]:overflow-x-auto [&_[data-mermaid-canvas]]:px-4 [&_[data-mermaid-canvas]]:py-6',
+  '[&_[data-mermaid-canvas]_svg]:mx-auto [&_[data-mermaid-canvas]_svg]:block [&_[data-mermaid-canvas]_svg]:h-auto',
+  '[&_[data-mermaid-canvas]_svg]:max-w-none',
+  '[&_[data-mermaid][data-mermaid-fit]_[data-mermaid-canvas]_svg]:max-w-full',
   '[&_[data-mermaid][data-mermaid-view=source]_[data-mermaid-canvas]]:hidden',
   '[&_[data-mermaid-note]]:m-0 [&_[data-mermaid-note]]:border-border [&_[data-mermaid-note]]:border-b',
   '[&_[data-mermaid-note]]:px-4 [&_[data-mermaid-note]]:py-2 [&_[data-mermaid-note]]:text-2xs [&_[data-mermaid-note]]:text-danger',
-  '[&_[data-mermaid-toggle]]:absolute [&_[data-mermaid-toggle]]:top-2 [&_[data-mermaid-toggle]]:right-2',
+  '[&_[data-mermaid-actions]]:absolute [&_[data-mermaid-actions]]:top-2 [&_[data-mermaid-actions]]:right-2',
+  '[&_[data-mermaid-actions]]:flex [&_[data-mermaid-actions]]:gap-1',
   '[&_[data-mermaid-toggle]]:cursor-pointer [&_[data-mermaid-toggle]]:rounded-sm [&_[data-mermaid-toggle]]:border [&_[data-mermaid-toggle]]:border-border',
   '[&_[data-mermaid-toggle]]:bg-surface [&_[data-mermaid-toggle]]:px-1.5 [&_[data-mermaid-toggle]]:py-0.5',
   '[&_[data-mermaid-toggle]]:text-2xs [&_[data-mermaid-toggle]]:text-muted',
@@ -61,9 +69,9 @@ export function mermaidConfig(styles: CSSStyleDeclaration, dark: boolean): Merma
     darkMode: dark,
     fontFamily: token(styles, '--font-sans', 'system-ui, sans-serif'),
     htmlLabels: false,
-    flowchart: { useMaxWidth: true, htmlLabels: false, curve: 'basis' },
-    sequence: { useMaxWidth: true },
-    gantt: { useMaxWidth: true },
+    flowchart: { useMaxWidth: false, htmlLabels: false, curve: 'basis' },
+    sequence: { useMaxWidth: false },
+    gantt: { useMaxWidth: false },
     themeVariables: {
       background: surfaceTwo,
       fontSize: '14px',
@@ -119,10 +127,15 @@ export function mermaidConfig(styles: CSSStyleDeclaration, dark: boolean): Merma
   };
 }
 
-function toggleButton(document: Document, view: string): HTMLButtonElement {
+function actionButton(document: Document): HTMLButtonElement {
   const button = document.createElement('button');
   button.type = 'button';
   button.setAttribute('data-mermaid-toggle', '');
+  return button;
+}
+
+function viewButton(document: Document, view: string): HTMLButtonElement {
+  const button = actionButton(document);
   applyView(button, view);
   button.addEventListener('click', () => {
     const block = button.closest<HTMLElement>(MERMAID_BLOCK);
@@ -141,6 +154,67 @@ function applyView(button: HTMLButtonElement, view: string): void {
   button.setAttribute('aria-label', showsDiagram ? SHOW_SOURCE_LABEL : SHOW_DIAGRAM_LABEL);
 }
 
+function scaleButton(document: Document): HTMLButtonElement {
+  const button = actionButton(document);
+  button.setAttribute('data-mermaid-scale', '');
+  applyScale(button, false);
+  button.addEventListener('click', () => {
+    const block = button.closest<HTMLElement>(MERMAID_BLOCK);
+    if (block === null) return;
+    const fits = !block.hasAttribute('data-mermaid-fit');
+    block.toggleAttribute('data-mermaid-fit', fits);
+    applyScale(button, fits);
+  });
+  return button;
+}
+
+function applyScale(button: HTMLButtonElement, fits: boolean): void {
+  button.textContent = fits ? 'Actual size' : 'Fit';
+  button.setAttribute('aria-label', fits ? ACTUAL_LABEL : FIT_LABEL);
+}
+
+export function fitsTheColumn(natural: number, available: number): boolean {
+  if (natural <= 0 || available <= 0) return false;
+  if (natural <= available) return true;
+  return available / natural >= LEGIBLE_SCALE;
+}
+
+function actionsOf(block: HTMLElement): HTMLElement {
+  const existing = block.querySelector<HTMLElement>('[data-mermaid-actions]');
+  if (existing !== null) return existing;
+  const actions = block.ownerDocument.createElement('div');
+  actions.setAttribute('data-mermaid-actions', '');
+  block.append(actions);
+  return actions;
+}
+
+export function naturalWidth(drawn: SVGSVGElement): number {
+  const box = drawn.viewBox?.baseVal ?? null;
+  if (box !== null && box.width > 0) return box.width;
+  return drawn.getBoundingClientRect().width;
+}
+
+function scaleInto(block: HTMLElement, canvas: HTMLElement): void {
+  const drawn = canvas.querySelector('svg');
+  if (drawn === null) return;
+  block.removeAttribute('data-mermaid-fit');
+  const natural = naturalWidth(drawn);
+  const available = canvas.clientWidth - PADDING;
+  if (natural <= 0 || available <= 0) return;
+
+  block.toggleAttribute('data-mermaid-fit', fitsTheColumn(natural, available));
+  if (natural <= available) {
+    block.querySelector('[data-mermaid-scale]')?.remove();
+    return;
+  }
+  const actions = actionsOf(block);
+  if (actions.querySelector('[data-mermaid-scale]') === null) {
+    actions.prepend(scaleButton(block.ownerDocument));
+  }
+  const button = actions.querySelector<HTMLButtonElement>('[data-mermaid-scale]');
+  if (button !== null) applyScale(button, block.hasAttribute('data-mermaid-fit'));
+}
+
 function noteOf(block: HTMLElement, message: string): void {
   const existing = block.querySelector('[data-mermaid-note]');
   if (existing !== null) existing.remove();
@@ -153,6 +227,45 @@ function noteOf(block: HTMLElement, message: string): void {
 function sourceOf(block: HTMLElement): string {
   return block.querySelector('code')?.textContent ?? '';
 }
+
+const LABEL_HOSTS = '.node, .cluster, .classGroup, .statediagram-state';
+
+function channels(fill: string): readonly number[] | null {
+  const match = /rgba?\(([^)]+)\)/.exec(fill);
+  if (match === null) return null;
+  const parts = (match[1] ?? '')
+    .split(/[\s,/]+/)
+    .filter((part) => part.length > 0)
+    .map(Number);
+  if (parts.some(Number.isNaN)) return null;
+  return parts;
+}
+
+export function inkOn(fill: string): string | null {
+  const parts = channels(fill);
+  if (parts === null) return null;
+  const [red, green, blue, alpha] = parts;
+  if (red === undefined || green === undefined || blue === undefined) return null;
+  if (alpha !== undefined && alpha < 0.5) return null;
+  const luminance = (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255;
+  return luminance > PALE_FILL ? DARK_INK : LIGHT_INK;
+}
+
+export function inkLabels(canvas: HTMLElement): void {
+  const view = canvas.ownerDocument.defaultView;
+  if (view === null) return;
+  for (const host of canvas.querySelectorAll(LABEL_HOSTS)) {
+    const shape = host.querySelector('rect, polygon, circle, ellipse, path');
+    if (shape === null) continue;
+    const ink = inkOn(view.getComputedStyle(shape).fill);
+    if (ink === null) continue;
+    for (const label of host.querySelectorAll<SVGElement>('text, tspan')) {
+      label.style.fill = ink;
+    }
+  }
+}
+
+const PADDING = 32;
 
 let sequence = 0;
 
@@ -168,15 +281,21 @@ function drawInto(block: HTMLElement, svg: string, source: string): void {
   canvas.setAttribute('role', 'img');
   canvas.setAttribute('aria-label', `Diagram: ${source.split('\n')[0] ?? ''}`.trim());
   canvas.innerHTML = svg;
+  inkLabels(canvas);
   block.setAttribute('data-mermaid-view', DIAGRAM_VIEW);
-  if (block.querySelector('[data-mermaid-toggle]') === null) {
-    block.append(toggleButton(document, DIAGRAM_VIEW));
+  const actions = actionsOf(block);
+  if (actions.querySelector('[data-mermaid-view-toggle]') === null) {
+    const view = viewButton(document, DIAGRAM_VIEW);
+    view.setAttribute('data-mermaid-view-toggle', '');
+    actions.append(view);
   }
+  scaleInto(block, canvas);
 }
 
 function failInto(block: HTMLElement, message = DIAGRAM_FAILED): void {
   block.querySelector('[data-mermaid-canvas]')?.remove();
-  block.querySelector('[data-mermaid-toggle]')?.remove();
+  block.querySelector('[data-mermaid-actions]')?.remove();
+  block.removeAttribute('data-mermaid-fit');
   block.setAttribute('data-mermaid-view', SOURCE_VIEW);
   noteOf(block, message);
 }

--- a/apps/web/src/features/docs/mermaid.ts
+++ b/apps/web/src/features/docs/mermaid.ts
@@ -189,6 +189,7 @@ function scaleButton(document: Document): HTMLButtonElement {
     if (block === null) return;
     const fits = !block.hasAttribute('data-mermaid-fit');
     block.toggleAttribute('data-mermaid-fit', fits);
+    block.setAttribute('data-mermaid-scaled-by-hand', '');
     applyScale(button, fits);
   });
   return button;
@@ -217,7 +218,30 @@ function actionsOf(block: HTMLElement): HTMLElement {
 export function naturalWidth(drawn: SVGSVGElement): number {
   const box = drawn.viewBox?.baseVal ?? null;
   if (box !== null && box.width > 0) return box.width;
+  const declared = Number.parseFloat(drawn.getAttribute('width') ?? '');
+  if (Number.isFinite(declared) && declared > 0) return declared;
   return drawn.getBoundingClientRect().width;
+}
+
+const widthWatchers = new WeakMap<HTMLElement, ResizeObserver>();
+
+function unwatchWidth(canvas: HTMLElement): void {
+  widthWatchers.get(canvas)?.disconnect();
+  widthWatchers.delete(canvas);
+}
+
+function watchWidth(block: HTMLElement, canvas: HTMLElement): void {
+  unwatchWidth(canvas);
+  if (typeof ResizeObserver === 'undefined') return;
+  let last = canvas.clientWidth;
+  const observer = new ResizeObserver(() => {
+    if (canvas.clientWidth === last) return;
+    last = canvas.clientWidth;
+    if (block.hasAttribute('data-mermaid-scaled-by-hand')) return;
+    scaleInto(block, canvas);
+  });
+  observer.observe(canvas);
+  widthWatchers.set(canvas, observer);
 }
 
 function scaleInto(block: HTMLElement, canvas: HTMLElement): void {
@@ -308,6 +332,7 @@ function drawInto(block: HTMLElement, svg: string): void {
   canvas.setAttribute('aria-label', DIAGRAM_LABEL);
   canvas.innerHTML = svg;
   inkLabels(canvas);
+  block.removeAttribute('data-mermaid-scaled-by-hand');
   block.setAttribute('data-mermaid-view', DIAGRAM_VIEW);
   const actions = actionsOf(block);
   if (actions.querySelector('[data-mermaid-expand]') === null) {
@@ -319,10 +344,13 @@ function drawInto(block: HTMLElement, svg: string): void {
     actions.append(view);
   }
   scaleInto(block, canvas);
+  watchWidth(block, canvas);
 }
 
 function failInto(block: HTMLElement, message = DIAGRAM_FAILED): void {
-  block.querySelector('[data-mermaid-canvas]')?.remove();
+  const canvas = block.querySelector<HTMLElement>('[data-mermaid-canvas]');
+  if (canvas !== null) unwatchWidth(canvas);
+  canvas?.remove();
   block.querySelector('[data-mermaid-actions]')?.remove();
   block.removeAttribute('data-mermaid-fit');
   block.setAttribute('data-mermaid-view', SOURCE_VIEW);

--- a/apps/web/src/features/docs/mermaid.ts
+++ b/apps/web/src/features/docs/mermaid.ts
@@ -9,12 +9,20 @@ export const SHOW_SOURCE_LABEL = 'Show the diagram source';
 export const SHOW_DIAGRAM_LABEL = 'Show the diagram';
 export const DIAGRAM_FAILED = 'This diagram could not be drawn.';
 export const DIAGRAM_UNAVAILABLE = 'The diagram renderer could not be loaded.';
-export const FIT_LABEL = 'Fit the diagram to the page';
+export const FIT_LABEL = 'Fit the diagram to the column';
 export const ACTUAL_LABEL = 'Show the diagram at its own size';
 export const LEGIBLE_SCALE = 0.75;
 export const DARK_INK = '#10131a';
 export const LIGHT_INK = '#f4f5f7';
 export const PALE_FILL = 0.55;
+export const EXPAND_LABEL = 'Open the diagram in a viewer';
+export const DIAGRAM_LABEL = 'Diagram';
+export const DIAGRAM_OPEN_EVENT = 'orbit:diagram-open';
+
+export interface DiagramOpenDetail {
+  readonly svg: string;
+  readonly label: string;
+}
 
 export const mermaidClassName = cn(
   '[&_[data-mermaid]]:relative [&_[data-mermaid]]:my-5',
@@ -154,6 +162,24 @@ function applyView(button: HTMLButtonElement, view: string): void {
   button.setAttribute('aria-label', showsDiagram ? SHOW_SOURCE_LABEL : SHOW_DIAGRAM_LABEL);
 }
 
+function expandButton(document: Document): HTMLButtonElement {
+  const button = actionButton(document);
+  button.setAttribute('data-mermaid-expand', '');
+  button.textContent = 'Expand';
+  button.setAttribute('aria-label', EXPAND_LABEL);
+  button.addEventListener('click', () => {
+    const block = button.closest<HTMLElement>(MERMAID_BLOCK);
+    const canvas = block?.querySelector('[data-mermaid-canvas]') ?? null;
+    if (block === null || canvas === null) return;
+    const detail: DiagramOpenDetail = {
+      svg: canvas.innerHTML,
+      label: canvas.getAttribute('aria-label') ?? 'Diagram',
+    };
+    block.dispatchEvent(new CustomEvent(DIAGRAM_OPEN_EVENT, { detail, bubbles: true }));
+  });
+  return button;
+}
+
 function scaleButton(document: Document): HTMLButtonElement {
   const button = actionButton(document);
   button.setAttribute('data-mermaid-scale', '');
@@ -269,7 +295,7 @@ const PADDING = 32;
 
 let sequence = 0;
 
-function drawInto(block: HTMLElement, svg: string, source: string): void {
+function drawInto(block: HTMLElement, svg: string): void {
   const document = block.ownerDocument;
   block.querySelector('[data-mermaid-note]')?.remove();
   let canvas = block.querySelector<HTMLElement>('[data-mermaid-canvas]');
@@ -279,11 +305,14 @@ function drawInto(block: HTMLElement, svg: string, source: string): void {
     block.prepend(canvas);
   }
   canvas.setAttribute('role', 'img');
-  canvas.setAttribute('aria-label', `Diagram: ${source.split('\n')[0] ?? ''}`.trim());
+  canvas.setAttribute('aria-label', DIAGRAM_LABEL);
   canvas.innerHTML = svg;
   inkLabels(canvas);
   block.setAttribute('data-mermaid-view', DIAGRAM_VIEW);
   const actions = actionsOf(block);
+  if (actions.querySelector('[data-mermaid-expand]') === null) {
+    actions.append(expandButton(document));
+  }
   if (actions.querySelector('[data-mermaid-view-toggle]') === null) {
     const view = viewButton(document, DIAGRAM_VIEW);
     view.setAttribute('data-mermaid-view-toggle', '');
@@ -384,6 +413,6 @@ export async function drawDiagrams(
       failInto(block);
       continue;
     }
-    drawInto(block, svg, source);
+    drawInto(block, svg);
   }
 }

--- a/apps/web/tests/features/docs/diagram-viewer.test.tsx
+++ b/apps/web/tests/features/docs/diagram-viewer.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   clampScale,
@@ -82,6 +82,33 @@ describe('the diagram viewer', () => {
 
     await user.keyboard('0');
     expect(moved.style.transform).toContain('translate(0px, 0px)');
+  });
+
+  it('pans while a pointer drags across it', () => {
+    render(<DiagramViewer svg={SVG} label="Diagram" onClose={mock()} />);
+    const viewport = screen.getByTestId('diagram-viewport');
+    const moved = viewport.firstElementChild as HTMLElement;
+
+    fireEvent.pointerDown(viewport, { pointerId: 1, clientX: 200, clientY: 120 });
+    fireEvent.pointerMove(viewport, { pointerId: 1, clientX: 260, clientY: 150 });
+
+    expect(moved.style.transform).toContain('translate(60px, 30px)');
+
+    fireEvent.pointerUp(viewport, { pointerId: 1 });
+    fireEvent.pointerMove(viewport, { pointerId: 1, clientX: 400, clientY: 400 });
+
+    expect(moved.style.transform).toContain('translate(60px, 30px)');
+  });
+
+  it('zooms with the wheel, in the direction the wheel turned', () => {
+    render(<DiagramViewer svg={SVG} label="Diagram" onClose={mock()} />);
+    const viewport = screen.getByTestId('diagram-viewport');
+
+    fireEvent.wheel(viewport, { deltaY: -120 });
+    expect(screen.getByTestId('diagram-zoom').textContent).toBe('125%');
+
+    fireEvent.wheel(viewport, { deltaY: 120 });
+    expect(screen.getByTestId('diagram-zoom').textContent).toBe('100%');
   });
 
   it('closes when the reader asks it to', async () => {

--- a/apps/web/tests/features/docs/diagram-viewer.test.tsx
+++ b/apps/web/tests/features/docs/diagram-viewer.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  clampScale,
+  DiagramViewer,
+  MAX_SCALE,
+  MIN_SCALE,
+  scaleToFit,
+} from '@/features/docs/diagram-viewer.tsx';
+
+afterEach(cleanup);
+
+const SVG = '<svg role="graphics-document" viewBox="0 0 2000 400"><g></g></svg>';
+
+describe('the scale a diagram opens at', () => {
+  it('shrinks a wide diagram to the viewport and never enlarges a small one', () => {
+    expect(scaleToFit(2000, 1000)).toBe(0.5);
+    expect(scaleToFit(400, 1000)).toBe(1);
+  });
+
+  it('stays inside the range the controls can reach', () => {
+    expect(scaleToFit(100_000, 100)).toBe(MIN_SCALE);
+    expect(clampScale(99)).toBe(MAX_SCALE);
+    expect(clampScale(0)).toBe(MIN_SCALE);
+  });
+
+  it('answers 1 before the viewport has been measured', () => {
+    expect(scaleToFit(0, 1000)).toBe(1);
+    expect(scaleToFit(2000, 0)).toBe(1);
+  });
+});
+
+describe('the diagram viewer', () => {
+  it('stays shut until a diagram is handed to it', () => {
+    render(<DiagramViewer svg={null} label="Diagram" onClose={mock()} />);
+
+    expect(screen.queryByTestId('diagram-viewer')).toBeNull();
+  });
+
+  it('shows the diagram with controls for zoom, pan and fit', () => {
+    render(<DiagramViewer svg={SVG} label="Edge and traffic path" onClose={mock()} />);
+
+    expect(screen.getByTestId('diagram-viewer')).toBeInTheDocument();
+    expect(screen.getByText('Edge and traffic path')).toBeInTheDocument();
+    for (const label of [
+      'Zoom in',
+      'Zoom out',
+      'Pan up',
+      'Pan down',
+      'Pan left',
+      'Pan right',
+      'Fit the diagram to the viewer',
+    ]) {
+      expect(screen.getByLabelText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('reports the zoom it is at, and moves it a step at a time', async () => {
+    const user = userEvent.setup();
+    render(<DiagramViewer svg={SVG} label="Diagram" onClose={mock()} />);
+
+    expect(screen.getByTestId('diagram-zoom').textContent).toBe('100%');
+
+    await user.click(screen.getByLabelText('Zoom in'));
+    expect(screen.getByTestId('diagram-zoom').textContent).toBe('125%');
+
+    await user.click(screen.getByLabelText('Zoom out'));
+    expect(screen.getByTestId('diagram-zoom').textContent).toBe('100%');
+  });
+
+  it('pans with the arrow keys and returns home on 0', async () => {
+    const user = userEvent.setup();
+    render(<DiagramViewer svg={SVG} label="Diagram" onClose={mock()} />);
+
+    const viewport = screen.getByTestId('diagram-viewport');
+    screen.getByTestId('diagram-viewer').focus();
+    await user.keyboard('{ArrowRight}');
+
+    const moved = viewport.firstElementChild as HTMLElement;
+    expect(moved.style.transform).toContain('translate(-80px, 0px)');
+
+    await user.keyboard('0');
+    expect(moved.style.transform).toContain('translate(0px, 0px)');
+  });
+
+  it('closes when the reader asks it to', async () => {
+    const user = userEvent.setup();
+    const onClose = mock();
+    render(<DiagramViewer svg={SVG} label="Diagram" onClose={onClose} />);
+
+    await user.click(screen.getByLabelText('Close'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/tests/features/docs/doc-mermaid.test.tsx
+++ b/apps/web/tests/features/docs/doc-mermaid.test.tsx
@@ -7,6 +7,8 @@ import {
   DIAGRAM_FAILED,
   DIAGRAM_UNAVAILABLE,
   drawDiagrams,
+  fitsTheColumn,
+  LEGIBLE_SCALE,
   type MermaidRenderer,
   mermaidConfig,
   SHOW_DIAGRAM_LABEL,
@@ -165,6 +167,29 @@ describe('the drawn markup', () => {
 
     expect(mermaidConfig(styles, false).htmlLabels).toBe(false);
     expect(mermaidConfig(styles, false).flowchart?.htmlLabels).toBe(false);
+  });
+});
+
+describe('a diagram wider than the column', () => {
+  it('is scaled down only while it stays legible, and otherwise keeps its own size', () => {
+    expect(fitsTheColumn(600, 700)).toBe(true);
+    expect(fitsTheColumn(800, 700)).toBe(true);
+    expect(fitsTheColumn(3000, 700)).toBe(false);
+    expect(fitsTheColumn(700 / LEGIBLE_SCALE, 700)).toBe(true);
+    expect(fitsTheColumn(700 / LEGIBLE_SCALE + 1, 700)).toBe(false);
+  });
+
+  it('decides nothing before the page has laid the block out', () => {
+    expect(fitsTheColumn(0, 700)).toBe(false);
+    expect(fitsTheColumn(600, 0)).toBe(false);
+  });
+
+  it('asks mermaid for the diagram at its own size, never squeezed into the column', () => {
+    const styles = { getPropertyValue: () => '' } as unknown as CSSStyleDeclaration;
+    const config = mermaidConfig(styles, false);
+
+    expect(config.flowchart?.useMaxWidth).toBe(false);
+    expect(config.sequence?.useMaxWidth).toBe(false);
   });
 });
 

--- a/apps/web/tests/features/docs/doc-mermaid.test.tsx
+++ b/apps/web/tests/features/docs/doc-mermaid.test.tsx
@@ -5,7 +5,9 @@ import userEvent from '@testing-library/user-event';
 import { DocBody, docProseClassName } from '@/features/docs/doc-body.tsx';
 import {
   DIAGRAM_FAILED,
+  DIAGRAM_OPEN_EVENT,
   DIAGRAM_UNAVAILABLE,
+  type DiagramOpenDetail,
   drawDiagrams,
   fitsTheColumn,
   LEGIBLE_SCALE,
@@ -98,7 +100,7 @@ describe('a mermaid diagram in a doc', () => {
 
     await drawDiagrams(host, 'light', () => Promise.resolve(renderer));
 
-    const toggle = host.querySelector<HTMLButtonElement>('[data-mermaid-toggle]');
+    const toggle = host.querySelector<HTMLButtonElement>('[data-mermaid-view-toggle]');
     expect(toggle?.getAttribute('aria-label')).toBe(SHOW_SOURCE_LABEL);
     if (toggle === null) throw new Error('no toggle');
 
@@ -211,6 +213,21 @@ describe('the diagram palette', () => {
 });
 
 describe('the diagram chrome', () => {
+  it('offers a viewer for a diagram that outgrew the column', async () => {
+    const host = blockFrom(DIAGRAM);
+    const { renderer } = fakeMermaid(SVG);
+    const opened: string[] = [];
+    host.addEventListener(DIAGRAM_OPEN_EVENT, (event) => {
+      opened.push((event as CustomEvent<DiagramOpenDetail>).detail.svg);
+    });
+
+    await drawDiagrams(host, 'light', () => Promise.resolve(renderer));
+    host.querySelector<HTMLButtonElement>('[data-mermaid-expand]')?.click();
+
+    expect(opened).toHaveLength(1);
+    expect(opened[0]).toContain('graphics-hint');
+  });
+
   it('reveals the toggle on hover and keeps it visible while the source is showing', () => {
     expect(docProseClassName).toContain(
       '[&_[data-mermaid]:hover_[data-mermaid-toggle]]:opacity-100',

--- a/apps/web/tests/features/docs/doc-mermaid.test.tsx
+++ b/apps/web/tests/features/docs/doc-mermaid.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { DocBody, docProseClassName } from '@/features/docs/doc-body.tsx';
 import {
   DIAGRAM_FAILED,
+  DIAGRAM_LABEL,
   DIAGRAM_OPEN_EVENT,
   DIAGRAM_UNAVAILABLE,
   type DiagramOpenDetail,
@@ -238,16 +239,17 @@ describe('the diagram chrome', () => {
   it('offers a viewer for a diagram that outgrew the column', async () => {
     const host = blockFrom(DIAGRAM);
     const { renderer } = fakeMermaid(SVG);
-    const opened: string[] = [];
+    const opened: DiagramOpenDetail[] = [];
     host.addEventListener(DIAGRAM_OPEN_EVENT, (event) => {
-      opened.push((event as CustomEvent<DiagramOpenDetail>).detail.svg);
+      opened.push((event as CustomEvent<DiagramOpenDetail>).detail);
     });
 
     await drawDiagrams(host, 'light', () => Promise.resolve(renderer));
     host.querySelector<HTMLButtonElement>('[data-mermaid-expand]')?.click();
 
     expect(opened).toHaveLength(1);
-    expect(opened[0]).toContain('graphics-hint');
+    expect(opened[0]?.svg).toContain('graphics-hint');
+    expect(opened[0]?.label).toBe(DIAGRAM_LABEL);
   });
 
   it('reveals the toggle on hover and keeps it visible while the source is showing', () => {

--- a/apps/web/tests/features/docs/doc-mermaid.test.tsx
+++ b/apps/web/tests/features/docs/doc-mermaid.test.tsx
@@ -13,6 +13,7 @@ import {
   LEGIBLE_SCALE,
   type MermaidRenderer,
   mermaidConfig,
+  naturalWidth,
   SHOW_DIAGRAM_LABEL,
   SHOW_SOURCE_LABEL,
   safeSvg,
@@ -192,6 +193,27 @@ describe('a diagram wider than the column', () => {
 
     expect(config.flowchart?.useMaxWidth).toBe(false);
     expect(config.sequence?.useMaxWidth).toBe(false);
+    expect(config.gantt?.useMaxWidth).toBe(false);
+  });
+});
+
+describe('the width a diagram is measured at', () => {
+  function svgWith(attributes: Record<string, string>): SVGSVGElement {
+    const element = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    for (const [name, value] of Object.entries(attributes)) element.setAttribute(name, value);
+    return element as unknown as SVGSVGElement;
+  }
+
+  it('reads the size the diagram was drawn at, not the size css left it', () => {
+    expect(naturalWidth(svgWith({ width: '1600', viewBox: '0 0 1600 400' }))).toBe(1600);
+  });
+
+  it('falls back to the declared width when the view box is out of reach', () => {
+    expect(naturalWidth(svgWith({ width: '820' }))).toBe(820);
+  });
+
+  it('answers 0 when a diagram declares nothing, so no decision is taken on it', () => {
+    expect(naturalWidth(svgWith({}))).toBe(0);
   });
 });
 


### PR DESCRIPTION
A wide diagram was scaled down to the column until its labels were unreadable, a node with a hardcoded fill kept themed label ink, and a diagram bigger than the column had nowhere to be seen in full.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes Mermaid diagrams retain a legible natural size when necessary and adds a full-screen viewer with zoom and pan controls.
- Recalculates reader and editor diagram fitting as their containers resize.
- Adds explicit fit and actual-size controls for wide diagrams.
- Corrects Mermaid label contrast for custom node fills.
- Adds unit and end-to-end coverage for fitting, resizing, viewer controls, and theme-aware label ink.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/docs/mermaid.ts | Adds responsive fit recalculation, scale and viewer actions, natural-width measurement, and contrast-aware label coloring; the previously reported stale-fit path is addressed. |
| apps/web/src/features/docs/diagram-viewer.tsx | Introduces a dialog viewer with fit, zoom, keyboard, pointer-drag, wheel, and directional pan controls. |
| apps/web/src/features/docs/editor/code-block-view.tsx | Updates editor previews to preserve wide-diagram legibility, observe container resizes, and open diagrams in the viewer. |
| apps/web/src/features/docs/doc-body.tsx | Connects rendered document diagrams to the new viewer through a bubbling diagram-open event. |
| apps/web/e2e/doc-mermaid.spec.ts | Verifies both directions of responsive fit recalculation, natural-size overflow, label contrast, and viewer interactions. |
| apps/web/tests/features/docs/diagram-viewer.test.tsx | Covers viewer scale bounds, zoom, pan, drag, wheel, fit reset, visibility, and close behavior. |
| apps/web/tests/features/docs/doc-mermaid.test.tsx | Covers fit thresholds, natural-width extraction, Mermaid sizing configuration, and viewer event details. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Mermaid source] --> B[Render and sanitize SVG]
  B --> C[Measure natural width]
  C --> D{Fits legibly?}
  D -->|Yes| E[Fit to document column]
  D -->|No| F[Keep natural size with scrolling]
  E --> G[Observe container resize]
  F --> G
  G --> C
  E --> H[Open full-screen viewer]
  F --> H
  H --> I[Zoom and pan]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge main into docs-mermaid-legibility"](https://github.com/noveum/orbit/commit/b5b2330919338f25eab27b3c44e5a831e4d5a3ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53325023)</sub>

<!-- /greptile_comment -->