### PR TITLE
fix(docs): enforce row-level security on doc collection deletion

### DIFF
--- a/packages/core/src/content/doc-service.ts
+++ b/packages/core/src/content/doc-service.ts
@@ -257,16 +257,25 @@ export async function docReadableBy(
   return canReadDoc(principal, doc, await grantedDocIds(executor, principal, [doc.id]));
 }
 
+export function evaluateDocAccessLevel(
+  principal: Principal,
+  doc: DocRow,
+  hasWriteGrant: boolean,
+): DocAccessLevel {
+  if (!can(principal, 'doc:write')) return 'read';
+  if (principal.role === 'admin') return 'write';
+  if (doc.authorId === principal.userId) return 'write';
+  if (!isRestricted(doc.visibility)) return 'write';
+  return hasWriteGrant ? 'write' : 'read';
+}
+
 export async function docAccessLevel(
   executor: Executor,
   principal: Principal,
   doc: DocRow,
 ): Promise<DocAccessLevel> {
-  if (!can(principal, 'doc:write')) return 'read';
-  if (principal.role === 'admin') return 'write';
-  if (doc.authorId === principal.userId) return 'write';
-  if (!isRestricted(doc.visibility)) return 'write';
-  return (await writeGrantedDocIds(executor, principal, doc.id)) ? 'write' : 'read';
+  const granted = await writeGrantedDocIds(executor, principal, doc.id);
+  return evaluateDocAccessLevel(principal, doc, granted);
 }
 
 export async function assertDocWritable(
@@ -310,16 +319,7 @@ async function assertDocsMovable(
   const blockingReadable: string[] = [];
   let blockingInvisibleCount = 0;
   for (const doc of docsToCheck) {
-    let canWrite = false;
-    if (principal.role === 'admin') {
-      canWrite = true;
-    } else if (doc.authorId === principal.userId) {
-      canWrite = true;
-    } else if (isRestricted(doc.visibility)) {
-      canWrite = writeGrants.has(doc.id);
-    } else {
-      canWrite = true;
-    }
+    const canWrite = evaluateDocAccessLevel(principal, doc, writeGrants.has(doc.id)) === 'write';
     if (!canWrite) {
       const canRead = canReadDoc(principal, doc, readGrantedArray);
       if (canRead) {
@@ -1581,8 +1581,9 @@ async function emptyCollection(
     .where(
       and(eq(schema.doc.organizationId, organizationId), eq(schema.doc.collectionId, collectionId)),
     );
-
+  if (docsToCheck.length === 0) return [];
   await assertDocsMovable(executor, principal, docsToCheck);
+  const docIds = docsToCheck.map((doc) => doc.id);
   const base = await nextSiblingOrder(executor, organizationId, {
     collectionId: reassignToId,
     projectId: null,
@@ -1592,7 +1593,11 @@ async function emptyCollection(
     .update(schema.doc)
     .set({ collectionId: reassignToId, updatedAt: new Date(), syncId })
     .where(
-      and(eq(schema.doc.organizationId, organizationId), eq(schema.doc.collectionId, collectionId)),
+      and(
+        eq(schema.doc.organizationId, organizationId),
+        eq(schema.doc.collectionId, collectionId),
+        inArray(schema.doc.id, docIds),
+      ),
     )
     .returning({ id: schema.doc.id, parentId: schema.doc.parentId });
   if (orphaned.length === 0) return [];

--- a/packages/core/src/content/doc-service.ts
+++ b/packages/core/src/content/doc-service.ts
@@ -210,17 +210,18 @@ async function grantedDocIds(
   return rows.map((row) => row.docId);
 }
 
-async function writeGrantedDocIds(
+async function batchedWriteGrantedDocIds(
   executor: Executor,
   principal: Principal,
-  docId: string,
-): Promise<boolean> {
+  docIds: readonly string[],
+): Promise<string[]> {
+  if (docIds.length === 0) return [];
   const rows = await executor
     .select({ docId: schema.docAccess.docId })
     .from(schema.docAccess)
     .where(
       and(
-        eq(schema.docAccess.docId, docId),
+        inArray(schema.docAccess.docId, [...docIds]),
         eq(schema.docAccess.level, 'write'),
         or(
           and(
@@ -235,9 +236,17 @@ async function writeGrantedDocIds(
               ),
         ),
       ),
-    )
-    .limit(1);
-  return rows.length > 0;
+    );
+  return rows.map((row) => row.docId);
+}
+
+async function writeGrantedDocIds(
+  executor: Executor,
+  principal: Principal,
+  docId: string,
+): Promise<boolean> {
+  const granted = await batchedWriteGrantedDocIds(executor, principal, [docId]);
+  return granted.length > 0;
 }
 
 export async function docReadableBy(
@@ -267,6 +276,63 @@ export async function assertDocWritable(
 ): Promise<void> {
   if ((await docAccessLevel(executor, principal, doc)) === 'write') return;
   throw forbidden('You only have read access to that doc.');
+}
+
+function buildBlockingMessage(blockingReadable: string[], blockingInvisibleCount: number): string {
+  const totalBlocking = blockingReadable.length + blockingInvisibleCount;
+  const noun = totalBlocking === 1 ? 'page' : 'pages';
+  const verb = totalBlocking === 1 ? 'is' : 'are';
+  let msg = `${totalBlocking} ${noun} in this folder ${verb} not yours to move`;
+  if (blockingReadable.length > 0) {
+    msg += `: ${blockingReadable.join(', ')}`;
+  }
+  if (blockingInvisibleCount > 0) {
+    msg +=
+      blockingReadable.length > 0
+        ? `, and ${blockingInvisibleCount} more you cannot see.`
+        : `. You cannot see ${blockingInvisibleCount === 1 ? 'it' : 'them'}.`;
+  } else {
+    msg += '.';
+  }
+  return msg;
+}
+
+async function assertDocsMovable(
+  executor: Executor,
+  principal: Principal,
+  docsToCheck: DocRow[],
+): Promise<void> {
+  if (docsToCheck.length === 0) return;
+  const docIds = docsToCheck.map((doc) => doc.id);
+  const readGrantedArray = await grantedDocIds(executor, principal, docIds);
+  const writeGrantedArray = await batchedWriteGrantedDocIds(executor, principal, docIds);
+  const writeGrants = new Set(writeGrantedArray);
+  const blockingReadable: string[] = [];
+  let blockingInvisibleCount = 0;
+  for (const doc of docsToCheck) {
+    let canWrite = false;
+    if (principal.role === 'admin') {
+      canWrite = true;
+    } else if (doc.authorId === principal.userId) {
+      canWrite = true;
+    } else if (isRestricted(doc.visibility)) {
+      canWrite = writeGrants.has(doc.id);
+    } else {
+      canWrite = true;
+    }
+    if (!canWrite) {
+      const canRead = canReadDoc(principal, doc, readGrantedArray);
+      if (canRead) {
+        blockingReadable.push(doc.title);
+      } else {
+        blockingInvisibleCount++;
+      }
+    }
+  }
+  const totalBlocking = blockingReadable.length + blockingInvisibleCount;
+  if (totalBlocking > 0) {
+    throw forbidden(buildBlockingMessage(blockingReadable, blockingInvisibleCount));
+  }
 }
 
 function assertMayWiden(principal: Principal, current: DocRow, next: string | undefined): void {
@@ -1493,11 +1559,30 @@ export async function updateDocCollection(
 
 async function emptyCollection(
   executor: Executor,
-  organizationId: string,
   collectionId: string,
   syncId: number,
   reassignToId: string | null,
+  principal: Principal,
 ): Promise<DocRow[]> {
+  const organizationId = principal.organizationId;
+  await executor
+    .select({ id: schema.docCollection.id })
+    .from(schema.docCollection)
+    .where(
+      and(
+        eq(schema.docCollection.organizationId, organizationId),
+        eq(schema.docCollection.id, collectionId),
+      ),
+    )
+    .for('update');
+  const docsToCheck = await executor
+    .select(DOC_COLUMNS)
+    .from(schema.doc)
+    .where(
+      and(eq(schema.doc.organizationId, organizationId), eq(schema.doc.collectionId, collectionId)),
+    );
+
+  await assertDocsMovable(executor, principal, docsToCheck);
   const base = await nextSiblingOrder(executor, organizationId, {
     collectionId: reassignToId,
     projectId: null,
@@ -1511,7 +1596,6 @@ async function emptyCollection(
     )
     .returning({ id: schema.doc.id, parentId: schema.doc.parentId });
   if (orphaned.length === 0) return [];
-
   const roots = orphaned.filter((row) => row.parentId === null).map((row) => row.id);
   if (roots.length > 0) {
     await renumber(executor, inArray(schema.doc.id, roots), base - SORT_ORDER_STEP, syncId);
@@ -1536,7 +1620,6 @@ export async function deleteDocCollection(
   if (reassignToId === collectionId) {
     throw validationFailed('A collection cannot take over its own pages.');
   }
-
   return await db.transaction(async (tx) => {
     if (reassignToId !== null) {
       const [target] = await tx
@@ -1553,13 +1636,7 @@ export async function deleteDocCollection(
     }
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
-    const homeless = await emptyCollection(
-      tx,
-      principal.organizationId,
-      collectionId,
-      syncId,
-      reassignToId,
-    );
+    const homeless = await emptyCollection(tx, collectionId, syncId, reassignToId, principal);
     const [removed] = await tx
       .delete(schema.docCollection)
       .where(
@@ -1570,7 +1647,6 @@ export async function deleteDocCollection(
       )
       .returning();
     const collection = requireRow(removed, 'That collection does not exist.');
-
     return [
       collectionAction(collection, syncId, actor, 'delete'),
       ...homeless.map((row) => docAction(row, syncId, actor, 'update')),

--- a/packages/core/tests/content/doc-service.test.ts
+++ b/packages/core/tests/content/doc-service.test.ts
@@ -261,6 +261,74 @@ describe('collections', () => {
       code: 'forbidden',
     });
   });
+
+  it('refuses deletion if the collection contains a document the deleter cannot write', async () => {
+    const member1 = await addMember(workspace, 'member', { name: 'Member One' });
+    const member2 = await addMember(workspace, 'member', { name: 'Member Two' });
+    const { collection } = await createDocCollection(member1.principal, { name: 'Shared Folder' });
+    const { doc } = await createDoc(member2.principal, {
+      title: 'Secret Doc',
+      collectionId: collection.id,
+      visibility: 'private',
+    });
+    await expect(deleteDocCollection(member1.principal, collection.id)).rejects.toMatchObject({
+      code: 'forbidden',
+    });
+    const detail = await getDoc(workspace.admin, doc.id);
+    expect(detail.doc.collectionId).toBe(collection.id);
+  });
+
+  it('refuses deletion if the collection contains a team document the deleter cannot write', async () => {
+    const { team } = await createTeam(workspace.admin, { name: 'Design', key: 'DES' });
+    const member1 = await addMember(workspace, 'member', { name: 'Member One' });
+    const member2 = await addMember(workspace, 'member', {
+      name: 'Member Two',
+      teamIds: [team.id],
+    });
+    const { collection } = await createDocCollection(member1.principal, { name: 'Shared Folder' });
+    const { doc } = await createDoc(member2.principal, {
+      title: 'Design Specs',
+      collectionId: collection.id,
+      visibility: 'team',
+    });
+    await setDocAccess(member2.principal, doc.id, {
+      grants: [
+        { subjectType: 'team', subjectId: team.id, level: 'write' },
+        { subjectType: 'user', subjectId: member1.principal.userId, level: 'read' },
+      ],
+    });
+    await expect(deleteDocCollection(member1.principal, collection.id)).rejects.toMatchObject({
+      code: 'forbidden',
+      message: expect.stringContaining('Design Specs'),
+    });
+    const detail = await getDoc(workspace.admin, doc.id);
+    expect(detail.doc.collectionId).toBe(collection.id);
+  });
+
+  it("allows an admin to delete a collection containing another member's private document", async () => {
+    const member = await addMember(workspace, 'member', { name: 'Member' });
+    const { collection } = await createDocCollection(workspace.admin, { name: 'Shared Folder' });
+    await createDoc(member.principal, {
+      title: 'Secret Doc',
+      collectionId: collection.id,
+      visibility: 'private',
+    });
+    const actions = await deleteDocCollection(workspace.admin, collection.id);
+    expect(actions[0]?.action).toBe('delete');
+  });
+
+  it("allows a member to delete a collection containing another member's published document", async () => {
+    const member1 = await addMember(workspace, 'member', { name: 'Member One' });
+    const member2 = await addMember(workspace, 'member', { name: 'Member Two' });
+    const { collection } = await createDocCollection(member1.principal, { name: 'Shared Folder' });
+    await createDoc(member2.principal, {
+      title: 'Public Doc',
+      collectionId: collection.id,
+      visibility: 'public',
+    });
+    const actions = await deleteDocCollection(member1.principal, collection.id);
+    expect(actions[0]?.action).toBe('delete');
+  });
 });
 
 describe('published doc urls', () => {

--- a/packages/mcp-server/src/tools/docs.ts
+++ b/packages/mcp-server/src/tools/docs.ts
@@ -473,7 +473,7 @@ export function registerDocTools(server: McpServer, principal: Principal): void 
       name: 'delete_doc_collection',
       title: 'Delete a document collection',
       description:
-        'Delete a folder. The documents inside are never deleted: they move to reassignTo, or become unfiled when you leave it out.',
+        'Deletes a document collection. The documents inside are never deleted: they move to reassignTo, or become unfiled when you leave it out. This action is refused if the folder holds a document you cannot write.',
       readOnly: false,
       inputSchema: {
         collection: collectionRef,


### PR DESCRIPTION
## What this changes

Updates `emptyCollection` to require the user's `Principal`, queries all nested documents in the collection, and runs `assertDocWritable` on each document before the `UPDATE` operation executes.

## Why

Closes #245

A member could previously delete a collection containing private documents created by other users because `emptyCollection` executed a bulk SQL `UPDATE` without checking row-level permissions on the individual documents being moved to the root level.

## How you know it works

Added an isolated test case in `doc-service.test.ts` where a member attempts to delete a collection containing another member's private document. Verified that the test correctly throws a `forbidden` error, causing the database transaction to rollback successfully. 

## Checklist

- [x] `bun run verify` is green, all four checks
- [x] Tests added or updated, and they fail without the change
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions
- [x] External input is parsed with a Zod schema from `@orbit/shared`
- [x] Authorization is enforced on the server through `packages/shared/src/policy`, not only in the UI
- [ ] Docs updated if behaviour, configuration or setup changed
- [ ] `bun run db:release` and `bun run db:check-drift` passed against the target database before this ships

## Anything reviewers should know

I chose Option 1 from the issue description (refusing the deletion entirely rather than skipping un-editable documents) as it provides a clearer failure state and prevents unexpected folder restructuring for other users.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds per-document write authorization before deleting a document collection and limits reassignment to the authorized snapshot.
- Batches document read and write grant evaluation.
- Locks the collection during deletion and checks every contained document.
- Adds authorization tests and documents the MCP tool’s refusal behavior.

<h3>Confidence Score: 2/5</h3>

The PR is not yet safe to merge because permission changes can bypass the authorization snapshot and concurrent move-outs can still cause false forbidden responses.

The collection lock blocks new documents from entering through the foreign-key relationship, but it does not serialize document moves, visibility changes, or grant mutations. Authorization and mutation can therefore operate on different document placement or permission states.

**Files Needing Attention:** packages/core/src/content/doc-service.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/content/doc-service.ts | Adds batched document authorization and collection locking around collection deletion. |
| packages/core/tests/content/doc-service.test.ts | Adds coverage for private, team-restricted, administrator, and published-document deletion behavior. |
| packages/mcp-server/src/tools/docs.ts | Updates the collection-deletion tool description to explain document write requirements. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant C as Caller
  participant S as Doc service
  participant DB as PostgreSQL
  C->>S: Delete collection
  S->>DB: Lock collection row
  S->>DB: Select contained documents and grants
  S->>S: Evaluate write access
  alt Any document is not writable
    S-->>C: Forbidden
  else All documents are writable
    S->>DB: Reassign matching snapshotted documents
    S->>DB: Delete collection
    S-->>C: Collection and document actions
  end
```
</details>

<sub>Reviews (9): Last reviewed commit: ["fix(docs): constrain collection update s..."](https://github.com/noveum/orbit/commit/5f24c4f9fc41226e23fb4d200146e5d65551edaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53566240)</sub>

**Context used:**

- Knowledge Base — [Core content and documents](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/docs/core-content-and-docs.md)
- Knowledge Base — [MCP authentication, workspace resolution, and authorized operations](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/docs/auth-and-mcp.md)

<!-- /greptile_comment -->