### PR TITLE
Ci/add links check

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
 
@@ -30,5 +30,5 @@ jobs:
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
         with:
           args: >-
-            "**/*.md" --exclude-path "node_modules|docs/assets"
+            "**/*.md" --exclude-path "node_modules|docs/assets" --exclude-all-private --exclude 'github\.com/[^/]+/[^/]+/stargazers'
         continue-on-error: true

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,33 @@
+name: Check links
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+  schedule:
+    - cron: '0 3 * * 1'
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check relative links (fail on error)
+        uses: lycheeverse/lychee-action@2c1f47c8b6b9d8e3f4a5b6c7d8e9f0a1b2c3d4e5
+        with:
+          args: --relative --exclude docs/assets/** --exclude node_modules/**
+
+      - name: Check external links (non-blocking)
+        uses: lycheeverse/lychee-action@2c1f47c8b6b9d8e3f4a5b6c7d8e9f0a1b2c3d4e5
+        with:
+          args: --exclude docs/assets/** --exclude node_modules/**
+        continue-on-error: true

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -2,8 +2,7 @@ name: Check links
 
 on:
   pull_request:
-    paths:
-      - '**/*.md'
+  workflow_dispatch:
   schedule:
     - cron: '0 3 * * 1'
 
@@ -22,12 +21,14 @@ jobs:
           fetch-depth: 0
 
       - name: Check relative links (fail on error)
-        uses: lycheeverse/lychee-action@2c1f47c8b6b9d8e3f4a5b6c7d8e9f0a1b2c3d4e5
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
         with:
-          args: --relative --exclude docs/assets/** --exclude node_modules/**
+          args: >-
+            --offline "**/*.md" --exclude-path "node_modules|docs/assets"
 
       - name: Check external links (non-blocking)
-        uses: lycheeverse/lychee-action@2c1f47c8b6b9d8e3f4a5b6c7d8e9f0a1b2c3d4e5
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
         with:
-          args: --exclude docs/assets/** --exclude node_modules/**
+          args: >-
+            "**/*.md" --exclude-path "node_modules|docs/assets"
         continue-on-error: true

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Check external links (non-blocking)
         uses: lycheeverse/lychee-action@2c1f47c8b6b9d8e3f4a5b6c7d8e9f0a1b2c3d4e5
         with:
-          args: --exclude docs/assets/** /**
+          args: /assets/** /**
         continue-on-error: true

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Check relative links (fail on error)
         uses: lycheeverse/lychee-action@2c1f47c8b6b9d8e3f4a5b6c7d8e9f0a1b2c3d4e5
         with:
-          args: --relative --exclude docs/assets/** --exclude node_modules/**
+          args: --relative --exclude docs/assets/** /**
 
       - name: Check external links (non-blocking)
         uses: lycheeverse/lychee-action@2c1f47c8b6b9d8e3f4a5b6c7d8e9f0a1b2c3d4e5
         with:
-          args: --exclude docs/assets/** --exclude node_modules/**
+          args: --exclude docs/assets/** /**
         continue-on-error: true

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
   links:
@@ -18,17 +17,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Check relative links (fail on error)
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
         with:
           args: >-
-            --offline "**/*.md" --exclude-path "node_modules|docs/assets"
+            --offline "**/*.md" --exclude-path "(^|/)node_modules/|^docs/assets/"
 
       - name: Check external links (non-blocking)
+        id: external
+        if: ${{ !cancelled() }}
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
         with:
           args: >-
-            "**/*.md" --exclude-path "node_modules|docs/assets" --exclude-all-private --exclude 'github\.com/[^/]+/[^/]+/stargazers'
-        continue-on-error: true
+            "**/*.md" --exclude-path "(^|/)node_modules/|^docs/assets/" --exclude-all-private --exclude 'github\.com/[^/]+/[^/]+/stargazers'
+          fail: false
+
+      - name: The external check itself must not be broken
+        if: ${{ !cancelled() }}
+        run: |
+          code="${{ steps.external.outputs.exit_code }}"
+          if [ "$code" != "0" ] && [ "$code" != "2" ]; then
+            echo "lychee exited $code, a runtime or configuration failure rather than link rot"
+            exit 1
+          fi

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Check relative links (fail on error)
         uses: lycheeverse/lychee-action@2c1f47c8b6b9d8e3f4a5b6c7d8e9f0a1b2c3d4e5
         with:
-          args: --relative --exclude docs/assets/** /**
+          args: --relative --exclude docs/assets/** --exclude node_modules/**
 
       - name: Check external links (non-blocking)
         uses: lycheeverse/lychee-action@2c1f47c8b6b9d8e3f4a5b6c7d8e9f0a1b2c3d4e5
         with:
-          args: /assets/** /**
+          args: --exclude docs/assets/** --exclude node_modules/**
         continue-on-error: true


### PR DESCRIPTION
<!-- Thanks for contributing. Keep this short. The parts reviewers actually read are what changed and how you know it works. -->

## What this changes
Add a CI workflow at `.github/workflows/links.ym` that runs lychee-action to validate Markdown links. It:

Runs on pull requests that touch **/*.md and on a weekly schedule.
Fails the job on broken relative links (our responsibility).
Does not fail the job on external links (non-blocking).
Ignores docs/assets/** and node_modules/**.
Pins lychee-action to a full commit SHA
<!-- One or two sentences. -->

## Why
Relative links between docs are fragile after renames and currently go uncaught  a single rename can silently produce multiple 404s. This workflow prevents regressions by failing PRs that introduce broken relative links while avoiding noisy failures from transient external link rot.
<!-- The problem this solves. Link the issue: Closes #123 -->

Closes #132 

## How you know it works

- I ran a repo-wide relative-link scan (excluding node_modules and docs/assets) and found 0 broken relative links.

- Created branch ci/add-links-check and pushed to the fork; local pre-push checks including bun run verify completed successfully.

- The workflow will execute on the PR and again on the weekly schedule to catch external rot without blocking contributors.

Quick local checks you can run:

```
bun install --frozen-lockfile
bun run verify
# quick scan used during validation:
python3 - <<'PY'
import re,os
p=re.compile(r"\]\((\.{1,2}/[^)\s]+)\)")
bad=[]
for d,r,fs in os.walk('.'):
  if 'node_modules' in d.split('/') or '.git' in d.split('/'): continue
  for f in fs:
    if not f.endswith('.md'): continue
    s=open(os.path.join(d,f),encoding='utf-8').read()
    for m in p.finditer(s):
      link=m.group(1).split('#',1)[0]
      if 'docs/assets/' in link: continue
      if not os.path.exists(os.path.normpath(os.path.join(d,link))): bad.append((d+'/'+f,link))
print('BROKEN',len(bad))
for b in bad: print(b)
PY 
```
<!-- The test you added, the manual check you ran, or both. "A feature is not done until it has a test that would fail if the feature broke." -->

## Screenshots
<img width="955" height="524" alt="image" src="https://github.com/user-attachments/assets/efab2d42-9a80-4e69-bf07-9ebe9753fab8" />
<img width="955" height="524" alt="image" src="https://github.com/user-attachments/assets/fe5012e7-7467-429a-8b83-7211583fad11" />


<!-- Anything visual needs a before and after. Both themes if you touched styling. Delete this section if the change is not visual. -->

## Checklist

- [ ] `bun run verify` is green, all four checks
- [ ] Tests added or updated, and they fail without the change
- [ ] No comments added to code, and no em-dash characters anywhere
- [ ] No `any`, no non-null assertions
- [ ] External input is parsed with a Zod schema from `@orbit/shared`
- [ ] Authorization is enforced on the server through `packages/shared/src/policy`, not only in the UI
- [ ] Docs updated if behaviour, configuration or setup changed
- [ ] `bun run db:release` and `bun run db:check-drift` passed against the target database before this ships

## Anything reviewers should know

- I intentionally excluded node_modules/** and docs/assets/** to avoid false positives from vendor READMEs and generated assets.

- The action is pinned to a full commit SHA; please update the SHA when we intentionally upgrade lychee-action.

- External links are checked but continue-on-error is used so temporary external failures won’t block contributors. If you'd like stricter handling for a subset of links, I can extend the workflow to treat specific domains as required.

<!-- Trade-offs you made, alternatives you rejected, parts you are unsure about. Flagging your own doubts speeds review up more than anything else. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a read-only link-checking workflow for Markdown files.
- Runs relative-link validation as a blocking check.
- Runs external-link validation without blocking on ordinary link failures.
- Supports pull-request, manual, and weekly scheduled execution.
- Pins checkout and lychee actions to immutable commit revisions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/links.yml | Adds the Markdown link-check workflow and resolves the previously reported missing input, invalid action revision, and mutable checkout reference issues. |

</details>

<sub>Reviews (6): Last reviewed commit: ["ci(links): stop the external check from ..."](https://github.com/noveum/orbit/commit/3acc6114484bfc120f3a037c05cc254973150db4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53455319)</sub>

<!-- /greptile_comment -->