### PR TITLE
feat(analytics): planning-grade sprint burn and insights lens

### DIFF
--- a/apps/web/e2e/analytics.spec.ts
+++ b/apps/web/e2e/analytics.spec.ts
@@ -168,3 +168,43 @@ test('a complete analytics view can be saved, pinned, and restored', async ({ br
 
   await context.close();
 });
+
+test('the insights lens configures measure, slice, and segment then renders bars, a linked table, and scatter percentiles', async ({
+  browser,
+}) => {
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const page = await signIn(context);
+
+  await page.goto(`${BASE}/analytics?range=last_90_days`);
+  await page.getByRole('tab', { name: 'Insights' }).click();
+  await expect(page).toHaveURL(/lens=insights/);
+
+  await expect(page.getByLabel('Insight measure')).toBeVisible();
+  await expect(page.getByLabel('Insight slice')).toBeVisible();
+  await expect(page.getByLabel('Insight segment')).toBeVisible();
+
+  await page.getByLabel('Insight slice').click();
+  await page.getByRole('option', { name: 'Assignee' }).click();
+  await expect(page).toHaveURL(/insightSlice=assignee/);
+
+  const barChart = page.getByRole('application', { name: 'Count by Assignee' });
+  await expect(barChart).toBeVisible();
+  await expect(barChart.locator('[data-testid^="plot-hit-"]').first()).toBeVisible();
+
+  await page.getByText(/View data/).click();
+  await expect(page.getByRole('table', { name: 'Count by Assignee data' })).toBeVisible();
+
+  await page.getByLabel('Insight measure').click();
+  await page.getByRole('option', { name: 'Cycle time' }).click();
+  await expect(page).toHaveURL(/insightMeasure=cycle_time/);
+
+  const scatter = page.getByRole('application', { name: 'Cycle time distribution' });
+  await expect(scatter).toBeVisible();
+  await expect(scatter.locator('[data-testid="plot-percentile-p25"]')).toBeAttached();
+  await expect(scatter.locator('[data-testid="plot-percentile-p50"]')).toBeAttached();
+  await expect(scatter.locator('[data-testid="plot-percentile-p75"]')).toBeAttached();
+  await expect(scatter.locator('[data-testid="plot-percentile-p95"]')).toBeAttached();
+  await expect(scatter.locator('[data-testid^="plot-scatter-"]').first()).toBeVisible();
+
+  await context.close();
+});

--- a/apps/web/e2e/analytics.spec.ts
+++ b/apps/web/e2e/analytics.spec.ts
@@ -13,6 +13,10 @@ const sprintSummarySchema = z.object({
   current: z.object({ summary: z.object({ completed: z.number(), remaining: z.number() }) }),
 });
 
+const sprintBurnLengthSchema = z.object({
+  current: z.object({ burn: z.array(z.unknown()) }),
+});
+
 async function json(page: Page, path: string, init?: RequestInit): Promise<unknown> {
   return await page.evaluate(
     async ({ url, options }) => {
@@ -79,15 +83,26 @@ test('analytics and the sprint page share sprint truth and expose exact hover va
   await expect(page.getByText('Flow time')).toBeVisible();
   await expect(page.getByText(/Current issue-row creation to durable completion/)).toBeVisible();
   await expect(page.getByText(/Current mutable startedAt column to completion/)).toBeVisible();
+  await expect(page.getByText(/Scope\s+\d+\s+(pts|issues)\s+·\s+\d+\s+(pts|issues)/)).toBeVisible();
 
-  const point = page.locator('[data-testid^="plot-hit-"]').last();
-  await point.hover({ force: true });
-  await expect(page.getByRole('tooltip')).toBeVisible();
+  const burnLength = sprintBurnLengthSchema.parse(await json(page, '/api/analytics/sprints'))
+    .current.burn.length;
 
   const chart = page.getByRole('application', { name: 'Sprint burn down' });
+  const dayHits = chart.locator('[data-testid="plot-day-hit"]');
+  await expect(dayHits).toHaveCount(burnLength);
+  await dayHits.last().hover({ force: true });
+  await expect(page.getByRole('tooltip')).toBeVisible();
+
   await chart.focus();
   await page.keyboard.press('End');
   await expect(page.getByRole('tooltip')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Burn up' }).click();
+  const upChart = page.getByRole('application', { name: 'Sprint burn up' });
+  await expect(upChart).toBeVisible();
+  await expect(upChart.locator('[data-testid="plot-day-hit"]')).toHaveCount(burnLength);
+  await expect(upChart.locator('[data-testid="plot-line-completed"]')).toBeVisible();
 
   await context.close();
 });

--- a/apps/web/src/app/(app)/analytics/page.tsx
+++ b/apps/web/src/app/(app)/analytics/page.tsx
@@ -1,10 +1,17 @@
 import { can } from '@orbit/shared/policy';
-import { analyticsQuerySchema } from '@orbit/shared/validators';
+import { analyticsInsightsQuerySchema, analyticsQuerySchema } from '@orbit/shared/validators';
 import { HydrationBoundary } from '@tanstack/react-query';
 import type { Metadata } from 'next';
 import { AnalyticsCockpit } from '@/features/analytics/analytics-cockpit.tsx';
-import { dehydratedAnalyticsLens, loadSavedViews } from '@/features/analytics/data.ts';
-import { parseAnalyticsSearchParams } from '@/features/analytics/query-state.ts';
+import {
+  dehydratedAnalyticsInsights,
+  dehydratedAnalyticsLens,
+  loadSavedViews,
+} from '@/features/analytics/data.ts';
+import {
+  insightConfigFromSearchParams,
+  parseAnalyticsSearchParams,
+} from '@/features/analytics/query-state.ts';
 import { pageContext } from '@/lib/api/handler.ts';
 
 export const metadata: Metadata = { title: 'Analytics' };
@@ -29,14 +36,23 @@ export default async function AnalyticsPage({ searchParams }: PageProps) {
     cleanUrl && typeof pinnedQuery === 'object' && pinnedQuery !== null
       ? analyticsQuerySchema.parse(pinnedQuery)
       : requestedQuery;
+  const initialInsight = insightConfigFromSearchParams(params);
+  const hydrationState =
+    query.lens === 'insights'
+      ? await dehydratedAnalyticsInsights(
+          principal,
+          analyticsInsightsQuerySchema.parse({ ...query, insight: initialInsight }),
+        )
+      : await dehydratedAnalyticsLens(principal, query);
 
   return (
-    <HydrationBoundary state={await dehydratedAnalyticsLens(principal, query)}>
+    <HydrationBoundary state={hydrationState}>
       <div className="px-4 py-5 sm:px-6 sm:py-6">
         <AnalyticsCockpit
           canManageAllViews={principal.role === 'admin'}
           canManageViews={can(principal, 'view:manage')}
           currentUserId={principal.userId}
+          initialInsight={initialInsight}
           initialQuery={query}
           savedViews={savedViews}
         />

--- a/apps/web/src/app/(app)/analytics/page.tsx
+++ b/apps/web/src/app/(app)/analytics/page.tsx
@@ -1,5 +1,9 @@
 import { can } from '@orbit/shared/policy';
-import { analyticsInsightsQuerySchema, analyticsQuerySchema } from '@orbit/shared/validators';
+import {
+  analyticsInsightsQuerySchema,
+  analyticsQuerySchema,
+  insightConfigSchema,
+} from '@orbit/shared/validators';
 import { HydrationBoundary } from '@tanstack/react-query';
 import type { Metadata } from 'next';
 import { AnalyticsCockpit } from '@/features/analytics/analytics-cockpit.tsx';
@@ -36,7 +40,10 @@ export default async function AnalyticsPage({ searchParams }: PageProps) {
     cleanUrl && typeof pinnedQuery === 'object' && pinnedQuery !== null
       ? analyticsQuerySchema.parse(pinnedQuery)
       : requestedQuery;
-  const initialInsight = insightConfigFromSearchParams(params);
+  const initialInsight =
+    cleanUrl && query.lens === 'insights'
+      ? insightConfigSchema.parse(pinned?.config['insight'] ?? {})
+      : insightConfigFromSearchParams(params);
   const hydrationState =
     query.lens === 'insights'
       ? await dehydratedAnalyticsInsights(

--- a/apps/web/src/app/api/analytics/export/route.ts
+++ b/apps/web/src/app/api/analytics/export/route.ts
@@ -36,7 +36,7 @@ export async function GET(request: Request): Promise<Response> {
             [
               'Formula',
               query.measure === 'points'
-                ? 'Sum of estimates; unestimated is zero'
+                ? 'Sum of estimates; unestimated counts as 1'
                 : 'Count of issues',
             ],
             ['Timezone', page.timezone],

--- a/apps/web/src/app/api/analytics/insights/route.ts
+++ b/apps/web/src/app/api/analytics/insights/route.ts
@@ -1,0 +1,10 @@
+import { loadAnalyticsInsightsData } from '@/features/analytics/data.ts';
+import { analyticsInsightsFromSearchParams } from '@/features/analytics/query-state.ts';
+import { handle } from '@/lib/api/handler.ts';
+
+export async function GET(request: Request): Promise<Response> {
+  return await handle(async (principal) => {
+    const parsed = analyticsInsightsFromSearchParams(new URL(request.url).searchParams);
+    return await loadAnalyticsInsightsData(principal, parsed, parsed.insight);
+  });
+}

--- a/apps/web/src/features/analytics/analytics-cockpit.tsx
+++ b/apps/web/src/features/analytics/analytics-cockpit.tsx
@@ -3,7 +3,6 @@
 import type { SavedAnalyticsViewPayload } from '@orbit/core';
 import {
   ANALYTICS_LENSES,
-  type AnalyticsLens,
   type AnalyticsQuery,
   analyticsQuerySchema,
 } from '@orbit/shared/validators';
@@ -34,7 +33,7 @@ function LensContent({
   onFocusProject,
   onFocusPerson,
 }: {
-  readonly data: AnalyticsResponseByLens[AnalyticsLens];
+  readonly data: AnalyticsResponseByLens[keyof AnalyticsResponseByLens];
   readonly query: AnalyticsQuery;
   readonly onFocusProject: (projectId: string) => void;
   readonly onFocusPerson: (personId: string) => void;

--- a/apps/web/src/features/analytics/analytics-cockpit.tsx
+++ b/apps/web/src/features/analytics/analytics-cockpit.tsx
@@ -4,27 +4,58 @@ import type { SavedAnalyticsViewPayload } from '@orbit/core';
 import {
   ANALYTICS_LENSES,
   type AnalyticsQuery,
+  analyticsInsightsQuerySchema,
   analyticsQuerySchema,
+  type InsightConfig,
+  insightConfigSchema,
 } from '@orbit/shared/validators';
 import { useState } from 'react';
 import { Skeleton } from '@/components/ui/skeleton.tsx';
 import { AnalyticsTabs } from './analytics-tabs.tsx';
 import { AnalyticsToolbar } from './analytics-toolbar.tsx';
 import type { AnalyticsResponseByLens } from './contracts.ts';
+import { InsightsLens } from './insights-lens.tsx';
 import { OverviewLens } from './overview-lens.tsx';
 import { PeopleLens } from './people-lens.tsx';
 import { ProjectsLens } from './projects-lens.tsx';
-import { searchParamsForAnalytics } from './query-state.ts';
+import { searchParamsForAnalytics, searchParamsForInsightConfig } from './query-state.ts';
 import { SavedViewBar } from './saved-view-bar.tsx';
 import { SprintLens } from './sprint-lens.tsx';
-import { useAnalyticsQuery } from './use-analytics-query.ts';
+import { useAnalyticsQuery, useInsightsQuery } from './use-analytics-query.ts';
 
 const defaultQuery = analyticsQuerySchema.parse({});
+const defaultInsightConfig = insightConfigSchema.parse({});
 
-function writeUrl(query: AnalyticsQuery) {
-  const search = searchParamsForAnalytics(query).toString();
+function writeUrl(query: AnalyticsQuery, insight: InsightConfig) {
+  const params = searchParamsForAnalytics(query);
+  for (const [key, value] of searchParamsForInsightConfig(insight)) params.set(key, value);
+  const search = params.toString();
   const path = typeof window === 'undefined' ? '/analytics' : window.location.pathname;
   window.history.replaceState(null, '', search.length === 0 ? path : `${path}?${search}`);
+}
+
+function AnalyticsErrorCard() {
+  return (
+    <section className="rounded-lg border border-danger/30 bg-surface p-6">
+      <h2 className="font-medium text-text">Analytics could not load</h2>
+      <p className="mt-1 text-muted text-sm">Try again or reset the view.</p>
+    </section>
+  );
+}
+
+function AnalyticsLoadingGrid() {
+  return (
+    <div
+      aria-label="Loading analytics"
+      className="grid grid-cols-2 gap-3 lg:grid-cols-4"
+      role="status"
+    >
+      <Skeleton className="h-28" />
+      <Skeleton className="h-28" />
+      <Skeleton className="h-28" />
+      <Skeleton className="h-28" />
+    </div>
+  );
 }
 
 function LensContent({
@@ -50,51 +81,82 @@ function LensContent({
   }
 }
 
+function headerCaptionFor(
+  query: AnalyticsQuery,
+  result: ReturnType<typeof useAnalyticsQuery>,
+  insightsResult: ReturnType<typeof useInsightsQuery>,
+): string {
+  if (query.lens === 'insights') {
+    return insightsResult.data === undefined ? 'Refreshing' : 'Insights are computed on demand';
+  }
+  if (result.data === undefined) return 'Refreshing';
+  return `Data through ${result.data.coverage.asOf.slice(0, 10)}`;
+}
+
+function insightsContent(
+  insightsResult: ReturnType<typeof useInsightsQuery>,
+  query: AnalyticsQuery,
+  insight: InsightConfig,
+  onInsightChange: (next: InsightConfig) => void,
+): React.ReactNode {
+  if (insightsResult.isError) return <AnalyticsErrorCard />;
+  if (insightsResult.data === undefined) return <AnalyticsLoadingGrid />;
+  return (
+    <InsightsLens
+      data={insightsResult.data}
+      insight={insight}
+      onInsightChange={onInsightChange}
+      query={query}
+    />
+  );
+}
+
 export function AnalyticsCockpit({
   initialQuery,
+  initialInsight = defaultInsightConfig,
   savedViews = [],
   canManageViews = false,
   canManageAllViews = false,
   currentUserId = null,
 }: {
   readonly initialQuery: AnalyticsQuery;
+  readonly initialInsight?: InsightConfig;
   readonly savedViews?: readonly SavedAnalyticsViewPayload[];
   readonly canManageViews?: boolean;
   readonly canManageAllViews?: boolean;
   readonly currentUserId?: string | null;
 }) {
   const [query, setQuery] = useState(initialQuery);
+  const [insight, setInsight] = useState(initialInsight);
   const result = useAnalyticsQuery(query);
+  const insightsResult = useInsightsQuery(
+    analyticsInsightsQuerySchema.parse({ ...query, insight }),
+    {
+      enabled: query.lens === 'insights',
+    },
+  );
   const update = (patch: Partial<AnalyticsQuery>) => {
     const next = analyticsQuerySchema.parse({ ...query, ...patch });
     setQuery(next);
-    writeUrl(next);
+    writeUrl(next, insight);
+  };
+  const updateInsight = (next: InsightConfig) => {
+    const parsed = insightConfigSchema.parse(next);
+    setInsight(parsed);
+    writeUrl(query, parsed);
   };
   const reset = () => {
     setQuery(defaultQuery);
-    writeUrl(defaultQuery);
+    setInsight(defaultInsightConfig);
+    writeUrl(defaultQuery, defaultInsightConfig);
   };
   let content: React.ReactNode;
-  if (result.isError) {
-    content = (
-      <section className="rounded-lg border border-danger/30 bg-surface p-6">
-        <h2 className="font-medium text-text">Analytics could not load</h2>
-        <p className="mt-1 text-muted text-sm">Try again or reset the view.</p>
-      </section>
-    );
+  if (query.lens === 'insights') {
+    content = insightsContent(insightsResult, query, insight, updateInsight);
+  } else if (result.isError) {
+    content = <AnalyticsErrorCard />;
   } else if (result.data === undefined) {
-    content = (
-      <div
-        aria-label="Loading analytics"
-        className="grid grid-cols-2 gap-3 lg:grid-cols-4"
-        role="status"
-      >
-        <Skeleton className="h-28" />
-        <Skeleton className="h-28" />
-        <Skeleton className="h-28" />
-        <Skeleton className="h-28" />
-      </div>
-    );
+    content = <AnalyticsLoadingGrid />;
   } else {
     content = (
       <LensContent
@@ -105,6 +167,7 @@ export function AnalyticsCockpit({
       />
     );
   }
+  const headerCaption = headerCaptionFor(query, result, insightsResult);
 
   return (
     <div className="flex min-w-0 flex-col gap-5">
@@ -116,11 +179,7 @@ export function AnalyticsCockpit({
               Plan scope, delivery, sprints, projects, and individual work from one shared source.
             </p>
           </div>
-          <p className="text-faint text-2xs">
-            {result.data === undefined
-              ? 'Refreshing'
-              : `Data through ${result.data.coverage.asOf.slice(0, 10)}`}
-          </p>
+          <p className="text-faint text-2xs">{headerCaption}</p>
         </div>
         <div className="overflow-x-auto">
           <AnalyticsTabs value={query.lens} onChange={(lens) => update({ lens })} />

--- a/apps/web/src/features/analytics/analytics-cockpit.tsx
+++ b/apps/web/src/features/analytics/analytics-cockpit.tsx
@@ -18,7 +18,7 @@ import { InsightsLens } from './insights-lens.tsx';
 import { OverviewLens } from './overview-lens.tsx';
 import { PeopleLens } from './people-lens.tsx';
 import { ProjectsLens } from './projects-lens.tsx';
-import { searchParamsForAnalytics, searchParamsForInsightConfig } from './query-state.ts';
+import { searchParamsForSavedAnalyticsView } from './query-state.ts';
 import { SavedViewBar } from './saved-view-bar.tsx';
 import { SprintLens } from './sprint-lens.tsx';
 import { useAnalyticsQuery, useInsightsQuery } from './use-analytics-query.ts';
@@ -27,9 +27,7 @@ const defaultQuery = analyticsQuerySchema.parse({});
 const defaultInsightConfig = insightConfigSchema.parse({});
 
 function writeUrl(query: AnalyticsQuery, insight: InsightConfig) {
-  const params = searchParamsForAnalytics(query);
-  for (const [key, value] of searchParamsForInsightConfig(insight)) params.set(key, value);
-  const search = params.toString();
+  const search = searchParamsForSavedAnalyticsView(query, insight).toString();
   const path = typeof window === 'undefined' ? '/analytics' : window.location.pathname;
   window.history.replaceState(null, '', search.length === 0 ? path : `${path}?${search}`);
 }
@@ -147,6 +145,13 @@ export function AnalyticsCockpit({
     setInsight(parsed);
     writeUrl(query, parsed);
   };
+  const applySavedView = (nextQuery: AnalyticsQuery, nextInsight?: InsightConfig) => {
+    const parsedInsight =
+      nextInsight === undefined ? insight : insightConfigSchema.parse(nextInsight);
+    setQuery(nextQuery);
+    setInsight(parsedInsight);
+    writeUrl(nextQuery, parsedInsight);
+  };
   const reset = () => {
     setQuery(defaultQuery);
     setInsight(defaultInsightConfig);
@@ -194,7 +199,8 @@ export function AnalyticsCockpit({
         canManage={canManageViews}
         canManageAll={canManageAllViews}
         currentUserId={currentUserId}
-        onApply={(saved) => update(saved)}
+        insight={insight}
+        onApply={applySavedView}
         query={query}
         views={savedViews}
       />

--- a/apps/web/src/features/analytics/analytics-cockpit.tsx
+++ b/apps/web/src/features/analytics/analytics-cockpit.tsx
@@ -93,6 +93,15 @@ function headerCaptionFor(
   return `Data through ${result.data.coverage.asOf.slice(0, 10)}`;
 }
 
+function insightForAppliedView(
+  nextQuery: AnalyticsQuery,
+  nextInsight: InsightConfig | undefined,
+  currentInsight: InsightConfig,
+): InsightConfig {
+  if (nextInsight !== undefined) return insightConfigSchema.parse(nextInsight);
+  return nextQuery.lens === 'insights' ? defaultInsightConfig : currentInsight;
+}
+
 function insightsContent(
   insightsResult: ReturnType<typeof useInsightsQuery>,
   query: AnalyticsQuery,
@@ -146,8 +155,7 @@ export function AnalyticsCockpit({
     writeUrl(query, parsed);
   };
   const applySavedView = (nextQuery: AnalyticsQuery, nextInsight?: InsightConfig) => {
-    const parsedInsight =
-      nextInsight === undefined ? insight : insightConfigSchema.parse(nextInsight);
+    const parsedInsight = insightForAppliedView(nextQuery, nextInsight, insight);
     setQuery(nextQuery);
     setInsight(parsedInsight);
     writeUrl(nextQuery, parsedInsight);

--- a/apps/web/src/features/analytics/analytics-cockpit.tsx
+++ b/apps/web/src/features/analytics/analytics-cockpit.tsx
@@ -87,8 +87,10 @@ function headerCaptionFor(
   insightsResult: ReturnType<typeof useInsightsQuery>,
 ): string {
   if (query.lens === 'insights') {
+    if (insightsResult.isError) return 'Analytics could not load';
     return insightsResult.data === undefined ? 'Refreshing' : 'Insights are computed on demand';
   }
+  if (result.isError) return 'Analytics could not load';
   if (result.data === undefined) return 'Refreshing';
   return `Data through ${result.data.coverage.asOf.slice(0, 10)}`;
 }

--- a/apps/web/src/features/analytics/analytics-keys.ts
+++ b/apps/web/src/features/analytics/analytics-keys.ts
@@ -1,9 +1,14 @@
 import type {
   AnalyticsDrilldownQuery,
+  AnalyticsInsightsQuery,
   AnalyticsLens,
   AnalyticsQuery,
 } from '@orbit/shared/validators';
-import { canonicalAnalyticsQuery, canonicalDrilldownQuery } from './query-state.ts';
+import {
+  canonicalAnalyticsQuery,
+  canonicalDrilldownQuery,
+  canonicalInsightsQuery,
+} from './query-state.ts';
 
 export const ANALYTICS_ROOT = 'analytics';
 
@@ -13,4 +18,6 @@ export const analyticsKeys = {
     [ANALYTICS_ROOT, 'lens', lens, canonicalAnalyticsQuery(query)] as const,
   drilldown: (query: AnalyticsDrilldownQuery) =>
     [ANALYTICS_ROOT, 'drilldown', canonicalDrilldownQuery(query)] as const,
+  insights: (input: AnalyticsInsightsQuery) =>
+    [ANALYTICS_ROOT, 'insights', canonicalInsightsQuery(input)] as const,
 } as const;

--- a/apps/web/src/features/analytics/analytics-tabs.tsx
+++ b/apps/web/src/features/analytics/analytics-tabs.tsx
@@ -4,8 +4,6 @@ import { ANALYTICS_LENSES, type AnalyticsLens } from '@orbit/shared/validators';
 import { useRef } from 'react';
 import { cn } from '@/lib/cn.ts';
 
-const TAB_LENSES = ANALYTICS_LENSES;
-
 const LABELS: Record<AnalyticsLens, string> = {
   overview: 'Overview',
   sprints: 'Sprints',
@@ -25,12 +23,13 @@ export function AnalyticsTabs({
 
   const move = (index: number, key: string) => {
     let next: number;
-    if (key === 'ArrowRight') next = (index + 1) % TAB_LENSES.length;
-    else if (key === 'ArrowLeft') next = (index - 1 + TAB_LENSES.length) % TAB_LENSES.length;
+    if (key === 'ArrowRight') next = (index + 1) % ANALYTICS_LENSES.length;
+    else if (key === 'ArrowLeft')
+      next = (index - 1 + ANALYTICS_LENSES.length) % ANALYTICS_LENSES.length;
     else if (key === 'Home') next = 0;
-    else if (key === 'End') next = TAB_LENSES.length - 1;
+    else if (key === 'End') next = ANALYTICS_LENSES.length - 1;
     else return;
-    const lens = TAB_LENSES[next];
+    const lens = ANALYTICS_LENSES[next];
     if (lens === undefined) return;
     onChange(lens);
     tabs.current[next]?.focus();
@@ -38,7 +37,7 @@ export function AnalyticsTabs({
 
   return (
     <div aria-label="Analytics views" className="flex min-w-max gap-1" role="tablist">
-      {TAB_LENSES.map((lens, index) => (
+      {ANALYTICS_LENSES.map((lens, index) => (
         <button
           aria-controls={`analytics-panel-${lens}`}
           aria-selected={value === lens}

--- a/apps/web/src/features/analytics/analytics-tabs.tsx
+++ b/apps/web/src/features/analytics/analytics-tabs.tsx
@@ -4,7 +4,11 @@ import { ANALYTICS_LENSES, type AnalyticsLens } from '@orbit/shared/validators';
 import { useRef } from 'react';
 import { cn } from '@/lib/cn.ts';
 
-const LABELS: Record<AnalyticsLens, string> = {
+type VisibleLens = Exclude<AnalyticsLens, 'insights'>;
+
+const TAB_LENSES = ANALYTICS_LENSES.filter((lens): lens is VisibleLens => lens !== 'insights');
+
+const LABELS: Record<VisibleLens, string> = {
   overview: 'Overview',
   sprints: 'Sprints',
   projects: 'Projects',
@@ -22,13 +26,12 @@ export function AnalyticsTabs({
 
   const move = (index: number, key: string) => {
     let next: number;
-    if (key === 'ArrowRight') next = (index + 1) % ANALYTICS_LENSES.length;
-    else if (key === 'ArrowLeft')
-      next = (index - 1 + ANALYTICS_LENSES.length) % ANALYTICS_LENSES.length;
+    if (key === 'ArrowRight') next = (index + 1) % TAB_LENSES.length;
+    else if (key === 'ArrowLeft') next = (index - 1 + TAB_LENSES.length) % TAB_LENSES.length;
     else if (key === 'Home') next = 0;
-    else if (key === 'End') next = ANALYTICS_LENSES.length - 1;
+    else if (key === 'End') next = TAB_LENSES.length - 1;
     else return;
-    const lens = ANALYTICS_LENSES[next];
+    const lens = TAB_LENSES[next];
     if (lens === undefined) return;
     onChange(lens);
     tabs.current[next]?.focus();
@@ -36,7 +39,7 @@ export function AnalyticsTabs({
 
   return (
     <div aria-label="Analytics views" className="flex min-w-max gap-1" role="tablist">
-      {ANALYTICS_LENSES.map((lens, index) => (
+      {TAB_LENSES.map((lens, index) => (
         <button
           aria-controls={`analytics-panel-${lens}`}
           aria-selected={value === lens}

--- a/apps/web/src/features/analytics/analytics-tabs.tsx
+++ b/apps/web/src/features/analytics/analytics-tabs.tsx
@@ -4,15 +4,14 @@ import { ANALYTICS_LENSES, type AnalyticsLens } from '@orbit/shared/validators';
 import { useRef } from 'react';
 import { cn } from '@/lib/cn.ts';
 
-type VisibleLens = Exclude<AnalyticsLens, 'insights'>;
+const TAB_LENSES = ANALYTICS_LENSES;
 
-const TAB_LENSES = ANALYTICS_LENSES.filter((lens): lens is VisibleLens => lens !== 'insights');
-
-const LABELS: Record<VisibleLens, string> = {
+const LABELS: Record<AnalyticsLens, string> = {
   overview: 'Overview',
   sprints: 'Sprints',
   projects: 'Projects',
   people: 'People',
+  insights: 'Insights',
 };
 
 export function AnalyticsTabs({

--- a/apps/web/src/features/analytics/burn-math.ts
+++ b/apps/web/src/features/analytics/burn-math.ts
@@ -82,24 +82,28 @@ export function personIdealSeries(burn: readonly PersonBurnPointLike[]): PlotSer
   };
 }
 
+function lastWithWorkingDay(burn: readonly BurnPointLike[]): BurnPointLike | undefined {
+  return burn.findLast((point) => point.workingDay != null);
+}
+
 export function neededPace(remaining: number, burn: readonly BurnPointLike[]): number | null {
   const current = burn
     .filter((point) => !point.future)
     .reverse()
     .find((point) => point.workingDay != null);
-  const last = burn.at(-1);
+  const last = lastWithWorkingDay(burn);
   if (current?.workingDay == null || last?.workingDay == null) return null;
   const daysLeft = last.workingDay - current.workingDay + 1;
   return daysLeft <= 0 ? null : remaining / daysLeft;
 }
 
 export function actualPace(burn: readonly BurnPointLike[]): number | null {
-  const observed = burn.filter((point) => point.available && !point.future);
-  const first = observed[0];
-  const current = observed.at(-1);
-  if (first?.workingDay == null || current?.workingDay == null) return null;
-  const elapsed = Math.max(1, current.workingDay - first.workingDay + 1);
-  return current.completed / elapsed;
+  const current = burn
+    .filter((point) => !point.future)
+    .reverse()
+    .find((point) => point.workingDay != null);
+  if (current?.workingDay == null) return null;
+  return current.completed / Math.max(1, current.workingDay);
 }
 
 export function forecastDate(
@@ -108,7 +112,7 @@ export function forecastDate(
 ): string | null {
   const inSeries = burn.find((point) => point.workingDay === completionWorkingDay);
   if (inSeries !== undefined) return inSeries.date;
-  const last = burn.at(-1);
+  const last = lastWithWorkingDay(burn);
   if (last?.workingDay == null) return null;
   let date = last.date;
   let workingDay = last.workingDay;

--- a/apps/web/src/features/analytics/burn-math.ts
+++ b/apps/web/src/features/analytics/burn-math.ts
@@ -1,11 +1,13 @@
 import type { SprintBurnPoint } from '@orbit/core';
-import type { PlotPoint } from './charts/line-plot.tsx';
+import type { PlotPoint, PlotSeries } from './charts/line-plot.tsx';
 import type { AnalyticsSprintsResponse } from './contracts.ts';
 
 export type BurnPointLike = Pick<
   SprintBurnPoint,
   'date' | 'workingDay' | 'available' | 'future' | 'completed' | 'remaining'
 >;
+
+export type PersonBurnPointLike = BurnPointLike & { readonly ideal: number };
 
 export interface SprintDay {
   readonly date: string;
@@ -36,6 +38,48 @@ export function sprintDays(burn: readonly BurnPointLike[], today: string): reado
     today: point.date === today,
     future: point.future,
   }));
+}
+
+export function todayDateOf(burn: readonly BurnPointLike[]): string {
+  return burn.filter((point) => !point.future).at(-1)?.date ?? burn.at(-1)?.date ?? '';
+}
+
+export function readableDate(value: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${value}T12:00:00.000Z`));
+}
+
+export function personCaptureCaption(burn: readonly BurnPointLike[]): string | undefined {
+  const firstAvailableIndex = burn.findIndex((point) => point.available);
+  if (firstAvailableIndex <= 0) return undefined;
+  const hasEarlierGap = burn
+    .slice(0, firstAvailableIndex)
+    .some((point) => !(point.available || point.future));
+  if (!hasEarlierGap) return undefined;
+  const firstAvailable = burn[firstAvailableIndex];
+  return firstAvailable === undefined
+    ? undefined
+    : `Capture began ${readableDate(firstAvailable.date)}. Earlier days show targets only.`;
+}
+
+export function personIdealSeries(burn: readonly PersonBurnPointLike[]): PlotSeries {
+  return {
+    id: 'ideal-person',
+    label: 'Ideal',
+    color: 2,
+    dashed: true,
+    dots: true,
+    points: burn.map((point) => ({
+      id: `${point.date}-ideal-person`,
+      label: point.date,
+      value: point.ideal,
+      cohort: { cohort: 'open' as const },
+    })),
+  };
 }
 
 export function neededPace(remaining: number, burn: readonly BurnPointLike[]): number | null {

--- a/apps/web/src/features/analytics/burn-math.ts
+++ b/apps/web/src/features/analytics/burn-math.ts
@@ -66,6 +66,12 @@ export function personCaptureCaption(burn: readonly BurnPointLike[]): string | u
     : `Capture began ${readableDate(firstAvailable.date)}. Earlier days show targets only.`;
 }
 
+export function unestimatedNote(count: number): string {
+  return count === 1
+    ? '1 unestimated issue counts as 1 point.'
+    : `${count} unestimated issues count as 1 point each.`;
+}
+
 export function personIdealSeries(burn: readonly PersonBurnPointLike[]): PlotSeries {
   return {
     id: 'ideal-person',

--- a/apps/web/src/features/analytics/burn-math.ts
+++ b/apps/web/src/features/analytics/burn-math.ts
@@ -1,6 +1,5 @@
 import type { SprintBurnPoint } from '@orbit/core';
 import type { PlotPoint, PlotSeries } from './charts/line-plot.tsx';
-import type { AnalyticsSprintsResponse } from './contracts.ts';
 
 export type BurnPointLike = Pick<
   SprintBurnPoint,
@@ -17,6 +16,7 @@ export interface SprintDay {
 }
 
 const DAY = 86_400_000;
+const MAX_FORECAST_WORKING_DAYS_AHEAD = 90;
 
 function weekday(date: string): number {
   return new Date(`${date}T12:00:00.000Z`).getUTCDay();
@@ -124,7 +124,7 @@ export function forecastDate(
 }
 
 export function burnForecast(
-  burn: NonNullable<AnalyticsSprintsResponse['current']>['burn'],
+  burn: readonly BurnPointLike[],
 ): { readonly completionWorkingDay: number; readonly points: readonly PlotPoint[] } | null {
   const observed = burn.filter((point) => point.available && point.workingDay !== null);
   if (observed.length < 3) return null;
@@ -143,6 +143,7 @@ export function burnForecast(
   const last = observed.at(-1);
   if (last === undefined || last.workingDay === null) return null;
   const completionWorkingDay = Math.max(last.workingDay, Math.ceil(-intercept / slope));
+  if (completionWorkingDay - last.workingDay > MAX_FORECAST_WORKING_DAYS_AHEAD) return null;
   return {
     completionWorkingDay,
     points: [

--- a/apps/web/src/features/analytics/burn-math.ts
+++ b/apps/web/src/features/analytics/burn-math.ts
@@ -1,0 +1,74 @@
+import type { SprintBurnPoint } from '@orbit/core';
+
+export type BurnPointLike = Pick<
+  SprintBurnPoint,
+  'date' | 'workingDay' | 'available' | 'future' | 'completed' | 'remaining'
+>;
+
+export interface SprintDay {
+  readonly date: string;
+  readonly weekend: boolean;
+  readonly today: boolean;
+  readonly future: boolean;
+}
+
+const DAY = 86_400_000;
+
+function weekday(date: string): number {
+  return new Date(`${date}T12:00:00.000Z`).getUTCDay();
+}
+
+function isWeekend(date: string): boolean {
+  const day = weekday(date);
+  return day === 0 || day === 6;
+}
+
+function nextDate(date: string): string {
+  return new Date(Date.parse(`${date}T00:00:00.000Z`) + DAY).toISOString().slice(0, 10);
+}
+
+export function sprintDays(burn: readonly BurnPointLike[], today: string): readonly SprintDay[] {
+  return burn.map((point) => ({
+    date: point.date,
+    weekend: isWeekend(point.date),
+    today: point.date === today,
+    future: point.future,
+  }));
+}
+
+export function neededPace(remaining: number, burn: readonly BurnPointLike[]): number | null {
+  const current = burn
+    .filter((point) => !point.future)
+    .reverse()
+    .find((point) => point.workingDay != null);
+  const last = burn.at(-1);
+  if (current?.workingDay == null || last?.workingDay == null) return null;
+  const daysLeft = last.workingDay - current.workingDay + 1;
+  return daysLeft <= 0 ? null : remaining / daysLeft;
+}
+
+export function actualPace(burn: readonly BurnPointLike[]): number | null {
+  const observed = burn.filter((point) => point.available && !point.future);
+  const first = observed[0];
+  const current = observed.at(-1);
+  if (first?.workingDay == null || current?.workingDay == null) return null;
+  const elapsed = Math.max(1, current.workingDay - first.workingDay + 1);
+  return current.completed / elapsed;
+}
+
+export function forecastDate(
+  burn: readonly BurnPointLike[],
+  completionWorkingDay: number,
+): string | null {
+  const inSeries = burn.find((point) => point.workingDay === completionWorkingDay);
+  if (inSeries !== undefined) return inSeries.date;
+  const last = burn.at(-1);
+  if (last?.workingDay == null) return null;
+  let date = last.date;
+  let workingDay = last.workingDay;
+  while (workingDay < completionWorkingDay) {
+    date = nextDate(date);
+    if (!isWeekend(date)) workingDay += 1;
+  }
+  return date;
+}

--- a/apps/web/src/features/analytics/burn-math.ts
+++ b/apps/web/src/features/analytics/burn-math.ts
@@ -1,4 +1,6 @@
 import type { SprintBurnPoint } from '@orbit/core';
+import type { PlotPoint } from './charts/line-plot.tsx';
+import type { AnalyticsSprintsResponse } from './contracts.ts';
 
 export type BurnPointLike = Pick<
   SprintBurnPoint,
@@ -71,4 +73,45 @@ export function forecastDate(
     if (!isWeekend(date)) workingDay += 1;
   }
   return date;
+}
+
+export function burnForecast(
+  burn: NonNullable<AnalyticsSprintsResponse['current']>['burn'],
+): { readonly completionWorkingDay: number; readonly points: readonly PlotPoint[] } | null {
+  const observed = burn.filter((point) => point.available && point.workingDay !== null);
+  if (observed.length < 3) return null;
+  const count = observed.length;
+  const meanX = observed.reduce((sum, point) => sum + (point.workingDay ?? 0), 0) / count;
+  const meanY = observed.reduce((sum, point) => sum + point.remaining, 0) / count;
+  const covariance = observed.reduce(
+    (sum, point) => sum + ((point.workingDay ?? 0) - meanX) * (point.remaining - meanY),
+    0,
+  );
+  const variance = observed.reduce((sum, point) => sum + ((point.workingDay ?? 0) - meanX) ** 2, 0);
+  if (variance === 0) return null;
+  const slope = covariance / variance;
+  if (slope >= 0) return null;
+  const intercept = meanY - slope * meanX;
+  const last = observed.at(-1);
+  if (last === undefined || last.workingDay === null) return null;
+  const completionWorkingDay = Math.max(last.workingDay, Math.ceil(-intercept / slope));
+  return {
+    completionWorkingDay,
+    points: [
+      {
+        id: 'forecast-current',
+        label: last.date,
+        value: last.remaining,
+        cohort: { cohort: 'open' },
+        x: last.workingDay,
+      },
+      {
+        id: 'forecast-completion',
+        label: `Forecast day ${completionWorkingDay}`,
+        value: 0,
+        cohort: { cohort: 'open' },
+        x: completionWorkingDay,
+      },
+    ],
+  };
 }

--- a/apps/web/src/features/analytics/charts/analytics-data-table.tsx
+++ b/apps/web/src/features/analytics/charts/analytics-data-table.tsx
@@ -11,6 +11,7 @@ export interface AnalyticsDataRow {
   readonly id: string;
   readonly label: string;
   readonly cells: Readonly<Record<string, ReactNode>>;
+  readonly activatable?: boolean;
 }
 
 interface AnalyticsDataTableProps {
@@ -65,7 +66,7 @@ export function AnalyticsDataTable({
                   )}
                   key={column.id}
                 >
-                  {index === 0 && onActivate !== undefined ? (
+                  {index === 0 && onActivate !== undefined && row.activatable !== false ? (
                     <button
                       aria-label={`${String(row.cells[column.id] ?? '')}, ${row.label}`}
                       className="rounded-sm text-left text-muted hover:text-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"

--- a/apps/web/src/features/analytics/charts/bar-plot.tsx
+++ b/apps/web/src/features/analytics/charts/bar-plot.tsx
@@ -2,25 +2,43 @@
 
 import type { AnalyticsDrilldownCohort } from '@orbit/shared/validators';
 import { useState } from 'react';
+import { useMeasuredWidth } from '@/lib/use-measured-width.ts';
 import { type AnalyticsDataRow, AnalyticsDataTable } from './analytics-data-table.tsx';
 import { ChartTooltip } from './chart-tooltip.tsx';
 import type { PlotPoint } from './line-plot.tsx';
 import { PlotFrame } from './plot-frame.tsx';
 
+export interface BarPair {
+  readonly id: string;
+  readonly label: string;
+  readonly primary: PlotPoint;
+  readonly secondary: PlotPoint;
+}
+
+export interface BarPlotAverageLine {
+  readonly value: number;
+  readonly label: string;
+}
+
 interface BarPlotProps {
   readonly label: string;
   readonly points: readonly PlotPoint[];
+  readonly pairs?: readonly BarPair[];
+  readonly averageLine?: BarPlotAverageLine;
   readonly onActivate?: (cohort: AnalyticsDrilldownCohort) => void;
   readonly valueFormatter?: (value: number) => string;
   readonly xAxisLabel?: string;
 }
 
-const WIDTH = 640;
 const LEFT = 170;
 const RIGHT = 64;
 const TOP = 12;
-const ROW_HEIGHT = 34;
 const BOTTOM = 42;
+const ROW_HEIGHT = 34;
+const PAIR_ROW_HEIGHT = 30;
+const PAIR_BAR_HEIGHT = 8;
+const PAIR_BAR_GAP = 4;
+const PAIR_BAR_TOP = 4;
 
 function truncatedLabel(label: string): string {
   return label.length > 24 ? `${label.slice(0, 23)}…` : label;
@@ -32,35 +50,180 @@ function xTickTestId(ratio: number): string | undefined {
   return undefined;
 }
 
-export function BarPlot({
-  label,
-  points,
-  onActivate,
-  valueFormatter = String,
-  xAxisLabel = 'Value',
-}: BarPlotProps) {
-  const [activeIndex, setActiveIndex] = useState<number | null>(null);
-  const activePoint = activeIndex === null ? undefined : points[activeIndex];
-  const max = Math.max(1, ...points.map((point) => point.value));
-  const plotWidth = WIDTH - LEFT - RIGHT;
-  const plotHeight = Math.max(ROW_HEIGHT, points.length * ROW_HEIGHT);
-  const height = TOP + plotHeight + BOTTOM;
-  const rows: AnalyticsDataRow[] = points.map((point) => ({
+function indexFromTarget(target: EventTarget): number | null {
+  if (!(target instanceof SVGElement)) return null;
+  const index = Number(target.dataset['pointIndex']);
+  return Number.isInteger(index) ? index : null;
+}
+
+function clampRowIndex(index: number, rowCount: number): number | null {
+  if (rowCount === 0) return null;
+  return Math.max(0, Math.min(index, rowCount - 1));
+}
+
+interface BarKeyResult {
+  readonly index: number | null;
+  readonly activate: boolean;
+}
+
+function barKeyResult(
+  key: string,
+  activeIndex: number | null,
+  rowCount: number,
+  canActivate: boolean,
+): BarKeyResult | null {
+  switch (key) {
+    case 'ArrowDown':
+    case 'ArrowRight':
+      return { index: clampRowIndex((activeIndex ?? -1) + 1, rowCount), activate: false };
+    case 'ArrowUp':
+    case 'ArrowLeft':
+      return { index: clampRowIndex((activeIndex ?? 1) - 1, rowCount), activate: false };
+    case 'Home':
+      return { index: clampRowIndex(0, rowCount), activate: false };
+    case 'End':
+      return { index: clampRowIndex(Number.MAX_SAFE_INTEGER, rowCount), activate: false };
+    case 'Escape':
+      return { index: null, activate: false };
+    case 'Enter':
+      return canActivate ? { index: activeIndex, activate: true } : null;
+    default:
+      return null;
+  }
+}
+
+function barWidthFor(value: number, max: number, plotWidth: number): number {
+  return Math.max(2, (value / max) * plotWidth);
+}
+
+function valueLabelX(width: number, barEndX: number): number {
+  return Math.min(width - RIGHT + 8, barEndX + 8);
+}
+
+interface BarGridProps {
+  readonly plotWidth: number;
+  readonly plotHeight: number;
+  readonly max: number;
+  readonly valueFormatter: (value: number) => string;
+  readonly xAxisLabel: string;
+}
+
+function BarGrid({ plotWidth, plotHeight, max, valueFormatter, xAxisLabel }: BarGridProps) {
+  return (
+    <>
+      {[0, 0.5, 1].map((ratio) => {
+        const x = LEFT + ratio * plotWidth;
+        const value = ratio * max;
+        return (
+          <g key={ratio}>
+            <line
+              data-testid="plot-grid-line"
+              stroke="var(--color-border)"
+              strokeDasharray={ratio === 0 ? undefined : '3 4'}
+              vectorEffect="non-scaling-stroke"
+              x1={x}
+              x2={x}
+              y1={TOP}
+              y2={TOP + plotHeight}
+            />
+            <text
+              data-testid={xTickTestId(ratio)}
+              fill="var(--color-faint)"
+              fontSize="10"
+              textAnchor="middle"
+              x={x}
+              y={TOP + plotHeight + 17}
+            >
+              {valueFormatter(value)}
+            </text>
+          </g>
+        );
+      })}
+      <text
+        data-testid="plot-x-axis-label"
+        fill="var(--color-muted)"
+        fontSize="11"
+        fontWeight="500"
+        textAnchor="middle"
+        x={LEFT + plotWidth / 2}
+        y={TOP + plotHeight + BOTTOM - 2}
+      >
+        {xAxisLabel}
+      </text>
+    </>
+  );
+}
+
+interface AverageLineMarkerProps {
+  readonly averageLine: BarPlotAverageLine;
+  readonly max: number;
+  readonly plotWidth: number;
+  readonly plotHeight: number;
+}
+
+function AverageLineMarker({ averageLine, max, plotWidth, plotHeight }: AverageLineMarkerProps) {
+  const ratio = Math.min(1, Math.max(0, averageLine.value / max));
+  const x = LEFT + ratio * plotWidth;
+  return (
+    <g>
+      <line
+        data-testid="plot-average-line"
+        stroke="var(--color-border-strong)"
+        strokeDasharray="4 4"
+        vectorEffect="non-scaling-stroke"
+        x1={x}
+        x2={x}
+        y1={TOP}
+        y2={TOP + plotHeight}
+      />
+      <text fill="var(--color-muted)" fontSize="10" textAnchor="middle" x={x} y={TOP - 2}>
+        {averageLine.label}
+      </text>
+    </g>
+  );
+}
+
+function pointsMax(points: readonly PlotPoint[]): number {
+  return Math.max(1, ...points.map((point) => point.value));
+}
+
+function pointsRows(
+  label: string,
+  points: readonly PlotPoint[],
+  valueFormatter: (value: number) => string,
+): AnalyticsDataRow[] {
+  return points.map((point) => ({
     id: point.id,
     label: `${label} ${valueFormatter(point.value)}`,
     cells: { label: point.label, value: valueFormatter(point.value) },
   }));
+}
 
-  function move(index: number) {
-    if (points.length === 0) return;
-    setActiveIndex(Math.max(0, Math.min(index, points.length - 1)));
-  }
+interface PointsBarPlotProps {
+  readonly label: string;
+  readonly points: readonly PlotPoint[];
+  readonly averageLine?: BarPlotAverageLine;
+  readonly onActivate?: (cohort: AnalyticsDrilldownCohort) => void;
+  readonly valueFormatter?: (value: number) => string;
+  readonly xAxisLabel?: string;
+}
 
-  function indexFromTarget(target: EventTarget): number | null {
-    if (!(target instanceof SVGElement)) return null;
-    const index = Number(target.dataset['pointIndex']);
-    return Number.isInteger(index) ? index : null;
-  }
+function PointsBarPlot({
+  label,
+  points,
+  averageLine,
+  onActivate,
+  valueFormatter = String,
+  xAxisLabel = 'Value',
+}: PointsBarPlotProps) {
+  const { ref, width } = useMeasuredWidth();
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const activePoint = activeIndex === null ? undefined : points[activeIndex];
+  const max = pointsMax(points);
+  const plotWidth = width - LEFT - RIGHT;
+  const plotHeight = Math.max(ROW_HEIGHT, points.length * ROW_HEIGHT);
+  const height = TOP + plotHeight + BOTTOM;
+  const rows = pointsRows(label, points, valueFormatter);
 
   return (
     <PlotFrame
@@ -101,7 +264,7 @@ export function BarPlot({
             label={activePoint.label}
             series={label}
             style={{
-              left: `${((LEFT + (activePoint.value / max) * plotWidth) / WIDTH) * 100}%`,
+              left: `${((LEFT + (activePoint.value / max) * plotWidth) / width) * 100}%`,
               top: `${((TOP + activeIndex * ROW_HEIGHT + ROW_HEIGHT / 2) / height) * 100}%`,
               transform: 'translate(-100%, -110%)',
             }}
@@ -110,122 +273,330 @@ export function BarPlot({
         )
       }
     >
-      <svg
-        aria-label={label}
-        className="h-auto w-full outline-none focus-visible:ring-2 focus-visible:ring-accent"
-        height={height}
-        onClick={(event) => {
-          const index = indexFromTarget(event.target);
-          const point = index === null ? undefined : points[index];
-          if (point !== undefined) onActivate?.(point.cohort);
-        }}
-        onFocus={() => {
-          if (activeIndex === null && points.length > 0) setActiveIndex(0);
-        }}
-        onKeyDown={(event) => {
-          if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
-            move((activeIndex ?? -1) + 1);
-          } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
-            move((activeIndex ?? 1) - 1);
-          } else if (event.key === 'Home') move(0);
-          else if (event.key === 'End') move(Number.MAX_SAFE_INTEGER);
-          else if (event.key === 'Escape') setActiveIndex(null);
-          else if (event.key === 'Enter' && activePoint !== undefined && onActivate !== undefined) {
-            onActivate(activePoint.cohort);
-          } else return;
-          event.preventDefault();
-        }}
-        onPointerOver={(event) => {
-          const index = indexFromTarget(event.target);
-          if (index !== null) setActiveIndex(index);
-        }}
-        onPointerLeave={() => setActiveIndex(null)}
-        role="application"
-        // biome-ignore lint/a11y/noNoninteractiveTabindex: The SVG is the chart's single keyboard focus surface.
-        tabIndex={0}
-        viewBox={`0 0 ${WIDTH} ${height}`}
-      >
-        <title>{label}</title>
-        {[0, 0.5, 1].map((ratio) => {
-          const x = LEFT + ratio * plotWidth;
-          const value = ratio * max;
-          return (
-            <g key={ratio}>
-              <line
-                data-testid="plot-grid-line"
-                stroke="var(--color-border)"
-                strokeDasharray={ratio === 0 ? undefined : '3 4'}
-                vectorEffect="non-scaling-stroke"
-                x1={x}
-                x2={x}
-                y1={TOP}
-                y2={TOP + plotHeight}
-              />
-              <text
-                data-testid={xTickTestId(ratio)}
-                fill="var(--color-faint)"
-                fontSize="10"
-                textAnchor="middle"
-                x={x}
-                y={TOP + plotHeight + 17}
-              >
-                {valueFormatter(value)}
-              </text>
-            </g>
-          );
-        })}
-        {points.map((point, index) => {
-          const y = TOP + index * ROW_HEIGHT + 6;
-          const barWidth = Math.max(2, (point.value / max) * plotWidth);
-          const isActive = activeIndex === index;
-          return (
-            <g key={point.id}>
-              <text
-                data-testid={`plot-category-${point.id}`}
-                fill="var(--color-muted)"
-                fontSize="11"
-                textAnchor="end"
-                x={LEFT - 10}
-                y={y + 15}
-              >
-                {truncatedLabel(point.label)}
-              </text>
-              <rect
-                data-active={isActive ? 'true' : 'false'}
-                data-point-index={index}
-                data-testid={`plot-hit-${point.id}`}
-                fill={isActive ? 'var(--color-accent)' : 'var(--color-accent-soft)'}
-                height="22"
-                rx="3"
-                width={barWidth}
-                x={LEFT}
-                y={y}
-              />
-              <text
-                data-testid={`plot-value-${point.id}`}
-                fill="var(--color-text)"
-                fontSize="11"
-                fontWeight="600"
-                x={Math.min(WIDTH - RIGHT + 8, LEFT + barWidth + 8)}
-                y={y + 15}
-              >
-                {valueFormatter(point.value)}
-              </text>
-            </g>
-          );
-        })}
-        <text
-          data-testid="plot-x-axis-label"
-          fill="var(--color-muted)"
-          fontSize="11"
-          fontWeight="500"
-          textAnchor="middle"
-          x={LEFT + plotWidth / 2}
-          y={height - 2}
+      <div className="w-full" ref={ref}>
+        <svg
+          aria-label={label}
+          className="block outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+          height={height}
+          onClick={(event) => {
+            const index = indexFromTarget(event.target);
+            const point = index === null ? undefined : points[index];
+            if (point !== undefined) onActivate?.(point.cohort);
+          }}
+          onFocus={() => {
+            if (activeIndex === null && points.length > 0) setActiveIndex(0);
+          }}
+          onKeyDown={(event) => {
+            const result = barKeyResult(
+              event.key,
+              activeIndex,
+              points.length,
+              activePoint !== undefined && onActivate !== undefined,
+            );
+            if (result === null) return;
+            setActiveIndex(result.index);
+            if (result.activate && activePoint !== undefined) onActivate?.(activePoint.cohort);
+            event.preventDefault();
+          }}
+          onPointerOver={(event) => {
+            const index = indexFromTarget(event.target);
+            if (index !== null) setActiveIndex(index);
+          }}
+          onPointerLeave={() => setActiveIndex(null)}
+          role="application"
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: The SVG is the chart's single keyboard focus surface.
+          tabIndex={0}
+          width={width}
         >
-          {xAxisLabel}
-        </text>
-      </svg>
+          <title>{label}</title>
+          <BarGrid
+            max={max}
+            plotHeight={plotHeight}
+            plotWidth={plotWidth}
+            valueFormatter={valueFormatter}
+            xAxisLabel={xAxisLabel}
+          />
+          {points.map((point, index) => {
+            const y = TOP + index * ROW_HEIGHT + 6;
+            const barWidth = barWidthFor(point.value, max, plotWidth);
+            const isActive = activeIndex === index;
+            return (
+              <g key={point.id}>
+                <text
+                  data-testid={`plot-category-${point.id}`}
+                  fill="var(--color-muted)"
+                  fontSize="11"
+                  textAnchor="end"
+                  x={LEFT - 10}
+                  y={y + 15}
+                >
+                  {truncatedLabel(point.label)}
+                </text>
+                <rect
+                  data-active={isActive ? 'true' : 'false'}
+                  data-point-index={index}
+                  data-testid={`plot-hit-${point.id}`}
+                  fill={isActive ? 'var(--color-accent)' : 'var(--color-accent-soft)'}
+                  height="22"
+                  rx="3"
+                  width={barWidth}
+                  x={LEFT}
+                  y={y}
+                />
+                <text
+                  data-testid={`plot-value-${point.id}`}
+                  fill="var(--color-text)"
+                  fontSize="11"
+                  fontWeight="600"
+                  x={valueLabelX(width, LEFT + barWidth)}
+                  y={y + 15}
+                >
+                  {valueFormatter(point.value)}
+                </text>
+              </g>
+            );
+          })}
+          {averageLine === undefined ? null : (
+            <AverageLineMarker
+              averageLine={averageLine}
+              max={max}
+              plotHeight={plotHeight}
+              plotWidth={plotWidth}
+            />
+          )}
+        </svg>
+      </div>
     </PlotFrame>
+  );
+}
+
+function pairsMax(pairs: readonly BarPair[]): number {
+  return Math.max(1, ...pairs.flatMap((pair) => [pair.primary.value, pair.secondary.value]));
+}
+
+function pairsRows(
+  pairs: readonly BarPair[],
+  valueFormatter: (value: number) => string,
+): AnalyticsDataRow[] {
+  return pairs.map((pair) => ({
+    id: pair.id,
+    label: `${pair.label}, ${pair.primary.label} ${valueFormatter(pair.primary.value)}, ${pair.secondary.label} ${valueFormatter(pair.secondary.value)}`,
+    cells: {
+      label: pair.label,
+      primary: valueFormatter(pair.primary.value),
+      secondary: valueFormatter(pair.secondary.value),
+    },
+  }));
+}
+
+function pairRowTop(index: number): number {
+  return TOP + index * PAIR_ROW_HEIGHT;
+}
+
+function pairPrimaryY(index: number): number {
+  return pairRowTop(index) + PAIR_BAR_TOP;
+}
+
+function pairSecondaryY(index: number): number {
+  return pairPrimaryY(index) + PAIR_BAR_HEIGHT + PAIR_BAR_GAP;
+}
+
+interface PairsBarPlotProps {
+  readonly label: string;
+  readonly pairs: readonly BarPair[];
+  readonly averageLine?: BarPlotAverageLine;
+  readonly onActivate?: (cohort: AnalyticsDrilldownCohort) => void;
+  readonly valueFormatter?: (value: number) => string;
+  readonly xAxisLabel?: string;
+}
+
+function PairsBarPlot({
+  label,
+  pairs,
+  averageLine,
+  onActivate,
+  valueFormatter = String,
+  xAxisLabel = 'Value',
+}: PairsBarPlotProps) {
+  const { ref, width } = useMeasuredWidth();
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const activePair = activeIndex === null ? undefined : pairs[activeIndex];
+  const max = pairsMax(pairs);
+  const plotWidth = width - LEFT - RIGHT;
+  const plotHeight = Math.max(PAIR_ROW_HEIGHT, pairs.length * PAIR_ROW_HEIGHT);
+  const height = TOP + plotHeight + BOTTOM;
+  const rows = pairsRows(pairs, valueFormatter);
+
+  return (
+    <PlotFrame
+      announcement={
+        activePair === undefined
+          ? ''
+          : `${activePair.label}, ${activePair.primary.label} ${valueFormatter(activePair.primary.value)}, ${activePair.secondary.label} ${valueFormatter(activePair.secondary.value)}`
+      }
+      dataCount={rows.length}
+      label={label}
+      legends={[]}
+      table={
+        <AnalyticsDataTable
+          ariaLabel={`${label} data`}
+          columns={[
+            { id: 'label', label: 'Category' },
+            { id: 'primary', label: 'Primary', align: 'right' },
+            { id: 'secondary', label: 'Secondary', align: 'right' },
+          ]}
+          rows={rows}
+          {...(onActivate === undefined
+            ? {}
+            : {
+                onActivate: (row: AnalyticsDataRow) => {
+                  const index = pairs.findIndex((pair) => pair.id === row.id);
+                  const selected = pairs[index];
+                  if (selected !== undefined) {
+                    setActiveIndex(index);
+                    onActivate(selected.primary.cohort);
+                  }
+                },
+              })}
+          {...(activePair === undefined ? {} : { activeRowId: activePair.id })}
+        />
+      }
+      tooltip={
+        activePair === undefined || activeIndex === null ? null : (
+          <ChartTooltip
+            label={activePair.label}
+            rows={[
+              {
+                id: 'primary',
+                series: activePair.primary.label,
+                value: valueFormatter(activePair.primary.value),
+              },
+              {
+                id: 'secondary',
+                series: activePair.secondary.label,
+                value: valueFormatter(activePair.secondary.value),
+              },
+            ]}
+            style={{
+              left: `${
+                ((LEFT +
+                  (Math.max(activePair.primary.value, activePair.secondary.value) / max) *
+                    plotWidth) /
+                  width) *
+                100
+              }%`,
+              top: `${((pairRowTop(activeIndex) + PAIR_ROW_HEIGHT / 2) / height) * 100}%`,
+              transform: 'translate(-100%, -110%)',
+            }}
+          />
+        )
+      }
+    >
+      <div className="w-full" ref={ref}>
+        <svg
+          aria-label={label}
+          className="block outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+          height={height}
+          onClick={(event) => {
+            const index = indexFromTarget(event.target);
+            const pair = index === null ? undefined : pairs[index];
+            if (pair !== undefined) onActivate?.(pair.primary.cohort);
+          }}
+          onFocus={() => {
+            if (activeIndex === null && pairs.length > 0) setActiveIndex(0);
+          }}
+          onKeyDown={(event) => {
+            const result = barKeyResult(
+              event.key,
+              activeIndex,
+              pairs.length,
+              activePair !== undefined && onActivate !== undefined,
+            );
+            if (result === null) return;
+            setActiveIndex(result.index);
+            if (result.activate && activePair !== undefined)
+              onActivate?.(activePair.primary.cohort);
+            event.preventDefault();
+          }}
+          onPointerOver={(event) => {
+            const index = indexFromTarget(event.target);
+            if (index !== null) setActiveIndex(index);
+          }}
+          onPointerLeave={() => setActiveIndex(null)}
+          role="application"
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: The SVG is the chart's single keyboard focus surface.
+          tabIndex={0}
+          width={width}
+        >
+          <title>{label}</title>
+          <BarGrid
+            max={max}
+            plotHeight={plotHeight}
+            plotWidth={plotWidth}
+            valueFormatter={valueFormatter}
+            xAxisLabel={xAxisLabel}
+          />
+          {pairs.map((pair, index) => {
+            const primaryY = pairPrimaryY(index);
+            const secondaryY = pairSecondaryY(index);
+            const primaryWidth = barWidthFor(pair.primary.value, max, plotWidth);
+            const secondaryWidth = barWidthFor(pair.secondary.value, max, plotWidth);
+            const isActive = activeIndex === index;
+            return (
+              <g key={pair.id}>
+                <text
+                  data-testid={`plot-category-${pair.id}`}
+                  fill="var(--color-muted)"
+                  fontSize="11"
+                  textAnchor="end"
+                  x={LEFT - 10}
+                  y={pairRowTop(index) + PAIR_ROW_HEIGHT / 2 + 4}
+                >
+                  {truncatedLabel(pair.label)}
+                </text>
+                <rect
+                  data-active={isActive ? 'true' : 'false'}
+                  data-point-index={index}
+                  data-testid={`plot-bar-primary-${pair.id}`}
+                  fill="var(--analytics-series-1)"
+                  height={PAIR_BAR_HEIGHT}
+                  rx="2"
+                  width={primaryWidth}
+                  x={LEFT}
+                  y={primaryY}
+                />
+                <rect
+                  data-active={isActive ? 'true' : 'false'}
+                  data-point-index={index}
+                  data-testid={`plot-bar-secondary-${pair.id}`}
+                  fill="var(--color-border-strong)"
+                  height={PAIR_BAR_HEIGHT}
+                  rx="2"
+                  width={secondaryWidth}
+                  x={LEFT}
+                  y={secondaryY}
+                />
+              </g>
+            );
+          })}
+          {averageLine === undefined ? null : (
+            <AverageLineMarker
+              averageLine={averageLine}
+              max={max}
+              plotHeight={plotHeight}
+              plotWidth={plotWidth}
+            />
+          )}
+        </svg>
+      </div>
+    </PlotFrame>
+  );
+}
+
+export function BarPlot({ points, pairs, ...rest }: BarPlotProps) {
+  return pairs === undefined ? (
+    <PointsBarPlot points={points} {...rest} />
+  ) : (
+    <PairsBarPlot pairs={pairs} {...rest} />
   );
 }

--- a/apps/web/src/features/analytics/charts/bar-plot.tsx
+++ b/apps/web/src/features/analytics/charts/bar-plot.tsx
@@ -562,7 +562,7 @@ function PairsBarPlot({
       label={label}
       legends={[
         { id: 'primary', label: primaryLabel, color: 1 },
-        { id: 'secondary', label: secondaryLabel, color: 4 },
+        { id: 'secondary', label: secondaryLabel, swatchVar: 'var(--color-border-strong)' },
       ]}
       table={
         <AnalyticsDataTable

--- a/apps/web/src/features/analytics/charts/bar-plot.tsx
+++ b/apps/web/src/features/analytics/charts/bar-plot.tsx
@@ -13,6 +13,7 @@ export interface BarPair {
   readonly label: string;
   readonly primary: PlotPoint;
   readonly secondary: PlotPoint;
+  readonly current?: boolean;
 }
 
 export interface BarPlotAverageLine {
@@ -543,7 +544,10 @@ function PairsBarPlot({
             const secondaryWidth = barWidthFor(pair.secondary.value, max, plotWidth);
             const isActive = activeIndex === index;
             return (
-              <g key={pair.id}>
+              <g
+                data-testid={pair.current === true ? 'plot-pair-current' : undefined}
+                key={pair.id}
+              >
                 <text
                   data-testid={`plot-category-${pair.id}`}
                   fill="var(--color-muted)"

--- a/apps/web/src/features/analytics/charts/bar-plot.tsx
+++ b/apps/web/src/features/analytics/charts/bar-plot.tsx
@@ -563,6 +563,7 @@ function PairsBarPlot({
                   data-point-index={index}
                   data-testid={`plot-bar-primary-${pair.id}`}
                   fill="var(--analytics-series-1)"
+                  fillOpacity={pair.current === true ? 0.45 : undefined}
                   height={PAIR_BAR_HEIGHT}
                   rx="2"
                   width={primaryWidth}
@@ -574,6 +575,7 @@ function PairsBarPlot({
                   data-point-index={index}
                   data-testid={`plot-bar-secondary-${pair.id}`}
                   fill="var(--color-border-strong)"
+                  fillOpacity={pair.current === true ? 0.45 : undefined}
                   height={PAIR_BAR_HEIGHT}
                   rx="2"
                   width={secondaryWidth}

--- a/apps/web/src/features/analytics/charts/bar-plot.tsx
+++ b/apps/web/src/features/analytics/charts/bar-plot.tsx
@@ -21,9 +21,20 @@ export interface BarPlotAverageLine {
   readonly label: string;
 }
 
+export interface BarPlotSegment {
+  readonly id: string;
+  readonly label: string;
+  readonly value: number;
+}
+
+export type BarPlotPoint = Omit<PlotPoint, 'cohort'> & {
+  readonly cohort: AnalyticsDrilldownCohort | null;
+  readonly segments?: readonly BarPlotSegment[];
+};
+
 interface BarPlotProps {
   readonly label: string;
-  readonly points: readonly PlotPoint[];
+  readonly points: readonly BarPlotPoint[];
   readonly pairs?: readonly BarPair[];
   readonly averageLine?: BarPlotAverageLine;
   readonly onActivate?: (cohort: AnalyticsDrilldownCohort) => void;
@@ -184,25 +195,122 @@ function AverageLineMarker({ averageLine, max, plotWidth, plotHeight }: AverageL
   );
 }
 
-function pointsMax(points: readonly PlotPoint[]): number {
+function pointsMax(points: readonly BarPlotPoint[]): number {
   return Math.max(1, ...points.map((point) => point.value));
 }
 
 function pointsRows(
   label: string,
-  points: readonly PlotPoint[],
+  points: readonly BarPlotPoint[],
   valueFormatter: (value: number) => string,
 ): AnalyticsDataRow[] {
   return points.map((point) => ({
     id: point.id,
     label: `${label} ${valueFormatter(point.value)}`,
     cells: { label: point.label, value: valueFormatter(point.value) },
+    activatable: point.cohort !== null,
   }));
+}
+
+function segmentColor(index: number): string {
+  return `var(--analytics-series-${(index % 4) + 1})`;
+}
+
+interface SegmentedBarProps {
+  readonly point: BarPlotPoint;
+  readonly segments: readonly BarPlotSegment[];
+  readonly index: number;
+  readonly isActive: boolean;
+  readonly totalWidth: number;
+  readonly y: number;
+}
+
+function SegmentedBar({ point, segments, index, isActive, totalWidth, y }: SegmentedBarProps) {
+  const total = segments.reduce((sum, segment) => sum + segment.value, 0) || 1;
+  let cursor = 0;
+  return (
+    <g>
+      {segments.map((segment, segmentIndex) => {
+        const width = (segment.value / total) * totalWidth;
+        const x = LEFT + cursor;
+        cursor += width;
+        return (
+          <rect
+            fill={segmentColor(segmentIndex)}
+            height="22"
+            key={segment.id}
+            width={width}
+            x={x}
+            y={y}
+          />
+        );
+      })}
+      <rect
+        data-active={isActive ? 'true' : 'false'}
+        data-point-index={index}
+        data-testid={`plot-hit-${point.id}`}
+        fill="transparent"
+        height="22"
+        width={Math.max(totalWidth, 2)}
+        x={LEFT}
+        y={y}
+      />
+    </g>
+  );
+}
+
+interface PointsTooltipProps {
+  readonly point: BarPlotPoint;
+  readonly index: number;
+  readonly label: string;
+  readonly max: number;
+  readonly plotWidth: number;
+  readonly width: number;
+  readonly height: number;
+  readonly valueFormatter: (value: number) => string;
+}
+
+function PointsTooltip({
+  point,
+  index,
+  label,
+  max,
+  plotWidth,
+  width,
+  height,
+  valueFormatter,
+}: PointsTooltipProps) {
+  const style = {
+    left: `${((LEFT + (point.value / max) * plotWidth) / width) * 100}%`,
+    top: `${((TOP + index * ROW_HEIGHT + ROW_HEIGHT / 2) / height) * 100}%`,
+    transform: 'translate(-100%, -110%)',
+  };
+  if (point.segments !== undefined && point.segments.length > 0) {
+    return (
+      <ChartTooltip
+        label={point.label}
+        rows={point.segments.map((segment) => ({
+          id: segment.id,
+          series: segment.label,
+          value: valueFormatter(segment.value),
+        }))}
+        style={style}
+      />
+    );
+  }
+  return (
+    <ChartTooltip
+      label={point.label}
+      series={label}
+      style={style}
+      value={valueFormatter(point.value)}
+    />
+  );
 }
 
 interface PointsBarPlotProps {
   readonly label: string;
-  readonly points: readonly PlotPoint[];
+  readonly points: readonly BarPlotPoint[];
   readonly averageLine?: BarPlotAverageLine;
   readonly onActivate?: (cohort: AnalyticsDrilldownCohort) => void;
   readonly valueFormatter?: (value: number) => string;
@@ -250,7 +358,7 @@ function PointsBarPlot({
                 onActivate: (row: AnalyticsDataRow) => {
                   const index = points.findIndex((point) => point.id === row.id);
                   const selected = points[index];
-                  if (selected !== undefined) {
+                  if (selected !== undefined && selected.cohort !== null) {
                     setActiveIndex(index);
                     onActivate(selected.cohort);
                   }
@@ -261,15 +369,15 @@ function PointsBarPlot({
       }
       tooltip={
         activePoint === undefined || activeIndex === null ? null : (
-          <ChartTooltip
-            label={activePoint.label}
-            series={label}
-            style={{
-              left: `${((LEFT + (activePoint.value / max) * plotWidth) / width) * 100}%`,
-              top: `${((TOP + activeIndex * ROW_HEIGHT + ROW_HEIGHT / 2) / height) * 100}%`,
-              transform: 'translate(-100%, -110%)',
-            }}
-            value={valueFormatter(activePoint.value)}
+          <PointsTooltip
+            height={height}
+            index={activeIndex}
+            label={label}
+            max={max}
+            plotWidth={plotWidth}
+            point={activePoint}
+            valueFormatter={valueFormatter}
+            width={width}
           />
         )
       }
@@ -282,7 +390,7 @@ function PointsBarPlot({
           onClick={(event) => {
             const index = indexFromTarget(event.target);
             const point = index === null ? undefined : points[index];
-            if (point !== undefined) onActivate?.(point.cohort);
+            if (point !== undefined && point.cohort !== null) onActivate?.(point.cohort);
           }}
           onFocus={() => {
             if (activeIndex === null && points.length > 0) setActiveIndex(0);
@@ -292,11 +400,13 @@ function PointsBarPlot({
               event.key,
               activeIndex,
               points.length,
-              activePoint !== undefined && onActivate !== undefined,
+              activePoint !== undefined && activePoint.cohort !== null && onActivate !== undefined,
             );
             if (result === null) return;
             setActiveIndex(result.index);
-            if (result.activate && activePoint !== undefined) onActivate?.(activePoint.cohort);
+            if (result.activate && activePoint !== undefined && activePoint.cohort !== null) {
+              onActivate?.(activePoint.cohort);
+            }
             event.preventDefault();
           }}
           onPointerOver={(event) => {
@@ -333,17 +443,28 @@ function PointsBarPlot({
                 >
                   {truncatedLabel(point.label)}
                 </text>
-                <rect
-                  data-active={isActive ? 'true' : 'false'}
-                  data-point-index={index}
-                  data-testid={`plot-hit-${point.id}`}
-                  fill={isActive ? 'var(--color-accent)' : 'var(--color-accent-soft)'}
-                  height="22"
-                  rx="3"
-                  width={barWidth}
-                  x={LEFT}
-                  y={y}
-                />
+                {point.segments === undefined || point.segments.length === 0 ? (
+                  <rect
+                    data-active={isActive ? 'true' : 'false'}
+                    data-point-index={index}
+                    data-testid={`plot-hit-${point.id}`}
+                    fill={isActive ? 'var(--color-accent)' : 'var(--color-accent-soft)'}
+                    height="22"
+                    rx="3"
+                    width={barWidth}
+                    x={LEFT}
+                    y={y}
+                  />
+                ) : (
+                  <SegmentedBar
+                    index={index}
+                    isActive={isActive}
+                    point={point}
+                    segments={point.segments}
+                    totalWidth={barWidth}
+                    y={y}
+                  />
+                )}
                 <text
                   data-testid={`plot-value-${point.id}`}
                   fill="var(--color-text)"

--- a/apps/web/src/features/analytics/charts/bar-plot.tsx
+++ b/apps/web/src/features/analytics/charts/bar-plot.tsx
@@ -548,6 +548,8 @@ function PairsBarPlot({
   const plotHeight = Math.max(PAIR_ROW_HEIGHT, pairs.length * PAIR_ROW_HEIGHT);
   const height = TOP + plotHeight + BOTTOM;
   const rows = pairsRows(pairs, valueFormatter);
+  const primaryLabel = pairs[0]?.primary.label ?? 'Primary';
+  const secondaryLabel = pairs[0]?.secondary.label ?? 'Secondary';
 
   return (
     <PlotFrame
@@ -558,14 +560,17 @@ function PairsBarPlot({
       }
       dataCount={rows.length}
       label={label}
-      legends={[]}
+      legends={[
+        { id: 'primary', label: primaryLabel, color: 1 },
+        { id: 'secondary', label: secondaryLabel, color: 4 },
+      ]}
       table={
         <AnalyticsDataTable
           ariaLabel={`${label} data`}
           columns={[
             { id: 'label', label: 'Category' },
-            { id: 'primary', label: 'Primary', align: 'right' },
-            { id: 'secondary', label: 'Secondary', align: 'right' },
+            { id: 'primary', label: primaryLabel, align: 'right' },
+            { id: 'secondary', label: secondaryLabel, align: 'right' },
           ]}
           rows={rows}
           {...(onActivate === undefined

--- a/apps/web/src/features/analytics/charts/chart-tooltip.tsx
+++ b/apps/web/src/features/analytics/charts/chart-tooltip.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties } from 'react';
 import { cn } from '@/lib/cn.ts';
 
 interface ChartTooltipRow {
+  readonly id: string;
   readonly series: string;
   readonly value: string;
 }
@@ -45,7 +46,7 @@ export function ChartTooltip(props: ChartTooltipProps) {
       ) : (
         <div className="mt-0.5 grid gap-0.5">
           {props.rows.map((row) => (
-            <p className="font-medium text-text" key={row.series}>
+            <p className="font-medium text-text" key={row.id}>
               {row.series} {row.value}
             </p>
           ))}

--- a/apps/web/src/features/analytics/charts/chart-tooltip.tsx
+++ b/apps/web/src/features/analytics/charts/chart-tooltip.tsx
@@ -1,15 +1,33 @@
 import type { CSSProperties } from 'react';
 import { cn } from '@/lib/cn.ts';
 
-interface ChartTooltipProps {
+interface ChartTooltipRow {
+  readonly series: string;
+  readonly value: string;
+}
+
+interface ChartTooltipSingleProps {
   readonly label: string;
   readonly series: string;
   readonly value: string;
+  readonly rows?: undefined;
   readonly className?: string;
   readonly style?: CSSProperties | undefined;
 }
 
-export function ChartTooltip({ label, series, value, className, style }: ChartTooltipProps) {
+interface ChartTooltipRowsProps {
+  readonly label: string;
+  readonly series?: undefined;
+  readonly value?: undefined;
+  readonly rows: readonly ChartTooltipRow[];
+  readonly className?: string;
+  readonly style?: CSSProperties | undefined;
+}
+
+type ChartTooltipProps = ChartTooltipRowsProps | ChartTooltipSingleProps;
+
+export function ChartTooltip(props: ChartTooltipProps) {
+  const { label, className, style } = props;
   return (
     <div
       className={cn(
@@ -20,9 +38,19 @@ export function ChartTooltip({ label, series, value, className, style }: ChartTo
       style={style}
     >
       <p className="text-faint">{label}</p>
-      <p className="mt-0.5 font-medium text-text">
-        {series} {value}
-      </p>
+      {props.rows === undefined ? (
+        <p className="mt-0.5 font-medium text-text">
+          {props.series} {props.value}
+        </p>
+      ) : (
+        <div className="mt-0.5 grid gap-0.5">
+          {props.rows.map((row) => (
+            <p className="font-medium text-text" key={row.series}>
+              {row.series} {row.value}
+            </p>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/analytics/charts/line-plot.tsx
+++ b/apps/web/src/features/analytics/charts/line-plot.tsx
@@ -26,6 +26,7 @@ export interface PlotPoint {
   readonly id: string;
   readonly label: string;
   readonly value: number;
+  readonly displayValue?: number;
   readonly cohort: AnalyticsDrilldownCohort;
   readonly x?: number;
   readonly available?: boolean;
@@ -503,7 +504,13 @@ function tooltipRowsForDay(
     );
     return point === undefined
       ? []
-      : [{ id: entry.id, series: entry.label, value: valueFormatter(point.value) }];
+      : [
+          {
+            id: entry.id,
+            series: entry.label,
+            value: valueFormatter(point.displayValue ?? point.value),
+          },
+        ];
   });
 }
 
@@ -552,7 +559,9 @@ function dayTableRows(
     for (const entry of series) {
       const point = entry.points.find((candidate) => candidate.label === day.date);
       const formatted =
-        point !== undefined && isAvailable(point) ? valueFormatter(point.value) : '';
+        point !== undefined && isAvailable(point)
+          ? valueFormatter(point.displayValue ?? point.value)
+          : '';
       cells[entry.id] = formatted;
       if (formatted !== '') parts.push(`${entry.label} ${formatted}`);
     }

--- a/apps/web/src/features/analytics/charts/line-plot.tsx
+++ b/apps/web/src/features/analytics/charts/line-plot.tsx
@@ -159,6 +159,13 @@ function firstAvailableIndex(points: readonly PlotPoint[]): number {
   );
 }
 
+function lastAvailableIndex(points: readonly PlotPoint[]): number {
+  for (let index = points.length - 1; index >= 0; index -= 1) {
+    if (isAvailable(points[index])) return index;
+  }
+  return Math.max(0, points.length - 1);
+}
+
 function movedPointIndex(
   points: readonly PlotPoint[],
   current: number | null,
@@ -167,7 +174,8 @@ function movedPointIndex(
   const direction = target >= (current ?? -1) ? 1 : -1;
   let next = clampIndex(target, points.length);
   while (next >= 0 && next < points.length && !isAvailable(points[next])) next += direction;
-  return isAvailable(points[next]) ? next : firstAvailableIndex(points);
+  if (isAvailable(points[next])) return next;
+  return direction === 1 ? lastAvailableIndex(points) : firstAvailableIndex(points);
 }
 
 function movedPoint(

--- a/apps/web/src/features/analytics/charts/line-plot.tsx
+++ b/apps/web/src/features/analytics/charts/line-plot.tsx
@@ -2,18 +2,25 @@
 
 import type { AnalyticsDrilldownCohort } from '@orbit/shared/validators';
 import { useState } from 'react';
-import { type AnalyticsDataRow, AnalyticsDataTable } from './analytics-data-table.tsx';
+import { useMeasuredWidth } from '@/lib/use-measured-width.ts';
+import type { SprintDay } from '../burn-math.ts';
+import {
+  type AnalyticsDataColumn,
+  type AnalyticsDataRow,
+  AnalyticsDataTable,
+} from './analytics-data-table.tsx';
 import { ChartTooltip } from './chart-tooltip.tsx';
 import { PlotFrame } from './plot-frame.tsx';
 import { PlotGuides } from './plot-guides.tsx';
 
-const WIDTH = 640;
-const HEIGHT = 260;
-const LEFT = 76;
-const RIGHT = 18;
-const TOP = 14;
-const BOTTOM = 42;
+const HEIGHT = 280;
+const LEFT = 56;
+const RIGHT = 16;
+const TOP = 12;
+const BOTTOM = 44;
 const PLOT_BOTTOM = HEIGHT - BOTTOM;
+const TICK_SPACING = 56;
+const DOT_RADIUS = 2.5;
 
 export interface PlotPoint {
   readonly id: string;
@@ -29,6 +36,8 @@ export interface PlotSeries {
   readonly label: string;
   readonly points: readonly PlotPoint[];
   readonly dashed?: boolean;
+  readonly step?: boolean;
+  readonly dots?: boolean;
 }
 
 interface ActivePoint {
@@ -39,6 +48,7 @@ interface ActivePoint {
 interface LinePlotProps {
   readonly label: string;
   readonly series: readonly PlotSeries[];
+  readonly days?: readonly SprintDay[];
   readonly onActivate?: (cohort: AnalyticsDrilldownCohort) => void;
   readonly valueFormatter?: (value: number) => string;
   readonly xAxisLabel?: string;
@@ -46,14 +56,22 @@ interface LinePlotProps {
   readonly annotation?: string;
 }
 
-function isAvailable(point: PlotPoint | undefined): boolean {
-  return point !== undefined && point.available !== false;
+type LegacyLinePlotProps = Omit<LinePlotProps, 'days'>;
+type DayLinePlotProps = Omit<LinePlotProps, 'days'> & { readonly days: readonly SprintDay[] };
+
+interface AxisTick {
+  readonly x: number;
+  readonly label: string;
+  readonly testId?: string;
 }
 
-function pointAt(series: readonly PlotSeries[], active: ActivePoint | null): PlotPoint | null {
-  if (active === null) return null;
-  const point = series[active.seriesIndex]?.points[active.pointIndex];
-  return point !== undefined && isAvailable(point) ? point : null;
+interface TooltipRow {
+  readonly series: string;
+  readonly value: string;
+}
+
+function isAvailable(point: PlotPoint | undefined): boolean {
+  return point !== undefined && point.available !== false;
 }
 
 function maxValue(series: readonly PlotSeries[]): number {
@@ -69,6 +87,52 @@ function yForValue(value: number, max: number): number {
   return PLOT_BOTTOM - (Math.max(0, value) / max) * (PLOT_BOTTOM - TOP);
 }
 
+function xTickLabel(label: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(label)) return label;
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${label}T12:00:00.000Z`));
+}
+
+function unavailableNote(count: number): string {
+  return `${count} ${count === 1 ? 'date' : 'dates'} unavailable`;
+}
+
+function unavailableDates(series: readonly PlotSeries[]): ReadonlySet<string> {
+  return new Set(
+    series.flatMap((entry) =>
+      entry.points.flatMap((point) => (isAvailable(point) ? [] : [point.label])),
+    ),
+  );
+}
+
+function clampIndex(index: number, length: number): number {
+  return Math.max(0, Math.min(index, length - 1));
+}
+
+function tooltipStyle(x: number | null, y: number | null, width: number) {
+  if (x === null || y === null) return undefined;
+  return {
+    left: `${(x / width) * 100}%`,
+    top: `${(y / HEIGHT) * 100}%`,
+    transform: x > width / 2 ? 'translate(-100%, -110%)' : 'translate(0, -110%)',
+  };
+}
+
+function xTickTestId(index: number, count: number): string | undefined {
+  if (index === 0) return 'plot-x-start';
+  if (index === count - 1) return 'plot-x-end';
+  return undefined;
+}
+
+function pointAt(series: readonly PlotSeries[], active: ActivePoint | null): PlotPoint | null {
+  if (active === null) return null;
+  const point = series[active.seriesIndex]?.points[active.pointIndex];
+  return point !== undefined && isAvailable(point) ? point : null;
+}
+
 function announcementOf(
   series: readonly PlotSeries[],
   active: ActivePoint | null,
@@ -81,150 +145,217 @@ function announcementOf(
     : `${point.label}, ${activeSeries.label} ${valueFormatter(point.value)}`;
 }
 
-function tooltipStyle(x: number | null, y: number | null) {
-  if (x === null || y === null) return undefined;
-  return {
-    left: `${(x / WIDTH) * 100}%`,
-    top: `${(y / HEIGHT) * 100}%`,
-    transform: x > WIDTH / 2 ? 'translate(-100%, -110%)' : 'translate(0, -110%)',
-  };
+function firstAvailableIndex(points: readonly PlotPoint[]): number {
+  return Math.max(
+    0,
+    points.findIndex((point) => isAvailable(point)),
+  );
 }
 
-function xTickTestId(index: number, count: number): string | undefined {
-  if (index === 0) return 'plot-x-start';
-  if (index === count - 1) return 'plot-x-end';
-  return undefined;
+function movedPointIndex(
+  points: readonly PlotPoint[],
+  current: number | null,
+  target: number,
+): number {
+  const direction = target >= (current ?? -1) ? 1 : -1;
+  let next = clampIndex(target, points.length);
+  while (next >= 0 && next < points.length && !isAvailable(points[next])) next += direction;
+  return isAvailable(points[next]) ? next : firstAvailableIndex(points);
 }
 
-function unavailableNote(count: number): string {
-  return `${count} ${count === 1 ? 'date' : 'dates'} unavailable`;
+function movedPoint(
+  series: readonly PlotSeries[],
+  active: ActivePoint | null,
+  target: number,
+): ActivePoint | null {
+  const seriesIndex = active?.seriesIndex ?? 0;
+  const points = series[seriesIndex]?.points ?? [];
+  if (points.length === 0) return active;
+  return { seriesIndex, pointIndex: movedPointIndex(points, active?.pointIndex ?? null, target) };
 }
 
-function xTickLabel(label: string): string {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(label)) return label;
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    timeZone: 'UTC',
-  }).format(new Date(`${label}T12:00:00.000Z`));
+function movedSeriesSelection(
+  series: readonly PlotSeries[],
+  active: ActivePoint | null,
+  delta: number,
+): ActivePoint | null {
+  if (series.length === 0) return active;
+  const seriesIndex = clampIndex((active?.seriesIndex ?? 0) + delta, series.length);
+  const points = series[seriesIndex]?.points ?? [];
+  const preferred = active?.pointIndex ?? firstAvailableIndex(points);
+  const pointIndex = isAvailable(points[preferred]) ? preferred : firstAvailableIndex(points);
+  return { seriesIndex, pointIndex };
 }
 
-export function LinePlot({
-  label,
-  series,
-  onActivate,
-  valueFormatter = String,
-  xAxisLabel = 'Date',
-  yAxisLabel = 'Value',
-  annotation,
-}: LinePlotProps) {
-  const [active, setActive] = useState<ActivePoint | null>(null);
-  const activePoint = pointAt(series, active);
-  const activeSeries = active === null ? undefined : series[active.seriesIndex];
-  const max = maxValue(series);
-  const explicitX = series.flatMap((entry) =>
+interface LegacyKeyResult {
+  readonly active: ActivePoint | null;
+  readonly activate: boolean;
+}
+
+function legacyKeyResult(
+  key: string,
+  series: readonly PlotSeries[],
+  active: ActivePoint | null,
+): LegacyKeyResult | null {
+  switch (key) {
+    case 'ArrowRight':
+      return {
+        active: movedPoint(series, active, (active?.pointIndex ?? -1) + 1),
+        activate: false,
+      };
+    case 'ArrowLeft':
+      return { active: movedPoint(series, active, (active?.pointIndex ?? 1) - 1), activate: false };
+    case 'ArrowDown':
+      return { active: movedSeriesSelection(series, active, 1), activate: false };
+    case 'ArrowUp':
+      return { active: movedSeriesSelection(series, active, -1), activate: false };
+    case 'Home':
+      return { active: movedPoint(series, active, 0), activate: false };
+    case 'End':
+      return { active: movedPoint(series, active, Number.MAX_SAFE_INTEGER), activate: false };
+    case 'Escape':
+      return { active: null, activate: false };
+    case 'Enter':
+      return { active, activate: true };
+    default:
+      return null;
+  }
+}
+
+function pointFromTarget(target: EventTarget): ActivePoint | null {
+  if (!(target instanceof SVGElement)) return null;
+  const seriesIndex = Number(target.dataset['seriesIndex']);
+  const pointIndex = Number(target.dataset['pointIndex']);
+  return Number.isInteger(seriesIndex) && Number.isInteger(pointIndex)
+    ? { seriesIndex, pointIndex }
+    : null;
+}
+
+function findPointForRow(series: readonly PlotSeries[], rowId: string): ActivePoint | null {
+  for (const [seriesIndex, entry] of series.entries()) {
+    const pointIndex = entry.points.findIndex((point) => point.id === rowId);
+    if (pointIndex >= 0) {
+      return isAvailable(entry.points[pointIndex]) ? { seriesIndex, pointIndex } : null;
+    }
+  }
+  return null;
+}
+
+interface ExplicitXRange {
+  readonly values: readonly number[];
+  readonly minimumX: number;
+  readonly maximumX: number;
+}
+
+function explicitXRange(series: readonly PlotSeries[]): ExplicitXRange {
+  const values = series.flatMap((entry) =>
     entry.points.flatMap((point) => (point.x === undefined ? [] : [point.x])),
   );
-  const minimumX = explicitX.length === 0 ? 0 : Math.min(...explicitX);
-  const maximumX = explicitX.length === 0 ? 0 : Math.max(...explicitX);
-  const plotWidth = WIDTH - LEFT - RIGHT;
-  function xForPoint(point: PlotPoint, index: number, count: number): number {
-    if (point.x === undefined || explicitX.length === 0 || minimumX === maximumX) {
-      return count <= 1 ? LEFT + plotWidth / 2 : LEFT + (index * plotWidth) / (count - 1);
-    }
-    return LEFT + ((point.x - minimumX) * plotWidth) / (maximumX - minimumX);
-  }
-  const activeX =
-    activePoint === null || active === null || activeSeries === undefined
-      ? null
-      : xForPoint(activePoint, active.pointIndex, activeSeries.points.length);
-  const activeY = activePoint === null ? null : yForValue(activePoint.value, max);
-  const pathFor = (entry: PlotSeries): string => {
-    let connected = false;
-    return entry.points
-      .flatMap((point, index) => {
-        if (!isAvailable(point)) {
-          connected = false;
-          return [];
-        }
-        const command = connected ? 'L' : 'M';
-        connected = true;
-        return [
-          `${command}${xForPoint(point, index, entry.points.length).toFixed(2)} ${yForValue(point.value, max).toFixed(2)}`,
-        ];
-      })
-      .join(' ');
+  return {
+    values,
+    minimumX: values.length === 0 ? 0 : Math.min(...values),
+    maximumX: values.length === 0 ? 0 : Math.max(...values),
   };
+}
 
-  function firstAvailable(seriesIndex: number): number {
-    return Math.max(0, series[seriesIndex]?.points.findIndex((point) => isAvailable(point)) ?? 0);
+function legacyXForPoint(
+  point: PlotPoint,
+  index: number,
+  count: number,
+  range: ExplicitXRange,
+  plotWidth: number,
+): number {
+  if (point.x === undefined || range.values.length === 0 || range.minimumX === range.maximumX) {
+    return count <= 1 ? LEFT + plotWidth / 2 : LEFT + (index * plotWidth) / (count - 1);
   }
+  return LEFT + ((point.x - range.minimumX) * plotWidth) / (range.maximumX - range.minimumX);
+}
 
-  function movePoint(index: number) {
-    const seriesIndex = active?.seriesIndex ?? 0;
-    const points = series[seriesIndex]?.points ?? [];
-    if (points.length === 0) return;
-    const direction = index >= (active?.pointIndex ?? -1) ? 1 : -1;
-    let next = Math.max(0, Math.min(index, points.length - 1));
-    while (!isAvailable(points[next]) && next >= 0 && next < points.length) next += direction;
-    if (!isAvailable(points[next])) next = firstAvailable(seriesIndex);
-    setActive({ seriesIndex, pointIndex: next });
+function legacyPathFor(
+  entry: PlotSeries,
+  range: ExplicitXRange,
+  plotWidth: number,
+  max: number,
+): string {
+  let connected = false;
+  return entry.points
+    .flatMap((point, index) => {
+      if (!isAvailable(point)) {
+        connected = false;
+        return [];
+      }
+      const command = connected ? 'L' : 'M';
+      connected = true;
+      const x = legacyXForPoint(point, index, entry.points.length, range, plotWidth);
+      const y = yForValue(point.value, max);
+      return [`${command}${x.toFixed(2)} ${y.toFixed(2)}`];
+    })
+    .join(' ');
+}
+
+interface AxisSource {
+  readonly point: PlotPoint;
+  readonly sourceIndex: number;
+  readonly sourceCount: number;
+}
+
+function legacyAxisPoints(
+  series: readonly PlotSeries[],
+  range: ExplicitXRange,
+): readonly AxisSource[] {
+  const firstSeriesPoints = series[0]?.points ?? [];
+  if (range.values.length === 0) {
+    return firstSeriesPoints.map((point, index) => ({
+      point,
+      sourceIndex: index,
+      sourceCount: firstSeriesPoints.length,
+    }));
   }
+  return [
+    ...new Map(
+      series.flatMap((entry) =>
+        entry.points.flatMap((point, index) =>
+          point.x === undefined
+            ? []
+            : [[point.x, { point, sourceIndex: index, sourceCount: entry.points.length }] as const],
+        ),
+      ),
+    ).values(),
+  ].sort((left, right) => (left.point.x ?? 0) - (right.point.x ?? 0));
+}
 
-  function moveSeries(delta: number) {
-    if (series.length === 0) return;
-    const seriesIndex = Math.max(
-      0,
-      Math.min((active?.seriesIndex ?? 0) + delta, series.length - 1),
+function legacyTicks(
+  series: readonly PlotSeries[],
+  range: ExplicitXRange,
+  plotWidth: number,
+): readonly AxisTick[] {
+  const axisPoints = legacyAxisPoints(series, range);
+  const xIndexes =
+    axisPoints.length <= 2
+      ? axisPoints.map((_, index) => index)
+      : [0, Math.floor((axisPoints.length - 1) / 2), axisPoints.length - 1];
+  return [...new Set(xIndexes)].flatMap((index) => {
+    const candidate = axisPoints[index];
+    if (candidate === undefined) return [];
+    const testId = xTickTestId(index, axisPoints.length);
+    const x = legacyXForPoint(
+      candidate.point,
+      candidate.sourceIndex,
+      candidate.sourceCount,
+      range,
+      plotWidth,
     );
-    const preferred = active?.pointIndex ?? firstAvailable(seriesIndex);
-    const pointIndex = isAvailable(series[seriesIndex]?.points[preferred])
-      ? preferred
-      : firstAvailable(seriesIndex);
-    setActive({ seriesIndex, pointIndex });
-  }
+    return [
+      { x, label: xTickLabel(candidate.point.label), ...(testId === undefined ? {} : { testId }) },
+    ];
+  });
+}
 
-  function handleKeyDown(key: string): boolean {
-    switch (key) {
-      case 'ArrowRight':
-        movePoint((active?.pointIndex ?? -1) + 1);
-        return true;
-      case 'ArrowLeft':
-        movePoint((active?.pointIndex ?? 1) - 1);
-        return true;
-      case 'ArrowDown':
-        moveSeries(1);
-        return true;
-      case 'ArrowUp':
-        moveSeries(-1);
-        return true;
-      case 'Home':
-        movePoint(0);
-        return true;
-      case 'End':
-        movePoint(Number.MAX_SAFE_INTEGER);
-        return true;
-      case 'Escape':
-        setActive(null);
-        return true;
-      case 'Enter':
-        if (activePoint !== null) onActivate?.(activePoint.cohort);
-        return true;
-      default:
-        return false;
-    }
-  }
-
-  function pointFromTarget(target: EventTarget): ActivePoint | null {
-    if (!(target instanceof SVGElement)) return null;
-    const seriesIndex = Number(target.dataset['seriesIndex']);
-    const pointIndex = Number(target.dataset['pointIndex']);
-    return Number.isInteger(seriesIndex) && Number.isInteger(pointIndex)
-      ? { seriesIndex, pointIndex }
-      : null;
-  }
-
-  const rows: AnalyticsDataRow[] = series.flatMap((entry) =>
+function legacyRows(
+  series: readonly PlotSeries[],
+  valueFormatter: (value: number) => string,
+): AnalyticsDataRow[] {
+  return series.flatMap((entry) =>
     entry.points.flatMap((point) =>
       isAvailable(point)
         ? [
@@ -237,51 +368,278 @@ export function LinePlot({
         : [],
     ),
   );
-  const firstSeriesPoints = series[0]?.points ?? [];
-  const axisPoints =
-    explicitX.length === 0
-      ? firstSeriesPoints.map((point, index) => ({
-          point,
-          sourceIndex: index,
-          sourceCount: firstSeriesPoints.length,
-        }))
-      : [
-          ...new Map(
-            series.flatMap((entry) =>
-              entry.points.flatMap((point, index) =>
-                point.x === undefined
-                  ? []
-                  : [
-                      [
-                        point.x,
-                        { point, sourceIndex: index, sourceCount: entry.points.length },
-                      ] as const,
-                    ],
-              ),
-            ),
-          ).values(),
-        ].sort((left, right) => (left.point.x ?? 0) - (right.point.x ?? 0));
-  const xIndexes =
-    axisPoints.length <= 2
-      ? axisPoints.map((_, index) => index)
-      : [0, Math.floor((axisPoints.length - 1) / 2), axisPoints.length - 1];
-  const xTicks = [...new Set(xIndexes)].flatMap((index) => {
-    const candidate = axisPoints[index];
-    if (candidate === undefined) return [];
-    const testId = xTickTestId(index, axisPoints.length);
+}
+
+interface DayGeometry {
+  readonly indexMap: ReadonlyMap<string, number>;
+  readonly slot: number;
+  readonly plotWidth: number;
+}
+
+function daySlot(width: number, dayCount: number): number {
+  return (width - LEFT - RIGHT) / Math.max(1, dayCount - 1);
+}
+
+function xForDay(index: number, slot: number): number {
+  return LEFT + index * slot;
+}
+
+function dayGeometryFor(days: readonly SprintDay[], width: number): DayGeometry {
+  return {
+    indexMap: new Map(days.map((day, index) => [day.date, index])),
+    slot: daySlot(width, days.length),
+    plotWidth: width - LEFT - RIGHT,
+  };
+}
+
+function dayTickIndexes(days: readonly SprintDay[], plotWidth: number): readonly number[] {
+  const maxLabels = Math.max(1, Math.floor(plotWidth / TICK_SPACING));
+  const step = Math.max(1, Math.ceil(days.length / maxLabels));
+  const stepCount = Math.ceil(days.length / step);
+  const indexes = new Set(Array.from({ length: stepCount }, (_unused, index) => index * step));
+  if (days.length > 0) {
+    indexes.add(0);
+    indexes.add(days.length - 1);
+  }
+  const todayIndex = days.findIndex((day) => day.today);
+  if (todayIndex >= 0) indexes.add(todayIndex);
+  return [...indexes].sort((left, right) => left - right);
+}
+
+function dayTicks(days: readonly SprintDay[], geometry: DayGeometry): readonly AxisTick[] {
+  return dayTickIndexes(days, geometry.plotWidth).flatMap((index) => {
+    const day = days[index];
+    if (day === undefined) return [];
+    const testId = xTickTestId(index, days.length);
     return [
       {
-        x: xForPoint(candidate.point, candidate.sourceIndex, candidate.sourceCount),
-        label: xTickLabel(candidate.point.label),
+        x: xForDay(index, geometry.slot),
+        label: xTickLabel(day.date),
         ...(testId === undefined ? {} : { testId }),
       },
     ];
   });
-  const unavailableDates = new Set(
-    series.flatMap((entry) =>
-      entry.points.flatMap((point) => (isAvailable(point) ? [] : [point.label])),
-    ),
-  );
+}
+
+function pointXInDayMode(
+  point: PlotPoint,
+  index: number,
+  count: number,
+  geometry: DayGeometry,
+): number {
+  const mapped = geometry.indexMap.get(point.label);
+  if (mapped !== undefined) return xForDay(mapped, geometry.slot);
+  return count <= 1
+    ? LEFT + geometry.plotWidth / 2
+    : LEFT + (index * geometry.plotWidth) / (count - 1);
+}
+
+function dayPathFor(entry: PlotSeries, geometry: DayGeometry, max: number): string {
+  let connected = false;
+  return entry.points
+    .flatMap((point, index) => {
+      if (!isAvailable(point)) {
+        connected = false;
+        return [];
+      }
+      const x = pointXInDayMode(point, index, entry.points.length, geometry);
+      const y = yForValue(point.value, max);
+      if (!connected) {
+        connected = true;
+        return [`M${x.toFixed(2)} ${y.toFixed(2)}`];
+      }
+      return entry.step
+        ? [`H${x.toFixed(2)}`, `V${y.toFixed(2)}`]
+        : [`L${x.toFixed(2)} ${y.toFixed(2)}`];
+    })
+    .join(' ');
+}
+
+function isWorkingDay(point: PlotPoint, days: readonly SprintDay[]): boolean {
+  const day = days.find((candidate) => candidate.date === point.label);
+  return day === undefined || !day.weekend;
+}
+
+interface PlottedDot {
+  readonly point: PlotPoint;
+  readonly x: number;
+  readonly y: number;
+}
+
+function dayDots(
+  entry: PlotSeries,
+  days: readonly SprintDay[],
+  geometry: DayGeometry,
+  max: number,
+): readonly PlottedDot[] {
+  if (entry.dots !== true) return [];
+  return entry.points.flatMap((point, index) => {
+    if (!(isAvailable(point) && isWorkingDay(point, days))) return [];
+    return [
+      {
+        point,
+        x: pointXInDayMode(point, index, entry.points.length, geometry),
+        y: yForValue(point.value, max),
+      },
+    ];
+  });
+}
+
+function tooltipRowsForDay(
+  series: readonly PlotSeries[],
+  day: SprintDay | undefined,
+  valueFormatter: (value: number) => string,
+): readonly TooltipRow[] {
+  if (day === undefined) return [];
+  return series.flatMap((entry) => {
+    const point = entry.points.find(
+      (candidate) => candidate.label === day.date && isAvailable(candidate),
+    );
+    return point === undefined ? [] : [{ series: entry.label, value: valueFormatter(point.value) }];
+  });
+}
+
+function topYForDay(
+  series: readonly PlotSeries[],
+  day: SprintDay | undefined,
+  max: number,
+): number | null {
+  if (day === undefined) return null;
+  const values = series.flatMap((entry) => {
+    const point = entry.points.find(
+      (candidate) => candidate.label === day.date && isAvailable(candidate),
+    );
+    return point === undefined ? [] : [point.value];
+  });
+  return values.length === 0 ? null : yForValue(Math.max(...values), max);
+}
+
+function announcementForDay(day: SprintDay | undefined, rows: readonly TooltipRow[]): string {
+  if (day === undefined || rows.length === 0) return '';
+  return `${xTickLabel(day.date)}, ${rows.map((row) => `${row.series} ${row.value}`).join(', ')}`;
+}
+
+function firstPointAtDay(
+  series: readonly PlotSeries[],
+  day: SprintDay | undefined,
+): PlotPoint | null {
+  if (day === undefined) return null;
+  for (const entry of series) {
+    const point = entry.points.find(
+      (candidate) => candidate.label === day.date && isAvailable(candidate),
+    );
+    if (point !== undefined) return point;
+  }
+  return null;
+}
+
+function dayTableRows(
+  series: readonly PlotSeries[],
+  days: readonly SprintDay[],
+  valueFormatter: (value: number) => string,
+): AnalyticsDataRow[] {
+  return days.map((day) => {
+    const cells: Record<string, string> = { date: xTickLabel(day.date) };
+    const parts: string[] = [];
+    for (const entry of series) {
+      const point = entry.points.find((candidate) => candidate.label === day.date);
+      const formatted =
+        point !== undefined && isAvailable(point) ? valueFormatter(point.value) : '';
+      cells[entry.id] = formatted;
+      if (formatted !== '') parts.push(`${entry.label} ${formatted}`);
+    }
+    return {
+      id: day.date,
+      label:
+        parts.length === 0 ? xTickLabel(day.date) : `${xTickLabel(day.date)} ${parts.join(', ')}`,
+      cells,
+    };
+  });
+}
+
+function dayTableColumns(series: readonly PlotSeries[]): readonly AnalyticsDataColumn[] {
+  return [
+    { id: 'date', label: 'Date' },
+    ...series.map((entry) => ({ id: entry.id, label: entry.label, align: 'right' as const })),
+  ];
+}
+
+function findDayForRow(days: readonly SprintDay[], rowId: string): number | null {
+  const index = days.findIndex((day) => day.date === rowId);
+  return index < 0 ? null : index;
+}
+
+function dayIndexFromTarget(target: EventTarget): number | null {
+  if (!(target instanceof SVGElement)) return null;
+  const index = Number(target.dataset['dayIndex']);
+  return Number.isInteger(index) ? index : null;
+}
+
+interface DayKeyResult {
+  readonly activeDay: number | null;
+  readonly activate: boolean;
+}
+
+function dayKeyResult(
+  key: string,
+  days: readonly SprintDay[],
+  activeDay: number | null,
+): DayKeyResult | null {
+  switch (key) {
+    case 'ArrowRight':
+      return {
+        activeDay: days.length === 0 ? activeDay : clampIndex((activeDay ?? -1) + 1, days.length),
+        activate: false,
+      };
+    case 'ArrowLeft':
+      return {
+        activeDay:
+          days.length === 0 ? activeDay : clampIndex((activeDay ?? days.length) - 1, days.length),
+        activate: false,
+      };
+    case 'Home':
+      return { activeDay: days.length === 0 ? activeDay : 0, activate: false };
+    case 'End':
+      return { activeDay: days.length === 0 ? activeDay : days.length - 1, activate: false };
+    case 'Escape':
+      return { activeDay: null, activate: false };
+    case 'Enter':
+      return { activeDay, activate: true };
+    default:
+      return null;
+  }
+}
+
+function LegacyLinePlot({
+  label,
+  series,
+  onActivate,
+  valueFormatter = String,
+  xAxisLabel = 'Date',
+  yAxisLabel = 'Value',
+  annotation,
+}: LegacyLinePlotProps) {
+  const { ref, width } = useMeasuredWidth();
+  const [active, setActive] = useState<ActivePoint | null>(null);
+  const activePoint = pointAt(series, active);
+  const activeSeries = active === null ? undefined : series[active.seriesIndex];
+  const max = maxValue(series);
+  const range = explicitXRange(series);
+  const plotWidth = width - LEFT - RIGHT;
+  const activeX =
+    activePoint === null || active === null || activeSeries === undefined
+      ? null
+      : legacyXForPoint(
+          activePoint,
+          active.pointIndex,
+          activeSeries.points.length,
+          range,
+          plotWidth,
+        );
+  const activeY = activePoint === null ? null : yForValue(activePoint.value, max);
+  const rows = legacyRows(series, valueFormatter);
+  const unavailable = unavailableDates(series);
+  const xTicks = legacyTicks(series, range, plotWidth);
 
   return (
     <PlotFrame
@@ -305,19 +663,12 @@ export function LinePlot({
             ? {}
             : {
                 onActivate: (row: AnalyticsDataRow) => {
-                  for (let seriesIndex = 0; seriesIndex < series.length; seriesIndex += 1) {
-                    const pointIndex = series[seriesIndex]?.points.findIndex(
-                      (point) => point.id === row.id,
-                    );
-                    if (pointIndex !== undefined && pointIndex >= 0) {
-                      const point = series[seriesIndex]?.points[pointIndex];
-                      if (point !== undefined && isAvailable(point)) {
-                        setActive({ seriesIndex, pointIndex });
-                        onActivate(point.cohort);
-                      }
-                      return;
-                    }
-                  }
+                  const next = findPointForRow(series, row.id);
+                  if (next === null) return;
+                  const point = series[next.seriesIndex]?.points[next.pointIndex];
+                  if (point === undefined) return;
+                  setActive(next);
+                  onActivate(point.cohort);
                 },
               })}
           rows={rows}
@@ -329,114 +680,320 @@ export function LinePlot({
           <ChartTooltip
             label={activePoint.label}
             series={activeSeries.label}
-            style={tooltipStyle(activeX, activeY)}
+            style={tooltipStyle(activeX, activeY, width)}
             value={valueFormatter(activePoint.value)}
           />
         )
       }
     >
-      <svg
-        aria-label={label}
-        className="h-auto min-h-64 w-full outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
-        onFocus={() => {
-          if (active === null && series.length > 0) {
-            setActive({ seriesIndex: 0, pointIndex: firstAvailable(0) });
-          }
-        }}
-        onClick={(event) => {
-          const next = pointFromTarget(event.target);
-          const point = pointAt(series, next);
-          if (point !== null) onActivate?.(point.cohort);
-        }}
-        onKeyDown={(event) => {
-          if (handleKeyDown(event.key)) event.preventDefault();
-        }}
-        onPointerOver={(event) => {
-          const next = pointFromTarget(event.target);
-          if (next !== null) setActive(next);
-        }}
-        onPointerLeave={() => setActive(null)}
-        role="application"
-        // biome-ignore lint/a11y/noNoninteractiveTabindex: The SVG is the chart's single keyboard focus surface.
-        tabIndex={0}
-        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-      >
-        <title>{label}</title>
-        <PlotGuides
-          bottom={BOTTOM}
+      <div className="w-full" ref={ref}>
+        <svg
+          aria-label={label}
+          className="block outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
           height={HEIGHT}
-          left={LEFT}
-          max={max}
-          right={RIGHT}
-          top={TOP}
-          valueFormatter={valueFormatter}
-          width={WIDTH}
-          xAxisLabel={xAxisLabel}
-          xTicks={xTicks}
-          yAxisLabel={yAxisLabel}
-        />
-        {series.map((entry, seriesIndex) => (
-          <g key={entry.id}>
-            <path
-              d={pathFor(entry)}
-              data-testid={`plot-line-${entry.id}`}
-              fill="none"
-              stroke={`var(--analytics-series-${(seriesIndex % 4) + 1})`}
-              strokeDasharray={entry.dashed ? '7 5' : undefined}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              vectorEffect="non-scaling-stroke"
-            />
-            {entry.points.map((point, pointIndex) => {
-              if (!isAvailable(point)) return null;
-              const isActive =
-                active?.seriesIndex === seriesIndex && active.pointIndex === pointIndex;
-              const cx = xForPoint(point, pointIndex, entry.points.length);
-              const cy = yForValue(point.value, max);
-              return (
-                <g key={point.id}>
-                  <circle
-                    cx={cx}
-                    cy={cy}
-                    data-testid={`plot-point-${point.id}`}
-                    fill={`var(--analytics-series-${(seriesIndex % 4) + 1})`}
-                    pointerEvents="none"
-                    r={isActive ? 4 : 3}
-                    stroke="var(--color-surface)"
-                    strokeWidth="1.5"
-                  />
-                  <circle
-                    cx={cx}
-                    cy={cy}
-                    data-active={isActive ? 'true' : 'false'}
-                    data-point-index={pointIndex}
-                    data-series-index={seriesIndex}
-                    data-testid={`plot-hit-${point.id}`}
-                    fill="transparent"
-                    r="10"
-                    stroke="transparent"
-                  />
-                </g>
-              );
-            })}
-          </g>
-        ))}
-        {activePoint === null || activeX === null ? null : (
-          <line
-            stroke="var(--color-border-strong)"
-            strokeDasharray="3 3"
-            vectorEffect="non-scaling-stroke"
-            x1={activeX}
-            x2={activeX}
-            y1={TOP}
-            y2={PLOT_BOTTOM}
+          onClick={(event) => {
+            const point = pointAt(series, pointFromTarget(event.target));
+            if (point !== null) onActivate?.(point.cohort);
+          }}
+          onFocus={() => {
+            if (active === null && series.length > 0) {
+              setActive({
+                seriesIndex: 0,
+                pointIndex: firstAvailableIndex(series[0]?.points ?? []),
+              });
+            }
+          }}
+          onKeyDown={(event) => {
+            const result = legacyKeyResult(event.key, series, active);
+            if (result === null) return;
+            setActive(result.active);
+            if (result.activate) {
+              const point = pointAt(series, result.active);
+              if (point !== null) onActivate?.(point.cohort);
+            }
+            event.preventDefault();
+          }}
+          onPointerOver={(event) => {
+            const next = pointFromTarget(event.target);
+            if (next !== null) setActive(next);
+          }}
+          onPointerLeave={() => setActive(null)}
+          role="application"
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: The SVG is the chart's single keyboard focus surface.
+          tabIndex={0}
+          width={width}
+        >
+          <title>{label}</title>
+          <PlotGuides
+            bottom={BOTTOM}
+            height={HEIGHT}
+            left={LEFT}
+            max={max}
+            right={RIGHT}
+            top={TOP}
+            valueFormatter={valueFormatter}
+            width={width}
+            xAxisLabel={xAxisLabel}
+            xTicks={xTicks}
+            yAxisLabel={yAxisLabel}
           />
-        )}
-      </svg>
-      {annotation === undefined && unavailableDates.size === 0 ? null : (
-        <p className="text-muted text-xs">{annotation ?? unavailableNote(unavailableDates.size)}</p>
+          {series.map((entry, seriesIndex) => (
+            <g key={entry.id}>
+              <path
+                d={legacyPathFor(entry, range, plotWidth, max)}
+                data-testid={`plot-line-${entry.id}`}
+                fill="none"
+                stroke={`var(--analytics-series-${(seriesIndex % 4) + 1})`}
+                strokeDasharray={entry.dashed ? '7 5' : undefined}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                vectorEffect="non-scaling-stroke"
+              />
+              {entry.points.map((point, pointIndex) => {
+                if (!isAvailable(point)) return null;
+                const isActive =
+                  active?.seriesIndex === seriesIndex && active.pointIndex === pointIndex;
+                const cx = legacyXForPoint(
+                  point,
+                  pointIndex,
+                  entry.points.length,
+                  range,
+                  plotWidth,
+                );
+                const cy = yForValue(point.value, max);
+                return (
+                  <g key={point.id}>
+                    <circle
+                      cx={cx}
+                      cy={cy}
+                      data-testid={`plot-point-${point.id}`}
+                      fill={`var(--analytics-series-${(seriesIndex % 4) + 1})`}
+                      pointerEvents="none"
+                      r={isActive ? 4 : 3}
+                      stroke="var(--color-surface)"
+                      strokeWidth="1.5"
+                    />
+                    <circle
+                      cx={cx}
+                      cy={cy}
+                      data-active={isActive ? 'true' : 'false'}
+                      data-point-index={pointIndex}
+                      data-series-index={seriesIndex}
+                      data-testid={`plot-hit-${point.id}`}
+                      fill="transparent"
+                      r="10"
+                      stroke="transparent"
+                    />
+                  </g>
+                );
+              })}
+            </g>
+          ))}
+          {activePoint === null || activeX === null ? null : (
+            <line
+              stroke="var(--color-border-strong)"
+              strokeDasharray="3 3"
+              vectorEffect="non-scaling-stroke"
+              x1={activeX}
+              x2={activeX}
+              y1={TOP}
+              y2={PLOT_BOTTOM}
+            />
+          )}
+        </svg>
+      </div>
+      {annotation === undefined && unavailable.size === 0 ? null : (
+        <p className="text-muted text-xs">{annotation ?? unavailableNote(unavailable.size)}</p>
       )}
     </PlotFrame>
   );
+}
+
+function DayLinePlot({
+  label,
+  series,
+  days,
+  onActivate,
+  valueFormatter = String,
+  xAxisLabel = 'Date',
+  yAxisLabel = 'Value',
+  annotation,
+}: DayLinePlotProps) {
+  const { ref, width } = useMeasuredWidth();
+  const [activeDay, setActiveDay] = useState<number | null>(null);
+  const max = maxValue(series);
+  const geometry = dayGeometryFor(days, width);
+  const activeDayEntry = activeDay === null ? undefined : days[activeDay];
+  const tooltipRows = tooltipRowsForDay(series, activeDayEntry, valueFormatter);
+  const tableRows = dayTableRows(series, days, valueFormatter);
+  const unavailable = unavailableDates(series);
+  const activeX = activeDay === null ? null : xForDay(activeDay, geometry.slot);
+  const activeY = topYForDay(series, activeDayEntry, max);
+
+  return (
+    <PlotFrame
+      announcement={announcementForDay(activeDayEntry, tooltipRows)}
+      dataCount={tableRows.length}
+      label={label}
+      legends={series.map((entry) => ({
+        id: entry.id,
+        label: entry.label,
+        ...(entry.dashed === undefined ? {} : { dashed: entry.dashed }),
+      }))}
+      table={
+        <AnalyticsDataTable
+          ariaLabel={`${label} data`}
+          columns={dayTableColumns(series)}
+          {...(onActivate === undefined
+            ? {}
+            : {
+                onActivate: (row: AnalyticsDataRow) => {
+                  const index = findDayForRow(days, row.id);
+                  if (index === null) return;
+                  const point = firstPointAtDay(series, days[index]);
+                  if (point === null) return;
+                  setActiveDay(index);
+                  onActivate(point.cohort);
+                },
+              })}
+          rows={tableRows}
+          {...(activeDayEntry === undefined ? {} : { activeRowId: activeDayEntry.date })}
+        />
+      }
+      tooltip={
+        activeDayEntry === undefined || tooltipRows.length === 0 ? null : (
+          <ChartTooltip
+            label={xTickLabel(activeDayEntry.date)}
+            rows={tooltipRows}
+            style={tooltipStyle(activeX, activeY, width)}
+          />
+        )
+      }
+    >
+      <div className="w-full" ref={ref}>
+        <svg
+          aria-label={label}
+          className="block outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+          height={HEIGHT}
+          onClick={(event) => {
+            const index = dayIndexFromTarget(event.target);
+            const point = index === null ? null : firstPointAtDay(series, days[index]);
+            if (point !== null) onActivate?.(point.cohort);
+          }}
+          onFocus={() => {
+            if (activeDay === null && days.length > 0) setActiveDay(0);
+          }}
+          onKeyDown={(event) => {
+            const result = dayKeyResult(event.key, days, activeDay);
+            if (result === null) return;
+            setActiveDay(result.activeDay);
+            if (result.activate) {
+              const day = result.activeDay === null ? undefined : days[result.activeDay];
+              const point = firstPointAtDay(series, day);
+              if (point !== null) onActivate?.(point.cohort);
+            }
+            event.preventDefault();
+          }}
+          onPointerOver={(event) => {
+            const index = dayIndexFromTarget(event.target);
+            if (index !== null) setActiveDay(index);
+          }}
+          onPointerLeave={() => setActiveDay(null)}
+          role="application"
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: The SVG is the chart's single keyboard focus surface.
+          tabIndex={0}
+          width={width}
+        >
+          <title>{label}</title>
+          {days.flatMap((day, index) =>
+            day.weekend
+              ? [
+                  <rect
+                    data-testid="plot-weekend-band"
+                    fill="var(--color-surface-raised)"
+                    height={PLOT_BOTTOM - TOP}
+                    key={day.date}
+                    opacity="0.5"
+                    width={geometry.slot}
+                    x={xForDay(index, geometry.slot) - geometry.slot / 2}
+                    y={TOP}
+                  />,
+                ]
+              : [],
+          )}
+          <PlotGuides
+            bottom={BOTTOM}
+            height={HEIGHT}
+            left={LEFT}
+            max={max}
+            right={RIGHT}
+            top={TOP}
+            valueFormatter={valueFormatter}
+            width={width}
+            xAxisLabel={xAxisLabel}
+            xTicks={dayTicks(days, geometry)}
+            yAxisLabel={yAxisLabel}
+          />
+          {series.map((entry, seriesIndex) => (
+            <g key={entry.id}>
+              <path
+                d={dayPathFor(entry, geometry, max)}
+                data-testid={`plot-line-${entry.id}`}
+                fill="none"
+                stroke={`var(--analytics-series-${(seriesIndex % 4) + 1})`}
+                strokeDasharray={entry.dashed ? '7 5' : undefined}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                vectorEffect="non-scaling-stroke"
+              />
+              {dayDots(entry, days, geometry, max).map((dot) => (
+                <circle
+                  cx={dot.x}
+                  cy={dot.y}
+                  data-testid={`plot-dot-${dot.point.id}`}
+                  fill={`var(--analytics-series-${(seriesIndex % 4) + 1})`}
+                  key={dot.point.id}
+                  pointerEvents="none"
+                  r={DOT_RADIUS}
+                />
+              ))}
+            </g>
+          ))}
+          {days.map((day, index) => (
+            <rect
+              data-day-index={index}
+              data-testid="plot-day-hit"
+              fill="transparent"
+              height={PLOT_BOTTOM - TOP}
+              key={day.date}
+              width={geometry.slot}
+              x={xForDay(index, geometry.slot) - geometry.slot / 2}
+              y={TOP}
+            />
+          ))}
+          {activeX === null ? null : (
+            <line
+              stroke="var(--color-border-strong)"
+              strokeDasharray="3 3"
+              vectorEffect="non-scaling-stroke"
+              x1={activeX}
+              x2={activeX}
+              y1={TOP}
+              y2={PLOT_BOTTOM}
+            />
+          )}
+        </svg>
+      </div>
+      {annotation === undefined && unavailable.size === 0 ? null : (
+        <p className="text-muted text-xs">{annotation ?? unavailableNote(unavailable.size)}</p>
+      )}
+    </PlotFrame>
+  );
+}
+
+export function LinePlot(props: LinePlotProps) {
+  const { days, ...rest } = props;
+  return days === undefined ? <LegacyLinePlot {...rest} /> : <DayLinePlot {...rest} days={days} />;
 }

--- a/apps/web/src/features/analytics/charts/line-plot.tsx
+++ b/apps/web/src/features/analytics/charts/line-plot.tsx
@@ -38,6 +38,7 @@ export interface PlotSeries {
   readonly dashed?: boolean;
   readonly step?: boolean;
   readonly dots?: boolean;
+  readonly color?: number;
 }
 
 interface ActivePoint {
@@ -73,6 +74,10 @@ interface TooltipRow {
 
 function isAvailable(point: PlotPoint | undefined): boolean {
   return point !== undefined && point.available !== false;
+}
+
+function seriesToken(entry: PlotSeries, index: number): number {
+  return entry.color ?? (index % 4) + 1;
 }
 
 function maxValue(series: readonly PlotSeries[]): number {
@@ -649,9 +654,10 @@ function LegacyLinePlot({
       announcement={announcementOf(series, active, valueFormatter)}
       dataCount={rows.length}
       label={label}
-      legends={series.map((entry) => ({
+      legends={series.map((entry, index) => ({
         id: entry.id,
         label: entry.label,
+        color: seriesToken(entry, index),
         ...(entry.dashed === undefined ? {} : { dashed: entry.dashed }),
       }))}
       table={
@@ -746,7 +752,7 @@ function LegacyLinePlot({
                 d={legacyPathFor(entry, range, plotWidth, max)}
                 data-testid={`plot-line-${entry.id}`}
                 fill="none"
-                stroke={`var(--analytics-series-${(seriesIndex % 4) + 1})`}
+                stroke={`var(--analytics-series-${seriesToken(entry, seriesIndex)})`}
                 strokeDasharray={entry.dashed ? '7 5' : undefined}
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -771,7 +777,7 @@ function LegacyLinePlot({
                       cx={cx}
                       cy={cy}
                       data-testid={`plot-point-${point.id}`}
-                      fill={`var(--analytics-series-${(seriesIndex % 4) + 1})`}
+                      fill={`var(--analytics-series-${seriesToken(entry, seriesIndex)})`}
                       pointerEvents="none"
                       r={isActive ? 4 : 3}
                       stroke="var(--color-surface)"
@@ -839,9 +845,10 @@ function DayLinePlot({
       announcement={announcementForDay(activeDayEntry, tooltipRows)}
       dataCount={tableRows.length}
       label={label}
-      legends={series.map((entry) => ({
+      legends={series.map((entry, index) => ({
         id: entry.id,
         label: entry.label,
+        color: seriesToken(entry, index),
         ...(entry.dashed === undefined ? {} : { dashed: entry.dashed }),
       }))}
       table={
@@ -944,7 +951,7 @@ function DayLinePlot({
                 d={dayPathFor(entry, geometry, max)}
                 data-testid={`plot-line-${entry.id}`}
                 fill="none"
-                stroke={`var(--analytics-series-${(seriesIndex % 4) + 1})`}
+                stroke={`var(--analytics-series-${seriesToken(entry, seriesIndex)})`}
                 strokeDasharray={entry.dashed ? '7 5' : undefined}
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -956,7 +963,7 @@ function DayLinePlot({
                   cx={dot.x}
                   cy={dot.y}
                   data-testid={`plot-dot-${dot.point.id}`}
-                  fill={`var(--analytics-series-${(seriesIndex % 4) + 1})`}
+                  fill={`var(--analytics-series-${seriesToken(entry, seriesIndex)})`}
                   key={dot.point.id}
                   pointerEvents="none"
                   r={DOT_RADIUS}

--- a/apps/web/src/features/analytics/charts/line-plot.tsx
+++ b/apps/web/src/features/analytics/charts/line-plot.tsx
@@ -66,6 +66,7 @@ interface AxisTick {
 }
 
 interface TooltipRow {
+  readonly id: string;
   readonly series: string;
   readonly value: string;
 }
@@ -495,7 +496,9 @@ function tooltipRowsForDay(
     const point = entry.points.find(
       (candidate) => candidate.label === day.date && isAvailable(candidate),
     );
-    return point === undefined ? [] : [{ series: entry.label, value: valueFormatter(point.value) }];
+    return point === undefined
+      ? []
+      : [{ id: entry.id, series: entry.label, value: valueFormatter(point.value) }];
   });
 }
 

--- a/apps/web/src/features/analytics/charts/plot-frame.tsx
+++ b/apps/web/src/features/analytics/charts/plot-frame.tsx
@@ -5,6 +5,7 @@ interface PlotLegend {
   readonly label: string;
   readonly dashed?: boolean;
   readonly color?: number;
+  readonly swatchVar?: string;
 }
 
 interface PlotFrameProps {
@@ -40,7 +41,9 @@ export function PlotFrame({
               <svg aria-hidden="true" height="6" viewBox="0 0 20 6" width="20">
                 <line
                   data-testid={`plot-legend-${legend.id}`}
-                  stroke={`var(--analytics-series-${legend.color ?? (index % 4) + 1})`}
+                  stroke={
+                    legend.swatchVar ?? `var(--analytics-series-${legend.color ?? (index % 4) + 1})`
+                  }
                   strokeDasharray={legend.dashed ? '5 3' : undefined}
                   strokeLinecap="round"
                   strokeWidth="2"

--- a/apps/web/src/features/analytics/charts/plot-frame.tsx
+++ b/apps/web/src/features/analytics/charts/plot-frame.tsx
@@ -4,6 +4,7 @@ interface PlotLegend {
   readonly id: string;
   readonly label: string;
   readonly dashed?: boolean;
+  readonly color?: number;
 }
 
 interface PlotFrameProps {
@@ -39,7 +40,7 @@ export function PlotFrame({
               <svg aria-hidden="true" height="6" viewBox="0 0 20 6" width="20">
                 <line
                   data-testid={`plot-legend-${legend.id}`}
-                  stroke={`var(--analytics-series-${(index % 4) + 1})`}
+                  stroke={`var(--analytics-series-${legend.color ?? (index % 4) + 1})`}
                   strokeDasharray={legend.dashed ? '5 3' : undefined}
                   strokeLinecap="round"
                   strokeWidth="2"

--- a/apps/web/src/features/analytics/charts/plot-guides.tsx
+++ b/apps/web/src/features/analytics/charts/plot-guides.tsx
@@ -18,9 +18,9 @@ interface PlotGuidesProps {
   readonly yAxisLabel: string;
 }
 
-function yTickTestId(index: number): string | undefined {
+function yTickTestId(index: number, count: number): string | undefined {
   if (index === 0) return 'plot-y-max';
-  if (index === 2) return 'plot-y-zero';
+  if (index === count - 1) return 'plot-y-zero';
   return undefined;
 }
 
@@ -39,17 +39,17 @@ export function PlotGuides({
 }: PlotGuidesProps) {
   const plotBottom = height - bottom;
   const plotHeight = plotBottom - top;
-  const ticks = [max, max / 2, 0];
+  const ticks = [max, (3 * max) / 4, max / 2, max / 4, 0];
   return (
     <g>
       {ticks.map((value, index) => {
-        const y = top + (index * plotHeight) / 2;
+        const y = top + (index * plotHeight) / (ticks.length - 1);
         return (
           <g key={value}>
             <line
               data-testid="plot-grid-line"
               stroke="var(--color-border)"
-              strokeDasharray={index === 2 ? undefined : '3 4'}
+              strokeDasharray={index === ticks.length - 1 ? undefined : '3 4'}
               vectorEffect="non-scaling-stroke"
               x1={left}
               x2={width - right}
@@ -57,7 +57,7 @@ export function PlotGuides({
               y2={y}
             />
             <text
-              data-testid={yTickTestId(index)}
+              data-testid={yTickTestId(index, ticks.length)}
               fill="var(--color-faint)"
               fontSize="11"
               textAnchor="end"

--- a/apps/web/src/features/analytics/charts/scatter-plot.tsx
+++ b/apps/web/src/features/analytics/charts/scatter-plot.tsx
@@ -1,0 +1,381 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+import { useRef, useState } from 'react';
+import { useMeasuredWidth } from '@/lib/use-measured-width.ts';
+import { ChartTooltip } from './chart-tooltip.tsx';
+import { PlotFrame } from './plot-frame.tsx';
+import { PlotGuides } from './plot-guides.tsx';
+
+export interface InsightScatterPoint {
+  readonly issueId: string;
+  readonly identifier: string;
+  readonly title: string;
+  readonly days: number;
+}
+
+export interface InsightPercentiles {
+  readonly p25: number;
+  readonly p50: number;
+  readonly p75: number;
+  readonly p95: number;
+}
+
+interface ScatterPlotProps {
+  readonly label: string;
+  readonly points: readonly InsightScatterPoint[];
+  readonly percentiles: InsightPercentiles | null;
+  readonly unitLabel: string;
+}
+
+const HEIGHT = 280;
+const LEFT = 56;
+const RIGHT = 64;
+const TOP = 16;
+const BOTTOM = 40;
+const PLOT_BOTTOM = HEIGHT - BOTTOM;
+const POINT_RADIUS = 3;
+const ACTIVE_POINT_RADIUS = 4;
+const HIT_RADIUS = 9;
+const PERCENTILE_HIT_WIDTH = 12;
+
+const PERCENTILE_KEYS = ['p25', 'p50', 'p75', 'p95'] as const;
+type PercentileKey = (typeof PERCENTILE_KEYS)[number];
+
+type ActiveTarget =
+  | { readonly kind: 'point'; readonly index: number }
+  | { readonly kind: 'percentile'; readonly key: PercentileKey }
+  | null;
+
+function isPercentileKey(value: string | undefined): value is PercentileKey {
+  return value === 'p25' || value === 'p50' || value === 'p75' || value === 'p95';
+}
+
+function percentileDisplayName(key: PercentileKey): string {
+  switch (key) {
+    case 'p25':
+      return '25th percentile';
+    case 'p50':
+      return 'Median';
+    case 'p75':
+      return '75th percentile';
+    case 'p95':
+      return '95th percentile';
+  }
+}
+
+function numberLabel(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function formatPointDays(value: number): string {
+  return `${value.toFixed(1)} days`;
+}
+
+function formatUnitValue(value: number, unitLabel: string): string {
+  return `${value.toFixed(1)} ${unitLabel}`;
+}
+
+function sortedByDays(points: readonly InsightScatterPoint[]): readonly InsightScatterPoint[] {
+  return [...points].sort((left, right) => left.days - right.days);
+}
+
+function maxValue(
+  points: readonly InsightScatterPoint[],
+  percentiles: InsightPercentiles | null,
+): number {
+  return Math.max(1, percentiles?.p95 ?? 0, ...points.map((point) => point.days));
+}
+
+function xForRank(index: number, count: number, plotWidth: number): number {
+  return count <= 1 ? LEFT + plotWidth / 2 : LEFT + (index * plotWidth) / (count - 1);
+}
+
+function yForValue(value: number, max: number): number {
+  return PLOT_BOTTOM - (Math.max(0, value) / max) * (PLOT_BOTTOM - TOP);
+}
+
+function clampIndex(index: number, length: number): number {
+  return Math.max(0, Math.min(index, length - 1));
+}
+
+function activeFromEventTarget(target: EventTarget): ActiveTarget {
+  if (!(target instanceof SVGElement)) return null;
+  const pointIndex = target.dataset['pointIndex'];
+  if (pointIndex !== undefined) {
+    const index = Number(pointIndex);
+    return Number.isInteger(index) ? { kind: 'point', index } : null;
+  }
+  const percentileKey = target.dataset['percentile'];
+  return isPercentileKey(percentileKey) ? { kind: 'percentile', key: percentileKey } : null;
+}
+
+interface KeyResult {
+  readonly active: ActiveTarget;
+  readonly focusAnchor: boolean;
+}
+
+function movedPointTarget(current: ActiveTarget, delta: number, count: number): ActiveTarget {
+  if (count === 0) return null;
+  const currentIndex = current?.kind === 'point' ? current.index : -1;
+  return { kind: 'point', index: clampIndex(currentIndex + delta, count) };
+}
+
+function keyResult(key: string, active: ActiveTarget, count: number): KeyResult | null {
+  switch (key) {
+    case 'ArrowRight':
+      return { active: movedPointTarget(active, 1, count), focusAnchor: false };
+    case 'ArrowLeft':
+      return { active: movedPointTarget(active, -1, count), focusAnchor: false };
+    case 'Home':
+      return { active: count === 0 ? null : { kind: 'point', index: 0 }, focusAnchor: false };
+    case 'End':
+      return {
+        active: count === 0 ? null : { kind: 'point', index: count - 1 },
+        focusAnchor: false,
+      };
+    case 'Escape':
+      return { active: null, focusAnchor: false };
+    case 'Enter':
+      return { active, focusAnchor: active?.kind === 'point' };
+    default:
+      return null;
+  }
+}
+
+function tooltipStyle(
+  x: number | null,
+  y: number | null,
+  width: number,
+): CSSProperties | undefined {
+  if (x === null || y === null) return undefined;
+  return {
+    left: `${(x / width) * 100}%`,
+    top: `${(y / HEIGHT) * 100}%`,
+    transform: x > width / 2 ? 'translate(-100%, -110%)' : 'translate(0, -110%)',
+  };
+}
+
+interface TooltipData {
+  readonly label: string;
+  readonly series: string;
+  readonly value: string;
+}
+
+interface ActiveInfo {
+  readonly x: number | null;
+  readonly y: number | null;
+  readonly announcement: string;
+  readonly tooltip: TooltipData | null;
+}
+
+const EMPTY_ACTIVE_INFO: ActiveInfo = { x: null, y: null, announcement: '', tooltip: null };
+
+function activePointInfo(
+  point: InsightScatterPoint,
+  index: number,
+  sortedPoints: readonly InsightScatterPoint[],
+  plotWidth: number,
+  max: number,
+): ActiveInfo {
+  const value = formatPointDays(point.days);
+  return {
+    x: xForRank(index, sortedPoints.length, plotWidth),
+    y: yForValue(point.days, max),
+    announcement: `${point.identifier}, ${point.title}, ${value}`,
+    tooltip: { label: point.identifier, series: point.title, value },
+  };
+}
+
+function activePercentileInfo(
+  key: PercentileKey,
+  value: number,
+  max: number,
+  width: number,
+  unitLabel: string,
+): ActiveInfo {
+  const formatted = formatUnitValue(value, unitLabel);
+  const displayName = percentileDisplayName(key);
+  return {
+    x: width - RIGHT,
+    y: yForValue(value, max),
+    announcement: `${displayName}, ${formatted}`,
+    tooltip: { label: displayName, series: 'Exact value', value: formatted },
+  };
+}
+
+function activeInfoFor(
+  active: ActiveTarget,
+  sortedPoints: readonly InsightScatterPoint[],
+  percentiles: InsightPercentiles | null,
+  max: number,
+  plotWidth: number,
+  width: number,
+  unitLabel: string,
+): ActiveInfo {
+  if (active?.kind === 'point') {
+    const point = sortedPoints[active.index];
+    return point === undefined
+      ? EMPTY_ACTIVE_INFO
+      : activePointInfo(point, active.index, sortedPoints, plotWidth, max);
+  }
+  if (active?.kind === 'percentile' && percentiles !== null) {
+    return activePercentileInfo(active.key, percentiles[active.key], max, width, unitLabel);
+  }
+  return EMPTY_ACTIVE_INFO;
+}
+
+export function ScatterPlot({ label, points, percentiles, unitLabel }: ScatterPlotProps) {
+  const { ref, width } = useMeasuredWidth();
+  const [active, setActive] = useState<ActiveTarget>(null);
+  const anchorRefs = useRef<Array<HTMLAnchorElement | null>>([]);
+  const sortedPoints = sortedByDays(points);
+
+  if (points.length === 0) {
+    return (
+      <PlotFrame label={label} legends={[]}>
+        <p className="py-12 text-center text-muted text-sm">No completed issues in range yet.</p>
+      </PlotFrame>
+    );
+  }
+
+  const max = maxValue(points, percentiles);
+  const plotWidth = width - LEFT - RIGHT;
+  const info = activeInfoFor(active, sortedPoints, percentiles, max, plotWidth, width, unitLabel);
+
+  return (
+    <PlotFrame
+      announcement={info.announcement}
+      label={label}
+      legends={[]}
+      tooltip={
+        info.tooltip === null ? null : (
+          <ChartTooltip
+            label={info.tooltip.label}
+            series={info.tooltip.series}
+            style={tooltipStyle(info.x, info.y, width)}
+            value={info.tooltip.value}
+          />
+        )
+      }
+    >
+      <div className="w-full" ref={ref}>
+        <svg
+          aria-label={label}
+          className="block outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+          height={HEIGHT}
+          onFocus={() => {
+            if (active === null && sortedPoints.length > 0) setActive({ kind: 'point', index: 0 });
+          }}
+          onKeyDown={(event) => {
+            const result = keyResult(event.key, active, sortedPoints.length);
+            if (result === null) return;
+            setActive(result.active);
+            if (result.focusAnchor && result.active?.kind === 'point') {
+              anchorRefs.current[result.active.index]?.focus();
+            }
+            event.preventDefault();
+          }}
+          onPointerLeave={() => setActive(null)}
+          onPointerOver={(event) => {
+            const next = activeFromEventTarget(event.target);
+            if (next !== null) setActive(next);
+          }}
+          role="application"
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: The SVG is the chart's single keyboard focus surface.
+          tabIndex={0}
+          width={width}
+        >
+          <title>{label}</title>
+          <PlotGuides
+            bottom={BOTTOM}
+            height={HEIGHT}
+            left={LEFT}
+            max={max}
+            right={RIGHT}
+            top={TOP}
+            valueFormatter={numberLabel}
+            width={width}
+            xAxisLabel={`Issues by ${unitLabel}`}
+            xTicks={[]}
+            yAxisLabel={unitLabel}
+          />
+          {percentiles === null
+            ? null
+            : PERCENTILE_KEYS.map((key) => {
+                const value = percentiles[key];
+                const y = yForValue(value, max);
+                return (
+                  <g key={key}>
+                    <line
+                      data-percentile={key}
+                      data-testid={`plot-percentile-${key}`}
+                      stroke="var(--color-border-strong)"
+                      strokeDasharray="4 4"
+                      vectorEffect="non-scaling-stroke"
+                      x1={LEFT}
+                      x2={width - RIGHT}
+                      y1={y}
+                      y2={y}
+                    />
+                    <line
+                      data-percentile={key}
+                      stroke="transparent"
+                      strokeWidth={PERCENTILE_HIT_WIDTH}
+                      vectorEffect="non-scaling-stroke"
+                      x1={LEFT}
+                      x2={width - RIGHT}
+                      y1={y}
+                      y2={y}
+                    />
+                    <text
+                      fill="var(--color-muted)"
+                      fontSize="10"
+                      textAnchor="start"
+                      x={width - RIGHT + 10}
+                      y={y + 3}
+                    >
+                      {formatUnitValue(value, unitLabel)}
+                    </text>
+                  </g>
+                );
+              })}
+          {sortedPoints.map((point, index) => {
+            const x = xForRank(index, sortedPoints.length, plotWidth);
+            const y = yForValue(point.days, max);
+            const isActive = active?.kind === 'point' && active.index === index;
+            return (
+              <a
+                aria-label={`${point.identifier} ${point.title}`}
+                href={`/issue/${point.identifier}`}
+                key={point.issueId}
+                ref={(node) => {
+                  anchorRefs.current[index] = node;
+                }}
+              >
+                <circle
+                  cx={x}
+                  cy={y}
+                  fill="var(--analytics-series-1)"
+                  pointerEvents="none"
+                  r={isActive ? ACTIVE_POINT_RADIUS : POINT_RADIUS}
+                  stroke="var(--color-surface)"
+                  strokeWidth="1"
+                />
+                <circle
+                  cx={x}
+                  cy={y}
+                  data-point-index={index}
+                  data-testid={`plot-scatter-${point.identifier}`}
+                  fill="transparent"
+                  r={HIT_RADIUS}
+                  stroke="transparent"
+                />
+              </a>
+            );
+          })}
+        </svg>
+      </div>
+    </PlotFrame>
+  );
+}

--- a/apps/web/src/features/analytics/charts/scatter-plot.tsx
+++ b/apps/web/src/features/analytics/charts/scatter-plot.tsx
@@ -68,10 +68,6 @@ function numberLabel(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(1);
 }
 
-function formatPointDays(value: number): string {
-  return `${value.toFixed(1)} days`;
-}
-
 function formatUnitValue(value: number, unitLabel: string): string {
   return `${value.toFixed(1)} ${unitLabel}`;
 }
@@ -181,8 +177,9 @@ function activePointInfo(
   sortedPoints: readonly InsightScatterPoint[],
   plotWidth: number,
   max: number,
+  unitLabel: string,
 ): ActiveInfo {
-  const value = formatPointDays(point.days);
+  const value = formatUnitValue(point.days, unitLabel);
   return {
     x: xForRank(index, sortedPoints.length, plotWidth),
     y: yForValue(point.days, max),
@@ -221,7 +218,7 @@ function activeInfoFor(
     const point = sortedPoints[active.index];
     return point === undefined
       ? EMPTY_ACTIVE_INFO
-      : activePointInfo(point, active.index, sortedPoints, plotWidth, max);
+      : activePointInfo(point, active.index, sortedPoints, plotWidth, max, unitLabel);
   }
   if (active?.kind === 'percentile' && percentiles !== null) {
     return activePercentileInfo(active.key, percentiles[active.key], max, width, unitLabel);

--- a/apps/web/src/features/analytics/charts/scatter-plot.tsx
+++ b/apps/web/src/features/analytics/charts/scatter-plot.tsx
@@ -110,6 +110,10 @@ function activeFromEventTarget(target: EventTarget): ActiveTarget {
   return isPercentileKey(percentileKey) ? { kind: 'percentile', key: percentileKey } : null;
 }
 
+function isEventInsideAnchor(target: EventTarget): boolean {
+  return target instanceof Element && target.closest('a') !== null;
+}
+
 interface KeyResult {
   readonly active: ActiveTarget;
   readonly focusAnchor: boolean;
@@ -228,7 +232,7 @@ function activeInfoFor(
 export function ScatterPlot({ label, points, percentiles, unitLabel }: ScatterPlotProps) {
   const { ref, width } = useMeasuredWidth();
   const [active, setActive] = useState<ActiveTarget>(null);
-  const anchorRefs = useRef<Array<HTMLAnchorElement | null>>([]);
+  const anchorRefs = useRef<Array<SVGAElement | null>>([]);
   const sortedPoints = sortedByDays(points);
 
   if (points.length === 0) {
@@ -268,6 +272,7 @@ export function ScatterPlot({ label, points, percentiles, unitLabel }: ScatterPl
             if (active === null && sortedPoints.length > 0) setActive({ kind: 'point', index: 0 });
           }}
           onKeyDown={(event) => {
+            if (event.key === 'Enter' && isEventInsideAnchor(event.target)) return;
             const result = keyResult(event.key, active, sortedPoints.length);
             if (result === null) return;
             setActive(result.active);
@@ -350,7 +355,7 @@ export function ScatterPlot({ label, points, percentiles, unitLabel }: ScatterPl
                 href={`/issue/${point.identifier}`}
                 key={point.issueId}
                 ref={(node) => {
-                  anchorRefs.current[index] = node;
+                  anchorRefs.current[index] = node as unknown as SVGAElement | null;
                 }}
               >
                 <circle

--- a/apps/web/src/features/analytics/contracts.ts
+++ b/apps/web/src/features/analytics/contracts.ts
@@ -488,3 +488,47 @@ export function analyticsWireResponse(
 export function analyticsDrilldownWireResponse(value: unknown): AnalyticsDrilldownResponse {
   return analyticsDrilldownResponseSchema.parse(jsonValue(value));
 }
+
+const insightSegmentValueSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  value: numberSchema,
+});
+
+const insightBucketSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  value: numberSchema,
+  segments: z.array(insightSegmentValueSchema),
+  cohort: analyticsDrilldownCohortSchema.nullable(),
+});
+
+const insightPercentilesSchema = z.object({
+  p25: numberSchema,
+  p50: numberSchema,
+  p75: numberSchema,
+  p95: numberSchema,
+});
+
+const insightScatterPointSchema = z.object({
+  issueId: z.string(),
+  identifier: z.string(),
+  title: z.string(),
+  days: numberSchema,
+});
+
+export const analyticsInsightsWireResponse = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('bars'),
+    unit: z.enum(['issues', 'points']),
+    buckets: z.array(insightBucketSchema),
+  }),
+  z.object({
+    kind: z.literal('scatter'),
+    unit: z.literal('days'),
+    points: z.array(insightScatterPointSchema),
+    percentiles: insightPercentilesSchema.nullable(),
+  }),
+]);
+
+export type AnalyticsInsightsResponse = z.infer<typeof analyticsInsightsWireResponse>;

--- a/apps/web/src/features/analytics/contracts.ts
+++ b/apps/web/src/features/analytics/contracts.ts
@@ -106,6 +106,7 @@ const sprintBurnPointSchema = z.object({
   ideal: numberSchema,
   available: z.boolean(),
   coverage: analyticsCoverageSchema.shape.kind,
+  future: z.boolean(),
 });
 
 const distributionSchema = z.object({
@@ -137,6 +138,14 @@ const sprintDetailSchema = z.object({
   sprint: sprintSummarySchema,
   measure: z.enum(['issues', 'points']),
   summary: sprintMeasureSummarySchema,
+  baseline: z
+    .object({
+      date: calendarDateSchema,
+      scope: numberSchema,
+      retroactive: z.boolean(),
+    })
+    .nullable(),
+  counterpart: sprintMeasureSummarySchema,
   scopeChanges: z.object({ added: numberSchema, removed: numberSchema }),
   burn: z.array(sprintBurnPointSchema),
   cohorts: z.object({

--- a/apps/web/src/features/analytics/data.ts
+++ b/apps/web/src/features/analytics/data.ts
@@ -13,6 +13,7 @@ import {
   listAnalyticsDrilldown,
   listCheckpoints,
   listSavedAnalyticsViews,
+  loadAnalyticsInsights,
   loadAnalyticsOverview,
   loadPeopleAnalytics,
   loadProjectAnalytics,
@@ -32,16 +33,23 @@ import { notFound } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan } from '@orbit/shared/policy';
 import { sprintLabel } from '@orbit/shared/utils';
-import type { AnalyticsLens, AnalyticsQuery } from '@orbit/shared/validators';
+import type {
+  AnalyticsInsightsQuery,
+  AnalyticsLens,
+  AnalyticsQuery,
+  InsightConfig,
+} from '@orbit/shared/validators';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { analyticsKeys } from './analytics-keys.ts';
 import {
   type AnalyticsDrilldownResponse,
+  type AnalyticsInsightsResponse,
   type AnalyticsPeopleResponse,
   type AnalyticsProjectsResponse,
   type AnalyticsResponseByLens,
   type AnalyticsSprintsResponse,
   analyticsDrilldownWireResponse,
+  analyticsInsightsWireResponse,
   analyticsWireResponse,
 } from './contracts.ts';
 import { selectedAssigneeIds } from './person-focus.ts';
@@ -249,6 +257,27 @@ export async function loadAnalyticsDrilldownData(
   input: AnalyticsDrilldownInput,
 ): Promise<AnalyticsDrilldownResponse> {
   return analyticsDrilldownWireResponse(await listAnalyticsDrilldown(principal, input));
+}
+
+export async function loadAnalyticsInsightsData(
+  principal: Principal,
+  query: AnalyticsQuery,
+  insight: InsightConfig,
+  now: Date = new Date(),
+): Promise<AnalyticsInsightsResponse> {
+  return analyticsInsightsWireResponse.parse(
+    await loadAnalyticsInsights(principal, query, insight, { now }),
+  );
+}
+
+export async function dehydratedAnalyticsInsights(
+  principal: Principal,
+  query: AnalyticsInsightsQuery,
+) {
+  const client = new QueryClient();
+  const payload = await loadAnalyticsInsightsData(principal, query, query.insight);
+  client.setQueryData(analyticsKeys.insights(query), payload);
+  return dehydrate(client);
 }
 
 export async function dehydratedAnalyticsLens(principal: Principal, query: AnalyticsQuery) {

--- a/apps/web/src/features/analytics/data.ts
+++ b/apps/web/src/features/analytics/data.ts
@@ -223,12 +223,12 @@ export async function loadAnalyticsLensData(
   principal: Principal,
   lens: AnalyticsLens,
   query: AnalyticsQuery,
-): Promise<AnalyticsResponseByLens[AnalyticsLens]>;
+): Promise<AnalyticsResponseByLens[keyof AnalyticsResponseByLens]>;
 export async function loadAnalyticsLensData(
   principal: Principal,
   lens: AnalyticsLens,
   query: AnalyticsQuery,
-): Promise<AnalyticsResponseByLens[AnalyticsLens]> {
+): Promise<AnalyticsResponseByLens[keyof AnalyticsResponseByLens]> {
   const normalized = { ...query, lens };
   switch (lens) {
     case 'overview':
@@ -239,6 +239,8 @@ export async function loadAnalyticsLensData(
       return analyticsWireResponse('projects', await loadProjectAnalytics(principal, normalized));
     case 'people':
       return analyticsWireResponse('people', await loadPeopleAnalytics(principal, normalized));
+    case 'insights':
+      throw notFound('Insights analytics is not available yet.');
   }
 }
 

--- a/apps/web/src/features/analytics/insights-lens.tsx
+++ b/apps/web/src/features/analytics/insights-lens.tsx
@@ -48,6 +48,7 @@ const SLICE_LABELS: Record<InsightSlice, string> = {
 };
 
 const WEEK_SLICES: ReadonlySet<InsightSlice> = new Set(['created_week', 'completed_week']);
+const DURATION_MEASURES: ReadonlySet<InsightMeasure> = new Set(['cycle_time', 'lead_time', 'age']);
 
 function valueLabel(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(1);
@@ -119,6 +120,7 @@ interface InsightPickersProps {
 }
 
 function InsightPickers({ insight, onInsightChange }: InsightPickersProps) {
+  const segmentDisabled = DURATION_MEASURES.has(insight.measure);
   return (
     <div className="flex flex-wrap items-center gap-2">
       <Select
@@ -152,8 +154,9 @@ function InsightPickers({ insight, onInsightChange }: InsightPickersProps) {
         </SelectContent>
       </Select>
       <Select
+        disabled={segmentDisabled}
         onValueChange={(value) => onInsightChange(withSegment(insight, value))}
-        value={insight.segment ?? NONE_SEGMENT}
+        value={segmentDisabled ? NONE_SEGMENT : (insight.segment ?? NONE_SEGMENT)}
       >
         <SelectTrigger aria-label="Insight segment" className="h-7 w-auto min-w-36 text-xs">
           <SelectValue />
@@ -248,6 +251,11 @@ export function InsightsLens({ data, query, insight, onInsightChange }: Insights
 
       <AnalyticsCard title={label}>
         <InsightChart data={data} insight={insight} label={label} onActivate={setEvidence} />
+        {insight.segment === 'label' ? (
+          <p className="text-muted text-xs">
+            Issues can carry several labels, so label segments may overlap.
+          </p>
+        ) : null}
       </AnalyticsCard>
 
       {evidence === null ? null : (

--- a/apps/web/src/features/analytics/insights-lens.tsx
+++ b/apps/web/src/features/analytics/insights-lens.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import {
+  type AnalyticsDrilldownCohort,
+  type AnalyticsQuery,
+  INSIGHT_MEASURES,
+  INSIGHT_SLICES,
+  type InsightConfig,
+  type InsightMeasure,
+  type InsightSlice,
+} from '@orbit/shared/validators';
+import { useState } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select.tsx';
+import { AnalyticsCard } from './analytics-card.tsx';
+import { AnalyticsDrilldownDialog } from './analytics-drilldown-dialog.tsx';
+import { BarPlot, type BarPlotPoint } from './charts/bar-plot.tsx';
+import type { PlotPoint } from './charts/line-plot.tsx';
+import { LinePlot } from './charts/line-plot.tsx';
+import { ScatterPlot } from './charts/scatter-plot.tsx';
+import type { AnalyticsInsightsResponse } from './contracts.ts';
+
+const NONE_SEGMENT = 'none';
+
+const MEASURE_LABELS: Record<InsightMeasure, string> = {
+  count: 'Count',
+  points: 'Points',
+  cycle_time: 'Cycle time',
+  lead_time: 'Lead time',
+  age: 'Age',
+};
+
+const SLICE_LABELS: Record<InsightSlice, string> = {
+  assignee: 'Assignee',
+  state: 'State',
+  state_category: 'State category',
+  project: 'Project',
+  label: 'Label',
+  priority: 'Priority',
+  sprint: 'Sprint',
+  created_week: 'Created week',
+  completed_week: 'Completed week',
+};
+
+const WEEK_SLICES: ReadonlySet<InsightSlice> = new Set(['created_week', 'completed_week']);
+
+function valueLabel(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function chartLabel(insight: InsightConfig): string {
+  if (insight.measure === 'count' || insight.measure === 'points') {
+    return `${MEASURE_LABELS[insight.measure]} by ${SLICE_LABELS[insight.slice]}`;
+  }
+  return `${MEASURE_LABELS[insight.measure]} distribution`;
+}
+
+function withMeasure(insight: InsightConfig, measure: InsightMeasure): InsightConfig {
+  return { ...insight, measure };
+}
+
+function withSlice(insight: InsightConfig, slice: InsightSlice): InsightConfig {
+  const cumulative = WEEK_SLICES.has(slice) ? insight.cumulative : false;
+  if (insight.segment === undefined || insight.segment === slice) {
+    return { measure: insight.measure, slice, cumulative };
+  }
+  return { measure: insight.measure, slice, segment: insight.segment, cumulative };
+}
+
+function withSegment(insight: InsightConfig, segment: string): InsightConfig {
+  if (segment === NONE_SEGMENT) {
+    return { measure: insight.measure, slice: insight.slice, cumulative: insight.cumulative };
+  }
+  return { ...insight, segment: segment as InsightSlice };
+}
+
+function withCumulative(insight: InsightConfig, cumulative: boolean): InsightConfig {
+  return { ...insight, cumulative };
+}
+
+type BarsResult = Extract<AnalyticsInsightsResponse, { kind: 'bars' }>;
+type InsightBucketWire = BarsResult['buckets'][number];
+
+function hasCohort(
+  bucket: InsightBucketWire,
+): bucket is InsightBucketWire & { cohort: AnalyticsDrilldownCohort } {
+  return bucket.cohort !== null;
+}
+
+function cumulativePoints(buckets: readonly InsightBucketWire[]): readonly PlotPoint[] {
+  const dated = buckets
+    .filter(hasCohort)
+    .toSorted((left, right) => left.id.localeCompare(right.id));
+  let total = 0;
+  return dated.map((bucket) => {
+    total += bucket.value;
+    return { id: bucket.id, label: bucket.label, value: total, cohort: bucket.cohort };
+  });
+}
+
+function barPointFrom(bucket: InsightBucketWire): BarPlotPoint {
+  return {
+    id: bucket.id,
+    label: bucket.label,
+    value: bucket.value,
+    cohort: bucket.cohort,
+    ...(bucket.segments.length > 0 ? { segments: bucket.segments } : {}),
+  };
+}
+
+interface InsightPickersProps {
+  readonly insight: InsightConfig;
+  readonly onInsightChange: (next: InsightConfig) => void;
+}
+
+function InsightPickers({ insight, onInsightChange }: InsightPickersProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Select
+        onValueChange={(value) => onInsightChange(withMeasure(insight, value as InsightMeasure))}
+        value={insight.measure}
+      >
+        <SelectTrigger aria-label="Insight measure" className="h-7 w-auto min-w-32 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {INSIGHT_MEASURES.map((measure) => (
+            <SelectItem key={measure} value={measure}>
+              {MEASURE_LABELS[measure]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select
+        onValueChange={(value) => onInsightChange(withSlice(insight, value as InsightSlice))}
+        value={insight.slice}
+      >
+        <SelectTrigger aria-label="Insight slice" className="h-7 w-auto min-w-32 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {INSIGHT_SLICES.map((slice) => (
+            <SelectItem key={slice} value={slice}>
+              {SLICE_LABELS[slice]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select
+        onValueChange={(value) => onInsightChange(withSegment(insight, value))}
+        value={insight.segment ?? NONE_SEGMENT}
+      >
+        <SelectTrigger aria-label="Insight segment" className="h-7 w-auto min-w-36 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={NONE_SEGMENT}>No segment</SelectItem>
+          {INSIGHT_SLICES.filter((slice) => slice !== insight.slice).map((slice) => (
+            <SelectItem key={slice} value={slice}>
+              {SLICE_LABELS[slice]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {WEEK_SLICES.has(insight.slice) ? (
+        <label className="flex items-center gap-2 text-muted text-xs">
+          <input
+            checked={insight.cumulative}
+            onChange={(event) =>
+              onInsightChange(withCumulative(insight, event.currentTarget.checked))
+            }
+            type="checkbox"
+          />
+          Cumulative
+        </label>
+      ) : null}
+    </div>
+  );
+}
+
+interface InsightChartProps {
+  readonly data: AnalyticsInsightsResponse;
+  readonly insight: InsightConfig;
+  readonly label: string;
+  readonly onActivate: (cohort: AnalyticsDrilldownCohort) => void;
+}
+
+function InsightChart({ data, insight, label, onActivate }: InsightChartProps) {
+  if (data.kind === 'scatter') {
+    return (
+      <ScatterPlot
+        label={label}
+        percentiles={data.percentiles}
+        points={data.points}
+        unitLabel="days"
+      />
+    );
+  }
+  if (data.buckets.length === 0) {
+    return (
+      <p className="py-8 text-center text-muted text-xs">No matching issues for this insight.</p>
+    );
+  }
+  const unit = data.unit === 'points' ? 'Points' : 'Issues';
+  if (insight.cumulative && WEEK_SLICES.has(insight.slice)) {
+    return (
+      <LinePlot
+        label={label}
+        onActivate={onActivate}
+        series={[{ id: 'cumulative', label, points: cumulativePoints(data.buckets) }]}
+        xAxisLabel="Week"
+        yAxisLabel={unit}
+      />
+    );
+  }
+  return (
+    <BarPlot
+      label={label}
+      onActivate={onActivate}
+      points={data.buckets.map(barPointFrom)}
+      valueFormatter={valueLabel}
+      xAxisLabel={unit}
+    />
+  );
+}
+
+interface InsightsLensProps {
+  readonly data: AnalyticsInsightsResponse;
+  readonly query: AnalyticsQuery;
+  readonly insight: InsightConfig;
+  readonly onInsightChange: (next: InsightConfig) => void;
+}
+
+export function InsightsLens({ data, query, insight, onInsightChange }: InsightsLensProps) {
+  const [evidence, setEvidence] = useState<AnalyticsDrilldownCohort | null>(null);
+  const label = chartLabel(insight);
+
+  return (
+    <div className="grid gap-4">
+      <AnalyticsCard title="Configure this insight">
+        <InsightPickers insight={insight} onInsightChange={onInsightChange} />
+      </AnalyticsCard>
+
+      <AnalyticsCard title={label}>
+        <InsightChart data={data} insight={insight} label={label} onActivate={setEvidence} />
+      </AnalyticsCard>
+
+      {evidence === null ? null : (
+        <AnalyticsDrilldownDialog
+          cohort={evidence}
+          onOpenChange={(open) => {
+            if (!open) setEvidence(null);
+          }}
+          open
+          query={query}
+          title={label}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/analytics/people-lens.tsx
+++ b/apps/web/src/features/analytics/people-lens.tsx
@@ -5,13 +5,16 @@ import { useState } from 'react';
 import { Avatar } from '@/components/ui/avatar.tsx';
 import { AnalyticsCard } from './analytics-card.tsx';
 import { AnalyticsDrilldownDialog } from './analytics-drilldown-dialog.tsx';
+import { personCaptureCaption, personIdealSeries, sprintDays, todayDateOf } from './burn-math.ts';
 import { type AnalyticsDataRow, AnalyticsDataTable } from './charts/analytics-data-table.tsx';
 import { BarPlot } from './charts/bar-plot.tsx';
-import { LinePlot } from './charts/line-plot.tsx';
+import { LinePlot, type PlotSeries } from './charts/line-plot.tsx';
 import type { AnalyticsPeopleResponse } from './contracts.ts';
 import { usesCurrentPersonDefault } from './person-focus.ts';
 
 type PersonRow = AnalyticsPeopleResponse['people'][number];
+type FocusedPerson = NonNullable<AnalyticsPeopleResponse['focused']>;
+type PersonSprintBurnPoints = NonNullable<FocusedPerson['sprintBurn']['current']>['burn'];
 
 interface EvidenceSelection {
   readonly title: string;
@@ -121,6 +124,22 @@ function PersonTimeline({
   );
 }
 
+function personRemainingSeries(burn: PersonSprintBurnPoints): PlotSeries {
+  return {
+    id: 'current-person',
+    label: 'Current sprint',
+    color: 1,
+    points: burn
+      .filter((point) => point.available && !point.future)
+      .map((point) => ({
+        id: `${point.date}-current-person`,
+        label: point.date,
+        value: point.remaining,
+        cohort: { cohort: 'open' as const },
+      })),
+  };
+}
+
 function PersonalSprintBurn({
   focused,
   points,
@@ -130,6 +149,7 @@ function PersonalSprintBurn({
 }) {
   const current = focused.sprintBurn.current;
   const selected = focused.sprintBurn.selected;
+  const previous = focused.sprintBurn.previous;
   if (current === null || selected === null) {
     return (
       <AnalyticsCard title="Personal sprint burn">
@@ -139,27 +159,8 @@ function PersonalSprintBurn({
       </AnalyticsCard>
     );
   }
-  const currentPoints = current.burn.map((point) => ({
-    id: `${point.date}-current-person`,
-    label: point.date,
-    value: point.remaining,
-    cohort: { cohort: 'open' as const },
-    x: point.workingDay ?? point.calendarDay,
-    available: point.available,
-  }));
-  const elapsed = currentPoints.at(-1)?.x ?? 0;
-  const previousPoints =
-    focused.sprintBurn.previous?.burn
-      .filter((point) => point.workingDay !== null && point.workingDay <= elapsed)
-      .map((point) => ({
-        id: `${point.date}-previous-person`,
-        label: `Previous day ${point.calendarDay}`,
-        value: point.remaining,
-        cohort: { cohort: 'open' as const },
-        x: point.workingDay ?? point.calendarDay,
-        available: point.available,
-      })) ?? [];
   const unit = points ? 'points' : 'issues';
+  const captureAnnotation = personCaptureCaption(current.burn);
   return (
     <AnalyticsCard title="Personal sprint burn">
       <div className="flex flex-wrap items-end justify-between gap-2">
@@ -172,17 +173,19 @@ function PersonalSprintBurn({
         <p className="text-faint text-xs">{current.coverage.kind}</p>
       </div>
       <LinePlot
+        {...(captureAnnotation === undefined ? {} : { annotation: captureAnnotation })}
+        days={sprintDays(current.burn, todayDateOf(current.burn))}
         label={`${focused.person.name} personal sprint burn`}
-        series={[
-          { id: 'current-person', label: 'Current sprint', points: currentPoints },
-          ...(previousPoints.length === 0
-            ? []
-            : [{ id: 'previous-person', label: 'Previous sprint', points: previousPoints }]),
-        ]}
+        series={[personRemainingSeries(current.burn), personIdealSeries(current.burn)]}
         valueFormatter={(value) => `${numberLabel(value)} ${unit}`}
-        xAxisLabel="Sprint working day"
+        xAxisLabel="Sprint day"
         yAxisLabel={`Remaining ${unit}`}
       />
+      {previous === null ? null : (
+        <p className="text-faint text-xs">
+          Previous sprint ended with {numberLabel(previous.summary.remaining)} {unit} remaining.
+        </p>
+      )}
       <p className="text-faint text-xs">
         Uses assignment history at each sprint point, not only current ownership.
       </p>

--- a/apps/web/src/features/analytics/people-lens.tsx
+++ b/apps/web/src/features/analytics/people-lens.tsx
@@ -305,8 +305,7 @@ function FocusedPerson({
         )}
         {points && focused.unestimated > 0 ? (
           <p className="text-muted text-xs">
-            {focused.unestimated} unestimated issue{focused.unestimated === 1 ? '' : 's'}{' '}
-            contributes zero points.
+            {focused.unestimated} unestimated issues count as 1 point each.
           </p>
         ) : null}
       </AnalyticsCard>

--- a/apps/web/src/features/analytics/people-lens.tsx
+++ b/apps/web/src/features/analytics/people-lens.tsx
@@ -5,7 +5,13 @@ import { useState } from 'react';
 import { Avatar } from '@/components/ui/avatar.tsx';
 import { AnalyticsCard } from './analytics-card.tsx';
 import { AnalyticsDrilldownDialog } from './analytics-drilldown-dialog.tsx';
-import { personCaptureCaption, personIdealSeries, sprintDays, todayDateOf } from './burn-math.ts';
+import {
+  personCaptureCaption,
+  personIdealSeries,
+  sprintDays,
+  todayDateOf,
+  unestimatedNote,
+} from './burn-math.ts';
 import { type AnalyticsDataRow, AnalyticsDataTable } from './charts/analytics-data-table.tsx';
 import { BarPlot } from './charts/bar-plot.tsx';
 import { LinePlot, type PlotSeries } from './charts/line-plot.tsx';
@@ -304,9 +310,7 @@ function FocusedPerson({
           </p>
         )}
         {points && focused.unestimated > 0 ? (
-          <p className="text-muted text-xs">
-            {focused.unestimated} unestimated issues count as 1 point each.
-          </p>
+          <p className="text-muted text-xs">{unestimatedNote(focused.unestimated)}</p>
         ) : null}
       </AnalyticsCard>
       <PersonFlowCards focused={focused} formulas={formulas} />

--- a/apps/web/src/features/analytics/projects-lens.tsx
+++ b/apps/web/src/features/analytics/projects-lens.tsx
@@ -153,7 +153,6 @@ function ProjectHealthUpdates({
   );
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: The project cockpit keeps coordinated portfolio and detail states in one render boundary.
 export function ProjectsLens({
   data,
   query,
@@ -236,8 +235,7 @@ export function ProjectsLens({
             </div>
             {points && focused.project.unestimated > 0 ? (
               <p className="text-muted text-xs">
-                {focused.project.unestimated} unestimated issue
-                {focused.project.unestimated === 1 ? '' : 's'} contributes zero points.
+                {focused.project.unestimated} unestimated issues count as 1 point each.
               </p>
             ) : null}
           </AnalyticsCard>

--- a/apps/web/src/features/analytics/projects-lens.tsx
+++ b/apps/web/src/features/analytics/projects-lens.tsx
@@ -4,6 +4,7 @@ import type { AnalyticsDrilldownCohort, AnalyticsQuery } from '@orbit/shared/val
 import { useState } from 'react';
 import { AnalyticsCard } from './analytics-card.tsx';
 import { AnalyticsDrilldownDialog } from './analytics-drilldown-dialog.tsx';
+import { unestimatedNote } from './burn-math.ts';
 import { type AnalyticsDataRow, AnalyticsDataTable } from './charts/analytics-data-table.tsx';
 import { LinePlot } from './charts/line-plot.tsx';
 import type { AnalyticsProjectsResponse } from './contracts.ts';
@@ -234,9 +235,7 @@ export function ProjectsLens({
               />
             </div>
             {points && focused.project.unestimated > 0 ? (
-              <p className="text-muted text-xs">
-                {focused.project.unestimated} unestimated issues count as 1 point each.
-              </p>
+              <p className="text-muted text-xs">{unestimatedNote(focused.project.unestimated)}</p>
             ) : null}
           </AnalyticsCard>
 

--- a/apps/web/src/features/analytics/query-state.ts
+++ b/apps/web/src/features/analytics/query-state.ts
@@ -192,3 +192,16 @@ export function searchParamsForInsights(query: AnalyticsInsightsQuery): URLSearc
 export function canonicalInsightsQuery(query: AnalyticsInsightsQuery): string {
   return searchParamsForInsights(query).toString();
 }
+
+export function searchParamsForSavedAnalyticsView(
+  query: AnalyticsQuery,
+  insight: InsightConfig,
+): URLSearchParams {
+  const params = searchParamsForAnalytics(query);
+  for (const [key, value] of searchParamsForInsightConfig(insight)) params.set(key, value);
+  return params;
+}
+
+export function canonicalSavedAnalyticsView(query: AnalyticsQuery, insight: InsightConfig): string {
+  return searchParamsForSavedAnalyticsView(query, insight).toString();
+}

--- a/apps/web/src/features/analytics/query-state.ts
+++ b/apps/web/src/features/analytics/query-state.ts
@@ -7,6 +7,8 @@ import {
   analyticsDrilldownQuerySchema,
   analyticsInsightsQuerySchema,
   analyticsQuerySchema,
+  type InsightConfig,
+  insightConfigSchema,
 } from '@orbit/shared/validators';
 import { z } from 'zod';
 
@@ -15,6 +17,7 @@ export type AnalyticsSearchParams =
   | Readonly<Record<string, string | string[] | undefined>>;
 
 const defaultAnalyticsQuery = analyticsQuerySchema.parse({});
+const defaultInsightConfig = insightConfigSchema.parse({});
 const encodedFilterSchema = z
   .string()
   .transform((encoded, context): unknown => {
@@ -135,6 +138,35 @@ export function canonicalAnalyticsQuery(query: AnalyticsQuery): string {
 
 export function canonicalDrilldownQuery(query: AnalyticsDrilldownQuery): string {
   return searchParamsForDrilldown(query).toString();
+}
+
+function insightConfigInput(params: AnalyticsSearchParams): unknown {
+  return {
+    measure: parameterValue(params, 'insightMeasure'),
+    slice: parameterValue(params, 'insightSlice'),
+    segment: parameterValue(params, 'insightSegment'),
+    cumulative: booleanValue(parameterValue(params, 'insightCumulative')),
+  };
+}
+
+export function insightConfigFromSearchParams(params: AnalyticsSearchParams): InsightConfig {
+  try {
+    return insightConfigSchema.parse(insightConfigInput(params));
+  } catch {
+    return defaultInsightConfig;
+  }
+}
+
+export function searchParamsForInsightConfig(insight: InsightConfig): URLSearchParams {
+  const parsed = insightConfigSchema.parse(insight);
+  const params = new URLSearchParams();
+  if (parsed.measure !== defaultInsightConfig.measure) params.set('insightMeasure', parsed.measure);
+  if (parsed.slice !== defaultInsightConfig.slice) params.set('insightSlice', parsed.slice);
+  if (parsed.segment !== undefined) params.set('insightSegment', parsed.segment);
+  if (parsed.cumulative !== defaultInsightConfig.cumulative) {
+    params.set('insightCumulative', parsed.cumulative ? '1' : '0');
+  }
+  return params;
 }
 
 export function analyticsInsightsFromSearchParams(

--- a/apps/web/src/features/analytics/query-state.ts
+++ b/apps/web/src/features/analytics/query-state.ts
@@ -1,8 +1,11 @@
+import { validationFailed } from '@orbit/shared/errors';
 import { encodeFilter, filterGroupSchema, isEmptyFilter } from '@orbit/shared/filters';
 import {
   type AnalyticsDrilldownQuery,
+  type AnalyticsInsightsQuery,
   type AnalyticsQuery,
   analyticsDrilldownQuerySchema,
+  analyticsInsightsQuerySchema,
   analyticsQuerySchema,
 } from '@orbit/shared/validators';
 import { z } from 'zod';
@@ -132,4 +135,28 @@ export function canonicalAnalyticsQuery(query: AnalyticsQuery): string {
 
 export function canonicalDrilldownQuery(query: AnalyticsDrilldownQuery): string {
   return searchParamsForDrilldown(query).toString();
+}
+
+export function analyticsInsightsFromSearchParams(
+  params: AnalyticsSearchParams,
+): AnalyticsInsightsQuery {
+  const raw = parameterValue(params, 'query');
+  let json: unknown;
+  try {
+    json = raw === undefined ? {} : JSON.parse(raw);
+  } catch {
+    throw validationFailed('That analytics insights query is not valid JSON.');
+  }
+  return analyticsInsightsQuerySchema.parse(json);
+}
+
+export function searchParamsForInsights(query: AnalyticsInsightsQuery): URLSearchParams {
+  const parsed = analyticsInsightsQuerySchema.parse(query);
+  const params = new URLSearchParams();
+  params.set('query', JSON.stringify(parsed));
+  return params;
+}
+
+export function canonicalInsightsQuery(query: AnalyticsInsightsQuery): string {
+  return searchParamsForInsights(query).toString();
 }

--- a/apps/web/src/features/analytics/saved-view-bar.tsx
+++ b/apps/web/src/features/analytics/saved-view-bar.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import type { SavedAnalyticsViewPayload } from '@orbit/core';
-import { type AnalyticsQuery, analyticsQuerySchema } from '@orbit/shared/validators';
+import {
+  type AnalyticsQuery,
+  analyticsQuerySchema,
+  type InsightConfig,
+  insightConfigSchema,
+} from '@orbit/shared/validators';
 import { useQueryClient } from '@tanstack/react-query';
 import { Pencil, Pin, Save, Trash2, Users } from 'lucide-react';
 import { type FormEvent, useState } from 'react';
@@ -9,19 +14,29 @@ import { Button } from '@/components/ui/button.tsx';
 import { useToast } from '@/components/ui/toast.tsx';
 import { apiRequest, messageOf } from '@/lib/api/client.ts';
 import { analyticsKeys } from './analytics-keys.ts';
-import { canonicalAnalyticsQuery } from './query-state.ts';
+import { canonicalSavedAnalyticsView, searchParamsForInsightConfig } from './query-state.ts';
 
 interface SavedViewBarProps {
   readonly views: readonly SavedAnalyticsViewPayload[];
   readonly query: AnalyticsQuery;
+  readonly insight: InsightConfig;
   readonly canManage: boolean;
   readonly canManageAll: boolean;
   readonly currentUserId: string | null;
-  readonly onApply: (query: AnalyticsQuery) => void;
+  readonly onApply: (query: AnalyticsQuery, insight?: InsightConfig) => void;
 }
+
+const defaultInsightConfig = insightConfigSchema.parse({});
 
 function queryOf(view: SavedAnalyticsViewPayload): AnalyticsQuery | null {
   const parsed = analyticsQuerySchema.safeParse(view.config['query'] ?? view.config);
+  return parsed.success ? parsed.data : null;
+}
+
+function insightOf(view: SavedAnalyticsViewPayload): InsightConfig | null {
+  const raw = view.config['insight'];
+  if (raw === undefined) return null;
+  const parsed = insightConfigSchema.safeParse(raw);
   return parsed.success ? parsed.data : null;
 }
 
@@ -29,9 +44,26 @@ function pinned(view: SavedAnalyticsViewPayload): boolean {
   return view.config['pinned'] === true;
 }
 
+function dashboardConfig(
+  targetQuery: AnalyticsQuery,
+  targetInsight: InsightConfig | null,
+  isPinned: boolean,
+): Record<string, unknown> {
+  const carriesInsight =
+    targetInsight !== null && searchParamsForInsightConfig(targetInsight).toString() !== '';
+  return {
+    kind: 'dashboard',
+    version: 1,
+    query: targetQuery,
+    ...(carriesInsight ? { insight: targetInsight } : {}),
+    pinned: isPinned,
+  };
+}
+
 export function SavedViewBar({
   views,
   query,
+  insight,
   canManage,
   canManageAll,
   currentUserId,
@@ -49,7 +81,12 @@ export function SavedViewBar({
   const dashboards = localViews.filter((view) => view.kind === 'dashboard');
   const active = dashboards.find((view) => {
     const saved = queryOf(view);
-    return saved !== null && canonicalAnalyticsQuery(saved) === canonicalAnalyticsQuery(query);
+    if (saved === null) return false;
+    const savedInsight = insightOf(view) ?? defaultInsightConfig;
+    return (
+      canonicalSavedAnalyticsView(saved, savedInsight) ===
+      canonicalSavedAnalyticsView(query, insight)
+    );
   });
 
   async function refresh(): Promise<void> {
@@ -68,7 +105,7 @@ export function SavedViewBar({
           body: {
             name: name.trim(),
             shared,
-            config: { kind: 'dashboard', version: 1, query, pinned: false },
+            config: dashboardConfig(query, insight, false),
           },
         },
       );
@@ -151,7 +188,8 @@ export function SavedViewBar({
                 className="rounded-l-md px-2.5 py-1.5 text-muted text-xs hover:text-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
                 disabled={saved === null}
                 onClick={() => {
-                  if (saved !== null) onApply(saved);
+                  if (saved === null) return;
+                  onApply(saved, insightOf(view) ?? undefined);
                 }}
                 type="button"
               >
@@ -166,12 +204,11 @@ export function SavedViewBar({
                   disabled={pending}
                   onClick={() =>
                     update(view.id, {
-                      config: {
-                        kind: 'dashboard',
-                        version: 1,
-                        query: saved ?? query,
-                        pinned: !pinned(view),
-                      },
+                      config: dashboardConfig(
+                        saved ?? query,
+                        saved === null ? insight : insightOf(view),
+                        !pinned(view),
+                      ),
                     })
                   }
                   type="button"
@@ -226,7 +263,7 @@ export function SavedViewBar({
           disabled={pending}
           onClick={() =>
             update(active.id, {
-              config: { kind: 'dashboard', version: 1, query, pinned: pinned(active) },
+              config: dashboardConfig(query, insight, pinned(active)),
             })
           }
           size="sm"

--- a/apps/web/src/features/analytics/sprint-lens.tsx
+++ b/apps/web/src/features/analytics/sprint-lens.tsx
@@ -12,6 +12,7 @@ import {
   type SprintDay,
   sprintDays,
   todayDateOf,
+  unestimatedNote,
 } from './burn-math.ts';
 import type { BarPair, BarPlotAverageLine } from './charts/bar-plot.tsx';
 import { BarPlot } from './charts/bar-plot.tsx';
@@ -415,7 +416,7 @@ export function SprintLens({
 
       {query.measure === 'points' && summary.unestimated > 0 ? (
         <p className="rounded-md border border-warning/30 bg-warning/5 px-3 py-2 text-muted text-xs">
-          {summary.unestimated} unestimated issues count as 1 point each.
+          {unestimatedNote(summary.unestimated)}
         </p>
       ) : null}
 

--- a/apps/web/src/features/analytics/sprint-lens.tsx
+++ b/apps/web/src/features/analytics/sprint-lens.tsx
@@ -3,7 +3,16 @@
 import type { AnalyticsQuery } from '@orbit/shared/validators';
 import { useState } from 'react';
 import { AnalyticsCard } from './analytics-card.tsx';
-import { burnForecast, forecastDate, type SprintDay, sprintDays } from './burn-math.ts';
+import {
+  burnForecast,
+  forecastDate,
+  personCaptureCaption,
+  personIdealSeries,
+  readableDate,
+  type SprintDay,
+  sprintDays,
+  todayDateOf,
+} from './burn-math.ts';
 import { BarPlot } from './charts/bar-plot.tsx';
 import type { PlotPoint, PlotSeries } from './charts/line-plot.tsx';
 import { LinePlot } from './charts/line-plot.tsx';
@@ -23,19 +32,6 @@ function numberLabel(value: number): string {
 
 function days(value: number): string {
   return `${numberLabel(value)}d`;
-}
-
-function readableDate(value: string): string {
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    timeZone: 'UTC',
-  }).format(new Date(`${value}T12:00:00.000Z`));
-}
-
-function todayDateOf(burn: SprintBurnPoints): string {
-  return burn.filter((point) => !point.future).at(-1)?.date ?? burn.at(-1)?.date ?? '';
 }
 
 function capturedPoints(burn: SprintBurnPoints): SprintBurnPoints {
@@ -70,6 +66,20 @@ function remainingSeries(burn: SprintBurnPoints): PlotSeries {
     color: 1,
     points: capturedPoints(burn).map((point) => ({
       id: `${point.date}-remaining`,
+      label: point.date,
+      value: point.remaining,
+      cohort: { cohort: 'open' as const },
+    })),
+  };
+}
+
+function focusRemainingSeries(burn: SprintBurnPoints): PlotSeries {
+  return {
+    id: 'person-remaining',
+    label: 'Remaining',
+    color: 1,
+    points: capturedPoints(burn).map((point) => ({
+      id: `${point.date}-person-remaining`,
       label: point.date,
       value: point.remaining,
       cohort: { cohort: 'open' as const },
@@ -282,6 +292,43 @@ function SprintBurnChart({
   );
 }
 
+function FocusBurnCard({
+  focus,
+  currentPerson,
+  measure,
+  measureFormatter,
+}: {
+  readonly focus: NonNullable<AnalyticsSprintsResponse['focus']>;
+  readonly currentPerson: boolean;
+  readonly measure: string;
+  readonly measureFormatter: (value: number) => string;
+}) {
+  const captureAnnotation = personCaptureCaption(focus.burn);
+  return (
+    <AnalyticsCard>
+      <div>
+        <p className="text-accent text-xs">
+          {currentPerson ? 'My sprint burn' : 'Selected person sprint burn'}
+        </p>
+        <h3 className="mt-1 font-medium text-sm text-text">{focus.name}</h3>
+        <p className="mt-1 text-muted text-xs">
+          Work assigned to {currentPerson ? 'you' : focus.name} over this sprint, using historical
+          assignment facts where available.
+        </p>
+      </div>
+      <LinePlot
+        {...(captureAnnotation === undefined ? {} : { annotation: captureAnnotation })}
+        days={sprintDays(focus.burn, todayDateOf(focus.burn))}
+        label={`${focus.name} remaining work`}
+        series={[focusRemainingSeries(focus.burn), personIdealSeries(focus.burn)]}
+        valueFormatter={measureFormatter}
+        xAxisLabel="Sprint day"
+        yAxisLabel={`Remaining ${measure}`}
+      />
+    </AnalyticsCard>
+  );
+}
+
 export function SprintLens({
   data,
   query,
@@ -402,38 +449,12 @@ export function SprintLens({
       </div>
 
       {data.focus === null ? null : (
-        <AnalyticsCard>
-          <div>
-            <p className="text-accent text-xs">
-              {currentPerson ? 'My sprint burn' : 'Selected person sprint burn'}
-            </p>
-            <h3 className="mt-1 font-medium text-sm text-text">{data.focus.name}</h3>
-            <p className="mt-1 text-muted text-xs">
-              Work assigned to {currentPerson ? 'you' : data.focus.name} over this sprint, using
-              historical assignment facts where available.
-            </p>
-          </div>
-          <LinePlot
-            label={`${data.focus.name} remaining work`}
-            series={[
-              {
-                id: 'person-remaining',
-                label: 'Remaining',
-                points: data.focus.burn.map((point) => ({
-                  id: `${point.date}-person-remaining`,
-                  label: point.date,
-                  value: point.remaining,
-                  cohort: { cohort: 'open' },
-                  x: point.workingDay ?? point.calendarDay,
-                  available: point.available,
-                })),
-              },
-            ]}
-            valueFormatter={measureFormatter}
-            xAxisLabel="Sprint working day"
-            yAxisLabel={`Remaining ${current.measure}`}
-          />
-        </AnalyticsCard>
+        <FocusBurnCard
+          currentPerson={currentPerson}
+          focus={data.focus}
+          measure={current.measure}
+          measureFormatter={measureFormatter}
+        />
       )}
     </div>
   );

--- a/apps/web/src/features/analytics/sprint-lens.tsx
+++ b/apps/web/src/features/analytics/sprint-lens.tsx
@@ -3,13 +3,19 @@
 import type { AnalyticsQuery } from '@orbit/shared/validators';
 import { useState } from 'react';
 import { AnalyticsCard } from './analytics-card.tsx';
-import { burnForecast } from './burn-math.ts';
+import { burnForecast, forecastDate, type SprintDay, sprintDays } from './burn-math.ts';
 import { BarPlot } from './charts/bar-plot.tsx';
+import type { PlotPoint, PlotSeries } from './charts/line-plot.tsx';
 import { LinePlot } from './charts/line-plot.tsx';
 import type { AnalyticsSprintsResponse } from './contracts.ts';
 import { usesCurrentPersonDefault } from './person-focus.ts';
+import { SprintStats } from './sprint-stats.tsx';
 
 type BurnMode = 'down' | 'up';
+type SprintCurrent = NonNullable<AnalyticsSprintsResponse['current']>;
+type SprintBurnPoints = SprintCurrent['burn'];
+
+const DAY_MILLISECONDS = 86_400_000;
 
 function numberLabel(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(1);
@@ -28,191 +34,186 @@ function readableDate(value: string): string {
   }).format(new Date(`${value}T12:00:00.000Z`));
 }
 
-function localDate(value: string, timezone: string): string {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    timeZone: timezone,
-  }).formatToParts(new Date(value));
-  const part = (type: Intl.DateTimeFormatPartTypes): string =>
-    parts.find((entry) => entry.type === type)?.value ?? '';
-  return `${part('year')}-${part('month')}-${part('day')}`;
+function todayDateOf(burn: SprintBurnPoints): string {
+  return burn.filter((point) => !point.future).at(-1)?.date ?? burn.at(-1)?.date ?? '';
 }
 
-function addUtcDays(value: string, amount: number): string {
-  const date = new Date(`${value}T00:00:00.000Z`);
-  date.setUTCDate(date.getUTCDate() + amount);
-  return date.toISOString().slice(0, 10);
+function capturedPoints(burn: SprintBurnPoints): SprintBurnPoints {
+  return burn.filter((point) => point.available && !point.future);
 }
 
-function workingDayNumber(start: string, end: string): number {
-  let day = start;
-  let count = 0;
-  while (day <= end) {
-    const weekday = new Date(`${day}T12:00:00.000Z`).getUTCDay();
-    if (weekday !== 0 && weekday !== 6) count += 1;
-    day = addUtcDays(day, 1);
+function initialScopeOf(current: SprintCurrent): number {
+  const firstAvailable = current.burn.find((point) => point.available);
+  return current.baseline?.scope ?? firstAvailable?.scope ?? 0;
+}
+
+function idealSeries(burn: SprintBurnPoints): PlotSeries {
+  return {
+    id: 'ideal',
+    label: 'Ideal',
+    dashed: true,
+    dots: true,
+    points: burn.map((point) => ({
+      id: `${point.date}-ideal`,
+      label: point.date,
+      value: point.ideal,
+      cohort: { cohort: 'open' as const },
+    })),
+  };
+}
+
+function remainingSeries(burn: SprintBurnPoints): PlotSeries {
+  return {
+    id: 'remaining',
+    label: 'Remaining',
+    points: capturedPoints(burn).map((point) => ({
+      id: `${point.date}-remaining`,
+      label: point.date,
+      value: point.remaining,
+      cohort: { cohort: 'open' as const },
+    })),
+  };
+}
+
+function scopeSeries(
+  burn: SprintBurnPoints,
+  options: { readonly step?: boolean } = {},
+): PlotSeries {
+  return {
+    id: 'scope',
+    label: 'Scope',
+    ...(options.step === true ? { step: true } : {}),
+    points: capturedPoints(burn).map((point) => ({
+      id: `${point.date}-scope`,
+      label: point.date,
+      value: point.scope,
+      cohort: { cohort: 'open' as const },
+    })),
+  };
+}
+
+function completedSeries(burn: SprintBurnPoints): PlotSeries {
+  return {
+    id: 'completed',
+    label: 'Completed',
+    points: capturedPoints(burn).map((point) => ({
+      id: `${point.date}-completed`,
+      label: point.date,
+      value: point.completed,
+      cohort: { cohort: 'completed' as const },
+    })),
+  };
+}
+
+function startedSeries(burn: SprintBurnPoints): PlotSeries {
+  return {
+    id: 'started',
+    label: 'Started',
+    points: capturedPoints(burn).map((point) => ({
+      id: `${point.date}-started`,
+      label: point.date,
+      value: point.completed + point.started,
+      cohort: { cohort: 'open' as const },
+    })),
+  };
+}
+
+function targetSeries(burn: SprintBurnPoints, initialScope: number): PlotSeries {
+  return {
+    id: 'target',
+    label: 'Target',
+    dashed: true,
+    points: burn.map((point) => ({
+      id: `${point.date}-target`,
+      label: point.date,
+      value: initialScope - point.ideal,
+      cohort: { cohort: 'open' as const },
+    })),
+  };
+}
+
+function daysBetweenDates(from: string, to: string): number {
+  return Math.round(
+    (Date.parse(`${to}T00:00:00.000Z`) - Date.parse(`${from}T00:00:00.000Z`)) / DAY_MILLISECONDS,
+  );
+}
+
+function forecastEndPoint(
+  startLabel: string,
+  startValue: number,
+  targetDate: string,
+  lastDayDate: string,
+): { readonly label: string; readonly value: number } {
+  if (targetDate <= lastDayDate) return { label: targetDate, value: 0 };
+  const span = daysBetweenDates(startLabel, targetDate);
+  const elapsed = daysBetweenDates(startLabel, lastDayDate);
+  const fraction = span <= 0 ? 1 : Math.min(1, Math.max(0, elapsed / span));
+  return { label: lastDayDate, value: Math.max(0, startValue * (1 - fraction)) };
+}
+
+function forecastSeriesFor(
+  forecast: ReturnType<typeof burnForecast>,
+  forecastDateValue: string | null,
+  sprintDaysList: readonly SprintDay[],
+): PlotSeries {
+  const start = forecast?.points[0];
+  const lastDay = sprintDaysList.at(-1);
+  const empty: PlotSeries = { id: 'forecast', label: 'Forecast', dashed: true, points: [] };
+  if (
+    forecast === null ||
+    start === undefined ||
+    forecastDateValue === null ||
+    lastDay === undefined
+  ) {
+    return empty;
   }
-  return Math.max(1, count);
-}
-
-function burnWithWorkingX(burn: NonNullable<AnalyticsSprintsResponse['current']>['burn']) {
-  let lastWorkingDay = 0;
-  return burn.map((point) => {
-    if (point.workingDay !== null) lastWorkingDay = point.workingDay;
-    return { point, x: lastWorkingDay };
-  });
-}
-
-function trackingAnnotation(
-  burn: NonNullable<AnalyticsSprintsResponse['current']>['burn'],
-  trackingStart: string | null,
-): string | undefined {
-  if (trackingStart === null) return 'No reliable burn history is available yet.';
-  if (burn.some((point) => !point.available)) {
-    const trendGuidance =
-      burn.filter((point) => point.available).length < 2
-        ? ' A second reliable day is needed before an actual trend line can be drawn.'
-        : '';
-    return `Tracking began ${readableDate(trackingStart)}. Earlier dates are not zero.${trendGuidance}`;
-  }
-  return undefined;
+  const end = forecastEndPoint(start.label, start.value, forecastDateValue, lastDay.date);
+  const points: PlotPoint[] = [
+    {
+      id: 'forecast-current',
+      label: start.label,
+      value: start.value,
+      cohort: { cohort: 'open' as const },
+    },
+    {
+      id: 'forecast-completion',
+      label: end.label,
+      value: end.value,
+      cohort: { cohort: 'open' as const },
+    },
+  ];
+  return { id: 'forecast', label: 'Forecast', dashed: true, points };
 }
 
 function SprintBurnChart({
   current,
-  previous,
   measureFormatter,
 }: {
-  readonly current: NonNullable<AnalyticsSprintsResponse['current']>;
-  readonly previous: AnalyticsSprintsResponse['previous'];
+  readonly current: SprintCurrent;
   readonly measureFormatter: (value: number) => string;
 }) {
   const [burnMode, setBurnMode] = useState<BurnMode>('down');
-  const currentBurn = burnWithWorkingX(current.burn);
-  const availableBurn = currentBurn.filter(({ point }) => point.available);
-  const trackingStart = availableBurn[0]?.point.date ?? null;
+  const sprintDaysList = sprintDays(current.burn, todayDateOf(current.burn));
   const forecast = burnForecast(current.burn);
-  const annotation = trackingAnnotation(current.burn, trackingStart);
-  const sprintStart = localDate(current.sprint.startsAt, current.sprint.timezone);
-  const sprintEnd = localDate(
-    new Date(Date.parse(current.sprint.endsAt) - 1).toISOString(),
-    current.sprint.timezone,
-  );
-  const sprintEndWorkingDay = workingDayNumber(sprintStart, sprintEnd);
-  const idealPoints = currentBurn.map(({ point, x }) => ({
-    id: `${point.date}-ideal`,
-    label: point.date,
-    value: point.ideal,
-    cohort: { cohort: 'open' as const },
-    x,
-    available: point.available,
-  }));
-  const lastIdeal = idealPoints.filter((point) => point.available).at(-1);
-  if (lastIdeal !== undefined && (lastIdeal.x ?? 0) < sprintEndWorkingDay) {
-    idealPoints.push({
-      id: 'sprint-end-ideal',
-      label: sprintEnd,
-      value: 0,
-      cohort: { cohort: 'open' },
-      x: sprintEndWorkingDay,
-      available: true,
-    });
-  }
-  const elapsedWorkingDay = currentBurn.at(-1)?.x ?? 0;
-  const previousBurn =
-    previous === null
-      ? []
-      : burnWithWorkingX(previous.burn).filter(
-          ({ point, x }) => point.workingDay !== null && x <= elapsedWorkingDay,
-        );
-  const burnSeries =
+  const forecastDateValue =
+    forecast === null ? null : forecastDate(current.burn, forecast.completionWorkingDay);
+  const captureAnnotation =
+    current.baseline?.retroactive === true
+      ? `Capture began ${readableDate(current.baseline.date)}. Earlier days show targets only.`
+      : undefined;
+  const burnSeries: readonly PlotSeries[] =
     burnMode === 'down'
       ? [
-          {
-            id: 'remaining',
-            label: 'Remaining',
-            points: currentBurn.map(({ point, x }) => ({
-              id: `${point.date}-remaining`,
-              label: point.date,
-              value: point.remaining,
-              cohort: { cohort: 'open' as const },
-              x,
-              available: point.available,
-            })),
-          },
-          {
-            id: 'scope',
-            label: 'Scope',
-            dashed: true,
-            points: currentBurn.map(({ point, x }) => ({
-              id: `${point.date}-scope`,
-              label: point.date,
-              value: point.scope,
-              cohort: { cohort: 'open' as const },
-              x,
-              available: point.available,
-            })),
-          },
-          {
-            id: 'ideal',
-            label: 'Ideal',
-            dashed: true,
-            points: idealPoints,
-          },
-          ...(forecast === null
-            ? []
-            : [
-                {
-                  id: 'forecast',
-                  label: 'Forecast',
-                  dashed: true,
-                  points: forecast.points,
-                },
-              ]),
-          ...(previous === null
-            ? []
-            : [
-                {
-                  id: 'previous',
-                  label: 'Previous remaining',
-                  points: previousBurn.map(({ point, x }) => ({
-                    id: `${point.date}-previous`,
-                    label: `Previous day ${point.calendarDay}`,
-                    value: point.remaining,
-                    cohort: { cohort: 'open' as const },
-                    x,
-                    available: point.available,
-                  })),
-                },
-              ]),
+          remainingSeries(current.burn),
+          idealSeries(current.burn),
+          forecastSeriesFor(forecast, forecastDateValue, sprintDaysList),
+          scopeSeries(current.burn, { step: true }),
         ]
       : [
-          {
-            id: 'completed',
-            label: 'Completed',
-            points: currentBurn.map(({ point, x }) => ({
-              id: `${point.date}-completed`,
-              label: point.date,
-              value: point.completed,
-              cohort: { cohort: 'completed' as const },
-              x,
-              available: point.available,
-            })),
-          },
-          {
-            id: 'scope',
-            label: 'Scope',
-            points: currentBurn.map(({ point, x }) => ({
-              id: `${point.date}-scope`,
-              label: point.date,
-              value: point.scope,
-              cohort: { cohort: 'open' as const },
-              x,
-              available: point.available,
-            })),
-          },
+          completedSeries(current.burn),
+          startedSeries(current.burn),
+          scopeSeries(current.burn),
+          targetSeries(current.burn, initialScopeOf(current)),
         ];
 
   return (
@@ -245,23 +246,19 @@ function SprintBurnChart({
         </fieldset>
       </div>
       <LinePlot
-        {...(annotation === undefined ? {} : { annotation })}
+        {...(captureAnnotation === undefined ? {} : { annotation: captureAnnotation })}
+        days={sprintDaysList}
         label={burnMode === 'down' ? 'Sprint burn down' : 'Sprint burn up'}
         series={burnSeries}
         valueFormatter={measureFormatter}
-        xAxisLabel="Sprint working day"
+        xAxisLabel="Sprint day"
         yAxisLabel={`${burnMode === 'down' ? 'Remaining' : 'Completed'} ${current.measure}`}
       />
       <p className="text-muted text-xs">
-        {forecast === null
+        {forecast === null || forecastDateValue === null
           ? 'Forecast needs at least 3 working days with a declining remaining-work trend.'
-          : `Current trend forecasts completion around working day ${forecast.completionWorkingDay}.`}
+          : `Current trend forecasts completion around ${readableDate(forecastDateValue)}.`}
       </p>
-      {trackingStart !== null && current.burn.some((point) => !point.available) ? (
-        <p className="text-faint text-xs">
-          The ideal line starts at the first reliable scope baseline and reaches zero at sprint end.
-        </p>
-      ) : null}
       <div className="flex flex-wrap gap-4 text-xs">
         <span className="text-muted">
           Added <strong className="text-text">{numberLabel(current.summary.added)}</strong>
@@ -319,34 +316,15 @@ export function SprintLens({
         </span>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-        {[
-          ['Planned', summary.planned],
-          ['Completed', summary.completed],
-          ['Remaining', summary.remaining],
-          ['Carryover', summary.carryover],
-        ].map(([label, value]) => (
-          <article className="rounded-lg border border-border bg-surface p-4" key={String(label)}>
-            <p className="text-muted text-xs">{label}</p>
-            <p className="mt-2 font-semibold text-2xl text-text tabular">
-              {numberLabel(Number(value))}
-            </p>
-            <p className="mt-1 text-faint text-2xs uppercase">{current.measure}</p>
-          </article>
-        ))}
-      </div>
+      <SprintStats current={current} measure={current.measure} />
 
       {query.measure === 'points' && summary.unestimated > 0 ? (
         <p className="rounded-md border border-warning/30 bg-warning/5 px-3 py-2 text-muted text-xs">
-          {summary.unestimated} unestimated issues contribute zero points.
+          {summary.unestimated} unestimated issues count as 1 point each.
         </p>
       ) : null}
 
-      <SprintBurnChart
-        current={current}
-        measureFormatter={measureFormatter}
-        previous={data.previous}
-      />
+      <SprintBurnChart current={current} measureFormatter={measureFormatter} />
 
       {data.previous === null ? (
         <p className="rounded-lg border border-border bg-surface px-4 py-3 text-muted text-xs">

--- a/apps/web/src/features/analytics/sprint-lens.tsx
+++ b/apps/web/src/features/analytics/sprint-lens.tsx
@@ -3,8 +3,9 @@
 import type { AnalyticsQuery } from '@orbit/shared/validators';
 import { useState } from 'react';
 import { AnalyticsCard } from './analytics-card.tsx';
+import { burnForecast } from './burn-math.ts';
 import { BarPlot } from './charts/bar-plot.tsx';
-import { LinePlot, type PlotPoint } from './charts/line-plot.tsx';
+import { LinePlot } from './charts/line-plot.tsx';
 import type { AnalyticsSprintsResponse } from './contracts.ts';
 import { usesCurrentPersonDefault } from './person-focus.ts';
 
@@ -54,47 +55,6 @@ function workingDayNumber(start: string, end: string): number {
     day = addUtcDays(day, 1);
   }
   return Math.max(1, count);
-}
-
-function burnForecast(
-  burn: NonNullable<AnalyticsSprintsResponse['current']>['burn'],
-): { readonly completionWorkingDay: number; readonly points: readonly PlotPoint[] } | null {
-  const observed = burn.filter((point) => point.available && point.workingDay !== null);
-  if (observed.length < 3) return null;
-  const count = observed.length;
-  const meanX = observed.reduce((sum, point) => sum + (point.workingDay ?? 0), 0) / count;
-  const meanY = observed.reduce((sum, point) => sum + point.remaining, 0) / count;
-  const covariance = observed.reduce(
-    (sum, point) => sum + ((point.workingDay ?? 0) - meanX) * (point.remaining - meanY),
-    0,
-  );
-  const variance = observed.reduce((sum, point) => sum + ((point.workingDay ?? 0) - meanX) ** 2, 0);
-  if (variance === 0) return null;
-  const slope = covariance / variance;
-  if (slope >= 0) return null;
-  const intercept = meanY - slope * meanX;
-  const last = observed.at(-1);
-  if (last === undefined || last.workingDay === null) return null;
-  const completionWorkingDay = Math.max(last.workingDay, Math.ceil(-intercept / slope));
-  return {
-    completionWorkingDay,
-    points: [
-      {
-        id: 'forecast-current',
-        label: last.date,
-        value: last.remaining,
-        cohort: { cohort: 'open' },
-        x: last.workingDay,
-      },
-      {
-        id: 'forecast-completion',
-        label: `Forecast day ${completionWorkingDay}`,
-        value: 0,
-        cohort: { cohort: 'open' },
-        x: completionWorkingDay,
-      },
-    ],
-  };
 }
 
 function burnWithWorkingX(burn: NonNullable<AnalyticsSprintsResponse['current']>['burn']) {

--- a/apps/web/src/features/analytics/sprint-lens.tsx
+++ b/apps/web/src/features/analytics/sprint-lens.tsx
@@ -129,6 +129,7 @@ function startedSeries(burn: SprintBurnPoints): PlotSeries {
       id: `${point.date}-started`,
       label: point.date,
       value: point.completed + point.started,
+      displayValue: point.started,
       cohort: { cohort: 'open' as const },
     })),
   };

--- a/apps/web/src/features/analytics/sprint-lens.tsx
+++ b/apps/web/src/features/analytics/sprint-lens.tsx
@@ -51,6 +51,7 @@ function idealSeries(burn: SprintBurnPoints): PlotSeries {
   return {
     id: 'ideal',
     label: 'Ideal',
+    color: 2,
     dashed: true,
     dots: true,
     points: burn.map((point) => ({
@@ -66,6 +67,7 @@ function remainingSeries(burn: SprintBurnPoints): PlotSeries {
   return {
     id: 'remaining',
     label: 'Remaining',
+    color: 1,
     points: capturedPoints(burn).map((point) => ({
       id: `${point.date}-remaining`,
       label: point.date,
@@ -82,6 +84,7 @@ function scopeSeries(
   return {
     id: 'scope',
     label: 'Scope',
+    color: 4,
     ...(options.step === true ? { step: true } : {}),
     points: capturedPoints(burn).map((point) => ({
       id: `${point.date}-scope`,
@@ -96,6 +99,7 @@ function completedSeries(burn: SprintBurnPoints): PlotSeries {
   return {
     id: 'completed',
     label: 'Completed',
+    color: 1,
     points: capturedPoints(burn).map((point) => ({
       id: `${point.date}-completed`,
       label: point.date,
@@ -109,6 +113,7 @@ function startedSeries(burn: SprintBurnPoints): PlotSeries {
   return {
     id: 'started',
     label: 'Started',
+    color: 2,
     points: capturedPoints(burn).map((point) => ({
       id: `${point.date}-started`,
       label: point.date,
@@ -122,6 +127,7 @@ function targetSeries(burn: SprintBurnPoints, initialScope: number): PlotSeries 
   return {
     id: 'target',
     label: 'Target',
+    color: 3,
     dashed: true,
     points: burn.map((point) => ({
       id: `${point.date}-target`,
@@ -155,17 +161,16 @@ function forecastSeriesFor(
   forecast: ReturnType<typeof burnForecast>,
   forecastDateValue: string | null,
   sprintDaysList: readonly SprintDay[],
-): PlotSeries {
+): PlotSeries | null {
   const start = forecast?.points[0];
   const lastDay = sprintDaysList.at(-1);
-  const empty: PlotSeries = { id: 'forecast', label: 'Forecast', dashed: true, points: [] };
   if (
     forecast === null ||
     start === undefined ||
     forecastDateValue === null ||
     lastDay === undefined
   ) {
-    return empty;
+    return null;
   }
   const end = forecastEndPoint(start.label, start.value, forecastDateValue, lastDay.date);
   const points: PlotPoint[] = [
@@ -182,7 +187,7 @@ function forecastSeriesFor(
       cohort: { cohort: 'open' as const },
     },
   ];
-  return { id: 'forecast', label: 'Forecast', dashed: true, points };
+  return { id: 'forecast', label: 'Forecast', color: 3, dashed: true, points };
 }
 
 function SprintBurnChart({
@@ -201,12 +206,13 @@ function SprintBurnChart({
     current.baseline?.retroactive === true
       ? `Capture began ${readableDate(current.baseline.date)}. Earlier days show targets only.`
       : undefined;
+  const forecastSeries = forecastSeriesFor(forecast, forecastDateValue, sprintDaysList);
   const burnSeries: readonly PlotSeries[] =
     burnMode === 'down'
       ? [
           remainingSeries(current.burn),
           idealSeries(current.burn),
-          forecastSeriesFor(forecast, forecastDateValue, sprintDaysList),
+          ...(forecastSeries === null ? [] : [forecastSeries]),
           scopeSeries(current.burn, { step: true }),
         ]
       : [

--- a/apps/web/src/features/analytics/sprint-lens.tsx
+++ b/apps/web/src/features/analytics/sprint-lens.tsx
@@ -13,6 +13,7 @@ import {
   sprintDays,
   todayDateOf,
 } from './burn-math.ts';
+import type { BarPair, BarPlotAverageLine } from './charts/bar-plot.tsx';
 import { BarPlot } from './charts/bar-plot.tsx';
 import type { PlotPoint, PlotSeries } from './charts/line-plot.tsx';
 import { LinePlot } from './charts/line-plot.tsx';
@@ -329,6 +330,50 @@ function FocusBurnCard({
   );
 }
 
+type SprintVelocityPoint = AnalyticsSprintsResponse['velocity'][number];
+
+function velocityPairPoints(idPrefix: string, planned: number, completed: number) {
+  return {
+    primary: {
+      id: `${idPrefix}-completed`,
+      label: 'Completed',
+      value: completed,
+      cohort: { cohort: 'completed' as const },
+    },
+    secondary: {
+      id: `${idPrefix}-planned`,
+      label: 'Planned',
+      value: planned,
+      cohort: { cohort: 'planned' as const },
+    },
+  };
+}
+
+function closedVelocityPairs(velocity: readonly SprintVelocityPoint[]): readonly BarPair[] {
+  return velocity.map((point) => ({
+    id: point.sprint.id,
+    label: point.sprint.name,
+    ...velocityPairPoints(point.sprint.id, point.planned, point.completed),
+  }));
+}
+
+function currentVelocityPair(current: SprintCurrent): BarPair {
+  return {
+    id: 'current',
+    label: current.sprint.name,
+    current: true,
+    ...velocityPairPoints('current', current.summary.planned, current.summary.completed),
+  };
+}
+
+function velocityAverageLine(
+  velocity: readonly SprintVelocityPoint[],
+): BarPlotAverageLine | undefined {
+  if (velocity.length === 0) return undefined;
+  const mean = velocity.reduce((total, point) => total + point.completed, 0) / velocity.length;
+  return { value: mean, label: `Avg ${numberLabel(mean)}` };
+}
+
 export function SprintLens({
   data,
   query,
@@ -347,12 +392,8 @@ export function SprintLens({
       </section>
     );
   }
-  const velocity = data.velocity.map((point) => ({
-    id: point.sprint.id,
-    label: point.sprint.name,
-    value: point.completed,
-    cohort: { cohort: 'completed' as const },
-  }));
+  const velocityPairs = [...closedVelocityPairs(data.velocity), currentVelocityPair(current)];
+  const velocityAverage = velocityAverageLine(data.velocity);
   const summary = current.summary;
   const measureFormatter = (value: number) => `${numberLabel(value)} ${current.measure}`;
   const currentPerson = usesCurrentPersonDefault(query);
@@ -382,7 +423,7 @@ export function SprintLens({
       {data.previous === null ? (
         <p className="rounded-lg border border-border bg-surface px-4 py-3 text-muted text-xs">
           {data.selected.completedAt === null
-            ? 'A comparison will appear after this sprint closes.'
+            ? 'Velocity below already includes this sprint as it happens.'
             : 'No earlier sprint is available for comparison.'}
         </p>
       ) : null}
@@ -433,18 +474,17 @@ export function SprintLens({
         </AnalyticsCard>
 
         <AnalyticsCard title="Velocity across sprints">
-          {velocity.length === 0 ? (
-            <p className="py-8 text-center text-muted text-xs">
-              Velocity appears after a sprint closes.
-            </p>
-          ) : (
-            <BarPlot
-              label="Completed scope"
-              points={velocity}
-              valueFormatter={measureFormatter}
-              xAxisLabel={`Completed ${current.measure}`}
-            />
-          )}
+          <BarPlot
+            {...(velocityAverage === undefined ? {} : { averageLine: velocityAverage })}
+            label="Sprint velocity"
+            pairs={velocityPairs}
+            points={[]}
+            valueFormatter={measureFormatter}
+            xAxisLabel={current.measure === 'points' ? 'Points' : 'Issues'}
+          />
+          {data.velocity.length === 0 ? (
+            <p className="text-muted text-xs">Velocity history builds as sprints complete.</p>
+          ) : null}
         </AnalyticsCard>
       </div>
 

--- a/apps/web/src/features/analytics/sprint-stats.tsx
+++ b/apps/web/src/features/analytics/sprint-stats.tsx
@@ -102,7 +102,7 @@ export function SprintStats({
         <strong className={`font-medium ${forecastColorClass(forecastDateValue, isLate)}`}>
           {forecastDateValue === null
             ? 'needs 3 working days'
-            : `${readableDate(forecastDateValue)} · ${isLate ? `${daysLate} days late` : 'on track'}`}
+            : `${readableDate(forecastDateValue)} · ${isLate ? `${daysLate} ${daysLate === 1 ? 'day' : 'days'} late` : 'on track'}`}
         </strong>
       </span>
       <span className="text-muted">

--- a/apps/web/src/features/analytics/sprint-stats.tsx
+++ b/apps/web/src/features/analytics/sprint-stats.tsx
@@ -1,5 +1,5 @@
 import type { AnalyticsMeasure } from '@orbit/shared/validators';
-import { actualPace, burnForecast, forecastDate, neededPace } from './burn-math.ts';
+import { actualPace, burnForecast, forecastDate, neededPace, readableDate } from './burn-math.ts';
 import type { AnalyticsSprintsResponse } from './contracts.ts';
 
 const DAY_MILLISECONDS = 86_400_000;
@@ -10,15 +10,6 @@ function numberLabel(value: number): string {
 
 function paceLabel(value: number): string {
   return `${value.toFixed(1)}/d`;
-}
-
-function readableDate(value: string): string {
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    timeZone: 'UTC',
-  }).format(new Date(`${value}T12:00:00.000Z`));
 }
 
 function unitLabel(measure: AnalyticsMeasure): string {

--- a/apps/web/src/features/analytics/sprint-stats.tsx
+++ b/apps/web/src/features/analytics/sprint-stats.tsx
@@ -1,0 +1,125 @@
+import type { AnalyticsMeasure } from '@orbit/shared/validators';
+import { actualPace, burnForecast, forecastDate, neededPace } from './burn-math.ts';
+import type { AnalyticsSprintsResponse } from './contracts.ts';
+
+const DAY_MILLISECONDS = 86_400_000;
+
+function numberLabel(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function paceLabel(value: number): string {
+  return `${value.toFixed(1)}/d`;
+}
+
+function readableDate(value: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${value}T12:00:00.000Z`));
+}
+
+function unitLabel(measure: AnalyticsMeasure): string {
+  return measure === 'points' ? 'pts' : 'issues';
+}
+
+function counterpartMeasure(measure: AnalyticsMeasure): AnalyticsMeasure {
+  return measure === 'points' ? 'issues' : 'points';
+}
+
+function percentOf(value: number, scope: number): number {
+  return Math.round((value / Math.max(1, scope)) * 100);
+}
+
+function daysBetweenUtc(from: string, to: string): number {
+  const fromMs = Date.parse(`${from}T00:00:00.000Z`);
+  const toMs = Date.parse(`${to}T00:00:00.000Z`);
+  return Math.round((toMs - fromMs) / DAY_MILLISECONDS);
+}
+
+function forecastColorClass(forecastDateValue: string | null, isLate: boolean): string {
+  if (forecastDateValue === null) return 'text-text';
+  return isLate ? 'text-warning' : 'text-accent';
+}
+
+export function SprintStats({
+  current,
+  measure,
+}: {
+  readonly current: NonNullable<AnalyticsSprintsResponse['current']>;
+  readonly measure: AnalyticsMeasure;
+}) {
+  const summary = current.summary;
+  const scope = summary.currentScope;
+  const completedPercent = percentOf(summary.completed, scope);
+  const lastObserved = current.burn.filter((point) => !point.future).at(-1);
+  const started = lastObserved?.started ?? 0;
+  const startedPercent = percentOf(started, scope);
+  const needed = neededPace(summary.remaining, current.burn);
+  const actual = actualPace(current.burn);
+  const forecast = burnForecast(current.burn);
+  const forecastDateValue =
+    forecast === null ? null : forecastDate(current.burn, forecast.completionWorkingDay);
+  const lastDay = current.burn.at(-1)?.date ?? null;
+  const daysLate =
+    forecastDateValue === null || lastDay === null ? 0 : daysBetweenUtc(lastDay, forecastDateValue);
+  const isLate = daysLate > 0;
+  const peopleCount = current.people.length;
+
+  return (
+    <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs">
+      <span className="text-muted">
+        Scope{' '}
+        <strong className="font-medium text-text">
+          {`${numberLabel(scope)} ${unitLabel(measure)} · ${numberLabel(current.counterpart.currentScope)} ${unitLabel(counterpartMeasure(measure))}`}
+        </strong>
+      </span>
+      <span className="text-muted">
+        Completed{' '}
+        <strong className="font-medium text-text">
+          {`${numberLabel(summary.completed)} (${completedPercent}%)`}
+        </strong>
+      </span>
+      <span className="text-muted">
+        Started{' '}
+        <strong className="font-medium text-text">
+          {`${numberLabel(started)} (${startedPercent}%)`}
+        </strong>
+      </span>
+      <span className="text-muted">
+        Remaining{' '}
+        <strong className="font-medium text-text">{numberLabel(summary.remaining)}</strong>
+      </span>
+      <span className="text-muted">
+        Churn{' '}
+        <strong className="font-medium text-text">
+          {`+${numberLabel(summary.added)} added · ${numberLabel(summary.removed)} removed`}
+        </strong>
+      </span>
+      <span className="text-muted">
+        Pace{' '}
+        <strong className="font-medium text-text">
+          {needed === null || actual === null
+            ? 'Not enough data'
+            : `needed ${paceLabel(needed)} · actual ${paceLabel(actual)}`}
+        </strong>
+      </span>
+      <span className="text-muted">
+        Forecast{' '}
+        <strong className={`font-medium ${forecastColorClass(forecastDateValue, isLate)}`}>
+          {forecastDateValue === null
+            ? 'needs 3 working days'
+            : `${readableDate(forecastDateValue)} · ${isLate ? `${daysLate} days late` : 'on track'}`}
+        </strong>
+      </span>
+      <span className="text-muted">
+        People{' '}
+        <strong className="font-medium text-text">
+          {`${peopleCount} ${peopleCount === 1 ? 'person' : 'people'}`}
+        </strong>
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/features/analytics/use-analytics-query.ts
+++ b/apps/web/src/features/analytics/use-analytics-query.ts
@@ -47,6 +47,17 @@ export async function fetchInsights(
   });
 }
 
+export function useInsightsQuery(
+  query: AnalyticsInsightsQuery,
+  options?: { readonly enabled?: boolean },
+): UseQueryResult<AnalyticsInsightsResponse> {
+  return useQuery<AnalyticsInsightsResponse>({
+    queryKey: analyticsKeys.insights(query),
+    queryFn: async ({ signal }) => await fetchInsights(query, signal),
+    ...(options?.enabled === false ? { enabled: false } : {}),
+  });
+}
+
 export function useAnalyticsQuery(
   query: AnalyticsQuery & { readonly lens: 'overview' },
 ): UseQueryResult<AnalyticsOverviewResponse>;
@@ -68,5 +79,6 @@ export function useAnalyticsQuery(
   return useQuery<AnalyticsResponseByLens[keyof AnalyticsResponseByLens]>({
     queryKey: analyticsKeys.lens(query.lens, query),
     queryFn: async ({ signal }) => await fetchAnalyticsLens(query, signal),
+    ...(query.lens === 'insights' ? { enabled: false } : {}),
   });
 }

--- a/apps/web/src/features/analytics/use-analytics-query.ts
+++ b/apps/web/src/features/analytics/use-analytics-query.ts
@@ -1,18 +1,20 @@
 'use client';
 
-import type { AnalyticsQuery } from '@orbit/shared/validators';
+import type { AnalyticsInsightsQuery, AnalyticsQuery } from '@orbit/shared/validators';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import { ApiError, apiFetch } from '@/lib/query/fetcher.ts';
 import { analyticsKeys } from './analytics-keys.ts';
 import {
+  type AnalyticsInsightsResponse,
   type AnalyticsOverviewResponse,
   type AnalyticsPeopleResponse,
   type AnalyticsProjectsResponse,
   type AnalyticsResponseByLens,
   type AnalyticsSprintsResponse,
+  analyticsInsightsWireResponse,
   analyticsLensResponseSchemas,
 } from './contracts.ts';
-import { searchParamsForAnalytics } from './query-state.ts';
+import { searchParamsForAnalytics, searchParamsForInsights } from './query-state.ts';
 
 async function fetchAnalyticsLens(
   query: AnalyticsQuery,
@@ -33,6 +35,16 @@ async function fetchAnalyticsLens(
     case 'insights':
       throw new ApiError(404, 'not_found', 'Insights analytics is not available yet.');
   }
+}
+
+export async function fetchInsights(
+  query: AnalyticsInsightsQuery,
+  signal: AbortSignal,
+): Promise<AnalyticsInsightsResponse> {
+  const search = searchParamsForInsights(query).toString();
+  return await apiFetch(`/api/analytics/insights?${search}`, analyticsInsightsWireResponse, {
+    signal,
+  });
 }
 
 export function useAnalyticsQuery(

--- a/apps/web/src/features/analytics/use-analytics-query.ts
+++ b/apps/web/src/features/analytics/use-analytics-query.ts
@@ -2,7 +2,7 @@
 
 import type { AnalyticsQuery } from '@orbit/shared/validators';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
-import { apiFetch } from '@/lib/query/fetcher.ts';
+import { ApiError, apiFetch } from '@/lib/query/fetcher.ts';
 import { analyticsKeys } from './analytics-keys.ts';
 import {
   type AnalyticsOverviewResponse,
@@ -30,6 +30,8 @@ async function fetchAnalyticsLens(
       return await apiFetch(path, analyticsLensResponseSchemas.projects, { signal });
     case 'people':
       return await apiFetch(path, analyticsLensResponseSchemas.people, { signal });
+    case 'insights':
+      throw new ApiError(404, 'not_found', 'Insights analytics is not available yet.');
   }
 }
 

--- a/apps/web/src/lib/use-measured-width.ts
+++ b/apps/web/src/lib/use-measured-width.ts
@@ -1,0 +1,21 @@
+import { type RefObject, useEffect, useRef, useState } from 'react';
+
+export function useMeasuredWidth(fallback = 640): {
+  readonly ref: RefObject<HTMLDivElement | null>;
+  readonly width: number;
+} {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(fallback);
+  useEffect(() => {
+    const node = ref.current;
+    if (node === null || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver((entries) => {
+      const measured = entries[0]?.contentRect.width;
+      if (measured !== undefined && measured > 0) setWidth(Math.round(measured));
+    });
+    observer.observe(node);
+    setWidth(Math.round(node.getBoundingClientRect().width) || fallback);
+    return () => observer.disconnect();
+  }, [fallback]);
+  return { ref, width };
+}

--- a/apps/web/tests/app/(app)/analytics/page.test.tsx
+++ b/apps/web/tests/app/(app)/analytics/page.test.tsx
@@ -1,8 +1,10 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
-import { analyticsQuerySchema } from '@orbit/shared/validators';
+import type { SavedAnalyticsViewPayload } from '@orbit/core';
+import { analyticsQuerySchema, insightConfigSchema } from '@orbit/shared/validators';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import * as navigation from 'next/navigation';
+import { ToastProvider } from '@/components/ui/toast.tsx';
 import * as dataModule from '@/features/analytics/data.ts';
 import * as handlerModule from '@/lib/api/handler.ts';
 import { QueryProvider } from '@/lib/query/provider.tsx';
@@ -34,8 +36,15 @@ const payload = {
   priorities: [],
   outliers: [],
 };
+const insightsPayload = {
+  kind: 'bars' as const,
+  unit: 'issues' as const,
+  buckets: [{ id: 'a1', label: 'Ada', value: 4, segments: [], cohort: { cohort: 'assignee:a1' } }],
+};
 
 let loads = 0;
+let savedViewsOverride: SavedAnalyticsViewPayload[] = [];
+let recordedInsight: unknown = null;
 
 mock.module('next/navigation', () => ({
   ...navigation,
@@ -52,7 +61,20 @@ mock.module(DATA_MODULE, () => ({
     client.setQueryData(analyticsKeys.lens('overview', query), payload);
     return Promise.resolve(dehydrate(client));
   },
-  loadSavedViews: () => Promise.resolve([]),
+  dehydratedAnalyticsInsights: (
+    _principal: unknown,
+    insightsQuery: { readonly insight: unknown },
+  ) => {
+    loads += 1;
+    recordedInsight = insightsQuery.insight;
+    const client = new QueryClient();
+    client.setQueryData(
+      analyticsKeys.insights(insightsQuery as Parameters<typeof analyticsKeys.insights>[0]),
+      insightsPayload,
+    );
+    return Promise.resolve(dehydrate(client));
+  },
+  loadSavedViews: () => Promise.resolve(savedViewsOverride),
 }));
 
 mock.module(HANDLER_MODULE, () => ({
@@ -79,11 +101,15 @@ const { default: AnalyticsPage } = await import('@/app/(app)/analytics/page.tsx'
 describe('AnalyticsPage', () => {
   beforeEach(() => {
     loads = 0;
+    savedViewsOverride = [];
+    recordedInsight = null;
   });
 
   it('loads one active lens and renders useful hydrated analytics', async () => {
     render(
-      <QueryProvider>{await AnalyticsPage({ searchParams: Promise.resolve({}) })}</QueryProvider>,
+      <QueryProvider>
+        <ToastProvider>{await AnalyticsPage({ searchParams: Promise.resolve({}) })}</ToastProvider>
+      </QueryProvider>,
     );
 
     expect(loads).toBe(1);
@@ -91,5 +117,40 @@ describe('AnalyticsPage', () => {
     expect(screen.getByText('Completed')).toBeVisible();
     expect(screen.getByText('18')).toBeVisible();
     expect(screen.queryByText('Analytics data is ready.')).not.toBeInTheDocument();
+  });
+
+  it('restores a pinned insights view from its stored insight config on a clean URL', async () => {
+    const pinnedInsight = insightConfigSchema.parse({ measure: 'points', slice: 'assignee' });
+    savedViewsOverride = [
+      {
+        id: 'pinned_1',
+        name: 'Points by assignee',
+        scopeType: 'workspace',
+        scopeId: null,
+        kind: 'dashboard',
+        config: {
+          kind: 'dashboard',
+          version: 1,
+          query: analyticsQuerySchema.parse({ lens: 'insights' }),
+          insight: pinnedInsight,
+          pinned: true,
+        },
+        shared: false,
+        ownerId: 'user-1',
+        createdAt: '2026-08-13T12:00:00.000Z',
+        updatedAt: '2026-08-13T12:00:00.000Z',
+      },
+    ];
+
+    render(
+      <QueryProvider>
+        <ToastProvider>{await AnalyticsPage({ searchParams: Promise.resolve({}) })}</ToastProvider>
+      </QueryProvider>,
+    );
+
+    expect(recordedInsight).toEqual(pinnedInsight);
+    expect(screen.getByRole('combobox', { name: 'Insight measure' })).toHaveTextContent('Points');
+    expect(screen.getByRole('combobox', { name: 'Insight slice' })).toHaveTextContent('Assignee');
+    expect(screen.getByRole('application', { name: 'Points by Assignee' })).toBeVisible();
   });
 });

--- a/apps/web/tests/app/api/analytics/export/route.test.ts
+++ b/apps/web/tests/app/api/analytics/export/route.test.ts
@@ -41,7 +41,7 @@ describe('GET /api/analytics/export', () => {
     expect(response.headers.get('x-orbit-export-truncated')).toBe('false');
     expect(csv).toContain('Predicate,current');
     expect(csv).toContain('Measure,points');
-    expect(csv).toContain('Formula,Sum of estimates; unestimated is zero');
+    expect(csv).toContain('Formula,Sum of estimates; unestimated counts as 1');
     expect(csv).toContain('Timezone,');
     expect(csv).toContain('Coverage,Exact semantic issue cohort');
     expect(csv).toContain("'=HYPERLINK");

--- a/apps/web/tests/app/api/analytics/insights/route.test.ts
+++ b/apps/web/tests/app/api/analytics/insights/route.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { createIssue } from '@orbit/core';
+import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test-support';
+import { mockSession } from '../../../../../tests-support.ts';
+
+let workspace: Workspace;
+let signedIn = false;
+
+mockSession(() =>
+  signedIn
+    ? {
+        user: workspace.adminUser,
+        session: { activeOrganizationId: workspace.organizationId },
+      }
+    : null,
+);
+
+const route = await import('../../../../../src/app/api/analytics/insights/route.ts');
+
+function request(query?: unknown): Request {
+  const url = new URL('http://localhost:3000/api/analytics/insights');
+  if (query !== undefined) url.searchParams.set('query', JSON.stringify(query));
+  return new Request(url.toString());
+}
+
+beforeEach(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+  await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Nova evidence' });
+  signedIn = true;
+});
+
+describe('GET /api/analytics/insights', () => {
+  it('returns a bars or scatter result for an authenticated valid query', async () => {
+    const response = await route.GET(request({ insight: { measure: 'count', slice: 'state' } }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(['bars', 'scatter']).toContain(payload.kind);
+  });
+
+  it('rejects a malformed insight measure as a validation error', async () => {
+    const response = await route.GET(request({ insight: { measure: 'not-a-real-measure' } }));
+
+    expect(response.status).toBe(422);
+  });
+
+  it('requires an authenticated session', async () => {
+    signedIn = false;
+
+    const response = await route.GET(request());
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/apps/web/tests/app/api/analytics/insights/route.test.ts
+++ b/apps/web/tests/app/api/analytics/insights/route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { createIssue } from '@orbit/core';
 import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test-support';
+import { analyticsInsightsWireResponse } from '../../../../../src/features/analytics/contracts.ts';
 import { mockSession } from '../../../../../tests-support.ts';
 
 let workspace: Workspace;
@@ -31,12 +32,12 @@ beforeEach(async () => {
 });
 
 describe('GET /api/analytics/insights', () => {
-  it('returns a bars or scatter result for an authenticated valid query', async () => {
+  it('returns a validated bars result for a count query', async () => {
     const response = await route.GET(request({ insight: { measure: 'count', slice: 'state' } }));
-    const payload = await response.json();
+    const payload = analyticsInsightsWireResponse.parse(await response.json());
 
     expect(response.status).toBe(200);
-    expect(['bars', 'scatter']).toContain(payload.kind);
+    expect(payload.kind).toBe('bars');
   });
 
   it('rejects a malformed insight measure as a validation error', async () => {

--- a/apps/web/tests/features/analytics/analytics-cockpit.test.tsx
+++ b/apps/web/tests/features/analytics/analytics-cockpit.test.tsx
@@ -242,8 +242,8 @@ describe('AnalyticsCockpit', () => {
     expect(window.location.search).toContain('lens=sprints');
 
     await user.keyboard('{End}');
-    expect(screen.getByRole('tab', { name: 'People' })).toHaveFocus();
-    expect(window.location.search).toContain('lens=people');
+    expect(screen.getByRole('tab', { name: 'Insights' })).toHaveFocus();
+    expect(window.location.search).toContain('lens=insights');
 
     await user.keyboard('{Home}');
     expect(screen.getByRole('tab', { name: 'Overview' })).toHaveFocus();

--- a/apps/web/tests/features/analytics/analytics-cockpit.test.tsx
+++ b/apps/web/tests/features/analytics/analytics-cockpit.test.tsx
@@ -236,13 +236,17 @@ const insightsBars: AnalyticsInsightsResponse = {
   ],
 };
 
-function renderCockpitWithInsights() {
+function renderCockpitWithInsights(
+  savedViews: readonly SavedAnalyticsViewPayload[] = [],
+  initialInsight = insightConfigSchema.parse({}),
+) {
   const query = analyticsQuerySchema.parse({ lens: 'insights' });
-  const insight = insightConfigSchema.parse({});
   const client = createQueryClient();
   client.setQueryDefaults(analyticsKeys.root, { enabled: false });
   client.setQueryData(
-    analyticsKeys.insights(analyticsInsightsQuerySchema.parse({ ...query, insight })),
+    analyticsKeys.insights(
+      analyticsInsightsQuerySchema.parse({ ...query, insight: initialInsight }),
+    ),
     insightsBars,
   );
   function Wrapper({ children }: { readonly children: ReactNode }) {
@@ -252,7 +256,14 @@ function renderCockpitWithInsights() {
       </QueryClientProvider>
     );
   }
-  return render(<AnalyticsCockpit initialQuery={query} savedViews={[]} />, { wrapper: Wrapper });
+  return render(
+    <AnalyticsCockpit
+      initialInsight={initialInsight}
+      initialQuery={query}
+      savedViews={savedViews}
+    />,
+    { wrapper: Wrapper },
+  );
 }
 
 describe('AnalyticsCockpit', () => {
@@ -559,6 +570,42 @@ describe('AnalyticsCockpit', () => {
     expect(window.location.search).toContain('measure=points');
     expect(window.location.search).toContain('includeArchived=1');
     expect(window.location.search).toContain(`personId=${personId}`);
+  });
+
+  it('restores measure, slice, and segment from a saved insights view', async () => {
+    const user = userEvent.setup();
+    const savedInsight = insightConfigSchema.parse({
+      measure: 'points',
+      slice: 'assignee',
+      segment: 'state',
+    });
+    renderCockpitWithInsights([
+      {
+        id: 'saved_insights_1',
+        name: 'Points by assignee',
+        scopeType: 'workspace',
+        scopeId: null,
+        kind: 'dashboard',
+        config: {
+          kind: 'dashboard',
+          version: 1,
+          query: analyticsQuerySchema.parse({ lens: 'insights' }),
+          insight: savedInsight,
+          pinned: false,
+        },
+        shared: false,
+        ownerId: personId,
+        createdAt: asOf,
+        updatedAt: asOf,
+      },
+    ]);
+
+    await user.click(screen.getByRole('button', { name: 'Points by assignee' }));
+
+    expect(window.location.search).toContain('lens=insights');
+    expect(window.location.search).toContain('insightMeasure=points');
+    expect(window.location.search).toContain('insightSlice=assignee');
+    expect(window.location.search).toContain('insightSegment=state');
   });
 
   it('dispatches to the insights lens for query.lens insights, rendering its pickers and bar chart', () => {

--- a/apps/web/tests/features/analytics/analytics-cockpit.test.tsx
+++ b/apps/web/tests/features/analytics/analytics-cockpit.test.tsx
@@ -608,6 +608,39 @@ describe('AnalyticsCockpit', () => {
     expect(window.location.search).toContain('insightSegment=state');
   });
 
+  it('resets the insight to its defaults when applying a saved insights view with no stored insight', async () => {
+    const user = userEvent.setup();
+    const nonDefaultInsight = insightConfigSchema.parse({ measure: 'points', slice: 'assignee' });
+    renderCockpitWithInsights(
+      [
+        {
+          id: 'saved_bare_insights',
+          name: 'Bare insights view',
+          scopeType: 'workspace',
+          scopeId: null,
+          kind: 'dashboard',
+          config: {
+            kind: 'dashboard',
+            version: 1,
+            query: analyticsQuerySchema.parse({ lens: 'insights' }),
+            pinned: false,
+          },
+          shared: false,
+          ownerId: personId,
+          createdAt: asOf,
+          updatedAt: asOf,
+        },
+      ],
+      nonDefaultInsight,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Bare insights view' }));
+
+    expect(window.location.search).toContain('lens=insights');
+    expect(window.location.search).not.toContain('insightMeasure');
+    expect(window.location.search).not.toContain('insightSlice');
+  });
+
   it('dispatches to the insights lens for query.lens insights, rendering its pickers and bar chart', () => {
     renderCockpitWithInsights();
 

--- a/apps/web/tests/features/analytics/analytics-cockpit.test.tsx
+++ b/apps/web/tests/features/analytics/analytics-cockpit.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 import type { SavedAnalyticsViewPayload } from '@orbit/core';
-import { analyticsQuerySchema } from '@orbit/shared/validators';
+import {
+  analyticsInsightsQuerySchema,
+  analyticsQuerySchema,
+  insightConfigSchema,
+} from '@orbit/shared/validators';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -9,6 +13,7 @@ import { ToastProvider } from '../../../src/components/ui/toast.tsx';
 import { AnalyticsCockpit } from '../../../src/features/analytics/analytics-cockpit.tsx';
 import { analyticsKeys } from '../../../src/features/analytics/analytics-keys.ts';
 import type {
+  AnalyticsInsightsResponse,
   AnalyticsOverviewResponse,
   AnalyticsPeopleResponse,
   AnalyticsProjectsResponse,
@@ -215,6 +220,39 @@ function renderCockpit(
   return render(<AnalyticsCockpit initialQuery={query} savedViews={savedViews} />, {
     wrapper: Wrapper,
   });
+}
+
+const insightsBars: AnalyticsInsightsResponse = {
+  kind: 'bars',
+  unit: 'issues',
+  buckets: [
+    {
+      id: 'started',
+      label: 'Started',
+      value: 4,
+      segments: [],
+      cohort: { cohort: 'state-category:started' },
+    },
+  ],
+};
+
+function renderCockpitWithInsights() {
+  const query = analyticsQuerySchema.parse({ lens: 'insights' });
+  const insight = insightConfigSchema.parse({});
+  const client = createQueryClient();
+  client.setQueryDefaults(analyticsKeys.root, { enabled: false });
+  client.setQueryData(
+    analyticsKeys.insights(analyticsInsightsQuerySchema.parse({ ...query, insight })),
+    insightsBars,
+  );
+  function Wrapper({ children }: { readonly children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  }
+  return render(<AnalyticsCockpit initialQuery={query} savedViews={[]} />, { wrapper: Wrapper });
 }
 
 describe('AnalyticsCockpit', () => {
@@ -521,5 +559,30 @@ describe('AnalyticsCockpit', () => {
     expect(window.location.search).toContain('measure=points');
     expect(window.location.search).toContain('includeArchived=1');
     expect(window.location.search).toContain(`personId=${personId}`);
+  });
+
+  it('dispatches to the insights lens for query.lens insights, rendering its pickers and bar chart', () => {
+    renderCockpitWithInsights();
+
+    expect(screen.getByRole('tab', { name: 'Insights' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('combobox', { name: 'Insight measure' })).toBeVisible();
+    expect(screen.getByRole('combobox', { name: 'Insight slice' })).toBeVisible();
+    expect(screen.getByRole('combobox', { name: 'Insight segment' })).toBeVisible();
+    expect(screen.getByRole('application', { name: 'Count by State category' })).toBeVisible();
+    expect(screen.getByText('Insights are computed on demand')).toBeVisible();
+  });
+
+  it('stops rendering the insights pickers and chart once the lens is switched away', async () => {
+    const user = userEvent.setup();
+    renderCockpitWithInsights();
+    expect(screen.getByRole('combobox', { name: 'Insight measure' })).toBeVisible();
+
+    await user.click(screen.getByRole('tab', { name: 'Overview' }));
+
+    expect(screen.queryByRole('combobox', { name: 'Insight measure' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('application', { name: 'Count by State category' }),
+    ).not.toBeInTheDocument();
+    expect(window.location.search).toBe('');
   });
 });

--- a/apps/web/tests/features/analytics/analytics-tabs.test.tsx
+++ b/apps/web/tests/features/analytics/analytics-tabs.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, mock, test } from 'bun:test';
+import userEvent from '@testing-library/user-event';
+import { AnalyticsTabs } from '../../../src/features/analytics/analytics-tabs.tsx';
+import { render, screen } from '../../../src/test/render.tsx';
+
+describe('AnalyticsTabs', () => {
+  test('renders every lens including Insights, in a stable order', () => {
+    render(<AnalyticsTabs onChange={mock()} value="overview" />);
+
+    expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
+      'Overview',
+      'Sprints',
+      'Projects',
+      'People',
+      'Insights',
+    ]);
+  });
+
+  test('selects the Insights tab and calls onChange with the insights lens', async () => {
+    const onChange = mock();
+    const user = userEvent.setup();
+    render(<AnalyticsTabs onChange={onChange} value="overview" />);
+
+    await user.click(screen.getByRole('tab', { name: 'Insights' }));
+
+    expect(onChange).toHaveBeenCalledWith('insights');
+  });
+
+  test('End moves keyboard focus to the last tab, which is now Insights', async () => {
+    const user = userEvent.setup();
+    render(<AnalyticsTabs onChange={mock()} value="overview" />);
+    screen.getByRole('tab', { name: 'Overview' }).focus();
+
+    await user.keyboard('{End}');
+
+    expect(screen.getByRole('tab', { name: 'Insights' })).toHaveFocus();
+  });
+});

--- a/apps/web/tests/features/analytics/bar-plot.test.tsx
+++ b/apps/web/tests/features/analytics/bar-plot.test.tsx
@@ -145,6 +145,22 @@ describe('BarPlot', () => {
     expect(bobSecondary.getAttribute('width')).toBe('406');
   });
 
+  test('labels the pairs legend and data-table columns with the real series names, not Primary and Secondary', async () => {
+    const user = userEvent.setup();
+    render(<BarPlot label="Sprint velocity" pairs={pairs} points={[]} />);
+
+    const legend = screen.getByTestId('plot-legend-primary').closest('span');
+    expect(legend).toHaveTextContent('This sprint');
+    const secondaryLegend = screen.getByTestId('plot-legend-secondary').closest('span');
+    expect(secondaryLegend).toHaveTextContent('Last sprint');
+    expect(screen.queryByText('Primary')).not.toBeInTheDocument();
+    expect(screen.queryByText('Secondary')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText('View data (2 rows)'));
+    expect(screen.getByRole('columnheader', { name: 'This sprint' })).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: 'Last sprint' })).toBeVisible();
+  });
+
   test('draws the average line at the correct proportion with its label, absent when not provided', () => {
     const { rerender } = render(<BarPlot label="Sprint velocity" pairs={pairs} points={[]} />);
     expect(screen.queryByTestId('plot-average-line')).not.toBeInTheDocument();

--- a/apps/web/tests/features/analytics/bar-plot.test.tsx
+++ b/apps/web/tests/features/analytics/bar-plot.test.tsx
@@ -178,4 +178,19 @@ describe('BarPlot', () => {
     await user.keyboard('{ArrowDown}{Enter}');
     expect(activate).toHaveBeenCalledWith({ cohort: 'state', bucket: 'bob-current' });
   });
+
+  test('marks exactly the pair flagged current with a row testid, leaving the rest untagged', () => {
+    const bob = pairs[1];
+    if (bob === undefined) throw new Error('missing bob pair fixture');
+    render(
+      <BarPlot
+        label="Sprint velocity"
+        pairs={[...pairs, { ...bob, id: 'current', current: true }]}
+        points={[]}
+      />,
+    );
+
+    expect(screen.getAllByTestId('plot-pair-current')).toHaveLength(1);
+    expect(screen.getByTestId('plot-bar-primary-current')).toBeInTheDocument();
+  });
 });

--- a/apps/web/tests/features/analytics/bar-plot.test.tsx
+++ b/apps/web/tests/features/analytics/bar-plot.test.tsx
@@ -149,10 +149,12 @@ describe('BarPlot', () => {
     const user = userEvent.setup();
     render(<BarPlot label="Sprint velocity" pairs={pairs} points={[]} />);
 
-    const legend = screen.getByTestId('plot-legend-primary').closest('span');
-    expect(legend).toHaveTextContent('This sprint');
-    const secondaryLegend = screen.getByTestId('plot-legend-secondary').closest('span');
-    expect(secondaryLegend).toHaveTextContent('Last sprint');
+    const legend = screen.getByTestId('plot-legend-primary');
+    expect(legend.closest('span')).toHaveTextContent('This sprint');
+    expect(legend).toHaveAttribute('stroke', 'var(--analytics-series-1)');
+    const secondaryLegend = screen.getByTestId('plot-legend-secondary');
+    expect(secondaryLegend.closest('span')).toHaveTextContent('Last sprint');
+    expect(secondaryLegend).toHaveAttribute('stroke', 'var(--color-border-strong)');
     expect(screen.queryByText('Primary')).not.toBeInTheDocument();
     expect(screen.queryByText('Secondary')).not.toBeInTheDocument();
 

--- a/apps/web/tests/features/analytics/bar-plot.test.tsx
+++ b/apps/web/tests/features/analytics/bar-plot.test.tsx
@@ -139,6 +139,7 @@ describe('BarPlot', () => {
     expect(aliceSecondary.getAttribute('fill')).toBe('var(--color-border-strong)');
     expect(alicePrimary.getAttribute('height')).toBe('8');
     expect(aliceSecondary.getAttribute('height')).toBe('8');
+    expect(alicePrimary.getAttribute('fill-opacity')).toBeNull();
 
     expect(alicePrimary.getAttribute('width')).toBe('203');
     expect(bobSecondary.getAttribute('width')).toBe('406');
@@ -192,5 +193,12 @@ describe('BarPlot', () => {
 
     expect(screen.getAllByTestId('plot-pair-current')).toHaveLength(1);
     expect(screen.getByTestId('plot-bar-primary-current')).toBeInTheDocument();
+    expect(screen.getByTestId('plot-bar-primary-current').getAttribute('fill-opacity')).toBe(
+      '0.45',
+    );
+    expect(screen.getByTestId('plot-bar-secondary-current').getAttribute('fill-opacity')).toBe(
+      '0.45',
+    );
+    expect(screen.getByTestId('plot-bar-primary-alice').getAttribute('fill-opacity')).toBeNull();
   });
 });

--- a/apps/web/tests/features/analytics/bar-plot.test.tsx
+++ b/apps/web/tests/features/analytics/bar-plot.test.tsx
@@ -180,6 +180,65 @@ describe('BarPlot', () => {
     expect(activate).toHaveBeenCalledWith({ cohort: 'state', bucket: 'bob-current' });
   });
 
+  test('renders one stacked rect per segment, cycling series colors, with every segment listed in the tooltip', async () => {
+    const user = userEvent.setup();
+    const segmented = {
+      id: 'state-0',
+      label: 'Backlog',
+      value: 10,
+      cohort: { cohort: 'state' as const, bucket: '0' },
+      segments: [
+        { id: 'a', label: 'Alpha', value: 2 },
+        { id: 'b', label: 'Bravo', value: 3 },
+        { id: 'c', label: 'Charlie', value: 1 },
+        { id: 'd', label: 'Delta', value: 3 },
+        { id: 'e', label: 'Echo', value: 1 },
+      ],
+    };
+    render(<BarPlot label="Workflow state" points={[segmented]} />);
+
+    expect(screen.getByTestId('plot-hit-state-0')).toBeInTheDocument();
+    const svg = screen.getByRole('application', { name: 'Workflow state' });
+    const segmentRects = svg.querySelectorAll('rect[fill^="var(--analytics-series-"]');
+    expect(segmentRects).toHaveLength(5);
+    expect(segmentRects[0]?.getAttribute('fill')).toBe('var(--analytics-series-1)');
+    expect(segmentRects[3]?.getAttribute('fill')).toBe('var(--analytics-series-4)');
+    expect(segmentRects[4]?.getAttribute('fill')).toBe('var(--analytics-series-1)');
+
+    await user.hover(screen.getByTestId('plot-hit-state-0'));
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Alpha 2');
+    expect(tooltip).toHaveTextContent('Bravo 3');
+    expect(tooltip).toHaveTextContent('Charlie 1');
+    expect(tooltip).toHaveTextContent('Delta 3');
+    expect(tooltip).toHaveTextContent('Echo 1');
+  });
+
+  test('leaves a null-cohort bucket inert to pointer and keyboard activation, without an evidence button', async () => {
+    const activate = mock();
+    const user = userEvent.setup();
+    render(
+      <BarPlot
+        label="Workflow state"
+        onActivate={activate}
+        points={[point(0, 4), { id: 'other', label: 'Other', value: 1, cohort: null }]}
+      />,
+    );
+
+    await user.click(screen.getByTestId('plot-hit-other'));
+    expect(activate).not.toHaveBeenCalled();
+
+    await user.click(screen.getByText('View data (2 rows)'));
+    expect(screen.getByRole('button', { name: 'State 0, Workflow state 4' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Other/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Other' })).toBeInTheDocument();
+
+    const plot = screen.getByRole('application', { name: 'Workflow state' });
+    plot.focus();
+    await user.keyboard('{ArrowDown}{Enter}');
+    expect(activate).not.toHaveBeenCalled();
+  });
+
   test('marks exactly the pair flagged current with a row testid, leaving the rest untagged', () => {
     const bob = pairs[1];
     if (bob === undefined) throw new Error('missing bob pair fixture');

--- a/apps/web/tests/features/analytics/bar-plot.test.tsx
+++ b/apps/web/tests/features/analytics/bar-plot.test.tsx
@@ -10,6 +10,41 @@ const point = (index: number, value = index) => ({
   cohort: { cohort: 'state' as const, bucket: String(index) },
 });
 
+const pairs = [
+  {
+    id: 'alice',
+    label: 'Alice',
+    primary: {
+      id: 'alice-primary',
+      label: 'This sprint',
+      value: 5,
+      cohort: { cohort: 'state' as const, bucket: 'alice-current' },
+    },
+    secondary: {
+      id: 'alice-secondary',
+      label: 'Last sprint',
+      value: 2,
+      cohort: { cohort: 'state' as const, bucket: 'alice-previous' },
+    },
+  },
+  {
+    id: 'bob',
+    label: 'Bob',
+    primary: {
+      id: 'bob-primary',
+      label: 'This sprint',
+      value: 3,
+      cohort: { cohort: 'state' as const, bucket: 'bob-current' },
+    },
+    secondary: {
+      id: 'bob-secondary',
+      label: 'Last sprint',
+      value: 10,
+      cohort: { cohort: 'state' as const, bucket: 'bob-previous' },
+    },
+  },
+];
+
 describe('BarPlot', () => {
   test('offers exact table activation and a pointer target for zero values', async () => {
     const activate = mock();
@@ -79,5 +114,68 @@ describe('BarPlot', () => {
     await user.hover(screen.getByTestId('plot-hit-state-1'));
     expect(screen.getByRole('tooltip').getAttribute('style')).toContain('left:');
     expect(screen.getByRole('tooltip').getAttribute('style')).toContain('top:');
+  });
+
+  test('renders the svg at the measured width instead of stretching a viewBox', () => {
+    render(<BarPlot label="Velocity" points={[point(0, 3)]} />);
+
+    const svg = screen.getByRole('application');
+    expect(svg.getAttribute('viewBox')).toBeNull();
+    expect(svg.getAttribute('width')).toBe('640');
+  });
+
+  test('renders both bars per pair row, colored and sized from the max across every pair', () => {
+    render(<BarPlot label="Sprint velocity" pairs={pairs} points={[]} />);
+
+    const svg = screen.getByRole('application', { name: 'Sprint velocity' });
+    expect(svg.getAttribute('viewBox')).toBeNull();
+    expect(svg.getAttribute('width')).toBe('640');
+
+    const alicePrimary = screen.getByTestId('plot-bar-primary-alice');
+    const aliceSecondary = screen.getByTestId('plot-bar-secondary-alice');
+    const bobSecondary = screen.getByTestId('plot-bar-secondary-bob');
+
+    expect(alicePrimary.getAttribute('fill')).toBe('var(--analytics-series-1)');
+    expect(aliceSecondary.getAttribute('fill')).toBe('var(--color-border-strong)');
+    expect(alicePrimary.getAttribute('height')).toBe('8');
+    expect(aliceSecondary.getAttribute('height')).toBe('8');
+
+    expect(alicePrimary.getAttribute('width')).toBe('203');
+    expect(bobSecondary.getAttribute('width')).toBe('406');
+  });
+
+  test('draws the average line at the correct proportion with its label, absent when not provided', () => {
+    const { rerender } = render(<BarPlot label="Sprint velocity" pairs={pairs} points={[]} />);
+    expect(screen.queryByTestId('plot-average-line')).not.toBeInTheDocument();
+
+    rerender(
+      <BarPlot
+        averageLine={{ value: 5, label: 'Avg 5' }}
+        label="Sprint velocity"
+        pairs={pairs}
+        points={[]}
+      />,
+    );
+
+    const line = screen.getByTestId('plot-average-line');
+    expect(line.getAttribute('x1')).toBe('373');
+    expect(line.getAttribute('x2')).toBe('373');
+    expect(line.getAttribute('y1')).toBe('12');
+    expect(line.getAttribute('y2')).toBe('72');
+    expect(line.getAttribute('stroke')).toBe('var(--color-border-strong)');
+    expect(line.getAttribute('stroke-dasharray')).toBe('4 4');
+    expect(screen.getByText('Avg 5')).toBeVisible();
+  });
+
+  test('keeps the existing keyboard model working across pair rows, activating the primary cohort on Enter', async () => {
+    const activate = mock();
+    const user = userEvent.setup();
+    render(<BarPlot label="Sprint velocity" onActivate={activate} pairs={pairs} points={[]} />);
+
+    const plot = screen.getByRole('application', { name: 'Sprint velocity' });
+    await user.tab();
+    expect(plot).toHaveFocus();
+    await user.keyboard('{ArrowDown}{Enter}');
+    expect(activate).toHaveBeenCalledWith({ cohort: 'state', bucket: 'bob-current' });
   });
 });

--- a/apps/web/tests/features/analytics/burn-math.test.ts
+++ b/apps/web/tests/features/analytics/burn-math.test.ts
@@ -9,6 +9,7 @@ import {
   readableDate,
   sprintDays,
   todayDateOf,
+  unestimatedNote,
 } from '../../../src/features/analytics/burn-math.ts';
 
 const point = (
@@ -173,6 +174,17 @@ describe('todayDateOf', () => {
 describe('readableDate', () => {
   test('formats an ISO date as a short month, day, year', () => {
     expect(readableDate('2026-08-14')).toBe('Aug 14, 2026');
+  });
+});
+
+describe('unestimatedNote', () => {
+  test('uses singular wording for exactly one unestimated issue', () => {
+    expect(unestimatedNote(1)).toBe('1 unestimated issue counts as 1 point.');
+  });
+
+  test('uses plural wording for any other count', () => {
+    expect(unestimatedNote(2)).toBe('2 unestimated issues count as 1 point each.');
+    expect(unestimatedNote(0)).toBe('0 unestimated issues count as 1 point each.');
   });
 });
 

--- a/apps/web/tests/features/analytics/burn-math.test.ts
+++ b/apps/web/tests/features/analytics/burn-math.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   actualPace,
+  burnForecast,
   forecastDate,
   neededPace,
   personCaptureCaption,
@@ -123,6 +124,26 @@ describe('forecastDate', () => {
       point('2026-08-16', null, { future: true }),
     ];
     expect(forecastDate(mondayToMondayBurn, 12)).toBe('2026-08-18');
+  });
+});
+
+describe('burnForecast', () => {
+  test('projects a completion working day from a real declining slope', () => {
+    const burn = [
+      point('2026-08-11', 1, { remaining: 20 }),
+      point('2026-08-12', 2, { remaining: 15 }),
+      point('2026-08-13', 3, { remaining: 10 }),
+    ];
+    expect(burnForecast(burn)?.completionWorkingDay).toBe(5);
+  });
+
+  test('returns null instead of a runaway forecast when the slope is nearly flat', () => {
+    const burn = [
+      point('2026-08-11', 1, { remaining: 50 }),
+      point('2026-08-12', 2, { remaining: 49.9 }),
+      point('2026-08-13', 3, { remaining: 49.8 }),
+    ];
+    expect(burnForecast(burn)).toBeNull();
   });
 });
 

--- a/apps/web/tests/features/analytics/burn-math.test.ts
+++ b/apps/web/tests/features/analytics/burn-math.test.ts
@@ -59,13 +59,43 @@ describe('pace', () => {
     expect(neededPace(7, burn)).toBeCloseTo(7 / 3, 5);
   });
 
-  test('actual pace divides completed since baseline by elapsed working days', () => {
+  test('actual pace divides completed by working days elapsed since sprint start, not since capture began', () => {
     const burn = [
       point('2026-08-11', 1, { available: false }),
       point('2026-08-13', 3, { completed: 2 }),
       point('2026-08-14', 4, { completed: 5 }),
     ];
-    expect(actualPace(burn)).toBeCloseTo(5 / 2, 5);
+    expect(actualPace(burn)).toBeCloseTo(5 / 4, 5);
+  });
+
+  test('mid-flight adoption does not inflate pace from a late capture start', () => {
+    const burn = [
+      point('2026-08-11', 1, { available: false }),
+      point('2026-08-12', 2, { available: false }),
+      point('2026-08-13', 3, { completed: 9 }),
+      point('2026-08-14', 4, { completed: 16 }),
+    ];
+    expect(actualPace(burn)).toBeCloseTo(4, 5);
+  });
+
+  test('needed pace uses the last working day in the series even when the sprint ends on a weekend', () => {
+    const mondayToMondayBurn = [
+      point('2026-08-03', 1),
+      point('2026-08-04', 2),
+      point('2026-08-05', 3),
+      point('2026-08-06', 4),
+      point('2026-08-07', 5),
+      point('2026-08-08', null),
+      point('2026-08-09', null),
+      point('2026-08-10', 6),
+      point('2026-08-11', 7),
+      point('2026-08-12', 8, { remaining: 6 }),
+      point('2026-08-13', 9, { future: true }),
+      point('2026-08-14', 10, { future: true }),
+      point('2026-08-15', null, { future: true }),
+      point('2026-08-16', null, { future: true }),
+    ];
+    expect(neededPace(6, mondayToMondayBurn)).toBeCloseTo(2, 5);
   });
 });
 
@@ -73,6 +103,26 @@ describe('forecastDate', () => {
   test('maps a completion working day to a calendar date beyond the series', () => {
     const burn = [point('2026-08-13', 1), point('2026-08-14', 2)];
     expect(forecastDate(burn, 4)).toBe('2026-08-18');
+  });
+
+  test('walks forward from the last working day even when the sprint ends on a weekend', () => {
+    const mondayToMondayBurn = [
+      point('2026-08-03', 1),
+      point('2026-08-04', 2),
+      point('2026-08-05', 3),
+      point('2026-08-06', 4),
+      point('2026-08-07', 5),
+      point('2026-08-08', null),
+      point('2026-08-09', null),
+      point('2026-08-10', 6),
+      point('2026-08-11', 7),
+      point('2026-08-12', 8),
+      point('2026-08-13', 9, { future: true }),
+      point('2026-08-14', 10, { future: true }),
+      point('2026-08-15', null, { future: true }),
+      point('2026-08-16', null, { future: true }),
+    ];
+    expect(forecastDate(mondayToMondayBurn, 12)).toBe('2026-08-18');
   });
 });
 

--- a/apps/web/tests/features/analytics/burn-math.test.ts
+++ b/apps/web/tests/features/analytics/burn-math.test.ts
@@ -3,7 +3,11 @@ import {
   actualPace,
   forecastDate,
   neededPace,
+  personCaptureCaption,
+  personIdealSeries,
+  readableDate,
   sprintDays,
+  todayDateOf,
 } from '../../../src/features/analytics/burn-math.ts';
 
 const point = (
@@ -14,6 +18,7 @@ const point = (
     future: boolean;
     completed: number;
     remaining: number;
+    ideal: number;
   }> = {},
 ) => ({
   date,
@@ -22,6 +27,7 @@ const point = (
   future: extra.future ?? false,
   completed: extra.completed ?? 0,
   remaining: extra.remaining ?? 0,
+  ideal: extra.ideal ?? 0,
 });
 
 describe('sprintDays', () => {
@@ -67,5 +73,78 @@ describe('forecastDate', () => {
   test('maps a completion working day to a calendar date beyond the series', () => {
     const burn = [point('2026-08-13', 1), point('2026-08-14', 2)];
     expect(forecastDate(burn, 4)).toBe('2026-08-18');
+  });
+});
+
+describe('todayDateOf', () => {
+  test('picks the last non-future date', () => {
+    const burn = [
+      point('2026-08-13', 1),
+      point('2026-08-14', 2),
+      point('2026-08-17', 3, { future: true }),
+    ];
+    expect(todayDateOf(burn)).toBe('2026-08-14');
+  });
+
+  test('falls back to the last date when every point is future', () => {
+    const burn = [
+      point('2026-08-13', 1, { future: true }),
+      point('2026-08-14', 2, { future: true }),
+    ];
+    expect(todayDateOf(burn)).toBe('2026-08-14');
+  });
+
+  test('returns an empty string for an empty burn', () => {
+    expect(todayDateOf([])).toBe('');
+  });
+});
+
+describe('readableDate', () => {
+  test('formats an ISO date as a short month, day, year', () => {
+    expect(readableDate('2026-08-14')).toBe('Aug 14, 2026');
+  });
+});
+
+describe('personCaptureCaption', () => {
+  test('is undefined when capture starts on day one', () => {
+    const burn = [point('2026-08-13', 1), point('2026-08-14', 2)];
+    expect(personCaptureCaption(burn)).toBeUndefined();
+  });
+
+  test('is undefined when no day is available yet', () => {
+    const burn = [
+      point('2026-08-13', 1, { available: false, future: true }),
+      point('2026-08-14', 2, { available: false, future: true }),
+    ];
+    expect(personCaptureCaption(burn)).toBeUndefined();
+  });
+
+  test('states the capture start when earlier days precede the first captured day', () => {
+    const burn = [
+      point('2026-08-13', 1, { available: false }),
+      point('2026-08-14', 2, { available: false }),
+      point('2026-08-17', 3),
+    ];
+    expect(personCaptureCaption(burn)).toBe(
+      'Capture began Aug 17, 2026. Earlier days show targets only.',
+    );
+  });
+});
+
+describe('personIdealSeries', () => {
+  test('includes every point, captured or not, using the ideal value', () => {
+    const burn = [
+      point('2026-08-13', 1, { available: false, ideal: 10 }),
+      point('2026-08-14', 2, { ideal: 8 }),
+    ];
+    const series = personIdealSeries(burn);
+    expect(series).toMatchObject({
+      id: 'ideal-person',
+      label: 'Ideal',
+      color: 2,
+      dashed: true,
+      dots: true,
+    });
+    expect(series.points.map((entry) => entry.value)).toEqual([10, 8]);
   });
 });

--- a/apps/web/tests/features/analytics/burn-math.test.ts
+++ b/apps/web/tests/features/analytics/burn-math.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  actualPace,
+  forecastDate,
+  neededPace,
+  sprintDays,
+} from '../../../src/features/analytics/burn-math.ts';
+
+const point = (
+  date: string,
+  workingDay: number | null,
+  extra: Partial<{
+    available: boolean;
+    future: boolean;
+    completed: number;
+    remaining: number;
+  }> = {},
+) => ({
+  date,
+  workingDay,
+  available: extra.available ?? true,
+  future: extra.future ?? false,
+  completed: extra.completed ?? 0,
+  remaining: extra.remaining ?? 0,
+});
+
+describe('sprintDays', () => {
+  test('flags weekends, today, and future days', () => {
+    const days = sprintDays(
+      [
+        point('2026-08-13', 1),
+        point('2026-08-14', 2),
+        point('2026-08-15', null, { future: true }),
+        point('2026-08-16', null, { future: true }),
+        point('2026-08-17', 3, { future: true }),
+      ],
+      '2026-08-14',
+    );
+    expect(days.map((day) => day.weekend)).toEqual([false, false, true, true, false]);
+    expect(days[1]?.today).toBe(true);
+    expect(days[4]?.future).toBe(true);
+  });
+});
+
+describe('pace', () => {
+  test('needed pace divides remaining by working days left including today', () => {
+    const burn = [
+      point('2026-08-13', 1, { remaining: 8 }),
+      point('2026-08-14', 2, { remaining: 7 }),
+      point('2026-08-17', 3, { future: true }),
+      point('2026-08-18', 4, { future: true }),
+    ];
+    expect(neededPace(7, burn)).toBeCloseTo(7 / 3, 5);
+  });
+
+  test('actual pace divides completed since baseline by elapsed working days', () => {
+    const burn = [
+      point('2026-08-11', 1, { available: false }),
+      point('2026-08-13', 3, { completed: 2 }),
+      point('2026-08-14', 4, { completed: 5 }),
+    ];
+    expect(actualPace(burn)).toBeCloseTo(5 / 2, 5);
+  });
+});
+
+describe('forecastDate', () => {
+  test('maps a completion working day to a calendar date beyond the series', () => {
+    const burn = [point('2026-08-13', 1), point('2026-08-14', 2)];
+    expect(forecastDate(burn, 4)).toBe('2026-08-18');
+  });
+});

--- a/apps/web/tests/features/analytics/insights-lens.test.tsx
+++ b/apps/web/tests/features/analytics/insights-lens.test.tsx
@@ -1,0 +1,241 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { analyticsQuerySchema, insightConfigSchema } from '@orbit/shared/validators';
+import userEvent from '@testing-library/user-event';
+import type { AnalyticsInsightsResponse } from '../../../src/features/analytics/contracts.ts';
+import { InsightsLens } from '../../../src/features/analytics/insights-lens.tsx';
+import { render, screen } from '../../../src/test/render.tsx';
+
+const originalFetch = globalThis.fetch;
+const query = analyticsQuerySchema.parse({});
+const defaultInsight = insightConfigSchema.parse({});
+
+const barsData: AnalyticsInsightsResponse = {
+  kind: 'bars',
+  unit: 'issues',
+  buckets: [
+    { id: 's1', label: 'In progress', value: 5, segments: [], cohort: { cohort: 'state:s1' } },
+    { id: 's2', label: 'Done', value: 3, segments: [], cohort: { cohort: 'state:s2' } },
+  ],
+};
+
+const scatterData: AnalyticsInsightsResponse = {
+  kind: 'scatter',
+  unit: 'days',
+  points: [{ issueId: 'i1', identifier: 'ORB-1', title: 'Fix the thing', days: 4.2 }],
+  percentiles: { p25: 1, p50: 2, p75: 3, p95: 4 },
+};
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('InsightsLens', () => {
+  test('renders the three pickers and a bar chart from a bars response', () => {
+    render(
+      <InsightsLens
+        data={barsData}
+        insight={defaultInsight}
+        onInsightChange={mock()}
+        query={query}
+      />,
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Insight measure' })).toBeVisible();
+    expect(screen.getByRole('combobox', { name: 'Insight slice' })).toBeVisible();
+    expect(screen.getByRole('combobox', { name: 'Insight segment' })).toBeVisible();
+    expect(screen.getByRole('application', { name: 'Count by State category' })).toBeVisible();
+    expect(screen.getByTestId('plot-category-s1')).toHaveTextContent('In progress');
+  });
+
+  test('switching measure to cycle_time asks the parent to fetch scatter data, which then renders as a scatterplot', async () => {
+    const user = userEvent.setup();
+    const onInsightChange = mock();
+    const { rerender } = render(
+      <InsightsLens
+        data={barsData}
+        insight={defaultInsight}
+        onInsightChange={onInsightChange}
+        query={query}
+      />,
+    );
+
+    await user.click(screen.getByRole('combobox', { name: 'Insight measure' }));
+    await user.click(screen.getByRole('option', { name: 'Cycle time' }));
+
+    expect(onInsightChange).toHaveBeenCalledWith({
+      measure: 'cycle_time',
+      slice: 'state_category',
+      cumulative: false,
+    });
+
+    rerender(
+      <InsightsLens
+        data={scatterData}
+        insight={{ measure: 'cycle_time', slice: 'state_category', cumulative: false }}
+        onInsightChange={onInsightChange}
+        query={query}
+      />,
+    );
+
+    expect(screen.getByRole('application', { name: 'Cycle time distribution' })).toBeVisible();
+    expect(screen.queryByTestId('plot-category-s1')).not.toBeInTheDocument();
+  });
+
+  test('clears the segment when the slice picker is changed to match it, instead of producing an invalid config', async () => {
+    const user = userEvent.setup();
+    const onInsightChange = mock();
+    const insight = {
+      measure: 'count' as const,
+      slice: 'state_category' as const,
+      segment: 'assignee' as const,
+      cumulative: false,
+    };
+    render(
+      <InsightsLens
+        data={barsData}
+        insight={insight}
+        onInsightChange={onInsightChange}
+        query={query}
+      />,
+    );
+
+    await user.click(screen.getByRole('combobox', { name: 'Insight slice' }));
+    await user.click(screen.getByRole('option', { name: 'Assignee' }));
+
+    expect(onInsightChange).toHaveBeenCalledWith({
+      measure: 'count',
+      slice: 'assignee',
+      cumulative: false,
+    });
+  });
+
+  test('clicking a bucket with a cohort opens the drilldown dialog for that cohort', async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            predicate: 'state:s1',
+            total: 5,
+            totalValue: 5,
+            details: { validCycleCount: 0, cycleTimeP50: null, cycleTimeP85: null },
+            issues: [],
+            nextCursor: null,
+            limit: 50,
+            asOf: '2026-08-15T00:00:00.000Z',
+            from: '2026-08-01T00:00:00.000Z',
+            to: '2026-08-15T00:00:00.000Z',
+            timezone: 'UTC',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+    const user = userEvent.setup();
+    const insight = { measure: 'count' as const, slice: 'state' as const, cumulative: false };
+    render(
+      <InsightsLens data={barsData} insight={insight} onInsightChange={mock()} query={query} />,
+    );
+
+    await user.click(screen.getByTestId('plot-hit-s1'));
+
+    expect(await screen.findByRole('dialog', { name: 'Count by State' })).toBeVisible();
+    expect(screen.getByText(/Predicate: state:s1/)).toBeVisible();
+  });
+
+  test('leaves the null-cohort overflow bucket without a drilldown action', async () => {
+    const user = userEvent.setup();
+    const data: AnalyticsInsightsResponse = {
+      kind: 'bars',
+      unit: 'issues',
+      buckets: [
+        ...(barsData.kind === 'bars' ? barsData.buckets : []),
+        { id: 'other', label: 'Other', value: 1, segments: [], cohort: null },
+      ],
+    };
+    render(
+      <InsightsLens data={data} insight={defaultInsight} onInsightChange={mock()} query={query} />,
+    );
+
+    await user.click(screen.getByTestId('plot-hit-other'));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  test('stacks one rect per segment when the response carries segment breakdowns', () => {
+    const data: AnalyticsInsightsResponse = {
+      kind: 'bars',
+      unit: 'issues',
+      buckets: [
+        {
+          id: 's1',
+          label: 'In progress',
+          value: 5,
+          segments: [
+            { id: 'alice', label: 'Alice', value: 3 },
+            { id: 'bob', label: 'Bob', value: 2 },
+          ],
+          cohort: { cohort: 'state:s1' },
+        },
+      ],
+    };
+    render(
+      <InsightsLens data={data} insight={defaultInsight} onInsightChange={mock()} query={query} />,
+    );
+
+    const svg = screen.getByRole('application', { name: 'Count by State category' });
+    const segmentRects = svg.querySelectorAll('rect[fill^="var(--analytics-series-"]');
+    expect(segmentRects).toHaveLength(2);
+  });
+
+  test('renders a cumulative line for completed_week when the toggle is on, summing week over week', async () => {
+    const user = userEvent.setup();
+    const data: AnalyticsInsightsResponse = {
+      kind: 'bars',
+      unit: 'issues',
+      buckets: [
+        {
+          id: '2026-08-10',
+          label: '2026-08-10',
+          value: 5,
+          segments: [],
+          cohort: { cohort: 'completed-week:2026-08-10' },
+        },
+        {
+          id: '2026-07-27',
+          label: '2026-07-27',
+          value: 3,
+          segments: [],
+          cohort: { cohort: 'completed-week:2026-07-27' },
+        },
+        {
+          id: '2026-08-03',
+          label: '2026-08-03',
+          value: 2,
+          segments: [],
+          cohort: { cohort: 'completed-week:2026-08-03' },
+        },
+      ],
+    };
+    const insight = {
+      measure: 'count' as const,
+      slice: 'completed_week' as const,
+      cumulative: true,
+    };
+    render(<InsightsLens data={data} insight={insight} onInsightChange={mock()} query={query} />);
+
+    expect(screen.getByTestId('plot-line-cumulative')).toBeInTheDocument();
+    expect(screen.queryByTestId('plot-hit-s1')).not.toBeInTheDocument();
+
+    await user.hover(screen.getByTestId('plot-hit-2026-08-10'));
+    expect(screen.getByRole('tooltip')).toHaveTextContent('10');
+  });
+
+  test('shows an honest empty state when there are no buckets', () => {
+    const data: AnalyticsInsightsResponse = { kind: 'bars', unit: 'issues', buckets: [] };
+    render(
+      <InsightsLens data={data} insight={defaultInsight} onInsightChange={mock()} query={query} />,
+    );
+
+    expect(screen.getByText('No matching issues for this insight.')).toBeVisible();
+  });
+});

--- a/apps/web/tests/features/analytics/insights-lens.test.tsx
+++ b/apps/web/tests/features/analytics/insights-lens.test.tsx
@@ -238,4 +238,67 @@ describe('InsightsLens', () => {
 
     expect(screen.getByText('No matching issues for this insight.')).toBeVisible();
   });
+
+  test('disables the segment picker to None for a duration measure like cycle time', () => {
+    const insight = {
+      measure: 'cycle_time' as const,
+      slice: 'state_category' as const,
+      cumulative: false,
+    };
+    render(
+      <InsightsLens data={scatterData} insight={insight} onInsightChange={mock()} query={query} />,
+    );
+
+    const segmentPicker = screen.getByRole('combobox', { name: 'Insight segment' });
+    expect(segmentPicker).toBeDisabled();
+    expect(segmentPicker).toHaveTextContent('No segment');
+  });
+
+  test('leaves the segment picker enabled for a count measure', () => {
+    render(
+      <InsightsLens
+        data={barsData}
+        insight={defaultInsight}
+        onInsightChange={mock()}
+        query={query}
+      />,
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Insight segment' })).toBeEnabled();
+  });
+
+  test('shows the label overlap caption only when segmenting by label', () => {
+    const withLabelSegment = {
+      measure: 'count' as const,
+      slice: 'state_category' as const,
+      segment: 'label' as const,
+      cumulative: false,
+    };
+    const caption = 'Issues can carry several labels, so label segments may overlap.';
+    const { rerender } = render(
+      <InsightsLens
+        data={barsData}
+        insight={withLabelSegment}
+        onInsightChange={mock()}
+        query={query}
+      />,
+    );
+    expect(screen.getByText(caption)).toBeVisible();
+
+    const withAssigneeSegment = {
+      measure: 'count' as const,
+      slice: 'state_category' as const,
+      segment: 'assignee' as const,
+      cumulative: false,
+    };
+    rerender(
+      <InsightsLens
+        data={barsData}
+        insight={withAssigneeSegment}
+        onInsightChange={mock()}
+        query={query}
+      />,
+    );
+    expect(screen.queryByText(caption)).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/tests/features/analytics/line-plot.test.tsx
+++ b/apps/web/tests/features/analytics/line-plot.test.tsx
@@ -308,4 +308,144 @@ describe('LinePlot', () => {
     expect(svg.getAttribute('viewBox')).toBeNull();
     expect(svg.getAttribute('width')).toBe('640');
   });
+
+  test('pivots one table row per sprint day with series columns, activation, and the active marker', async () => {
+    const user = userEvent.setup();
+    const activate = mock();
+    const days = [
+      { date: '2026-08-13', weekend: false, today: false, future: false },
+      { date: '2026-08-14', weekend: false, today: true, future: false },
+      { date: '2026-08-15', weekend: true, today: false, future: true },
+      { date: '2026-08-16', weekend: true, today: false, future: true },
+      { date: '2026-08-17', weekend: false, today: false, future: true },
+    ];
+    render(
+      <LinePlot
+        days={days}
+        label="Burn"
+        onActivate={activate}
+        series={[
+          {
+            id: 'remaining',
+            label: 'Remaining',
+            points: days.map((day, index) => ({
+              id: `r${index}`,
+              label: day.date,
+              value: 8 - index,
+              cohort: { cohort: 'open', bucket: day.date },
+            })),
+          },
+          {
+            id: 'ideal',
+            label: 'Ideal',
+            dashed: true,
+            points: days.map((day, index) => ({
+              id: `i${index}`,
+              label: day.date,
+              value: 8 - index,
+              cohort: { cohort: 'open', bucket: `ideal-${day.date}` },
+            })),
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByText('View data (5 rows)'));
+
+    expect(screen.getByRole('columnheader', { name: 'Remaining' })).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: 'Ideal' })).toBeVisible();
+
+    await user.hover(screen.getAllByTestId('plot-day-hit')[1] as Element);
+    const activeRow = screen.getByRole('row', { name: /Aug 14/ });
+    expect(activeRow).toHaveAttribute('data-active', 'true');
+
+    await user.click(screen.getByRole('button', { name: /Aug 14/ }));
+    expect(activate).toHaveBeenLastCalledWith({ cohort: 'open', bucket: '2026-08-14' });
+  });
+
+  test('supports day-mode keyboard navigation, activation, and escape', async () => {
+    const user = userEvent.setup();
+    const activate = mock();
+    const days = [
+      { date: '2026-08-13', weekend: false, today: false, future: false },
+      { date: '2026-08-14', weekend: false, today: false, future: false },
+      { date: '2026-08-15', weekend: true, today: false, future: false },
+      { date: '2026-08-16', weekend: true, today: false, future: false },
+      { date: '2026-08-17', weekend: false, today: false, future: false },
+    ];
+    render(
+      <LinePlot
+        days={days}
+        label="Burn"
+        onActivate={activate}
+        series={[
+          {
+            id: 'remaining',
+            label: 'Remaining',
+            points: days.map((day, index) => ({
+              id: `r${index}`,
+              label: day.date,
+              value: 8 - index,
+              cohort: { cohort: 'open', bucket: day.date },
+            })),
+          },
+        ]}
+      />,
+    );
+
+    const plot = screen.getByRole('application', { name: 'Burn' });
+    await user.tab();
+    expect(plot).toHaveFocus();
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Aug 13');
+
+    await user.keyboard('{ArrowRight}');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Aug 14');
+    await user.keyboard('{ArrowRight}');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Aug 15');
+
+    await user.keyboard('{Home}');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Aug 13');
+    await user.keyboard('{End}');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Aug 17');
+
+    await user.keyboard('{Enter}');
+    expect(activate).toHaveBeenLastCalledWith({ cohort: 'open', bucket: '2026-08-17' });
+
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  test('draws a staircase path for a step series and a straight line without it', () => {
+    const days = [
+      { date: '2026-08-13', weekend: false, today: false, future: false },
+      { date: '2026-08-14', weekend: false, today: false, future: false },
+      { date: '2026-08-15', weekend: false, today: false, future: false },
+    ];
+    const points = days.map((day, index) => ({
+      id: `s${index}`,
+      label: day.date,
+      value: index + 1,
+      cohort: { cohort: 'open' as const },
+    }));
+
+    const { rerender } = render(
+      <LinePlot
+        days={days}
+        label="Scope"
+        series={[{ id: 'scope', label: 'Scope', points, step: true }]}
+      />,
+    );
+    const stepPath = screen.getByTestId('plot-line-scope').getAttribute('d');
+    expect(stepPath).toContain('H');
+    expect(stepPath).toContain('V');
+    expect(stepPath).not.toContain('L');
+
+    rerender(
+      <LinePlot days={days} label="Scope" series={[{ id: 'scope', label: 'Scope', points }]} />,
+    );
+    const linePath = screen.getByTestId('plot-line-scope').getAttribute('d');
+    expect(linePath).toContain('L');
+    expect(linePath).not.toContain('H');
+    expect(linePath).not.toContain('V');
+  });
 });

--- a/apps/web/tests/features/analytics/line-plot.test.tsx
+++ b/apps/web/tests/features/analytics/line-plot.test.tsx
@@ -172,7 +172,7 @@ describe('LinePlot', () => {
       />,
     );
 
-    expect(screen.getAllByTestId('plot-grid-line')).toHaveLength(3);
+    expect(screen.getAllByTestId('plot-grid-line')).toHaveLength(5);
     expect(screen.getByTestId('plot-y-max')).toHaveTextContent('7');
     expect(screen.getByTestId('plot-x-start')).toHaveTextContent('Aug 10');
     expect(screen.getByTestId('plot-x-end')).toHaveTextContent('Aug 11');
@@ -186,7 +186,7 @@ describe('LinePlot', () => {
     expect(screen.getByTestId('plot-legend-completed')).not.toHaveAttribute('stroke-dasharray');
 
     await user.hover(screen.getByTestId('plot-hit-2026-08-11-completed'));
-    expect(screen.getByRole('tooltip')).toHaveStyle({ left: '97.1875%' });
+    expect(screen.getByRole('tooltip')).toHaveStyle({ left: '97.5%' });
   });
 
   test('shows dashed legend keys and short calendar ticks', () => {
@@ -241,7 +241,71 @@ describe('LinePlot', () => {
 
     expect(screen.queryByTestId('plot-point-missing-1')).not.toBeInTheDocument();
     expect(screen.queryByTestId('plot-point-missing-2')).not.toBeInTheDocument();
-    expect(screen.getByTestId('plot-line-remaining').getAttribute('d')).not.toContain(' 218.00');
+    expect(screen.getByTestId('plot-line-remaining').getAttribute('d')).not.toContain(' 236.00');
     expect(screen.getByText('2 dates unavailable')).toBeVisible();
+  });
+
+  test('renders one slot per sprint day with weekend bands and a full-day tooltip', async () => {
+    const user = userEvent.setup();
+    const days = [
+      { date: '2026-08-13', weekend: false, today: false, future: false },
+      { date: '2026-08-14', weekend: false, today: true, future: false },
+      { date: '2026-08-15', weekend: true, today: false, future: true },
+      { date: '2026-08-16', weekend: true, today: false, future: true },
+      { date: '2026-08-17', weekend: false, today: false, future: true },
+    ];
+    render(
+      <LinePlot
+        days={days}
+        label="Burn"
+        series={[
+          {
+            id: 'remaining',
+            label: 'Remaining',
+            points: [
+              { id: 'r1', label: '2026-08-13', value: 8, cohort: { cohort: 'open' } },
+              { id: 'r2', label: '2026-08-14', value: 7, cohort: { cohort: 'open' } },
+            ],
+          },
+          {
+            id: 'ideal',
+            label: 'Ideal',
+            dashed: true,
+            dots: true,
+            points: days.map((day, index) => ({
+              id: `i${index}`,
+              label: day.date,
+              value: 8 - index,
+              cohort: { cohort: 'open' },
+            })),
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByTestId('plot-weekend-band')).toHaveLength(2);
+    expect(screen.getAllByTestId('plot-day-hit')).toHaveLength(5);
+    await user.hover(screen.getAllByTestId('plot-day-hit')[1] as Element);
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Remaining 7');
+    expect(tooltip).toHaveTextContent('Ideal 7');
+  });
+
+  test('renders the svg at the measured width instead of stretching a viewBox', () => {
+    render(
+      <LinePlot
+        label="Burn"
+        series={[
+          {
+            id: 'remaining',
+            label: 'Remaining',
+            points: [{ id: 'r1', label: '2026-08-13', value: 8, cohort: { cohort: 'open' } }],
+          },
+        ]}
+      />,
+    );
+    const svg = screen.getByRole('application');
+    expect(svg.getAttribute('viewBox')).toBeNull();
+    expect(svg.getAttribute('width')).toBe('640');
   });
 });

--- a/apps/web/tests/features/analytics/line-plot.test.tsx
+++ b/apps/web/tests/features/analytics/line-plot.test.tsx
@@ -220,6 +220,41 @@ describe('LinePlot', () => {
     expect(screen.getByTestId('plot-x-end')).toHaveTextContent('Aug 24');
   });
 
+  test('lets a series pin an explicit color token instead of taking its array position', () => {
+    render(
+      <LinePlot
+        label="Sprint burn"
+        series={[
+          { ...series[0], id: 'remaining', label: 'Remaining', color: 1 },
+          { ...series[1], id: 'scope', label: 'Scope', color: 4 },
+          {
+            ...series[0],
+            id: 'ideal',
+            label: 'Ideal',
+            points: series[0].points.map((point) => ({ ...point, id: `ideal-${point.id}` })),
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('plot-line-remaining')).toHaveAttribute(
+      'stroke',
+      'var(--analytics-series-1)',
+    );
+    expect(screen.getByTestId('plot-line-scope')).toHaveAttribute(
+      'stroke',
+      'var(--analytics-series-4)',
+    );
+    expect(screen.getByTestId('plot-legend-scope')).toHaveAttribute(
+      'stroke',
+      'var(--analytics-series-4)',
+    );
+    expect(screen.getByTestId('plot-line-ideal')).toHaveAttribute(
+      'stroke',
+      'var(--analytics-series-3)',
+    );
+  });
+
   test('leaves unavailable history as a visible gap instead of drawing false zeroes', () => {
     render(
       <LinePlot

--- a/apps/web/tests/features/analytics/line-plot.test.tsx
+++ b/apps/web/tests/features/analytics/line-plot.test.tsx
@@ -280,6 +280,64 @@ describe('LinePlot', () => {
     expect(screen.getByText('2 dates unavailable')).toBeVisible();
   });
 
+  test('lands End on the last available point, not the first, when trailing points are unavailable', async () => {
+    const user = userEvent.setup();
+    render(
+      <LinePlot
+        label="Sprint burn"
+        series={[
+          {
+            id: 'remaining',
+            label: 'Remaining',
+            points: [
+              { ...series[0].points[0], id: 'known-1', value: 9 },
+              { ...series[0].points[1], id: 'known-2', value: 7 },
+              { ...series[0].points[0], id: 'missing-1', label: 'Aug 12', available: false },
+              { ...series[0].points[1], id: 'missing-2', label: 'Aug 13', available: false },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const plot = screen.getByRole('application', { name: 'Sprint burn' });
+    await user.tab();
+    expect(plot).toHaveFocus();
+
+    await user.keyboard('{End}');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Aug 11');
+  });
+
+  test('keeps ArrowRight at the last available point instead of wrapping to the first', async () => {
+    const user = userEvent.setup();
+    render(
+      <LinePlot
+        label="Sprint burn"
+        series={[
+          {
+            id: 'remaining',
+            label: 'Remaining',
+            points: [
+              { ...series[0].points[0], id: 'known-1', value: 9 },
+              { ...series[0].points[1], id: 'known-2', value: 7 },
+              { ...series[0].points[0], id: 'missing-1', label: 'Aug 12', available: false },
+              { ...series[0].points[1], id: 'missing-2', label: 'Aug 13', available: false },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const plot = screen.getByRole('application', { name: 'Sprint burn' });
+    await user.tab();
+    expect(plot).toHaveFocus();
+
+    await user.keyboard('{End}');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Aug 11');
+    await user.keyboard('{ArrowRight}');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Aug 11');
+  });
+
   test('renders one slot per sprint day with weekend bands and a full-day tooltip', async () => {
     const user = userEvent.setup();
     const days = [

--- a/apps/web/tests/features/analytics/people-lens.test.tsx
+++ b/apps/web/tests/features/analytics/people-lens.test.tsx
@@ -9,6 +9,47 @@ const personId = '00000000-0000-7000-8000-000000000001';
 const secondPersonId = '00000000-0000-7000-8000-000000000002';
 const asOf = '2026-08-14T10:00:00.000Z';
 const sprintId = '00000000-0000-7000-8000-000000000003';
+
+function dayOffset(start: string, offset: number): string {
+  const value = new Date(`${start}T00:00:00.000Z`);
+  value.setUTCDate(value.getUTCDate() + offset);
+  return value.toISOString().slice(0, 10);
+}
+
+function buildPersonBurn(options: {
+  readonly start: string;
+  readonly count: number;
+  readonly observedCount: number;
+  readonly scope: number;
+}) {
+  return Array.from({ length: options.count }, (_unused, index) => {
+    const date = dayOffset(options.start, index);
+    const observed = index < options.observedCount;
+    const completed = observed ? index : 0;
+    return {
+      date,
+      calendarDay: index + 1,
+      workingDay: index + 1,
+      scope: observed ? options.scope : 0,
+      started: observed ? completed : 0,
+      completed,
+      remaining: observed ? Math.max(0, options.scope - completed) : 0,
+      added: 0,
+      removed: 0,
+      ideal: Math.max(0, options.scope - index),
+      available: observed,
+      coverage: 'captured' as const,
+      future: !observed,
+    };
+  });
+}
+
+const fullSpanPersonBurn = buildPersonBurn({
+  start: '2026-08-10',
+  count: 10,
+  observedCount: 6,
+  scope: 8,
+});
 const cohort = (name: string, id = personId) => ({ cohort: `${name}:${id}` });
 const person = (id: string, name: string, status: 'current' | 'former') => ({
   person: { id, name, image: null, currentMember: status === 'current', status },
@@ -184,7 +225,8 @@ describe('PeopleLens', () => {
     expect(onFocus).toHaveBeenCalledWith(secondPersonId);
   });
 
-  test('leaves a gap in the personal burn where sprint history is unavailable', () => {
+  test('excludes an unavailable day from the personal burn instead of leaving a fabricated gap', async () => {
+    const user = userEvent.setup();
     const focused = data.focused;
     if (focused === null) throw new Error('Missing focused person fixture.');
     const sprintBurn = focused.sprintBurn;
@@ -219,9 +261,124 @@ describe('PeopleLens', () => {
       />,
     );
 
-    expect(screen.queryByTestId('plot-point-2026-08-10-current-person')).not.toBeInTheDocument();
-    expect(screen.getByTestId('plot-point-2026-08-14-current-person')).toBeInTheDocument();
+    expect(screen.getByText(/capture began aug 14/i)).toBeVisible();
+    expect(screen.queryByText(/dates unavailable/i)).not.toBeInTheDocument();
     expect(screen.getByTestId('plot-line-current-person').getAttribute('d')).not.toContain('L');
-    expect(screen.getByText('1 date unavailable')).toBeVisible();
+
+    const dayHits = screen.getAllByTestId('plot-day-hit');
+    expect(dayHits).toHaveLength(2);
+    await user.hover(dayHits[0] as Element);
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Ideal');
+    expect(tooltip).not.toHaveTextContent('Current sprint');
+  });
+
+  test('frames the personal burn across the whole sprint with an ideal series', () => {
+    const focused = data.focused;
+    if (focused === null) throw new Error('Missing focused person fixture.');
+    const current = focused.sprintBurn.current;
+    if (current === null) throw new Error('Missing personal sprint burn fixture.');
+    render(
+      <PeopleLens
+        data={{
+          ...data,
+          focused: {
+            ...focused,
+            sprintBurn: {
+              ...focused.sprintBurn,
+              current: { ...current, burn: fullSpanPersonBurn },
+            },
+          },
+        }}
+        onFocusPerson={mock()}
+        query={analyticsQuerySchema.parse({
+          lens: 'people',
+          measure: 'points',
+          focus: { personId },
+        })}
+      />,
+    );
+
+    expect(screen.getAllByTestId('plot-day-hit')).toHaveLength(fullSpanPersonBurn.length);
+    expect(screen.getByTestId('plot-line-ideal-person')).toBeInTheDocument();
+  });
+
+  test('states the capture start once instead of a dates-unavailable fallback', () => {
+    const focused = data.focused;
+    if (focused === null) throw new Error('Missing focused person fixture.');
+    const current = focused.sprintBurn.current;
+    if (current === null) throw new Error('Missing personal sprint burn fixture.');
+    const firstDay = fullSpanPersonBurn[0];
+    if (firstDay === undefined) throw new Error('Missing burn fixture.');
+    const retroBurn = [
+      { ...firstDay, available: false, future: false, remaining: 0, scope: 0 },
+      ...fullSpanPersonBurn.slice(1),
+    ];
+    render(
+      <PeopleLens
+        data={{
+          ...data,
+          focused: {
+            ...focused,
+            sprintBurn: { ...focused.sprintBurn, current: { ...current, burn: retroBurn } },
+          },
+        }}
+        onFocusPerson={mock()}
+        query={analyticsQuerySchema.parse({
+          lens: 'people',
+          measure: 'points',
+          focus: { personId },
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/capture began aug 11/i)).toBeVisible();
+    expect(screen.queryByText(/dates unavailable/i)).not.toBeInTheDocument();
+  });
+
+  test('replaces the previous-sprint overlay with a caption since the frame cannot mix sprints', () => {
+    const focused = data.focused;
+    if (focused === null) throw new Error('Missing focused person fixture.');
+    const sprintBurn = focused.sprintBurn;
+    const current = sprintBurn.current;
+    if (current === null) throw new Error('Missing personal sprint burn fixture.');
+    render(
+      <PeopleLens
+        data={{
+          ...data,
+          focused: {
+            ...focused,
+            sprintBurn: {
+              ...sprintBurn,
+              previous: {
+                personId,
+                name: 'Ada Lovelace',
+                burn: [],
+                summary: {
+                  planned: 6,
+                  currentScope: 6,
+                  completed: 4,
+                  remaining: 2,
+                  added: 0,
+                  removed: 0,
+                  carryover: 0,
+                  unestimated: 0,
+                },
+                coverage: { kind: 'captured', from: '2026-07-27T00:00:00.000Z', asOf },
+              },
+            },
+          },
+        }}
+        onFocusPerson={mock()}
+        query={analyticsQuerySchema.parse({
+          lens: 'people',
+          measure: 'points',
+          focus: { personId },
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/previous sprint ended with 2 points remaining/i)).toBeVisible();
+    expect(screen.queryByTestId('plot-line-previous-person')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/tests/features/analytics/people-lens.test.tsx
+++ b/apps/web/tests/features/analytics/people-lens.test.tsx
@@ -100,6 +100,7 @@ const data: AnalyticsPeopleResponse = {
             ideal: 8,
             available: true,
             coverage: 'captured',
+            future: false,
           },
           {
             date: '2026-08-14',
@@ -114,6 +115,7 @@ const data: AnalyticsPeopleResponse = {
             ideal: 5,
             available: true,
             coverage: 'live',
+            future: false,
           },
         ],
         summary: {

--- a/apps/web/tests/features/analytics/people-lens.test.tsx
+++ b/apps/web/tests/features/analytics/people-lens.test.tsx
@@ -220,6 +220,7 @@ describe('PeopleLens', () => {
     ).toBeVisible();
     expect(screen.getByText('Sprint 4')).toBeVisible();
     expect(screen.getByText('5 points remaining')).toBeVisible();
+    expect(screen.getByText('1 unestimated issues count as 1 point each.')).toBeVisible();
 
     await user.click(screen.getByRole('button', { name: /Grace Hopper/ }));
     expect(onFocus).toHaveBeenCalledWith(secondPersonId);

--- a/apps/web/tests/features/analytics/people-lens.test.tsx
+++ b/apps/web/tests/features/analytics/people-lens.test.tsx
@@ -220,7 +220,7 @@ describe('PeopleLens', () => {
     ).toBeVisible();
     expect(screen.getByText('Sprint 4')).toBeVisible();
     expect(screen.getByText('5 points remaining')).toBeVisible();
-    expect(screen.getByText('1 unestimated issues count as 1 point each.')).toBeVisible();
+    expect(screen.getByText('1 unestimated issue counts as 1 point.')).toBeVisible();
 
     await user.click(screen.getByRole('button', { name: /Grace Hopper/ }));
     expect(onFocus).toHaveBeenCalledWith(secondPersonId);

--- a/apps/web/tests/features/analytics/projects-lens.test.tsx
+++ b/apps/web/tests/features/analytics/projects-lens.test.tsx
@@ -132,7 +132,7 @@ describe('ProjectsLens', () => {
     expect(screen.getAllByText('At risk').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Public beta').length).toBeGreaterThan(0);
     expect(screen.getByText('5 / 13 points')).toBeVisible();
-    expect(screen.getByText(/1 unestimated issue contributes zero points/i)).toBeVisible();
+    expect(screen.getByText(/1 unestimated issues count as 1 point each/i)).toBeVisible();
     expect(screen.getByRole('application', { name: 'Platform migration delivery' })).toBeVisible();
     expect(screen.getByText('API migration is waiting on the billing cutover.')).toBeVisible();
     expect(screen.getByText(/Grace Hopper/)).toBeVisible();

--- a/apps/web/tests/features/analytics/projects-lens.test.tsx
+++ b/apps/web/tests/features/analytics/projects-lens.test.tsx
@@ -132,7 +132,7 @@ describe('ProjectsLens', () => {
     expect(screen.getAllByText('At risk').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Public beta').length).toBeGreaterThan(0);
     expect(screen.getByText('5 / 13 points')).toBeVisible();
-    expect(screen.getByText(/1 unestimated issues count as 1 point each/i)).toBeVisible();
+    expect(screen.getByText('1 unestimated issue counts as 1 point.')).toBeVisible();
     expect(screen.getByRole('application', { name: 'Platform migration delivery' })).toBeVisible();
     expect(screen.getByText('API migration is waiting on the billing cutover.')).toBeVisible();
     expect(screen.getByText(/Grace Hopper/)).toBeVisible();

--- a/apps/web/tests/features/analytics/query-state.test.ts
+++ b/apps/web/tests/features/analytics/query-state.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from 'bun:test';
-import { analyticsQuerySchema } from '@orbit/shared/validators';
+import { analyticsQuerySchema, insightConfigSchema } from '@orbit/shared/validators';
 import { analyticsKeys } from '../../../src/features/analytics/analytics-keys.ts';
 import {
   canonicalAnalyticsQuery,
+  insightConfigFromSearchParams,
   parseAnalyticsSearchParams,
   searchParamsForAnalytics,
+  searchParamsForInsightConfig,
 } from '../../../src/features/analytics/query-state.ts';
 
 const defaults = analyticsQuerySchema.parse({});
+const defaultInsight = insightConfigSchema.parse({});
 
 describe('analytics URL state', () => {
   it('keeps the zero-configuration defaults out of the URL', () => {
@@ -83,5 +86,44 @@ describe('analytics URL state', () => {
     expect(canonicalAnalyticsQuery(fromUrl)).toEqual(canonicalAnalyticsQuery(fromObject));
     expect(analyticsKeys.lens('people', fromUrl)).toEqual(analyticsKeys.lens('people', fromObject));
     expect(analyticsKeys.root).toEqual(['analytics']);
+  });
+
+  it('keeps the default insight config out of the URL', () => {
+    expect(searchParamsForInsightConfig(defaultInsight).toString()).toBe('');
+    expect(insightConfigFromSearchParams(new URLSearchParams())).toEqual(defaultInsight);
+  });
+
+  it('round trips a non-default insight config through flat params', () => {
+    const insight = insightConfigSchema.parse({
+      measure: 'points',
+      slice: 'assignee',
+      segment: 'state',
+      cumulative: false,
+    });
+
+    const encoded = searchParamsForInsightConfig(insight);
+
+    expect(encoded.get('insightMeasure')).toBe('points');
+    expect(encoded.get('insightSlice')).toBe('assignee');
+    expect(encoded.get('insightSegment')).toBe('state');
+    expect(encoded.get('insightCumulative')).toBeNull();
+    expect(insightConfigFromSearchParams(encoded)).toEqual(insight);
+  });
+
+  it('round trips cumulative on a week slice', () => {
+    const insight = insightConfigSchema.parse({ slice: 'completed_week', cumulative: true });
+
+    const encoded = searchParamsForInsightConfig(insight);
+
+    expect(encoded.get('insightCumulative')).toBe('1');
+    expect(insightConfigFromSearchParams(encoded)).toEqual(insight);
+  });
+
+  it('falls back to the default insight config when the URL value is malformed', () => {
+    const parsed = insightConfigFromSearchParams(
+      new URLSearchParams('insightMeasure=not-a-measure'),
+    );
+
+    expect(parsed).toEqual(defaultInsight);
   });
 });

--- a/apps/web/tests/features/analytics/saved-view-bar.test.tsx
+++ b/apps/web/tests/features/analytics/saved-view-bar.test.tsx
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { SavedAnalyticsViewPayload } from '@orbit/core';
+import { analyticsQuerySchema, insightConfigSchema } from '@orbit/shared/validators';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { ToastProvider } from '../../../src/components/ui/toast.tsx';
+import { SavedViewBar } from '../../../src/features/analytics/saved-view-bar.tsx';
+import { createQueryClient } from '../../../src/lib/query/provider.tsx';
+
+const realFetch = globalThis.fetch;
+
+interface Sent {
+  readonly url: string;
+  readonly method: string;
+  readonly body: Record<string, unknown>;
+}
+
+let sent: Sent[] = [];
+
+function respondWith(status: number, payload: unknown): void {
+  globalThis.fetch = mock((url: string, init: { method: string; body?: string }) => {
+    sent.push({
+      url,
+      method: init.method,
+      body: init.body === undefined ? {} : (JSON.parse(init.body) as Record<string, unknown>),
+    });
+    return Promise.resolve({
+      ok: status < 400,
+      status,
+      json: () => Promise.resolve(payload),
+    });
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  sent = [];
+  respondWith(200, {});
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function Wrapper({ children }: { readonly children: ReactNode }) {
+  const client = createQueryClient();
+  return (
+    <QueryClientProvider client={client}>
+      <ToastProvider>{children}</ToastProvider>
+    </QueryClientProvider>
+  );
+}
+
+const asOf = '2026-08-15T00:00:00.000Z';
+
+describe('SavedViewBar', () => {
+  it('includes the current insight config in the saved payload when the lens is insights', async () => {
+    const user = userEvent.setup();
+    const query = analyticsQuerySchema.parse({ lens: 'insights' });
+    const insight = insightConfigSchema.parse({
+      measure: 'points',
+      slice: 'assignee',
+      segment: 'state',
+    });
+    respondWith(200, {
+      view: {
+        id: 'view_1',
+        name: 'Points by assignee',
+        scopeType: 'workspace',
+        scopeId: null,
+        kind: 'dashboard',
+        config: { kind: 'dashboard', version: 1, query, insight, pinned: false },
+        shared: false,
+        ownerId: 'user_1',
+        createdAt: asOf,
+        updatedAt: asOf,
+      },
+    });
+
+    render(
+      <SavedViewBar
+        canManage
+        canManageAll={false}
+        currentUserId="user_1"
+        insight={insight}
+        onApply={mock()}
+        query={query}
+        views={[]}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save view' }));
+    await user.type(screen.getByLabelText('Analytics view name'), 'Points by assignee');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.body['config']).toMatchObject({ insight });
+  });
+
+  it('leaves a non-insights save without an insight key, byte-identical to before', async () => {
+    const user = userEvent.setup();
+    const query = analyticsQuerySchema.parse({ lens: 'overview' });
+    const defaultInsight = insightConfigSchema.parse({});
+    respondWith(200, {
+      view: {
+        id: 'view_2',
+        name: 'Q3',
+        scopeType: 'workspace',
+        scopeId: null,
+        kind: 'dashboard',
+        config: { kind: 'dashboard', version: 1, query, pinned: false },
+        shared: false,
+        ownerId: 'user_1',
+        createdAt: asOf,
+        updatedAt: asOf,
+      },
+    });
+
+    render(
+      <SavedViewBar
+        canManage
+        canManageAll={false}
+        currentUserId="user_1"
+        insight={defaultInsight}
+        onApply={mock()}
+        query={query}
+        views={[]}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save view' }));
+    await user.type(screen.getByLabelText('Analytics view name'), 'Q3');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.body['config']).toEqual({
+      kind: 'dashboard',
+      version: 1,
+      query,
+      pinned: false,
+    });
+  });
+
+  it('applies a saved view together with its stored insight config', async () => {
+    const user = userEvent.setup();
+    const query = analyticsQuerySchema.parse({ lens: 'insights' });
+    const savedInsight = insightConfigSchema.parse({
+      measure: 'points',
+      slice: 'assignee',
+      segment: 'state',
+    });
+    const onApply = mock();
+    const view: SavedAnalyticsViewPayload = {
+      id: 'view_3',
+      name: 'Points by assignee',
+      scopeType: 'workspace',
+      scopeId: null,
+      kind: 'dashboard',
+      config: { kind: 'dashboard', version: 1, query, insight: savedInsight, pinned: false },
+      shared: false,
+      ownerId: 'user_1',
+      createdAt: asOf,
+      updatedAt: asOf,
+    };
+
+    render(
+      <SavedViewBar
+        canManage={false}
+        canManageAll={false}
+        currentUserId="user_1"
+        insight={insightConfigSchema.parse({})}
+        onApply={onApply}
+        query={analyticsQuerySchema.parse({})}
+        views={[view]}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Points by assignee' }));
+
+    expect(onApply).toHaveBeenCalledWith(query, savedInsight);
+  });
+});

--- a/apps/web/tests/features/analytics/scatter-plot.test.tsx
+++ b/apps/web/tests/features/analytics/scatter-plot.test.tsx
@@ -49,6 +49,23 @@ describe('ScatterPlot', () => {
     expect(tooltip).toHaveTextContent('5.1 days');
   });
 
+  test('hovering a point formats its value with the given unit label, not a hardcoded days suffix', async () => {
+    const user = userEvent.setup();
+    render(
+      <ScatterPlot
+        label="Time in review"
+        percentiles={percentiles}
+        points={points}
+        unitLabel="hours"
+      />,
+    );
+
+    await user.hover(screen.getByTestId('plot-scatter-NOV-2'));
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('5.1 hours');
+    expect(tooltip).not.toHaveTextContent('5.1 days');
+  });
+
   test('hovering a percentile line shows its exact value', async () => {
     const user = userEvent.setup();
     render(

--- a/apps/web/tests/features/analytics/scatter-plot.test.tsx
+++ b/apps/web/tests/features/analytics/scatter-plot.test.tsx
@@ -94,6 +94,29 @@ describe('ScatterPlot', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 
+  test('focuses the active anchor on the first Enter and lets a second Enter navigate', async () => {
+    const user = userEvent.setup();
+    render(<ScatterPlot label="Cycle time" percentiles={null} points={points} unitLabel="days" />);
+
+    const plot = screen.getByRole('application', { name: 'Cycle time' });
+    await user.tab();
+    expect(plot).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    const anchor = document.activeElement;
+    expect(anchor).not.toBe(plot);
+    expect(anchor?.tagName.toLowerCase()).toBe('a');
+    expect(anchor).toHaveAttribute('href', '/issue/NOV-1');
+
+    const secondEnter = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    });
+    anchor?.dispatchEvent(secondEnter);
+    expect(secondEnter.defaultPrevented).toBe(false);
+  });
+
   test('shows an empty state with no percentile lines when there are no points', () => {
     render(
       <ScatterPlot label="Cycle time" percentiles={percentiles} points={[]} unitLabel="days" />,

--- a/apps/web/tests/features/analytics/scatter-plot.test.tsx
+++ b/apps/web/tests/features/analytics/scatter-plot.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test';
+import userEvent from '@testing-library/user-event';
+import { ScatterPlot } from '../../../src/features/analytics/charts/scatter-plot.tsx';
+import { render, screen } from '../../../src/test/render.tsx';
+
+const points = [
+  { issueId: 'issue-1', identifier: 'NOV-1', title: 'Fix flaky login test', days: 2.4 },
+  { issueId: 'issue-2', identifier: 'NOV-2', title: 'Add scatterplot primitive', days: 5.1 },
+  { issueId: 'issue-3', identifier: 'NOV-3', title: 'Refactor plot guides', days: 3.8 },
+  { issueId: 'issue-4', identifier: 'NOV-4', title: 'Ship insights lens', days: 8.0 },
+] as const;
+
+const percentiles = { p25: 2.5, p50: 4.0, p75: 6.0, p95: 8.5 } as const;
+
+describe('ScatterPlot', () => {
+  test('renders one scatter hit per point', () => {
+    render(
+      <ScatterPlot label="Cycle time" percentiles={percentiles} points={points} unitLabel="days" />,
+    );
+
+    for (const point of points) {
+      expect(screen.getByTestId(`plot-scatter-${point.identifier}`)).toBeInTheDocument();
+    }
+  });
+
+  test('draws the four percentile lines with right-edge labels', () => {
+    render(
+      <ScatterPlot label="Cycle time" percentiles={percentiles} points={points} unitLabel="days" />,
+    );
+
+    expect(screen.getByTestId('plot-percentile-p25')).toBeInTheDocument();
+    expect(screen.getByTestId('plot-percentile-p50')).toBeInTheDocument();
+    expect(screen.getByTestId('plot-percentile-p75')).toBeInTheDocument();
+    expect(screen.getByTestId('plot-percentile-p95')).toBeInTheDocument();
+    expect(screen.getByText('4.0 days')).toBeInTheDocument();
+    expect(screen.getByText('8.5 days')).toBeInTheDocument();
+  });
+
+  test('hovering a point shows its identifier and formatted duration', async () => {
+    const user = userEvent.setup();
+    render(
+      <ScatterPlot label="Cycle time" percentiles={percentiles} points={points} unitLabel="days" />,
+    );
+
+    await user.hover(screen.getByTestId('plot-scatter-NOV-2'));
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('NOV-2');
+    expect(tooltip).toHaveTextContent('Add scatterplot primitive');
+    expect(tooltip).toHaveTextContent('5.1 days');
+  });
+
+  test('hovering a percentile line shows its exact value', async () => {
+    const user = userEvent.setup();
+    render(
+      <ScatterPlot label="Cycle time" percentiles={percentiles} points={points} unitLabel="days" />,
+    );
+
+    await user.hover(screen.getByTestId('plot-percentile-p75'));
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('75th percentile');
+    expect(tooltip).toHaveTextContent('6.0 days');
+  });
+
+  test('links each point at the issue route', () => {
+    render(
+      <ScatterPlot label="Cycle time" percentiles={percentiles} points={points} unitLabel="days" />,
+    );
+
+    const hit = screen.getByTestId('plot-scatter-NOV-1');
+    const anchor = hit.closest('a');
+    expect(anchor).toHaveAttribute('href', '/issue/NOV-1');
+    expect(anchor).toHaveAttribute('aria-label', 'NOV-1 Fix flaky login test');
+  });
+
+  test('walks points by rank with arrow keys, Home, End, and Escape', async () => {
+    const user = userEvent.setup();
+    render(<ScatterPlot label="Cycle time" percentiles={null} points={points} unitLabel="days" />);
+
+    const plot = screen.getByRole('application', { name: 'Cycle time' });
+    await user.tab();
+    expect(plot).toHaveFocus();
+    expect(screen.getByRole('tooltip')).toHaveTextContent('NOV-1');
+
+    await user.keyboard('{ArrowRight}');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('NOV-3');
+
+    await user.keyboard('{End}');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('NOV-4');
+
+    await user.keyboard('{Home}');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('NOV-1');
+
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  test('shows an empty state with no percentile lines when there are no points', () => {
+    render(
+      <ScatterPlot label="Cycle time" percentiles={percentiles} points={[]} unitLabel="days" />,
+    );
+
+    expect(screen.getByText('No completed issues in range yet.')).toBeInTheDocument();
+    expect(screen.queryByTestId('plot-percentile-p50')).not.toBeInTheDocument();
+    expect(screen.queryByRole('application')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/features/analytics/sprint-lens.test.tsx
+++ b/apps/web/tests/features/analytics/sprint-lens.test.tsx
@@ -3,7 +3,7 @@ import { analyticsQuerySchema } from '@orbit/shared/validators';
 import userEvent from '@testing-library/user-event';
 import type { AnalyticsSprintsResponse } from '../../../src/features/analytics/contracts.ts';
 import { SprintLens } from '../../../src/features/analytics/sprint-lens.tsx';
-import { render, screen } from '../../../src/test/render.tsx';
+import { render, screen, within } from '../../../src/test/render.tsx';
 
 const asOf = '2026-08-14T10:00:00.000Z';
 const flow = {
@@ -459,6 +459,59 @@ describe('SprintLens', () => {
 
     expect(screen.getByText('My sprint burn')).toBeVisible();
     expect(screen.getByRole('application', { name: 'Ada remaining work' })).toBeVisible();
+  });
+
+  test('frames the focus card across the whole sprint with an ideal series', () => {
+    const focusBurn = buildSprintBurn({
+      start: '2026-08-13',
+      count: 8,
+      observedCount: 5,
+      scope: 6,
+    });
+    render(
+      <SprintLens
+        data={{
+          ...data,
+          focus: {
+            personId: '00000000-0000-7000-8000-000000000009',
+            name: 'Ada',
+            burn: focusBurn,
+            summary,
+            coverage: { kind: 'captured', from: sprint.startsAt, asOf },
+          },
+        }}
+        query={analyticsQuerySchema.parse({ lens: 'sprints' })}
+      />,
+    );
+
+    const focusChart = screen.getByRole('application', { name: 'Ada remaining work' });
+    expect(within(focusChart).getAllByTestId('plot-day-hit')).toHaveLength(focusBurn.length);
+    expect(screen.getByTestId('plot-line-ideal-person')).toBeInTheDocument();
+  });
+
+  test('states the capture start on the focus card instead of a dates-unavailable fallback', () => {
+    const focusBurn = [
+      { ...burnDay1, available: false, future: false, scope: 0, remaining: 0, ideal: 8 },
+      { ...burnDay2, available: true, future: false },
+    ];
+    render(
+      <SprintLens
+        data={{
+          ...data,
+          focus: {
+            personId: '00000000-0000-7000-8000-000000000009',
+            name: 'Ada',
+            burn: focusBurn,
+            summary,
+            coverage: { kind: 'captured', from: sprint.startsAt, asOf },
+          },
+        }}
+        query={analyticsQuerySchema.parse({ lens: 'sprints' })}
+      />,
+    );
+
+    expect(screen.getByText(/capture began aug 14/i)).toBeVisible();
+    expect(screen.queryByText(/dates unavailable/i)).not.toBeInTheDocument();
   });
 
   test('labels an explicitly selected developer without calling them the current user', () => {

--- a/apps/web/tests/features/analytics/sprint-lens.test.tsx
+++ b/apps/web/tests/features/analytics/sprint-lens.test.tsx
@@ -206,10 +206,16 @@ describe('SprintLens', () => {
     expect(screen.getByText('Lead time p85')).toBeVisible();
     expect(screen.getByText('7d')).toBeVisible();
     expect(screen.getByText('Cycle time p85')).toBeVisible();
-    expect(screen.getByText(/comparison will appear after this sprint closes/i)).toBeVisible();
+    expect(screen.getByText(/velocity below already includes this sprint/i)).toBeVisible();
     expect(screen.getByText(/2 unestimated issues count as 1 point each/i)).toBeVisible();
-    expect(screen.getByTestId('plot-y-axis-label')).toHaveTextContent('Remaining points');
-    expect(screen.getByTestId('plot-x-axis-label')).toHaveTextContent('Sprint day');
+    const burnFigure = screen
+      .getByRole('application', { name: 'Sprint burn down' })
+      .closest('figure');
+    if (burnFigure === null) throw new Error('missing burn chart figure');
+    expect(within(burnFigure).getByTestId('plot-y-axis-label')).toHaveTextContent(
+      'Remaining points',
+    );
+    expect(within(burnFigure).getByTestId('plot-x-axis-label')).toHaveTextContent('Sprint day');
     expect(screen.getByText(/forecast needs at least 3 working days/i)).toBeVisible();
 
     await user.click(screen.getByRole('button', { name: 'Burn up' }));
@@ -334,7 +340,11 @@ describe('SprintLens', () => {
     );
     expect(screen.queryByTestId('plot-legend-forecast')).not.toBeInTheDocument();
 
-    await user.click(screen.getByText(/View data/));
+    const burnFigure = screen
+      .getByRole('application', { name: 'Sprint burn down' })
+      .closest('figure');
+    if (burnFigure === null) throw new Error('missing burn chart figure');
+    await user.click(within(burnFigure).getByText(/View data/));
     expect(screen.queryByRole('columnheader', { name: 'Forecast' })).not.toBeInTheDocument();
   });
 
@@ -536,6 +546,80 @@ describe('SprintLens', () => {
     expect(screen.queryByText('My sprint burn')).not.toBeInTheDocument();
     expect(screen.getByText(/assigned to Ada over this sprint/i)).toBeVisible();
     expect(screen.queryByText(/assigned to you/i)).not.toBeInTheDocument();
+  });
+
+  test('pairs planned against completed velocity per closed sprint, averages them, and appends the current sprint as an in-progress pair', async () => {
+    const user = userEvent.setup();
+    const closedSprintOne = {
+      ...sprint,
+      id: '00000000-0000-7000-8000-000000000002',
+      name: 'Sprint 2',
+      number: 2,
+    };
+    const closedSprintTwo = {
+      ...sprint,
+      id: '00000000-0000-7000-8000-000000000003',
+      name: 'Sprint 3',
+      number: 3,
+    };
+    render(
+      <SprintLens
+        data={{
+          ...data,
+          velocity: [
+            {
+              sprint: closedSprintOne,
+              planned: 10,
+              completed: 8,
+              carryover: 1,
+              coverage: 'captured',
+            },
+            {
+              sprint: closedSprintTwo,
+              planned: 12,
+              completed: 10,
+              carryover: 0,
+              coverage: 'captured',
+            },
+          ],
+        }}
+        query={sprintQueryFixture}
+      />,
+    );
+
+    expect(screen.getByTestId(`plot-category-${closedSprintOne.id}`)).toHaveTextContent('Sprint 2');
+    expect(screen.getByTestId(`plot-bar-primary-${closedSprintOne.id}`).getAttribute('fill')).toBe(
+      'var(--analytics-series-1)',
+    );
+    expect(
+      screen.getByTestId(`plot-bar-secondary-${closedSprintOne.id}`).getAttribute('fill'),
+    ).toBe('var(--color-border-strong)');
+
+    await user.hover(screen.getByTestId(`plot-bar-primary-${closedSprintOne.id}`));
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Completed');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('8 points');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Planned');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('10 points');
+
+    expect(screen.getByTestId('plot-average-line')).toBeInTheDocument();
+    expect(screen.getByText('Avg 9')).toBeVisible();
+
+    expect(screen.getByTestId('plot-pair-current')).toBeInTheDocument();
+    expect(screen.getByTestId('plot-category-current')).toHaveTextContent('Sprint 1');
+    expect(screen.getByTestId('plot-bar-primary-current')).toBeInTheDocument();
+    expect(screen.getByTestId('plot-bar-secondary-current')).toBeInTheDocument();
+
+    expect(
+      screen.queryByText('Velocity history builds as sprints complete.'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('captions the velocity chart until any sprint has closed', () => {
+    render(<SprintLens data={data} query={sprintQueryFixture} />);
+
+    expect(screen.getByTestId('plot-pair-current')).toBeInTheDocument();
+    expect(screen.queryByTestId('plot-average-line')).not.toBeInTheDocument();
+    expect(screen.getByText('Velocity history builds as sprints complete.')).toBeVisible();
   });
 
   test('shows unavailable flow honestly and explains a closed first sprint', () => {

--- a/apps/web/tests/features/analytics/sprint-lens.test.tsx
+++ b/apps/web/tests/features/analytics/sprint-lens.test.tsx
@@ -55,6 +55,11 @@ const burn = [
     future: false,
   },
 ];
+const burnDay1 = burn[0];
+const burnDay2 = burn[1];
+if (burnDay1 === undefined || burnDay2 === undefined) {
+  throw new Error('Missing burn fixture.');
+}
 const sprint = {
   id: '00000000-0000-7000-8000-000000000001',
   name: 'Sprint 1',
@@ -99,17 +104,99 @@ const data: AnalyticsSprintsResponse = {
   },
 };
 
+const sprintQueryFixture = analyticsQuerySchema.parse({ lens: 'sprints', measure: 'points' });
+
+function dayOffset(start: string, offset: number): string {
+  const value = new Date(`${start}T00:00:00.000Z`);
+  value.setUTCDate(value.getUTCDate() + offset);
+  return value.toISOString().slice(0, 10);
+}
+
+function isWeekendDate(value: string): boolean {
+  const weekday = new Date(`${value}T12:00:00.000Z`).getUTCDay();
+  return weekday === 0 || weekday === 6;
+}
+
+function buildSprintBurn(options: {
+  readonly start: string;
+  readonly count: number;
+  readonly observedCount: number;
+  readonly scope: number;
+}) {
+  let workingDay = 0;
+  return Array.from({ length: options.count }, (_unused, index) => {
+    const date = dayOffset(options.start, index);
+    const weekend = isWeekendDate(date);
+    if (!weekend) workingDay += 1;
+    const observed = index < options.observedCount;
+    const completed = observed ? index : 0;
+    return {
+      date,
+      calendarDay: index + 1,
+      workingDay: weekend ? null : workingDay,
+      scope: observed ? options.scope : 0,
+      started: observed ? completed : 0,
+      completed,
+      remaining: observed ? Math.max(0, options.scope - completed) : 0,
+      added: 0,
+      removed: 0,
+      ideal: Math.max(0, options.scope - index),
+      available: observed,
+      coverage: 'captured' as const,
+      future: !observed,
+    };
+  });
+}
+
+const dataWithFutureBurn: AnalyticsSprintsResponse = {
+  ...data,
+  current:
+    data.current === null
+      ? null
+      : {
+          ...data.current,
+          burn: buildSprintBurn({ start: '2026-08-13', count: 14, observedCount: 4, scope: 10 }),
+        },
+};
+
+const dataWithRetroBaseline: AnalyticsSprintsResponse = {
+  ...data,
+  current:
+    data.current === null
+      ? null
+      : {
+          ...data.current,
+          baseline: { date: '2026-08-14', scope: 10, retroactive: true },
+          burn: [
+            { ...burnDay1, available: false, future: false, scope: 0, remaining: 0, ideal: 10 },
+            { ...burnDay2, available: true, future: false, scope: 10 },
+          ],
+        },
+};
+
 describe('SprintLens', () => {
+  test('frames the whole sprint with weekend bands and a day tooltip', async () => {
+    const user = userEvent.setup();
+    render(<SprintLens data={dataWithFutureBurn} query={sprintQueryFixture} />);
+    expect(screen.getAllByTestId('plot-weekend-band').length).toBeGreaterThanOrEqual(4);
+    expect(screen.getAllByTestId('plot-day-hit')).toHaveLength(14);
+    await user.hover(screen.getAllByTestId('plot-day-hit')[3] as Element);
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Remaining');
+    expect(tooltip).toHaveTextContent('Ideal');
+  });
+
+  test('states the capture start once instead of blanking the frame', () => {
+    render(<SprintLens data={dataWithRetroBaseline} query={sprintQueryFixture} />);
+    expect(screen.getByText(/capture began aug 14/i)).toBeVisible();
+    expect(screen.queryByText(/dates unavailable/i)).not.toBeInTheDocument();
+  });
+
   test('shows live burn values, formulas, churn, and honest first-sprint guidance', async () => {
     const user = userEvent.setup();
-    render(
-      <SprintLens
-        data={data}
-        query={analyticsQuerySchema.parse({ lens: 'sprints', measure: 'points' })}
-      />,
-    );
+    render(<SprintLens data={data} query={sprintQueryFixture} />);
 
-    await user.hover(screen.getByTestId('plot-hit-2026-08-14-remaining'));
+    await user.hover(screen.getAllByTestId('plot-day-hit')[1] as Element);
     expect(screen.getByRole('tooltip')).toHaveTextContent('Remaining 7 points');
     expect(screen.getByText('Added').parentElement).toHaveTextContent('Added 2');
     expect(screen.getByText('Removed').parentElement).toHaveTextContent('Removed 1');
@@ -120,79 +207,37 @@ describe('SprintLens', () => {
     expect(screen.getByText('7d')).toBeVisible();
     expect(screen.getByText('Cycle time p85')).toBeVisible();
     expect(screen.getByText(/comparison will appear after this sprint closes/i)).toBeVisible();
-    expect(screen.getByText(/2 unestimated issues contribute zero points/i)).toBeVisible();
+    expect(screen.getByText(/2 unestimated issues count as 1 point each/i)).toBeVisible();
     expect(screen.getByTestId('plot-y-axis-label')).toHaveTextContent('Remaining points');
-    expect(screen.getByTestId('plot-x-axis-label')).toHaveTextContent('Sprint working day');
+    expect(screen.getByTestId('plot-x-axis-label')).toHaveTextContent('Sprint day');
     expect(screen.getByText(/forecast needs at least 3 working days/i)).toBeVisible();
 
     await user.click(screen.getByRole('button', { name: 'Burn up' }));
-    await user.hover(screen.getByTestId('plot-hit-2026-08-14-completed'));
+    await user.hover(screen.getAllByTestId('plot-day-hit')[1] as Element);
     expect(screen.getByRole('tooltip')).toHaveTextContent('Completed 3');
   });
 
-  test('does not draw pre-capture dates as zero and explains when tracking began', () => {
-    const firstBurnPoint = burn[0];
-    const secondBurnPoint = burn[1];
-    if (firstBurnPoint === undefined || secondBurnPoint === undefined) {
-      throw new Error('Missing burn fixture.');
-    }
-    const observedBurn = [
-      {
-        ...firstBurnPoint,
-        date: '2026-08-11',
-        scope: 0,
-        remaining: 0,
-        ideal: 0,
-        available: false,
-        future: false,
-      },
-      {
-        ...firstBurnPoint,
-        date: '2026-08-12',
-        scope: 0,
-        remaining: 0,
-        ideal: 0,
-        available: false,
-        future: false,
-      },
-      {
-        ...firstBurnPoint,
-        date: '2026-08-13',
-        scope: 0,
-        remaining: 0,
-        ideal: 0,
-        available: false,
-        future: false,
-      },
-      {
-        ...secondBurnPoint,
-        date: '2026-08-14',
-        scope: 194,
-        remaining: 178,
-        ideal: 194,
-        available: true,
-        future: false,
-      },
+  test('shows only the ideal target on a pre-capture day instead of a fabricated zero', async () => {
+    const user = userEvent.setup();
+    const preCaptureBurn = [
+      { ...burnDay1, available: false, future: false, scope: 0, remaining: 0, ideal: 8 },
+      { ...burnDay2, available: true, future: false },
     ];
     render(
       <SprintLens
         data={{
           ...data,
-          current: data.current === null ? null : { ...data.current, burn: observedBurn },
+          current: data.current === null ? null : { ...data.current, burn: preCaptureBurn },
         }}
-        query={analyticsQuerySchema.parse({ lens: 'sprints' })}
+        query={sprintQueryFixture}
       />,
     );
 
-    expect(screen.getByText(/tracking began aug 14, 2026/i)).toBeVisible();
-    expect(screen.getByText(/second reliable day is needed/i)).toBeVisible();
-    expect(
-      screen.getByText(/ideal line starts at the first reliable scope baseline/i),
-    ).toBeVisible();
-    expect(screen.queryByTestId('plot-point-2026-08-11-remaining')).not.toBeInTheDocument();
-    expect(screen.getByTestId('plot-point-2026-08-14-remaining')).toBeInTheDocument();
-    expect(screen.getByTestId('plot-point-sprint-end-ideal')).toBeInTheDocument();
-    expect(screen.getByTestId('plot-x-end')).toHaveTextContent('Aug 27');
+    await user.hover(screen.getAllByTestId('plot-day-hit')[0] as Element);
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Ideal');
+    expect(tooltip).not.toHaveTextContent('Remaining');
+    expect(screen.getByTestId('plot-x-end')).toHaveTextContent('Aug 14');
   });
 
   test('keeps the ideal line at zero when the sprint ends on a weekend', async () => {
@@ -203,14 +248,12 @@ describe('SprintLens', () => {
       startsAt: '2026-08-03T00:00:00.000Z',
       endsAt: '2026-08-16T00:00:00.000Z',
     };
-    const template = burn[0];
-    if (template === undefined) throw new Error('Missing burn fixture.');
     const weekendBurn = [
-      { ...template, date: '2026-08-03', calendarDay: 1, workingDay: 1, ideal: 9, future: false },
-      { ...template, date: '2026-08-13', calendarDay: 11, workingDay: 9, ideal: 1, future: false },
-      { ...template, date: '2026-08-14', calendarDay: 12, workingDay: 10, ideal: 0, future: false },
+      { ...burnDay1, date: '2026-08-03', calendarDay: 1, workingDay: 1, ideal: 9, future: false },
+      { ...burnDay1, date: '2026-08-13', calendarDay: 11, workingDay: 9, ideal: 1, future: false },
+      { ...burnDay1, date: '2026-08-14', calendarDay: 12, workingDay: 10, ideal: 0, future: false },
       {
-        ...template,
+        ...burnDay1,
         date: '2026-08-15',
         calendarDay: 13,
         workingDay: null,
@@ -228,25 +271,20 @@ describe('SprintLens', () => {
               ? null
               : { ...data.current, sprint: weekendSprint, burn: weekendBurn },
         }}
-        query={analyticsQuerySchema.parse({ lens: 'sprints', measure: 'points' })}
+        query={sprintQueryFixture}
       />,
     );
 
-    expect(screen.queryByTestId('plot-point-sprint-end-ideal')).not.toBeInTheDocument();
     expect(screen.getByTestId('plot-x-end')).toHaveTextContent('Aug 15');
-    await user.hover(screen.getByTestId('plot-hit-2026-08-15-ideal'));
+    const dayHits = screen.getAllByTestId('plot-day-hit');
+    await user.hover(dayHits.at(-1) as Element);
     expect(screen.getByRole('tooltip')).toHaveTextContent('Ideal 0 points');
   });
 
   test('adds a dotted forecast only after a measurable declining trend exists', () => {
-    const firstBurnPoint = burn[0];
-    const secondBurnPoint = burn[1];
-    if (firstBurnPoint === undefined || secondBurnPoint === undefined) {
-      throw new Error('Missing burn fixture.');
-    }
     const forecastBurn = [
       {
-        ...firstBurnPoint,
+        ...burnDay1,
         date: '2026-08-11',
         workingDay: 1,
         scope: 12,
@@ -254,7 +292,7 @@ describe('SprintLens', () => {
         future: false,
       },
       {
-        ...secondBurnPoint,
+        ...burnDay2,
         date: '2026-08-12',
         workingDay: 2,
         scope: 12,
@@ -262,7 +300,7 @@ describe('SprintLens', () => {
         future: false,
       },
       {
-        ...secondBurnPoint,
+        ...burnDay2,
         date: '2026-08-13',
         workingDay: 3,
         scope: 12,
@@ -280,9 +318,10 @@ describe('SprintLens', () => {
       />,
     );
 
-    expect(screen.getByText(/forecasts completion around working day 6/i)).toBeVisible();
+    expect(screen.getByText(/forecasts completion around aug 18, 2026/i)).toBeVisible();
     expect(screen.getByTestId('plot-line-forecast')).toHaveAttribute('stroke-dasharray', '7 5');
-    expect(screen.getByTestId('plot-line-scope')).toHaveAttribute('stroke-dasharray', '7 5');
+    expect(screen.getByTestId('plot-line-scope')).not.toHaveAttribute('stroke-dasharray');
+    expect(screen.getByTestId('plot-line-scope').getAttribute('d')).toContain('H');
   });
 
   test('does not invent velocity before any sprint exists', () => {

--- a/apps/web/tests/features/analytics/sprint-lens.test.tsx
+++ b/apps/web/tests/features/analytics/sprint-lens.test.tsx
@@ -450,7 +450,7 @@ describe('SprintLens', () => {
     );
 
     expect(screen.getByText(/forecasts completion around aug 18, 2026/i)).toBeVisible();
-    expect(screen.getByText('Aug 18, 2026 · 1 days late')).toBeVisible();
+    expect(screen.getByText('Aug 18, 2026 · 1 day late')).toBeVisible();
 
     const dayHits = screen.getAllByTestId('plot-day-hit');
     expect(dayHits).toHaveLength(7);

--- a/apps/web/tests/features/analytics/sprint-lens.test.tsx
+++ b/apps/web/tests/features/analytics/sprint-lens.test.tsx
@@ -324,6 +324,110 @@ describe('SprintLens', () => {
     expect(screen.getByTestId('plot-line-scope').getAttribute('d')).toContain('H');
   });
 
+  test('omits an unearned forecast entirely instead of a blank legend entry and table column', async () => {
+    const user = userEvent.setup();
+    render(<SprintLens data={data} query={sprintQueryFixture} />);
+
+    expect(screen.getByTestId('plot-line-scope')).toHaveAttribute(
+      'stroke',
+      'var(--analytics-series-4)',
+    );
+    expect(screen.queryByTestId('plot-legend-forecast')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText(/View data/));
+    expect(screen.queryByRole('columnheader', { name: 'Forecast' })).not.toBeInTheDocument();
+  });
+
+  test('clamps a far forecast to the frame edge with an interpolated value', async () => {
+    const user = userEvent.setup();
+    const forecastBurn = [
+      {
+        ...burnDay1,
+        date: '2026-08-11',
+        workingDay: 1,
+        scope: 12,
+        remaining: 10,
+        ideal: 12,
+        future: false,
+      },
+      {
+        ...burnDay2,
+        date: '2026-08-12',
+        workingDay: 2,
+        scope: 12,
+        remaining: 8,
+        ideal: 9,
+        future: false,
+      },
+      {
+        ...burnDay2,
+        date: '2026-08-13',
+        workingDay: 3,
+        scope: 12,
+        remaining: 6,
+        ideal: 6,
+        future: false,
+      },
+      {
+        ...burnDay2,
+        date: '2026-08-14',
+        workingDay: 4,
+        scope: 0,
+        remaining: 0,
+        ideal: 3,
+        available: false,
+        future: true,
+      },
+      {
+        ...burnDay2,
+        date: '2026-08-15',
+        workingDay: null,
+        scope: 0,
+        remaining: 0,
+        ideal: 3,
+        available: false,
+        future: true,
+      },
+      {
+        ...burnDay2,
+        date: '2026-08-16',
+        workingDay: null,
+        scope: 0,
+        remaining: 0,
+        ideal: 3,
+        available: false,
+        future: true,
+      },
+      {
+        ...burnDay2,
+        date: '2026-08-17',
+        workingDay: 5,
+        scope: 0,
+        remaining: 0,
+        ideal: 0,
+        available: false,
+        future: true,
+      },
+    ];
+    render(
+      <SprintLens
+        data={{
+          ...data,
+          current: data.current === null ? null : { ...data.current, burn: forecastBurn },
+        }}
+        query={analyticsQuerySchema.parse({ lens: 'sprints' })}
+      />,
+    );
+
+    expect(screen.getByText(/forecasts completion around aug 18, 2026/i)).toBeVisible();
+    expect(screen.getByText('Aug 18, 2026 · 1 days late')).toBeVisible();
+
+    const dayHits = screen.getAllByTestId('plot-day-hit');
+    expect(dayHits).toHaveLength(7);
+    await user.hover(dayHits.at(-1) as Element);
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Forecast 1.2 points');
+  });
+
   test('does not invent velocity before any sprint exists', () => {
     render(
       <SprintLens

--- a/apps/web/tests/features/analytics/sprint-lens.test.tsx
+++ b/apps/web/tests/features/analytics/sprint-lens.test.tsx
@@ -37,6 +37,7 @@ const burn = [
     ideal: 8,
     available: true,
     coverage: 'captured' as const,
+    future: false,
   },
   {
     date: '2026-08-14',
@@ -51,6 +52,7 @@ const burn = [
     ideal: 7,
     available: true,
     coverage: 'live' as const,
+    future: false,
   },
 ];
 const sprint = {
@@ -71,6 +73,8 @@ const data: AnalyticsSprintsResponse = {
     sprint,
     measure: 'points',
     summary,
+    baseline: { date: '2026-08-13', scope: 9, retroactive: false },
+    counterpart: summary,
     scopeChanges: { added: 2, removed: 1 },
     burn,
     cohorts: { planned: [], added: [], removed: [], completed: [], incomplete: [], carryover: [] },
@@ -133,9 +137,33 @@ describe('SprintLens', () => {
       throw new Error('Missing burn fixture.');
     }
     const observedBurn = [
-      { ...firstBurnPoint, date: '2026-08-11', scope: 0, remaining: 0, ideal: 0, available: false },
-      { ...firstBurnPoint, date: '2026-08-12', scope: 0, remaining: 0, ideal: 0, available: false },
-      { ...firstBurnPoint, date: '2026-08-13', scope: 0, remaining: 0, ideal: 0, available: false },
+      {
+        ...firstBurnPoint,
+        date: '2026-08-11',
+        scope: 0,
+        remaining: 0,
+        ideal: 0,
+        available: false,
+        future: false,
+      },
+      {
+        ...firstBurnPoint,
+        date: '2026-08-12',
+        scope: 0,
+        remaining: 0,
+        ideal: 0,
+        available: false,
+        future: false,
+      },
+      {
+        ...firstBurnPoint,
+        date: '2026-08-13',
+        scope: 0,
+        remaining: 0,
+        ideal: 0,
+        available: false,
+        future: false,
+      },
       {
         ...secondBurnPoint,
         date: '2026-08-14',
@@ -143,6 +171,7 @@ describe('SprintLens', () => {
         remaining: 178,
         ideal: 194,
         available: true,
+        future: false,
       },
     ];
     render(
@@ -177,10 +206,17 @@ describe('SprintLens', () => {
     const template = burn[0];
     if (template === undefined) throw new Error('Missing burn fixture.');
     const weekendBurn = [
-      { ...template, date: '2026-08-03', calendarDay: 1, workingDay: 1, ideal: 9 },
-      { ...template, date: '2026-08-13', calendarDay: 11, workingDay: 9, ideal: 1 },
-      { ...template, date: '2026-08-14', calendarDay: 12, workingDay: 10, ideal: 0 },
-      { ...template, date: '2026-08-15', calendarDay: 13, workingDay: null, ideal: 0 },
+      { ...template, date: '2026-08-03', calendarDay: 1, workingDay: 1, ideal: 9, future: false },
+      { ...template, date: '2026-08-13', calendarDay: 11, workingDay: 9, ideal: 1, future: false },
+      { ...template, date: '2026-08-14', calendarDay: 12, workingDay: 10, ideal: 0, future: false },
+      {
+        ...template,
+        date: '2026-08-15',
+        calendarDay: 13,
+        workingDay: null,
+        ideal: 0,
+        future: false,
+      },
     ];
     render(
       <SprintLens
@@ -209,9 +245,30 @@ describe('SprintLens', () => {
       throw new Error('Missing burn fixture.');
     }
     const forecastBurn = [
-      { ...firstBurnPoint, date: '2026-08-11', workingDay: 1, scope: 12, remaining: 10 },
-      { ...secondBurnPoint, date: '2026-08-12', workingDay: 2, scope: 12, remaining: 8 },
-      { ...secondBurnPoint, date: '2026-08-13', workingDay: 3, scope: 12, remaining: 6 },
+      {
+        ...firstBurnPoint,
+        date: '2026-08-11',
+        workingDay: 1,
+        scope: 12,
+        remaining: 10,
+        future: false,
+      },
+      {
+        ...secondBurnPoint,
+        date: '2026-08-12',
+        workingDay: 2,
+        scope: 12,
+        remaining: 8,
+        future: false,
+      },
+      {
+        ...secondBurnPoint,
+        date: '2026-08-13',
+        workingDay: 3,
+        scope: 12,
+        remaining: 6,
+        future: false,
+      },
     ];
     render(
       <SprintLens

--- a/apps/web/tests/features/analytics/sprint-lens.test.tsx
+++ b/apps/web/tests/features/analytics/sprint-lens.test.tsx
@@ -608,6 +608,12 @@ describe('SprintLens', () => {
     expect(screen.getByTestId('plot-category-current')).toHaveTextContent('Sprint 1');
     expect(screen.getByTestId('plot-bar-primary-current')).toBeInTheDocument();
     expect(screen.getByTestId('plot-bar-secondary-current')).toBeInTheDocument();
+    expect(screen.getByTestId('plot-bar-primary-current').getAttribute('fill-opacity')).toBe(
+      '0.45',
+    );
+    expect(
+      screen.getByTestId(`plot-bar-primary-${closedSprintOne.id}`).getAttribute('fill-opacity'),
+    ).toBeNull();
 
     expect(
       screen.queryByText('Velocity history builds as sprints complete.'),

--- a/apps/web/tests/features/analytics/sprint-lens.test.tsx
+++ b/apps/web/tests/features/analytics/sprint-lens.test.tsx
@@ -223,6 +223,26 @@ describe('SprintLens', () => {
     expect(screen.getByRole('tooltip')).toHaveTextContent('Completed 3');
   });
 
+  test('shows the burn-up Started tooltip and table with the raw started count while the line still plots the stacked height', async () => {
+    const user = userEvent.setup();
+    render(<SprintLens data={data} query={sprintQueryFixture} />);
+
+    await user.click(screen.getByRole('button', { name: 'Burn up' }));
+    await user.hover(screen.getAllByTestId('plot-day-hit')[1] as Element);
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Started 6 points');
+    expect(tooltip).not.toHaveTextContent('Started 9 points');
+
+    const burnFigure = screen
+      .getByRole('application', { name: 'Sprint burn up' })
+      .closest('figure');
+    if (burnFigure === null) throw new Error('missing burn chart figure');
+    await user.click(within(burnFigure).getByText(/View data/));
+    expect(within(burnFigure).getByRole('cell', { name: '6 points' })).toBeVisible();
+
+    expect(screen.getByTestId('plot-line-started').getAttribute('d')).toContain('34.40');
+  });
+
   test('shows only the ideal target on a pre-capture day instead of a fabricated zero', async () => {
     const user = userEvent.setup();
     const preCaptureBurn = [

--- a/apps/web/tests/features/analytics/sprint-stats.test.tsx
+++ b/apps/web/tests/features/analytics/sprint-stats.test.tsx
@@ -194,4 +194,21 @@ describe('SprintStats', () => {
     expect(screen.getByText('Pace')).toHaveTextContent('Pace Not enough data');
     expect(screen.getByText('Forecast')).toHaveTextContent('Forecast needs 3 working days');
   });
+
+  test('uses singular day wording for a forecast that lands exactly one day late', () => {
+    const oneDayLateBurn = [
+      observedDay1,
+      observedDay2,
+      observedDay3,
+      observedDay4,
+      futurePoint('2026-08-07', 5, 5),
+      futurePoint('2026-08-10', 6, 6),
+      futurePoint('2026-08-11', 7, 7),
+      futurePoint('2026-08-12', 8, 8),
+    ];
+    render(<SprintStats current={{ ...current, burn: oneDayLateBurn }} measure="issues" />);
+
+    const forecastValue = screen.getByText('Aug 13, 2026 · 1 day late');
+    expect(forecastValue).toHaveClass('text-warning');
+  });
 });

--- a/apps/web/tests/features/analytics/sprint-stats.test.tsx
+++ b/apps/web/tests/features/analytics/sprint-stats.test.tsx
@@ -1,0 +1,197 @@
+import { describe, expect, test } from 'bun:test';
+import type { AnalyticsSprintsResponse } from '../../../src/features/analytics/contracts.ts';
+import { SprintStats } from '../../../src/features/analytics/sprint-stats.tsx';
+import { render, screen } from '../../../src/test/render.tsx';
+
+const asOf = '2026-08-14T10:00:00.000Z';
+const flow = {
+  leadTime: { count: 3, p50: 4, p85: 7, min: 2, max: 8, average: 4.5 },
+  cycleTime: { count: 3, p50: 2, p85: 3, min: 1, max: 4, average: 2.2 },
+  completed: 3,
+  leadTimeCoverage: 'current-row' as const,
+  cycleTimeCoverage: 'current-column' as const,
+};
+const summary = {
+  planned: 20,
+  currentScope: 21,
+  completed: 10,
+  remaining: 11,
+  added: 2,
+  removed: 1,
+  carryover: 0,
+  unestimated: 0,
+};
+const counterpart = {
+  planned: 50,
+  currentScope: 55,
+  completed: 24,
+  remaining: 31,
+  added: 5,
+  removed: 2,
+  carryover: 0,
+  unestimated: 0,
+};
+
+const observedDay1 = {
+  date: '2026-08-03',
+  calendarDay: 1,
+  workingDay: 1,
+  scope: 20,
+  started: 2,
+  completed: 0,
+  remaining: 20,
+  added: 0,
+  removed: 0,
+  ideal: 20,
+  available: true,
+  coverage: 'captured' as const,
+  future: false,
+};
+const observedDay2 = {
+  date: '2026-08-04',
+  calendarDay: 2,
+  workingDay: 2,
+  scope: 20,
+  started: 5,
+  completed: 2,
+  remaining: 18,
+  added: 0,
+  removed: 0,
+  ideal: 15,
+  available: true,
+  coverage: 'captured' as const,
+  future: false,
+};
+const observedDay3 = {
+  date: '2026-08-05',
+  calendarDay: 3,
+  workingDay: 3,
+  scope: 22,
+  started: 9,
+  completed: 6,
+  remaining: 16,
+  added: 2,
+  removed: 0,
+  ideal: 10,
+  available: true,
+  coverage: 'captured' as const,
+  future: false,
+};
+const observedDay4 = {
+  date: '2026-08-06',
+  calendarDay: 4,
+  workingDay: 4,
+  scope: 21,
+  started: 12,
+  completed: 10,
+  remaining: 11,
+  added: 0,
+  removed: 1,
+  ideal: 5,
+  available: true,
+  coverage: 'live' as const,
+  future: false,
+};
+const futurePoint = (date: string, calendarDay: number, workingDay: number | null) => ({
+  date,
+  calendarDay,
+  workingDay,
+  scope: 0,
+  started: 0,
+  completed: 0,
+  remaining: 0,
+  added: 0,
+  removed: 0,
+  ideal: 0,
+  available: false,
+  coverage: 'live' as const,
+  future: true,
+});
+
+const burn = [
+  observedDay1,
+  observedDay2,
+  observedDay3,
+  observedDay4,
+  futurePoint('2026-08-07', 5, 5),
+];
+
+const sprint = {
+  id: '00000000-0000-7000-8000-000000000001',
+  name: 'Sprint 1',
+  number: 1,
+  teamId: null,
+  timezone: 'UTC',
+  startsAt: '2026-08-03T00:00:00.000Z',
+  endsAt: '2026-08-08T00:00:00.000Z',
+  completedAt: null,
+  archivedAt: null,
+};
+const person = {
+  personId: '00000000-0000-7000-8000-000000000009',
+  name: 'Ada',
+  burn,
+  summary,
+  coverage: { kind: 'captured' as const, from: sprint.startsAt, asOf },
+};
+const current: NonNullable<AnalyticsSprintsResponse['current']> = {
+  sprint,
+  measure: 'issues',
+  summary,
+  baseline: { date: '2026-08-03', scope: 20, retroactive: false },
+  counterpart,
+  scopeChanges: { added: 2, removed: 1 },
+  burn,
+  cohorts: { planned: [], added: [], removed: [], completed: [], incomplete: [], carryover: [] },
+  teams: [],
+  people: Array.from({ length: 9 }, (_, index) => ({
+    ...person,
+    personId: `00000000-0000-7000-8000-00000000000${index}`,
+    name: `Person ${index}`,
+  })),
+  flow,
+  coverage: { kind: 'captured', from: sprint.startsAt, asOf },
+};
+
+describe('SprintStats', () => {
+  test('renders both measures in scope, computed percentages, pace, people, and a late forecast', () => {
+    render(<SprintStats current={current} measure="issues" />);
+
+    expect(screen.getByText('Scope')).toHaveTextContent('Scope 21 issues · 55 pts');
+    expect(screen.getByText('Completed')).toHaveTextContent('Completed 10 (48%)');
+    expect(screen.getByText('Started')).toHaveTextContent('Started 12 (57%)');
+    expect(screen.getByText('Remaining')).toHaveTextContent('Remaining 11');
+    expect(screen.getByText('Churn')).toHaveTextContent('Churn +2 added · 1 removed');
+    expect(screen.getByText('Pace')).toHaveTextContent('Pace needed 5.5/d · actual 2.5/d');
+    expect(screen.getByText('People')).toHaveTextContent('People 9 people');
+
+    const forecastValue = screen.getByText('Aug 13, 2026 · 6 days late');
+    expect(forecastValue).toHaveClass('text-warning');
+  });
+
+  test('shows an on-track forecast in the accent color when it lands inside the sprint', () => {
+    const onTrackBurn = [
+      observedDay1,
+      observedDay2,
+      observedDay3,
+      observedDay4,
+      futurePoint('2026-08-07', 5, 5),
+      futurePoint('2026-08-10', 6, 6),
+      futurePoint('2026-08-11', 7, 7),
+      futurePoint('2026-08-12', 8, 8),
+      futurePoint('2026-08-13', 9, 9),
+    ];
+    render(<SprintStats current={{ ...current, burn: onTrackBurn }} measure="issues" />);
+
+    const forecastValue = screen.getByText('Aug 13, 2026 · on track');
+    expect(forecastValue).toHaveClass('text-accent');
+  });
+
+  test('shows the pace fallback and forecast fallback when history is insufficient', () => {
+    const sparseBurn = [futurePoint('2026-08-07', 5, 5)];
+    render(<SprintStats current={{ ...current, burn: sparseBurn }} measure="issues" />);
+
+    expect(screen.getByText('Pace')).toHaveTextContent('Pace Not enough data');
+    expect(screen.getByText('Forecast')).toHaveTextContent('Forecast needs 3 working days');
+  });
+});

--- a/apps/web/tests/lib/use-measured-width.test.tsx
+++ b/apps/web/tests/lib/use-measured-width.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { useMeasuredWidth } from '../../src/lib/use-measured-width.ts';
+
+describe('useMeasuredWidth', () => {
+  it('returns the fallback width when ResizeObserver is not available', () => {
+    function TestComponent() {
+      const { ref, width } = useMeasuredWidth(640);
+      return <div ref={ref}>{width}</div>;
+    }
+
+    const { container } = render(<TestComponent />);
+    const element = container.querySelector('div');
+    expect(element?.textContent).toBe('640');
+  });
+
+  it('attaches ref to the div element', () => {
+    function TestComponent() {
+      const { ref } = useMeasuredWidth();
+      return <div ref={ref} data-testid="measured-div" />;
+    }
+
+    render(<TestComponent />);
+    const element = screen.getByTestId('measured-div');
+    expect(element).toBeInstanceOf(HTMLDivElement);
+  });
+});

--- a/docs/superpowers/plans/2026-08-15-sprint-analytics-redesign.md
+++ b/docs/superpowers/plans/2026-08-15-sprint-analytics-redesign.md
@@ -1,0 +1,1062 @@
+# Sprint Analytics Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the sprint burn experience to Linear cycle-graph quality (native-scale charts, full-span ideal, forecast, pace stats, retroactive baseline) and add a Measure by Slice by Segment insights lens, both in one pull request.
+
+**Architecture:** Phase 1 changes `burnFor` in core to emit a full-span series with a retroactive baseline, future ideal-only points, and a counterpart-measure summary, then rebuilds the two SVG chart primitives to render at measured native pixel size with a calendar-day domain. Phase 2 adds an `insights` lens: one core aggregation function compiled from the existing workspace analytics predicate, new drilldown cohorts for the new slice dimensions, a scatterplot primitive with percentile lines, and stacked segments in the bar primitive.
+
+**Tech Stack:** Bun 1.3+, TypeScript 5.9, Next.js 16 App Router, React 19, PostgreSQL, Drizzle ORM, Zod 4, TanStack Query 5, Bun test, Testing Library, Playwright.
+
+## Global Constraints
+
+- Use Bun only. No npm, pnpm, yarn, turbo.
+- Shipped web and core code runs on Node and must not import Bun built-ins.
+- No code comments except functional directives accepted by `bun run check-comments`.
+- No em-dash characters in code, docs, commits, branch names, or pull request text.
+- No AI attribution anywhere.
+- Strict types: no `any`, no non-null assertions, Zod parsing for every external input.
+- Tests live in each package's `tests/` tree, import from `bun:test`, and mirror `src/` layout.
+- Database-backed test commands use `ORBIT_TEST_LANE=analytics-redesign`.
+- Charts stay hand-rolled SVG: no chart library. Colors only through CSS custom properties (`var(--analytics-series-N)`, surface and border tokens). Motion transform and opacity only.
+- The PR 313 regression suite must stay green in meaning: weekend ideal reaches zero, half-open sprint boundary, bootstrap capture excluded from churn. Expectation values may change where this spec redefines the ideal line; the properties may not.
+- The approved design is `docs/superpowers/specs/2026-08-15-sprint-analytics-redesign-design.md`.
+- Branch: `analytics-insights-redesign`. Small scoped commits, imperative subjects.
+
+---
+
+## File structure map
+
+### Phase 1: server
+
+- Modify `packages/core/src/analytics/sprints.ts`: `SprintBurnPoint.future`, retroactive ideal from day 1, future points through sprint end, baseline object, planned adoption, counterpart summary, points valuation.
+- Modify `packages/core/tests/analytics/sprints.test.ts`: updated expectations plus new baseline and future-point tests.
+- Modify `packages/core/tests/analytics/burndown.test.ts` only if ideal expectations shift.
+
+### Phase 1: web
+
+- Create `apps/web/src/lib/use-measured-width.ts`: ResizeObserver width hook.
+- Create `apps/web/src/features/analytics/burn-math.ts`: pace, forecast date, day-domain helpers (pure, unit-tested).
+- Rewrite `apps/web/src/features/analytics/charts/line-plot.tsx`: native scale, day domain, weekend tint, day-snap tooltip, pivoted table rows.
+- Modify `apps/web/src/features/analytics/charts/plot-guides.tsx`, `plot-frame.tsx`, `chart-tooltip.tsx` as the new geometry requires.
+- Modify `apps/web/src/features/analytics/charts/bar-plot.tsx`: native scale, grouped pairs, average marker.
+- Create `apps/web/src/features/analytics/sprint-stats.tsx`: the stat strip.
+- Modify `apps/web/src/features/analytics/sprint-lens.tsx`, `people-lens.tsx`, `contracts.ts`.
+- Tests under `apps/web/tests/features/analytics/` and `apps/web/tests/lib/`.
+
+### Phase 2
+
+- Modify `packages/shared/src/validators/analytics.ts`: insight constants and schemas, `insights` lens.
+- Modify `packages/core/src/analytics/drilldown.ts`: cohorts for assignee, label, sprint, created-week, completed-week.
+- Create `packages/core/src/analytics/insights.ts` and `packages/core/tests/analytics/insights.test.ts`.
+- Create `apps/web/src/app/api/analytics/insights/route.ts` and its test.
+- Create `apps/web/src/features/analytics/charts/scatter-plot.tsx` and test.
+- Create `apps/web/src/features/analytics/insights-lens.tsx` and test.
+- Modify `analytics-tabs.tsx`, `data.ts`, `contracts.ts`, `analytics-keys.ts`, `query-state.ts`, `page.tsx`.
+- Modify `apps/web/e2e/analytics.spec.ts`.
+
+---
+
+### Task 1: Retroactive baseline and full-span burn series in core
+
+**Files:**
+- Modify: `packages/core/src/analytics/sprints.ts`
+- Test: `packages/core/tests/analytics/sprints.test.ts`
+
+**Interfaces:**
+- Consumes: existing `burnFor`, `summaryFor`, `detailFor`, `idealRemaining`, `workingDaysBetween`, `dateText`, `addDate`, `isWorkingDay`.
+- Produces: `SprintBurnPoint` gains `readonly future: boolean`; `SprintDetail` gains `readonly baseline: SprintBaseline | null` and `readonly counterpart: SprintMeasureSummary` where `SprintBaseline = { readonly date: string; readonly scope: number; readonly retroactive: boolean }`. Points valuation counts unestimated as 1. The sprint `formulas().points` text becomes `Unestimated work counts as 1 point until estimated.`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/core/tests/analytics/sprints.test.ts`:
+
+```ts
+it('extends the burn with ideal-only future points through sprint end', async () => {
+  const cycleId = await cycle(1, '2026-08-11T00:00:00.000Z', '2026-08-25T00:00:00.000Z');
+  const issueId = await insertIssue(workspace, {
+    number: 1,
+    state: 'Todo',
+    cycleId,
+    createdAt: new Date('2026-08-01T00:00:00.000Z'),
+  });
+  await membership(cycleId, issueId, {
+    addedAt: '2026-08-14T07:00:00.000Z',
+    coverage: 'observed',
+    entryKind: 'bootstrap',
+  });
+
+  const result = await loadSprintAnalytics(workspace.admin, sprintQuery(cycleId), {
+    now: new Date('2026-08-14T12:00:00.000Z'),
+  });
+  const burn = currentOf(result).burn;
+  const past = burn.filter((point) => !point.future);
+  const future = burn.filter((point) => point.future);
+
+  expect(burn.at(-1)?.date).toBe('2026-08-24');
+  expect(past.map((point) => point.date).at(-1)).toBe('2026-08-14');
+  expect(future.every((point) => point.scope === 0 && point.remaining === 0)).toBe(true);
+  expect(future.at(-1)?.ideal).toBe(0);
+});
+
+it('draws the ideal from day 1 at the retroactive baseline scope', async () => {
+  const cycleId = await cycle(1, '2026-08-11T00:00:00.000Z', '2026-08-25T00:00:00.000Z');
+  const issueId = await insertIssue(workspace, {
+    number: 1,
+    state: 'Todo',
+    cycleId,
+    createdAt: new Date('2026-08-01T00:00:00.000Z'),
+  });
+  await membership(cycleId, issueId, {
+    addedAt: '2026-08-14T07:00:00.000Z',
+    coverage: 'observed',
+    entryKind: 'bootstrap',
+  });
+
+  const result = await loadSprintAnalytics(workspace.admin, sprintQuery(cycleId), {
+    now: new Date('2026-08-14T12:00:00.000Z'),
+  });
+  const burn = currentOf(result).burn;
+
+  expect(burn[0]?.ideal).toBe(1);
+  expect(burn[3]?.ideal).toBeCloseTo(6 / 9, 5);
+  expect(currentOf(result).baseline).toEqual({
+    date: '2026-08-14',
+    scope: 1,
+    retroactive: true,
+  });
+  expect(currentOf(result).summary.planned).toBe(1);
+});
+
+it('reports the counterpart measure summary alongside the requested one', async () => {
+  const cycleId = await cycle(1, '2026-08-11T00:00:00.000Z', '2026-08-25T00:00:00.000Z');
+  const estimated = await insertIssue(workspace, {
+    number: 1,
+    state: 'Todo',
+    cycleId,
+    estimate: 5,
+    createdAt: new Date('2026-08-01T00:00:00.000Z'),
+  });
+  const unestimated = await insertIssue(workspace, {
+    number: 2,
+    state: 'Todo',
+    cycleId,
+    createdAt: new Date('2026-08-01T00:00:00.000Z'),
+  });
+  await membership(cycleId, estimated, { addedAt: '2026-08-11T00:00:00.000Z', estimate: 5 });
+  await membership(cycleId, unestimated, { addedAt: '2026-08-11T00:00:00.000Z' });
+
+  const result = await loadSprintAnalytics(workspace.admin, sprintQuery(cycleId), {
+    now: new Date('2026-08-12T12:00:00.000Z'),
+  });
+
+  expect(currentOf(result).summary.currentScope).toBe(2);
+  expect(currentOf(result).counterpart.currentScope).toBe(6);
+  expect(result.formulas.points).toContain('counts as 1 point');
+});
+```
+
+The counterpart expectation encodes the new points valuation: 5 estimated plus 1 default for the unestimated issue.
+
+- [ ] **Step 2: Run and confirm the new tests fail**
+
+Run: `cd packages/core && ORBIT_TEST_LANE=analytics-redesign bun --env-file=../../.env test tests/analytics/sprints.test.ts`
+
+Expected: FAIL on `future`, `baseline`, `counterpart` being undefined.
+
+- [ ] **Step 3: Implement in `sprints.ts`**
+
+1. Extend the interfaces:
+
+```ts
+export interface SprintBurnPoint {
+  readonly date: string;
+  readonly calendarDay: number;
+  readonly workingDay: number | null;
+  readonly scope: number;
+  readonly started: number;
+  readonly completed: number;
+  readonly remaining: number;
+  readonly added: number;
+  readonly removed: number;
+  readonly ideal: number;
+  readonly available: boolean;
+  readonly future: boolean;
+  readonly coverage: AnalyticsCoverage['kind'];
+}
+
+export interface SprintBaseline {
+  readonly date: string;
+  readonly scope: number;
+  readonly retroactive: boolean;
+}
+```
+
+`SprintDetail` gains `readonly baseline: SprintBaseline | null;` and `readonly counterpart: SprintMeasureSummary;`.
+
+2. In `valueAt`, change the points fallback from `?? 0` to `?? 1`.
+
+3. In `burnFor`, after the existing loop over observed days, append future days: starting at `addDate(lastDay, 1)` through `sprintFinalDay` (already computed), push a point per calendar day with `scope: 0, started: 0, completed: 0, remaining: 0, added: 0, removed: 0, available: false, future: true`, `calendarDay` continuing the count, `workingDay` via the existing working-day logic. Existing observed points get `future: false`.
+
+4. Replace the ideal mapping. The baseline stays the first available point, but the trajectory anchors at day 1:
+
+```ts
+const baseline = points.find((point) => point.available && !point.future);
+const initialScope = baseline?.scope ?? 0;
+const plannedWorkingDays = Math.max(1, workingDaysBetween(startDay, sprintFinalDay));
+return points.map((point) => ({
+  ...point,
+  ideal: idealRemaining(
+    initialScope,
+    workingDaysBetween(startDay, point.date) - 1,
+    plannedWorkingDays - 1,
+  ),
+}));
+```
+
+Every point gets an ideal, including pre-capture and future days. Weekends inherit the previous working day's value because `workingDaysBetween` does not advance on them, which is the flat-weekend behavior.
+
+5. In `detailFor`, compute the baseline and counterpart:
+
+```ts
+const baselinePoint = burn.find((point) => point.available && !point.future);
+const capturedPlanned = cohortsPlannedValue;
+const baseline =
+  baselinePoint === undefined
+    ? null
+    : {
+        date: baselinePoint.date,
+        scope: baselinePoint.scope,
+        retroactive: capturedPlanned === 0 && baselinePoint.scope > 0,
+      };
+const otherMeasure = measure === 'issues' ? ('points' as const) : ('issues' as const);
+const counterpartBurn = burnFor(facts, otherMeasure, now, null);
+const counterpart = summaryFor(facts, counterpartBurn, cohorts, otherMeasure, now, null);
+```
+
+where `cohortsPlannedValue` is the existing `sumCohort(cohorts.planned)` result surfaced from `summaryFor`. The cleanest cut: give `summaryFor` an options argument `{ baselineScope: number | null }` and inside it set `planned: captured > 0 ? captured : (baselineScope ?? 0)`. `detailFor` passes the team baseline for the team summary and each person's own first available burn scope for person summaries.
+
+6. Update `formulas()`: `points: 'Unestimated work counts as 1 point until estimated.'` and extend the `burn` text with `The ideal line starts at sprint day 1 using the first reliable scope baseline and holds flat over weekends.`
+
+7. Fix the existing expectations this intentionally changes:
+   - `marks dates before observed membership capture as unavailable`: the series now runs to sprint end; assert on `burn.filter((point) => !point.future)` for the availability array, change `burn[3]?.ideal` to `toBeCloseTo(6 / 9, 5)`, and drop the assertion that unavailable ideals are 0 in favor of `burn[0]?.ideal` being the baseline scope.
+   - Any burndown test that consumed trailing ideal values shifts the same way; `cycleBurndown` reads `point.ideal` from the series so its reference expectations may need the day-1 anchor values.
+
+- [ ] **Step 4: Run the suite**
+
+Run: `cd packages/core && ORBIT_TEST_LANE=analytics-redesign bun --env-file=../../.env test tests/analytics/`
+
+Expected: PASS, including the untouched weekend-zero, half-open boundary, and bootstrap churn tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/analytics/sprints.ts packages/core/tests/analytics/sprints.test.ts packages/core/tests/analytics/burndown.test.ts
+git commit -m "feat(analytics): anchor sprint burn on a retroactive baseline"
+```
+
+### Task 2: Web contracts for the new burn shape
+
+**Files:**
+- Modify: `apps/web/src/features/analytics/contracts.ts`
+- Modify: `apps/web/tests/features/analytics/sprint-lens.test.tsx`, `people-lens.test.tsx` (fixtures only in this task)
+
+**Interfaces:**
+- Consumes: Task 1's `future`, `baseline`, `counterpart`.
+- Produces: `sprintBurnPointSchema` gains `future: z.boolean()`; the sprint detail schema gains `baseline: z.object({ date: z.iso.date(), scope: z.number(), retroactive: z.boolean() }).nullable()` and `counterpart: sprintMeasureSummarySchema`. Fixture burn points across web tests carry `future: false`.
+
+- [ ] **Step 1: Extend the Zod schemas** in `contracts.ts` exactly as above, next to `sprintBurnPointSchema` (line 96).
+
+- [ ] **Step 2: Update every web fixture** that builds burn points (`sprint-lens.test.tsx`, `people-lens.test.tsx`) to add `future: false`, and give the sprint fixtures `baseline: { date: '2026-08-13', scope: 9, retroactive: false }` and a `counterpart` mirroring `summary`.
+
+- [ ] **Step 3: Typecheck and run the web analytics tests**
+
+Run: `cd apps/web && bun run typecheck && ORBIT_TEST_LANE=analytics-redesign bun --env-file=../../.env test tests/features/analytics/`
+
+Expected: PASS. The UI does not consume the fields yet.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/features/analytics/contracts.ts apps/web/tests/features/analytics/
+git commit -m "feat(analytics): carry baseline and future points in the wire contract"
+```
+
+### Task 3: Native-width hook and burn math helpers
+
+**Files:**
+- Create: `apps/web/src/lib/use-measured-width.ts`
+- Create: `apps/web/src/features/analytics/burn-math.ts`
+- Test: `apps/web/tests/lib/use-measured-width.test.tsx`, `apps/web/tests/features/analytics/burn-math.test.ts`
+
+**Interfaces:**
+- Produces:
+
+```ts
+export function useMeasuredWidth(fallback?: number): {
+  readonly ref: RefObject<HTMLDivElement | null>;
+  readonly width: number;
+};
+
+export interface SprintDay {
+  readonly date: string;
+  readonly weekend: boolean;
+  readonly today: boolean;
+  readonly future: boolean;
+}
+export function sprintDays(burn: readonly BurnPointLike[], today: string): readonly SprintDay[];
+export function neededPace(remaining: number, burn: readonly BurnPointLike[]): number | null;
+export function actualPace(burn: readonly BurnPointLike[]): number | null;
+export function forecastDate(
+  burn: readonly BurnPointLike[],
+  completionWorkingDay: number,
+): string | null;
+```
+
+with `BurnPointLike = Pick<SprintBurnPoint, 'date' | 'workingDay' | 'available' | 'future' | 'completed' | 'remaining'>`.
+
+- [ ] **Step 1: Write the failing math tests**
+
+```ts
+import { describe, expect, test } from 'bun:test';
+import {
+  actualPace,
+  forecastDate,
+  neededPace,
+  sprintDays,
+} from '../../../src/features/analytics/burn-math.ts';
+
+const point = (
+  date: string,
+  workingDay: number | null,
+  extra: Partial<{ available: boolean; future: boolean; completed: number; remaining: number }> = {},
+) => ({
+  date,
+  workingDay,
+  available: extra.available ?? true,
+  future: extra.future ?? false,
+  completed: extra.completed ?? 0,
+  remaining: extra.remaining ?? 0,
+});
+
+describe('sprintDays', () => {
+  test('flags weekends, today, and future days', () => {
+    const days = sprintDays(
+      [
+        point('2026-08-13', 1),
+        point('2026-08-14', 2),
+        point('2026-08-15', null, { future: true }),
+        point('2026-08-16', null, { future: true }),
+        point('2026-08-17', 3, { future: true }),
+      ],
+      '2026-08-14',
+    );
+    expect(days.map((day) => day.weekend)).toEqual([false, false, true, true, false]);
+    expect(days[1]?.today).toBe(true);
+    expect(days[4]?.future).toBe(true);
+  });
+});
+
+describe('pace', () => {
+  test('needed pace divides remaining by working days left including today', () => {
+    const burn = [
+      point('2026-08-13', 1, { remaining: 8 }),
+      point('2026-08-14', 2, { remaining: 7 }),
+      point('2026-08-17', 3, { future: true }),
+      point('2026-08-18', 4, { future: true }),
+    ];
+    expect(neededPace(7, burn)).toBeCloseTo(7 / 3, 5);
+  });
+
+  test('actual pace divides completed since baseline by elapsed working days', () => {
+    const burn = [
+      point('2026-08-11', 1, { available: false }),
+      point('2026-08-13', 3, { completed: 2 }),
+      point('2026-08-14', 4, { completed: 5 }),
+    ];
+    expect(actualPace(burn)).toBeCloseTo(5 / 2, 5);
+  });
+});
+
+describe('forecastDate', () => {
+  test('maps a completion working day to a calendar date beyond the series', () => {
+    const burn = [point('2026-08-13', 1), point('2026-08-14', 2)];
+    expect(forecastDate(burn, 4)).toBe('2026-08-18');
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `cd apps/web && ORBIT_TEST_LANE=analytics-redesign bun --env-file=../../.env test tests/features/analytics/burn-math.test.ts`
+
+Expected: FAIL, module missing.
+
+- [ ] **Step 3: Implement `burn-math.ts`**
+
+```ts
+const DAY = 86_400_000;
+
+function weekday(date: string): number {
+  return new Date(`${date}T12:00:00.000Z`).getUTCDay();
+}
+
+function isWeekend(date: string): boolean {
+  const day = weekday(date);
+  return day === 0 || day === 6;
+}
+
+function nextDate(date: string): string {
+  return new Date(Date.parse(`${date}T00:00:00.000Z`) + DAY).toISOString().slice(0, 10);
+}
+
+export function sprintDays(burn: readonly BurnPointLike[], today: string): readonly SprintDay[] {
+  return burn.map((point) => ({
+    date: point.date,
+    weekend: isWeekend(point.date),
+    today: point.date === today,
+    future: point.future,
+  }));
+}
+
+export function neededPace(remaining: number, burn: readonly BurnPointLike[]): number | null {
+  const current = burn.filter((point) => !point.future).at(-1);
+  const last = burn.at(-1);
+  if (current?.workingDay == null || last?.workingDay == null) return null;
+  const daysLeft = last.workingDay - current.workingDay + 1;
+  return daysLeft <= 0 ? null : remaining / daysLeft;
+}
+
+export function actualPace(burn: readonly BurnPointLike[]): number | null {
+  const observed = burn.filter((point) => point.available && !point.future);
+  const first = observed[0];
+  const current = observed.at(-1);
+  if (first?.workingDay == null || current?.workingDay == null) return null;
+  const elapsed = Math.max(1, current.workingDay - first.workingDay + 1);
+  return current.completed / elapsed;
+}
+
+export function forecastDate(
+  burn: readonly BurnPointLike[],
+  completionWorkingDay: number,
+): string | null {
+  const inSeries = burn.find((point) => point.workingDay === completionWorkingDay);
+  if (inSeries !== undefined) return inSeries.date;
+  const last = burn.at(-1);
+  if (last?.workingDay == null) return null;
+  let date = last.date;
+  let workingDay = last.workingDay;
+  while (workingDay < completionWorkingDay) {
+    date = nextDate(date);
+    if (!isWeekend(date)) workingDay += 1;
+  }
+  return date;
+}
+```
+
+`neededPace` uses the current working day when today is a working day because `current.workingDay` is that day's number; on a weekend the last non-future point carries the weekend date with `workingDay: null`, so walk back to the latest point with a working day before dividing (implement exactly that: take the last non-future point whose `workingDay` is not null).
+
+Implement `use-measured-width.ts`:
+
+```ts
+import { type RefObject, useEffect, useRef, useState } from 'react';
+
+export function useMeasuredWidth(fallback = 640): {
+  readonly ref: RefObject<HTMLDivElement | null>;
+  readonly width: number;
+} {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(fallback);
+  useEffect(() => {
+    const node = ref.current;
+    if (node === null || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver((entries) => {
+      const measured = entries[0]?.contentRect.width;
+      if (measured !== undefined && measured > 0) setWidth(Math.round(measured));
+    });
+    observer.observe(node);
+    setWidth(Math.round(node.getBoundingClientRect().width) || fallback);
+    return () => observer.disconnect();
+  }, [fallback]);
+  return { ref, width };
+}
+```
+
+The hook test renders a div, asserts the fallback width when `ResizeObserver` is absent in happy-dom, and asserts the ref is attached. Follow `apps/web/src/features/docs/diagram-viewer.tsx:82` for the guard pattern.
+
+- [ ] **Step 4: Run both test files, expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/use-measured-width.ts apps/web/src/features/analytics/burn-math.ts apps/web/tests/lib/use-measured-width.test.tsx apps/web/tests/features/analytics/burn-math.test.ts
+git commit -m "feat(analytics): add native width hook and burn math"
+```
+
+### Task 4: Rebuild LinePlot on a native-scale day domain
+
+**Files:**
+- Rewrite: `apps/web/src/features/analytics/charts/line-plot.tsx`
+- Modify: `apps/web/src/features/analytics/charts/plot-guides.tsx`, `chart-tooltip.tsx`
+- Test: `apps/web/tests/features/analytics/line-plot.test.tsx`
+
+**Interfaces:**
+- Consumes: `useMeasuredWidth`, `SprintDay` from Task 3.
+- Produces:
+
+```ts
+export interface PlotPoint {
+  readonly id: string;
+  readonly label: string;
+  readonly value: number;
+  readonly cohort: AnalyticsDrilldownCohort;
+  readonly x?: number;
+  readonly available?: boolean;
+}
+export interface PlotSeries {
+  readonly id: string;
+  readonly label: string;
+  readonly points: readonly PlotPoint[];
+  readonly dashed?: boolean;
+  readonly step?: boolean;
+  readonly dots?: boolean;
+}
+interface LinePlotProps {
+  readonly label: string;
+  readonly series: readonly PlotSeries[];
+  readonly days?: readonly SprintDay[];
+  readonly onActivate?: (cohort: AnalyticsDrilldownCohort) => void;
+  readonly valueFormatter?: (value: number) => string;
+  readonly xAxisLabel?: string;
+  readonly yAxisLabel?: string;
+  readonly annotation?: string;
+}
+```
+
+When `days` is provided the x domain is one slot per day, points map to slots by `point.label` matching `day.date`, weekend slots draw a `var(--color-surface-raised)` background band, hover and keyboard focus select a day (not a point), and the tooltip lists every series with a value on that day. Without `days` the existing index and explicit-x behavior remains for velocity and timeline callers. `step` renders the scope staircase (horizontal then vertical segments). `dots` renders a small dot on each working-day point of that series (the ideal).
+
+- [ ] **Step 1: Write the failing tests**
+
+Keep the existing keyboard, gap, and table tests, then add:
+
+```ts
+test('renders one slot per sprint day with weekend bands and a full-day tooltip', async () => {
+  const user = userEvent.setup();
+  const days = [
+    { date: '2026-08-13', weekend: false, today: false, future: false },
+    { date: '2026-08-14', weekend: false, today: true, future: false },
+    { date: '2026-08-15', weekend: true, today: false, future: true },
+    { date: '2026-08-16', weekend: true, today: false, future: true },
+    { date: '2026-08-17', weekend: false, today: false, future: true },
+  ];
+  render(
+    <LinePlot
+      days={days}
+      label="Burn"
+      series={[
+        {
+          id: 'remaining',
+          label: 'Remaining',
+          points: [
+            { id: 'r1', label: '2026-08-13', value: 8, cohort: { cohort: 'open' } },
+            { id: 'r2', label: '2026-08-14', value: 7, cohort: { cohort: 'open' } },
+          ],
+        },
+        {
+          id: 'ideal',
+          label: 'Ideal',
+          dashed: true,
+          dots: true,
+          points: days.map((day, index) => ({
+            id: `i${index}`,
+            label: day.date,
+            value: 8 - index,
+            cohort: { cohort: 'open' },
+          })),
+        },
+      ]}
+    />,
+  );
+
+  expect(screen.getAllByTestId('plot-weekend-band')).toHaveLength(2);
+  expect(screen.getAllByTestId('plot-day-hit')).toHaveLength(5);
+  await user.hover(screen.getAllByTestId('plot-day-hit')[1] as Element);
+  const tooltip = screen.getByRole('tooltip');
+  expect(tooltip).toHaveTextContent('Remaining 7');
+  expect(tooltip).toHaveTextContent('Ideal 7');
+});
+
+test('renders the svg at the measured width instead of stretching a viewBox', () => {
+  render(
+    <LinePlot
+      label="Burn"
+      series={[
+        {
+          id: 'remaining',
+          label: 'Remaining',
+          points: [{ id: 'r1', label: '2026-08-13', value: 8, cohort: { cohort: 'open' } }],
+        },
+      ]}
+    />,
+  );
+  const svg = screen.getByRole('application');
+  expect(svg.getAttribute('viewBox')).toBeNull();
+  expect(svg.getAttribute('width')).toBe('640');
+});
+```
+
+- [ ] **Step 2: Run, confirm the new tests fail**
+
+- [ ] **Step 3: Rewrite the component**
+
+Geometry: `const { ref, width } = useMeasuredWidth();` and `const HEIGHT = 280; const LEFT = 56; const RIGHT = 16; const TOP = 12; const BOTTOM = 44;`. The `<svg>` gets `width={width} height={HEIGHT}` and no `viewBox`. Wrap it in `<div ref={ref} className="w-full">`.
+
+Day domain: `const slot = (width - LEFT - RIGHT) / Math.max(1, days.length - 1);` and `xForDay(index) = LEFT + index * slot`. Weekend bands: for each weekend day render `<rect data-testid="plot-weekend-band" x={xForDay(index) - slot / 2} width={slot} y={TOP} height={HEIGHT - TOP - BOTTOM} fill="var(--color-surface-raised)" opacity="0.5" />` before the gridlines. Day hits: one `<rect data-testid="plot-day-hit" data-day-index={index}>` per day spanning the full plot height with `fill="transparent"`, driving `onPointerOver` and click. Ticks: label every `Math.ceil(days.length / Math.floor((width - LEFT - RIGHT) / 56))` days, always the first, last, and `today` slots.
+
+Series drawing: for each series, map points into day slots via a `Map(day.date -> index)`; a point whose label is not in the map falls back to the legacy index positioning. `step: true` emits `H` then `V` path segments between consecutive points. `dots: true` draws `r=2.5` circles on points whose day is not a weekend. Availability gaps keep the existing `M`-restart behavior.
+
+Tooltip: active state becomes `{ dayIndex: number }` when `days` is present. The tooltip body lists every series that has a point at that day: series label, formatted value, one line each, using the existing `ChartTooltip` extended with a `rows?: readonly { series: string; value: string }[]` prop. Keyboard: ArrowLeft and ArrowRight move the day index, Home and End jump, Enter activates the cohort of the first series with a point on that day, Escape clears. The announcement string joins the same rows for the live region.
+
+Table rows: when `days` is present, pivot: one `AnalyticsDataRow` per day whose `cells` map series id to formatted value, columns built from the series list, first column the day date. Without `days`, keep the existing long format.
+
+Legacy mode: everything currently passing (velocity, people timeline, forecast series with explicit `x`) must still render; keep the explicit-x code path intact behind `days === undefined`.
+
+Update `plot-guides.tsx` to take `width`, `height`, and pixel margins as before but with 5 gridlines: `const ticks = [max, (3 * max) / 4, max / 2, max / 4, 0];` and font sizes stay 10 and 11.
+
+- [ ] **Step 4: Run the full web analytics chart tests**
+
+Run: `cd apps/web && ORBIT_TEST_LANE=analytics-redesign bun --env-file=../../.env test tests/features/analytics/line-plot.test.tsx tests/features/analytics/sprint-lens.test.tsx tests/features/analytics/people-lens.test.tsx tests/features/analytics/overview-lens.test.tsx`
+
+Expected: PASS. Fix any caller fallout inside this task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/features/analytics/charts/ apps/web/tests/features/analytics/
+git commit -m "feat(analytics): render line charts native scale on a day domain"
+```
+
+### Task 5: BarPlot native scale, pairs, and average marker
+
+**Files:**
+- Modify: `apps/web/src/features/analytics/charts/bar-plot.tsx`
+- Test: `apps/web/tests/features/analytics/bar-plot.test.tsx`
+
+**Interfaces:**
+- Produces: `BarPlotProps` gains `readonly pairs?: readonly { readonly id: string; readonly label: string; readonly primary: PlotPoint; readonly secondary: PlotPoint }[];` and `readonly averageLine?: { readonly value: number; readonly label: string };`. `primary` renders in `var(--analytics-series-1)`, `secondary` in `var(--color-border-strong)`, two thin bars per row. The average line is a vertical dashed line at its value with an end label. The svg renders at measured width like Task 4.
+
+- [ ] **Step 1: Write failing tests**: paired rows render two bars each (`plot-bar-primary-<id>`, `plot-bar-secondary-<id>`), the average line renders at the correct x proportion with its label, and the svg has explicit `width` and no `viewBox`.
+
+- [ ] **Step 2: Run, confirm failure.**
+
+- [ ] **Step 3: Implement** using `useMeasuredWidth`; pairs mode computes `max` over both values of every pair; each row is `ROW_HEIGHT = 30` with two 8px bars. Average line: `<line x1={x} x2={x} y1={TOP} y2={TOP + plotHeight} strokeDasharray="4 4" stroke="var(--color-border-strong)" data-testid="plot-average-line" />` plus an 10px text label above.
+
+- [ ] **Step 4: Run bar-plot and overview-lens tests, expect PASS.**
+
+- [ ] **Step 5: Commit** `feat(analytics): bar plot native scale with pairs and average marker`.
+
+### Task 6: Sprint stat strip
+
+**Files:**
+- Create: `apps/web/src/features/analytics/sprint-stats.tsx`
+- Test: `apps/web/tests/features/analytics/sprint-stats.test.tsx`
+
+**Interfaces:**
+- Consumes: `neededPace`, `actualPace`, `forecastDate`, `burnForecast` (exported from `sprint-lens.tsx` or moved into `burn-math.ts`; move it into `burn-math.ts` and re-export), the Task 1 contract fields.
+- Produces: `export function SprintStats({ current, measure }: { current: SprintCurrent; measure: AnalyticsMeasure })` rendering one dense strip with items: Scope (`194 issues · 502 pts`, both measures from `summary` plus `counterpart`), Completed with percent, Started with percent, Remaining, Churn (`+1 added · 0 removed`), Pace (`needed 17.8/d · actual 5.3/d`), Forecast (date plus `N days late` in `text-warning` when past sprint end, `on track` in accent otherwise, `needs 3 working days` when null), People (count of `current.people`).
+
+- [ ] **Step 1: Failing test**: render with the sprint fixture and assert the strip shows both measures in Scope, computed percentages, pace values from the fixture burn, `9 people` for a nine-entry people array, and the late forecast case colors via `toHaveClass('text-warning')` on the forecast value when the forecast date exceeds the sprint end date.
+
+- [ ] **Step 2: Run, confirm failure.**
+
+- [ ] **Step 3: Implement.** Layout: `flex flex-wrap gap-x-5 gap-y-1 text-xs`, each item `<span className="text-muted">Label <strong className="font-medium text-text">value</strong></span>`. Percentages: `Math.round((completed / Math.max(1, scope)) * 100)`. Started value comes from the last non-future burn point's `started`.
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit** `feat(analytics): add the sprint stat strip`.
+
+### Task 7: Wire the sprint lens
+
+**Files:**
+- Modify: `apps/web/src/features/analytics/sprint-lens.tsx`
+- Test: `apps/web/tests/features/analytics/sprint-lens.test.tsx`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1 through 6.
+- Produces: the sprint page renders `SprintStats` instead of the four summary cards, a full-span day-domain burn chart, and honest captions.
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+test('frames the whole sprint with weekend bands and a day tooltip', async () => {
+  const user = userEvent.setup();
+  render(<SprintLens data={dataWithFutureBurn} query={sprintQueryFixture} />);
+  expect(screen.getAllByTestId('plot-weekend-band').length).toBeGreaterThanOrEqual(4);
+  expect(screen.getAllByTestId('plot-day-hit')).toHaveLength(14);
+  await user.hover(screen.getAllByTestId('plot-day-hit')[3] as Element);
+  const tooltip = screen.getByRole('tooltip');
+  expect(tooltip).toHaveTextContent('Remaining');
+  expect(tooltip).toHaveTextContent('Ideal');
+});
+
+test('states the capture start once instead of blanking the frame', () => {
+  render(<SprintLens data={dataWithRetroBaseline} query={sprintQueryFixture} />);
+  expect(screen.getByText(/capture began aug 14/i)).toBeVisible();
+  expect(screen.queryByText(/dates unavailable/i)).not.toBeInTheDocument();
+});
+```
+
+`dataWithFutureBurn` builds a 14-day burn (Aug 13 sprint fixture start Aug 13 to Aug 27 exclusive gives Aug 13 through Aug 26: use 14 points, days 1 and 2 observed, the rest `future: true`).
+
+- [ ] **Step 2: Run, confirm failure.**
+
+- [ ] **Step 3: Rewire `SprintBurnChart`:**
+  - Build `days = sprintDays(current.burn, todayDate)` where `todayDate` is the last non-future point's date, pass `days` to `LinePlot`.
+  - Burn-down series: Remaining (`available && !future` points only), Scope (`step: true`, gray via series token 4, observed points only), Ideal (`dashed: true, dots: true`, every point), Forecast (existing dotted extension, explicit x preserved by mapping its two points onto day labels: current date and `forecastDate` result; when the forecast lands past sprint end, clamp the segment at the final day and let the stat strip carry the date).
+  - Burn-up series: Completed, Started rendered as `completed + started` (stacked visually by drawing Started above Completed), Scope, Target (`dashed`, `initialScope - ideal` per point).
+  - Delete the local `workingDayNumber`, `sprintEnd` computation, and synthetic `sprint-end-ideal` point: the server now supplies the full span. Delete `trackingAnnotation`'s multi-line gap warnings; replace with the single caption `Capture began {readableDate(baseline.date)}. Earlier days show targets only.` shown only when `baseline?.retroactive` is true.
+  - Replace the summary card grid with `<SprintStats current={current} measure={current.measure} />`.
+  - Update the unestimated copy to `N unestimated issues count as 1 point each.`
+- Move `burnForecast` into `burn-math.ts` unchanged and import it.
+
+- [ ] **Step 4: Run the sprint lens suite, expect PASS.** Update surviving expectations (`plot-x-end` now reads the final sprint day, the old `sprint-end-ideal` assertions are deleted with the feature they tested, weekend expectations move to the new day-domain test).
+
+- [ ] **Step 5: Commit** `feat(analytics): rebuild the sprint lens on the full sprint frame`.
+
+### Task 8: Personal burn on the same frame
+
+**Files:**
+- Modify: `apps/web/src/features/analytics/people-lens.tsx` and the `focus` section of `sprint-lens.tsx`
+- Test: `apps/web/tests/features/analytics/people-lens.test.tsx`
+
+- [ ] **Step 1: Failing test**: the personal chart renders one `plot-day-hit` per sprint day and an `plot-line-ideal-person` series; with a retro baseline fixture it shows the capture caption and no `dates unavailable` text.
+
+- [ ] **Step 2: Run, confirm failure.**
+
+- [ ] **Step 3: Implement:** `PersonalSprintBurn` passes `days={sprintDays(current.burn, today)}`, adds an Ideal series from `point.ideal` (`dashed, dots`), keeps Remaining on observed points, keeps the previous-sprint overlay in legacy explicit-x form clamped to elapsed days. Apply the same to the `focus` burn card in `sprint-lens.tsx`.
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit** `feat(analytics): give personal burn the full sprint frame`.
+
+### Task 9: Velocity pairs and phase 1 verification
+
+**Files:**
+- Modify: `apps/web/src/features/analytics/sprint-lens.tsx` (velocity card)
+- Modify: `apps/web/e2e/analytics.spec.ts`
+- Test: `apps/web/tests/features/analytics/sprint-lens.test.tsx`
+
+- [ ] **Step 1: Failing test**: velocity renders paired bars (planned secondary, completed primary) per past sprint, an average line labeled with the mean completed value, and the current sprint appended with `--analytics-series` lightened styling (`data-testid="plot-pair-current"`).
+
+- [ ] **Step 2: Run, confirm failure.**
+
+- [ ] **Step 3: Implement** with Task 5's `pairs` and `averageLine`: pairs from `data.velocity` (`planned` and `completed` fields), average over completed values, current sprint pair from `current.summary` marked in-progress.
+
+- [ ] **Step 4: Update the Playwright spec:** the sprint page shows `plot-day-hit` count equal to sprint length, the stat strip with both measures, and toggling Burn up swaps series without losing the frame. Run `cd apps/web && bun run test:e2e -- analytics.spec.ts` if the project defines it, otherwise `bunx playwright test e2e/analytics.spec.ts`.
+
+- [ ] **Step 5: Run the full phase 1 gate**
+
+Run: `ORBIT_TEST_LANE=analytics-redesign bun run verify`
+
+Expected: green. Capture light and dark screenshots of the sprint page at 1680x1000 for the PR.
+
+- [ ] **Step 6: Commit** `feat(analytics): pair velocity bars and verify phase 1`.
+
+### Task 10: Insight contract and lens registration
+
+**Files:**
+- Modify: `packages/shared/src/validators/analytics.ts`
+- Test: `packages/shared/tests/validators/analytics.test.ts`
+
+**Interfaces:**
+- Produces:
+
+```ts
+export const INSIGHT_MEASURES = ['count', 'points', 'cycle_time', 'lead_time', 'age'] as const;
+export const INSIGHT_SLICES = [
+  'assignee',
+  'state',
+  'state_category',
+  'project',
+  'label',
+  'priority',
+  'sprint',
+  'created_week',
+  'completed_week',
+] as const;
+export const insightConfigSchema = z
+  .object({
+    measure: z.enum(INSIGHT_MEASURES).default('count'),
+    slice: z.enum(INSIGHT_SLICES).default('state_category'),
+    segment: z.enum(INSIGHT_SLICES).optional(),
+    cumulative: z.boolean().default(false),
+  })
+  .refine((config) => config.segment !== config.slice, {
+    message: 'Segment must differ from slice.',
+    path: ['segment'],
+  });
+export const analyticsInsightsQuerySchema = analyticsQuerySchema.extend({
+  insight: insightConfigSchema.default({}),
+});
+export type InsightMeasure = (typeof INSIGHT_MEASURES)[number];
+export type InsightSlice = (typeof INSIGHT_SLICES)[number];
+export type InsightConfig = z.infer<typeof insightConfigSchema>;
+export type AnalyticsInsightsQuery = z.infer<typeof analyticsInsightsQuerySchema>;
+```
+
+`ANALYTICS_LENSES` gains `'insights'`. Segments are only meaningful for `count` and `points`; the schema allows them anywhere and the server ignores them for scatter measures (documented in the route test).
+
+- [ ] **Step 1: Failing tests**: defaults fill, `segment === slice` rejects, `'insights'` is a valid lens.
+
+- [ ] **Step 2: Run shared tests, confirm failure.**
+
+- [ ] **Step 3: Implement, run shared tests and typecheck, expect PASS.** Check every `switch` over `AnalyticsLens` in web and core still typechecks; add `insights` arms where the compiler demands.
+
+- [ ] **Step 4: Commit** `feat(analytics): define the insight query contract`.
+
+### Task 11: Drilldown cohorts for the new slices
+
+**Files:**
+- Modify: `packages/core/src/analytics/drilldown.ts`
+- Test: `packages/core/tests/analytics/drilldown.test.ts`
+
+**Interfaces:**
+- Produces: valid cohort keys `assignee:<id>`, `assignee:none`, `label:<id>`, `label:none`, `sprint:<id>`, `sprint:none`, `created-week:<iso-date>`, `completed-week:<iso-date>` with matching predicates in `dimensionCohortPredicate`:
+
+```ts
+if (cohort.cohort.startsWith('assignee:')) {
+  const id = cohort.cohort.slice('assignee:'.length);
+  return id === 'none' ? isNull(schema.issue.assigneeId) : eq(schema.issue.assigneeId, id);
+}
+if (cohort.cohort.startsWith('label:')) {
+  const id = cohort.cohort.slice('label:'.length);
+  return id === 'none'
+    ? sql`not exists (select 1 from issue_label where issue_label.issue_id = ${schema.issue.id})`
+    : sql`exists (select 1 from issue_label where issue_label.issue_id = ${schema.issue.id} and issue_label.label_id = ${id})`;
+}
+if (cohort.cohort.startsWith('sprint:')) {
+  const id = cohort.cohort.slice('sprint:'.length);
+  return id === 'none' ? isNull(schema.issue.cycleId) : eq(schema.issue.cycleId, id);
+}
+if (cohort.cohort.startsWith('created-week:')) {
+  const week = cohort.cohort.slice('created-week:'.length);
+  return sql`date_trunc('week', ${schema.issue.createdAt}) = ${week}::date`;
+}
+if (cohort.cohort.startsWith('completed-week:')) {
+  const week = cohort.cohort.slice('completed-week:'.length);
+  return sql`date_trunc('week', ${schema.issue.completedAt}) = ${week}::date`;
+}
+```
+
+`validDimensionCohort` accepts the id forms via `validIdCohort(value, 'assignee', new Set(['none']))` and the week forms via `/^(created|completed)-week:\d{4}-\d{2}-\d{2}$/`.
+
+- [ ] **Step 1: Failing tests**: one positive drilldown per new cohort (create issues, assert the filtered listing) and the malformed list extended with `assignee:`, `label:not-an-id`, `sprint:`, `created-week:junk`, `completed-week:2026-13-99` still rejecting before SQL.
+
+- [ ] **Step 2: Run, confirm failure. Step 3: Implement. Step 4: Run drilldown tests, expect PASS.**
+
+- [ ] **Step 5: Commit** `feat(analytics): drill into assignee, label, sprint, and week cohorts`.
+
+### Task 12: Core insights aggregation
+
+**Files:**
+- Create: `packages/core/src/analytics/insights.ts`
+- Modify: `packages/core/src/analytics/index.ts`, `packages/core/src/analytics/math.ts`
+- Test: `packages/core/tests/analytics/insights.test.ts`, `packages/core/tests/analytics/math.test.ts`
+
+**Interfaces:**
+- Consumes: `baseAnalyticsPredicate` and the query resolution helpers exported by `drilldown.ts` (export them if still module-private), `assertCan(principal, 'analytics:read')`.
+- Produces:
+
+```ts
+export interface InsightSegmentValue {
+  readonly id: string;
+  readonly label: string;
+  readonly value: number;
+}
+export interface InsightBucket {
+  readonly id: string;
+  readonly label: string;
+  readonly value: number;
+  readonly segments: readonly InsightSegmentValue[];
+  readonly cohort: AnalyticsDrilldownCohort;
+}
+export interface InsightScatterPoint {
+  readonly issueId: string;
+  readonly identifier: string;
+  readonly title: string;
+  readonly days: number;
+}
+export interface InsightPercentiles {
+  readonly p25: number;
+  readonly p50: number;
+  readonly p75: number;
+  readonly p95: number;
+}
+export type InsightResult =
+  | { readonly kind: 'bars'; readonly unit: 'issues' | 'points'; readonly buckets: readonly InsightBucket[] }
+  | { readonly kind: 'scatter'; readonly unit: 'days'; readonly points: readonly InsightScatterPoint[]; readonly percentiles: InsightPercentiles | null };
+
+export async function loadAnalyticsInsights(
+  principal: Principal,
+  query: AnalyticsQuery,
+  insight: InsightConfig,
+  context: { readonly now: Date; readonly timezone?: string },
+): Promise<InsightResult>;
+```
+
+`math.ts` gains `export function percentilesOf(values: readonly number[]): InsightPercentiles | null` (null for empty input, linear interpolation between ranks).
+
+Slice SQL, one dimension table used by both the id and the label expression:
+
+```ts
+const SLICE_SQL: Record<InsightSlice, { id: SQL<unknown>; label: SQL<unknown>; cohortPrefix: string }> = {
+  assignee: {
+    id: sql`coalesce(${schema.issue.assigneeId}, 'none')`,
+    label: sql`coalesce("user".name, 'Unassigned')`,
+    cohortPrefix: 'assignee',
+  },
+  state: {
+    id: sql`${schema.issue.stateId}`,
+    label: sql`workflow_state.name`,
+    cohortPrefix: 'state',
+  },
+  state_category: {
+    id: sql`workflow_state.category::text`,
+    label: sql`workflow_state.category::text`,
+    cohortPrefix: 'state-category',
+  },
+  project: {
+    id: sql`coalesce(${schema.issue.projectId}, 'none')`,
+    label: sql`coalesce(project.name, 'No project')`,
+    cohortPrefix: 'project',
+  },
+  label: {
+    id: sql`coalesce(issue_label.label_id, 'none')`,
+    label: sql`coalesce(label.name, 'No label')`,
+    cohortPrefix: 'label',
+  },
+  priority: {
+    id: sql`${schema.issue.priority}::text`,
+    label: sql`${schema.issue.priority}::text`,
+    cohortPrefix: 'priority',
+  },
+  sprint: {
+    id: sql`coalesce(${schema.issue.cycleId}, 'none')`,
+    label: sql`coalesce(cycle.name, 'No sprint')`,
+    cohortPrefix: 'sprint',
+  },
+  created_week: {
+    id: sql`to_char(date_trunc('week', ${schema.issue.createdAt}), 'YYYY-MM-DD')`,
+    label: sql`to_char(date_trunc('week', ${schema.issue.createdAt}), 'YYYY-MM-DD')`,
+    cohortPrefix: 'created-week',
+  },
+  completed_week: {
+    id: sql`to_char(date_trunc('week', ${schema.issue.completedAt}), 'YYYY-MM-DD')`,
+    label: sql`to_char(date_trunc('week', ${schema.issue.completedAt}), 'YYYY-MM-DD')`,
+    cohortPrefix: 'completed-week',
+  },
+};
+```
+
+Bars query: from `issue` joined to `workflow_state` (always), left joined to `user`, `project`, `cycle`, `issue_label` plus `label` only when the slice or segment needs them, where the base predicate holds, `completed_week` additionally requires `completedAt is not null`, group by slice id and label plus segment id and label when present, weight `sql`1`` for count and `coalesce(issue.estimate, 1)` for points (matching Task 1's default), ordered by total descending, slices capped at 30 and segments per slice at 8 with an `other` rollup, priority labels mapped through `PRIORITY_LABELS` in TypeScript after the query.
+
+Scatter query: `cycle_time` selects `extract(epoch from (completed_at - started_at)) / 86400` where both timestamps exist, `lead_time` uses `created_at`, `age` uses `now - created_at` for issues whose state category is not completed or canceled. Cap at 500 points ordered by duration descending, and compute percentiles in TypeScript from the full value list fetched as durations only (`select` the duration column for all matching rows, cap only the joined issue details).
+
+- [ ] **Step 1: Failing tests**: percentile math unit tests (`percentilesOf([1,2,3,4])`), a bars test (two states, segment by priority, sums and cohorts assert), a labels test (an issue with two labels appears under both and the caption count reflects it), a scatter test (two completed issues with known durations produce points and exact percentiles), and an authorization test that a principal without `analytics:read` is rejected (follow the existing drilldown test's pattern).
+
+- [ ] **Step 2: Run, confirm failure. Step 3: Implement. Step 4: Run insights, math, and drilldown suites, expect PASS.**
+
+- [ ] **Step 5: Commit** `feat(analytics): aggregate insights by measure, slice, and segment`.
+
+### Task 13: Insights API route and web contract
+
+**Files:**
+- Create: `apps/web/src/app/api/analytics/insights/route.ts`
+- Modify: `apps/web/src/features/analytics/contracts.ts`, `analytics-keys.ts`, `data.ts`
+- Test: `apps/web/tests/app/api/analytics/insights/route.test.ts`
+
+**Interfaces:**
+- Consumes: `loadAnalyticsInsights`, `analyticsInsightsQuerySchema`.
+- Produces: `GET /api/analytics/insights?query=<url-encoded json>` following the exact parse-authenticate-respond pattern of `apps/web/src/app/api/analytics/drilldown/route.ts`, returning `InsightResult` as JSON; `analyticsInsightsWireResponse` Zod schema in `contracts.ts` (discriminated union on `kind`); `analyticsKeys.insights(input)` query key; a `fetchInsights` helper beside the other fetchers in `data.ts`.
+
+- [ ] **Step 1: Failing route test**: authenticated request with a valid query returns 200 and a `kind`; malformed `insight.measure` returns 422; unauthenticated returns 401. Copy the harness style from the existing drilldown route test.
+
+- [ ] **Step 2 through 4: Run failing, implement, run passing.**
+
+- [ ] **Step 5: Commit** `feat(analytics): serve insights over the analytics api`.
+
+### Task 14: Scatterplot primitive
+
+**Files:**
+- Create: `apps/web/src/features/analytics/charts/scatter-plot.tsx`
+- Test: `apps/web/tests/features/analytics/scatter-plot.test.tsx`
+
+**Interfaces:**
+- Consumes: `useMeasuredWidth`, `PlotFrame`, `ChartTooltip`, `InsightScatterPoint`, `InsightPercentiles`.
+- Produces:
+
+```ts
+interface ScatterPlotProps {
+  readonly label: string;
+  readonly points: readonly InsightScatterPoint[];
+  readonly percentiles: InsightPercentiles | null;
+  readonly unitLabel: string;
+}
+```
+
+X is the point's index ordered by duration ascending (rank), y is `days`. Percentile lines: horizontal dashed lines at p25, p50, p75, p95 with `data-testid="plot-percentile-p50"` and right-edge labels; hovering a line shows its exact value in the tooltip. Each point is a 3px circle plus a 9px hit circle carrying `data-testid={`plot-scatter-${identifier}`}`; hover shows identifier, title, and `N days`; click and Enter open `/issue/${identifier}` via `next/link` semantics (render each hit inside an `<a href>` wrapper so keyboard access is native). Arrow keys walk points by rank.
+
+- [ ] **Step 1: Failing tests**: four points render four hits, the four percentile lines exist, hovering a point shows its identifier and formatted days, the point link points at `/issue/NOV-1`.
+
+- [ ] **Step 2 through 4: fail, implement, pass.**
+
+- [ ] **Step 5: Commit** `feat(analytics): add the percentile scatterplot`.
+
+### Task 15: Insights lens UI
+
+**Files:**
+- Create: `apps/web/src/features/analytics/insights-lens.tsx`
+- Modify: `apps/web/src/features/analytics/charts/bar-plot.tsx` (stacked segments), `analytics-tabs.tsx`, `query-state.ts`, `apps/web/src/app/(app)/analytics/page.tsx`, `data.ts`
+- Test: `apps/web/tests/features/analytics/insights-lens.test.tsx`, `apps/web/tests/features/analytics/bar-plot.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 13's fetcher and keys, Task 14's scatterplot, Task 5's bar plot.
+- Produces:
+  - `BarPlot` gains `readonly segments?: boolean` mode: when a point carries `readonly segments: readonly InsightSegmentValue[]`, the row renders stacked rectangles colored `var(--analytics-series-N)` cycling 1 through 4, tooltip lists each segment value.
+  - `InsightsLens` renders three `MeasureToggle`-style pickers (Measure, Slice, Segment with a None option) that write `insight.measure`, `insight.slice`, `insight.segment`, `insight.cumulative` into the URL through `query-state.ts`, fetches via TanStack Query, renders bars for count and points, scatter for durations, and for `created_week` and `completed_week` slices offers a `Cumulative` toggle that turns the bar data into a running-total line rendered with `LinePlot` (legacy mode, week labels on x).
+  - Bar activation: property slices push a temporary filter chip: build the matching filter condition (`property: 'assignee' | 'state' | 'project' | 'label' | 'priority' | 'cycle'`, `operator: 'in'`, `values: [id]`) into `query.filter` through the existing filter helpers in `query-state.ts`, rendered with the toolbar's existing chip removal. Week slices open the drilldown dialog with the `created-week:` or `completed-week:` cohort instead.
+  - Chart and table link: hovering a bar row highlights the matching table row through the existing `activeRowId` mechanism and the reverse through `onActivate`.
+  - `analytics-tabs.tsx` adds the Insights tab for lens `insights`; `page.tsx` renders the lens; `data.ts` prefetches the default insight for the lens on the server like the other lenses.
+
+- [ ] **Step 1: Failing tests**: lens renders pickers and a bar chart from a mocked bars response; switching measure to `cycle_time` renders the scatterplot; clicking a state bar calls the filter-push handler with the `in` condition; segment stacking renders one rect per segment; cumulative toggle renders a line plot for `completed_week`.
+
+- [ ] **Step 2 through 4: fail, implement, pass.** Include `analytics-tabs` and `query-state` test updates for the new lens value.
+
+- [ ] **Step 5: Commit** `feat(analytics): add the insights lens`.
+
+### Task 16: End-to-end coverage and final verification
+
+**Files:**
+- Modify: `apps/web/e2e/analytics.spec.ts`
+- Modify: `docs/superpowers/specs/2026-08-15-sprint-analytics-redesign-design.md` only if reality diverged; note divergences in the PR body instead where possible.
+
+- [ ] **Step 1: Extend the Playwright spec**: navigate to the insights lens, assert the pickers render, choose slice assignee, assert bars and the linked table, choose measure cycle time, assert the scatterplot and percentile lines.
+
+- [ ] **Step 2: Run the whole gate**
+
+Run: `ORBIT_TEST_LANE=analytics-redesign bun run verify`
+Run: `cd apps/web && bun run build`
+
+Expected: everything green, production build clean.
+
+- [ ] **Step 3: Capture light and dark screenshots** of the sprint lens and insights lens at 1680x1000 for the PR body.
+
+- [ ] **Step 4: Commit** `test(analytics): cover the redesigned lenses end to end`, then open the PR titled `feat(analytics): planning-grade sprint burn and insights lens` with the spec linked, screenshots, and the verification evidence. Merge the current `main` in first and let checks run against the merged state per the repository review rules.
+
+---
+
+## Self-review notes
+
+- Spec coverage: rendering model (Task 4), burn series (Tasks 1, 7), stat strip (Task 6), retroactive baseline (Tasks 1, 7), pivoted table (Task 4), personal burn (Task 8), velocity (Task 9), grammar and measures (Tasks 10, 12), scatter percentiles (Tasks 12, 14), linked table and temporary filters (Task 15), burn-up cumulative (Task 15), drill cohorts (Task 11), route (Task 13), e2e and screenshots (Tasks 9, 16). Non-goals stay out.
+- The PR 313 properties are restated in Global Constraints so expectation updates in Task 1 cannot silently delete them.
+- Type names used across tasks: `SprintDay`, `InsightBucket`, `InsightScatterPoint`, `InsightPercentiles`, `InsightResult`, `InsightConfig` are defined once (Tasks 3, 10, 12) and only consumed elsewhere.

--- a/docs/superpowers/specs/2026-08-15-sprint-analytics-redesign-design.md
+++ b/docs/superpowers/specs/2026-08-15-sprint-analytics-redesign-design.md
@@ -1,0 +1,172 @@
+# Sprint analytics redesign: Linear-grade burn charts and an insights grammar
+
+Date: 2026-08-15
+Branch: `analytics-insights-redesign`
+Delivery: phase 1 as one pull request; phase 2 as a follow-up pull request once phase 1 has shipped and been used.
+
+## Executive decision
+
+The analytics charts shipped in PR 313 are honest but useless for planning. A sprint adopted mid-flight renders a nearly empty frame, the fixed 640x260 viewBox stretches every label to roughly 2.6x its intended size, the x axis shows three irregular dates, Planned reads 0 for a sprint holding 194 issues, and no number on the page answers the questions a lead actually asks: what is our velocity, what should the burn be, where will we land.
+
+This redesign rebuilds the sprint experience to the standard of Linear's cycle graph and then, as a second phase, adds a Measure by Slice by Segment insights grammar modeled on Linear Insights. Orbit keeps its own tokens, density, typography, and component language: this adapts Linear's interaction model, not its skin.
+
+Decisions locked with the user:
+
+1. Scope: both phases designed in this one spec, built and shipped separately, sprint graph first.
+2. Mid-flight adoption: retroactive baseline. The first captured scope is treated as the sprint's baseline from day 1.
+3. Measures: one chart with a points and issues toggle; the header stat strip always shows both measures.
+4. Charts stay hand-rolled SVG. No chart library: it would fight the single-instance dependency rule, the transform-and-opacity-only motion rule, CSS variable theming, and the existing keyboard access model.
+
+References:
+
+- [Linear cycle graph](https://linear.app/docs/cycle-graph)
+- [Linear project graph](https://linear.app/docs/project-graph)
+- [Linear Insights](https://linear.app/docs/insights)
+- [Linear dashboards](https://linear.app/docs/dashboards)
+
+## Problems being fixed, verified against the code
+
+1. Scale bug: `LinePlot` and `BarPlot` render a fixed `viewBox="0 0 640 260"` SVG with `w-full`, so an 1650px card scales 11px text to about 29px. This one bug produces most of the "gigantic and empty" impression.
+2. Axis poverty: three x ticks chosen by array index produce sequences like Aug 11, Aug 13, Aug 24. No tick per day, no weekend distinction, no dots on the ideal line.
+3. Adoption emptiness: capture began Aug 14 for a sprint started Aug 11, so `available: false` blanks three of four days, the personal chart draws one dot, and the frame carries no ideal context for the sprint's future.
+4. Planned 0: planned counts membership captured within 24 hours of sprint start. A bootstrap capture three days in yields planned 0 against a real scope of 194. Technically defined, practically wrong.
+5. No planning answers: no needed versus actual burn rate, no forecast date stat, no started series on the chart, no people count, one measure at a time, a long flat data table.
+
+The arithmetic that does render is correct: scope 194 minus remaining 178 equals completed 16, matching the summary cards. The failures are framing and coverage, not sums.
+
+## Phase 1: the sprint graph
+
+### 1. Rendering model
+
+- Charts measure their container with a `ResizeObserver` and render the SVG at native pixel size. An 11px label is 11px at every viewport. No stretched viewBox anywhere in analytics.
+- Chart height approximately 280px; width fills the card.
+- X axis spans the full sprint in calendar days, sprint start through the last included day (the half-open interval convention from PR 313 stands: the `endsAt` day belongs to the next sprint).
+- Every calendar day owns an x slot. Weekend columns get a faint background tint using an existing surface token. Tick labels render every 1 to 3 days depending on measured width, always including the first and last day and today.
+- Y axis: 4 or 5 gridlines with values, formatted by the active measure.
+- Fonts 10 to 11px, weights and colors from existing tokens. Reduced motion is already respected; nothing here animates layout.
+- `BarPlot` receives the same native-scale treatment.
+
+### 2. Burn chart series
+
+Burn down mode:
+
+- Remaining: solid line, actual data points only on days with capture.
+- Scope: gray step line across captured days, so scope creep reads as steps.
+- Ideal: dotted line from day 1 at the baseline scope to zero on the last working day, flat across weekends, with a small dot on each working day so "where should we be on the 19th" is readable directly.
+- Forecast: dotted extension from today's remaining to projected zero, drawn only when at least three captured working days exist and the fitted slope is negative (the PR 313 guard stands). The projected date also appears as a header stat.
+
+Burn up mode:
+
+- Completed: solid rising line.
+- Started: stacked on top of completed, Linear's yellow-on-blue arrangement using the analytics series tokens.
+- Scope: gray line above.
+- Target: dotted rising line, the inverse of the ideal.
+
+Hover and keyboard focus snap to the nearest day column and show one tooltip listing every series value for that day, not one point at a time. Arrow keys move by day, Home and End jump, Enter drills down, matching the existing access model.
+
+### 3. Header stat strip
+
+One dense strip replaces the four large summary cards:
+
+- Scope: `194 issues · 502 pts`
+- Completed: `16 (8%)`
+- Started: `42 (22%)`
+- Remaining: `178`
+- Churn: `+1 added · 0 removed`
+- Pace: `needed 17.8/day · actual 5.3/day`
+- Forecast: `Aug 28, 3 days late` (accent color when on or before sprint end, warning color when after)
+- People: `9`
+
+Definitions:
+
+- Needed pace: remaining divided by working days left including today.
+- Actual pace: completed since baseline divided by elapsed working days since baseline.
+- People: distinct persons in the sprint detail's people series.
+- Both measures always appear in the Scope stat. The chart's measure toggle does not change the strip.
+- In points mode, an unestimated issue counts as 1 point, and the caption states the count: `18 unestimated counted as 1 pt each`. A configurable team default estimate is out of scope for this spec.
+
+### 4. Retroactive baseline semantics
+
+- The first captured burn point defines the baseline: its date and scope.
+- Planned adopts the baseline scope when no membership was captured inside the planning window. The formulas metadata says so explicitly.
+- The ideal line starts at day 1 with the baseline scope, not at the baseline date.
+- Days before capture draw no actual-series points. The `available` flag stays in the contract and the server keeps computing it; the client stops letting it blank the frame.
+- One caption line replaces the current gap warnings: `Capture began Aug 14. Earlier days show targets only.`
+- Added and removed keep excluding the bootstrap capture (PR 313 behavior stands): a baseline is not churn.
+
+### 5. Data table
+
+- Pivoted: one row per day, one column per series, right-aligned numbers, compact row height.
+- A 14-day sprint renders 14 rows instead of a 40-plus row series list.
+- Row hover highlights the matching day column in the chart; the existing activation behavior (Enter or click drills into the day's cohort) is preserved.
+
+### 6. Personal burn
+
+- Same frame as the team chart: full sprint x axis, weekend tint, native scale.
+- The person's ideal runs from day 1 at the person's baseline scope share to zero at sprint end.
+- Same retroactive baseline caption. No more single-dot charts with `3 dates unavailable`.
+
+### 7. Velocity
+
+- Paired bars per completed sprint: planned versus completed, in the active measure.
+- A horizontal average line across the shown sprints, labeled with the value.
+- The current sprint appears as a lighter in-progress pair so the strip is never empty for a first sprint.
+
+### Server changes for phase 1
+
+- `SprintBurnPoint` gains one field: `readonly future: boolean`. The series already carries date, scope, started, completed, remaining, ideal, available, workingDay.
+- The burn series extends through the last included sprint day. Future points carry only the ideal value with `future: true` and zeroed actual fields; the client draws no actual series for them, so it never invents geometry.
+- `SprintDetail` gains a `baseline` object: date, scope in both measures, and whether it was adopted retroactively.
+- `summaryFor` adopts the baseline scope for planned when the planning window captured nothing, and the formulas text changes accordingly.
+- Points-mode valuation counts unestimated issues as 1 with the unestimated count already present in the summary.
+
+### Testing phase 1
+
+- Chart primitives: bun DOM tests for native sizing (mocked ResizeObserver), day-slot ticks including weekend flags, per-day tooltip aggregation, keyboard day navigation, table pivot and linked highlight.
+- Core: baseline adoption of planned, ideal-from-day-1 values, future ideal-only points, pace stats inputs, all against the real test database.
+- The PR 313 regression suite (weekend ideal zero, half-open boundary, bootstrap churn exclusion) must stay green unchanged.
+- Playwright: the analytics sprint page renders the full-span chart with a mid-flight fixture, both toggle states, and the stat strip.
+- Light and dark screenshots at 1680x1000 in the PR.
+
+## Phase 2: the insights grammar
+
+Built after phase 1 ships. Everything below reuses the phase 1 primitives.
+
+### Grammar
+
+- Any filtered issue view can open an Insights panel: Measure by Slice by optional Segment.
+- Measures: issue count, points, cycle time, lead time, issue age.
+- Slices: assignee, state, state category, project, label, priority, sprint, week created, week completed.
+- Segment: a second dimension rendered as stacked color within each slice, bar charts only.
+- The existing drilldown cohort machinery (extended for state categories in PR 313) is the click-through: every bar, point, and table row resolves to a cohort listing the exact issues.
+
+### Chart forms
+
+- Bar chart: counts and points, horizontal ranked layout as today, segments stacked.
+- Scatterplot: duration measures (cycle time, lead time, age), one point per issue, with horizontal percentile lines at 25, 50, 75, 95. Hovering a percentile shows its value; selecting a point opens the issue.
+- Burn up: selecting the time slice with a cumulative setting produces the cumulative flow variant using the phase 1 line chart.
+
+### Interactivity
+
+- Chart and table are linked: hovering a bar highlights its row and the reverse.
+- Clicking a bar or segment filters the underlying view temporarily, matching Linear's temporary-filter behavior.
+- Keyboard access mirrors phase 1: arrows move across slices, Enter drills down.
+
+### Explicit non-goals
+
+- Dashboards as a separate composable surface. Linear gates these to Enterprise; Orbit's saved views already cover persistence. Revisit only after phase 2 is in use.
+- Linear's cycle success score (completed plus a quarter of started). No user asked for it.
+- Optimistic and pessimistic forecast bands. A single forecast line is enough at sprint scale; bands earn their keep on multi-month projects.
+- Triage time as a measure, until Orbit captures triage state durations.
+- A configurable team default estimate setting.
+
+### Testing phase 2
+
+- Core: each measure and slice pair against seeded data, percentile math, segment stacking sums, cohort round-trips from every chart form.
+- Web: scatterplot rendering and percentile interaction, linked table highlighting, temporary filter application and removal.
+
+## Rollout
+
+1. Phase 1 lands as `feat(analytics): rebuild sprint burn to planning grade` with small scoped commits.
+2. Verify on the live workspace against the running Sprint 1: the mid-flight baseline path is the very case that prompted this redesign.
+3. Phase 2 begins only after phase 1 feedback, as its own branch and spec-referencing PR.

--- a/docs/superpowers/specs/2026-08-15-sprint-analytics-redesign-design.md
+++ b/docs/superpowers/specs/2026-08-15-sprint-analytics-redesign-design.md
@@ -134,7 +134,7 @@ Built after phase 1 ships. Everything below reuses the phase 1 primitives.
 
 ### Grammar
 
-- Any filtered issue view can open an Insights panel: Measure by Slice by optional Segment.
+- The analytics page gains an Insights lens over the filtered dataset: Measure by Slice by optional Segment. The existing filter bar and saved views make the current view the dataset, so this covers filtered issue exploration without mounting a panel into every issue list.
 - Measures: issue count, points, cycle time, lead time, issue age.
 - Slices: assignee, state, state category, project, label, priority, sprint, week created, week completed.
 - Segment: a second dimension rendered as stacked color within each slice, bar charts only.

--- a/docs/superpowers/specs/2026-08-15-sprint-analytics-redesign-design.md
+++ b/docs/superpowers/specs/2026-08-15-sprint-analytics-redesign-design.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-15
 Branch: `analytics-insights-redesign`
-Delivery: phase 1 as one pull request; phase 2 as a follow-up pull request once phase 1 has shipped and been used.
+Delivery: both phases in one pull request, built phase 1 first, with small scoped commits.
 
 ## Executive decision
 
@@ -167,6 +167,5 @@ Built after phase 1 ships. Everything below reuses the phase 1 primitives.
 
 ## Rollout
 
-1. Phase 1 lands as `feat(analytics): rebuild sprint burn to planning grade` with small scoped commits.
+1. One pull request carries both phases, phase 1 commits first, phase 2 commits after, each small and scoped.
 2. Verify on the live workspace against the running Sprint 1: the mid-flight baseline path is the very case that prompted this redesign.
-3. Phase 2 begins only after phase 1 feedback, as its own branch and spec-referencing PR.

--- a/packages/core/src/analytics/burndown.ts
+++ b/packages/core/src/analytics/burndown.ts
@@ -103,7 +103,7 @@ export async function cycleBurndown(
     });
   }
   const scopeStart = points[0]?.scope ?? 0;
-  const last = actual.at(-1);
+  const last = actual.filter((point) => !point.future).at(-1);
   const totalDays = Math.max(1, points.length - 1);
   const compatiblePoints = points.map((point, index) => ({
     ...point,

--- a/packages/core/src/analytics/burndown.ts
+++ b/packages/core/src/analytics/burndown.ts
@@ -84,6 +84,7 @@ export async function cycleBurndown(
   const cycle = analytics.current.sprint;
   const today = calendarDateLabel(now, cycle.timezone);
   const actual = analytics.current.burn;
+  const lastObserved = actual.filter((point) => !point.future).at(-1);
   const points: BurndownPoint[] = [];
   const finalDay = calendarDateLabel(new Date(Date.parse(cycle.endsAt) - 1), cycle.timezone);
   for (
@@ -92,18 +93,19 @@ export async function cycleBurndown(
     day = nextCalendarDay(day)
   ) {
     const found = actual.find((point) => point.date === day);
+    const observed = found !== undefined && !found.future ? found : undefined;
     const isFuture = day > today || found === undefined;
     points.push({
       date: day,
-      scope: found?.scope ?? actual.at(-1)?.scope ?? 0,
+      scope: observed?.scope ?? lastObserved?.scope ?? 0,
       completed: isFuture ? null : (found?.completed ?? 0),
       remaining: isFuture ? null : (found?.remaining ?? 0),
-      ideal: found?.ideal ?? actual.at(-1)?.ideal ?? 0,
+      ideal: observed?.ideal ?? lastObserved?.ideal ?? 0,
       isFuture,
     });
   }
   const scopeStart = points[0]?.scope ?? 0;
-  const last = actual.filter((point) => !point.future).at(-1);
+  const last = lastObserved;
   const totalDays = Math.max(1, points.length - 1);
   const compatiblePoints = points.map((point, index) => ({
     ...point,

--- a/packages/core/src/analytics/drilldown.ts
+++ b/packages/core/src/analytics/drilldown.ts
@@ -294,7 +294,7 @@ function otherDimensionPredicate(
     dimension === 'state'
       ? sql`${schema.issue.stateId}`
       : sql`coalesce(${schema.issue.projectId}, 'none')`;
-  const weight = resolved.measure === 'points' ? sql`coalesce(issue.estimate, 0)` : sql`1`;
+  const weight = resolved.measure === 'points' ? sql`coalesce(issue.estimate, 1)` : sql`1`;
   return sql`${dimensionId} not in (
     select ranked.dimension_id from (
       select ${dimensionId} as dimension_id
@@ -1082,7 +1082,7 @@ export async function listAnalyticsDrilldown(
     ? Math.max(1, Math.min(MAX_LIMIT, Math.trunc(requestedLimit)))
     : 50;
   const weight =
-    resolved.measure === 'points' ? sql`coalesce(${schema.issue.estimate}, 0)` : sql`1`;
+    resolved.measure === 'points' ? sql`coalesce(${schema.issue.estimate}, 1)` : sql`1`;
   const [aggregate] = await db.execute<AggregateRow>(sql`
     select
       count(*) as total,

--- a/packages/core/src/analytics/drilldown.ts
+++ b/packages/core/src/analytics/drilldown.ts
@@ -11,7 +11,7 @@ import { validationFailed } from '@orbit/shared/errors';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan } from '@orbit/shared/policy';
 import type { AnalyticsDrilldownCohort, AnalyticsQuery } from '@orbit/shared/validators';
-import { issueFilterSchema } from '@orbit/shared/validators';
+import { calendarDateSchema, issueFilterSchema } from '@orbit/shared/validators';
 import type { SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
 import { buildIssueWhere } from '../work/issue-query.ts';
@@ -116,7 +116,12 @@ export type AnalyticsOverviewCohortKey =
   | `state:${string}`
   | `project:${string}`
   | `priority:${number}`
-  | `outlier:${string}`;
+  | `outlier:${string}`
+  | `assignee:${string}`
+  | `label:${string}`
+  | `sprint:${string}`
+  | `created-week:${string}`
+  | `completed-week:${string}`;
 
 export interface AnalyticsServiceContext {
   readonly now?: Date;
@@ -302,6 +307,32 @@ function otherDimensionPredicate(
   )`;
 }
 
+function sliceCohortPredicate(cohort: AnalyticsDrilldownCohort): SQL<unknown> | null {
+  if (cohort.cohort.startsWith('assignee:')) {
+    const id = cohort.cohort.slice('assignee:'.length);
+    return id === 'none' ? isNull(schema.issue.assigneeId) : eq(schema.issue.assigneeId, id);
+  }
+  if (cohort.cohort.startsWith('label:')) {
+    const id = cohort.cohort.slice('label:'.length);
+    return id === 'none'
+      ? sql`not exists (select 1 from issue_label where issue_label.issue_id = ${schema.issue.id})`
+      : sql`exists (select 1 from issue_label where issue_label.issue_id = ${schema.issue.id} and issue_label.label_id = ${id})`;
+  }
+  if (cohort.cohort.startsWith('sprint:')) {
+    const id = cohort.cohort.slice('sprint:'.length);
+    return id === 'none' ? isNull(schema.issue.cycleId) : eq(schema.issue.cycleId, id);
+  }
+  if (cohort.cohort.startsWith('created-week:')) {
+    const week = cohort.cohort.slice('created-week:'.length);
+    return sql`date_trunc('week', ${schema.issue.createdAt}) = ${week}::date`;
+  }
+  if (cohort.cohort.startsWith('completed-week:')) {
+    const week = cohort.cohort.slice('completed-week:'.length);
+    return sql`date_trunc('week', ${schema.issue.completedAt}) = ${week}::date`;
+  }
+  return null;
+}
+
 function dimensionCohortPredicate(
   resolved: ResolvedAnalyticsQuery,
   cohort: AnalyticsDrilldownCohort,
@@ -332,13 +363,20 @@ function dimensionCohortPredicate(
   if (cohort.cohort.startsWith('outlier:')) {
     return eq(schema.issue.id, cohort.cohort.slice('outlier:'.length));
   }
-  return null;
+  return sliceCohortPredicate(cohort);
 }
 
 function validIdCohort(value: string, prefix: string, special: ReadonlySet<string>): boolean {
   const match = new RegExp(`^${prefix}:(.+)$`, 'i').exec(value);
   const suffix = match?.[1];
   return suffix !== undefined && (special.has(suffix) || UUID_PATTERN.test(suffix));
+}
+
+const WEEK_COHORT_PATTERN = /^(?:created|completed)-week:(\d{4}-\d{2}-\d{2})$/;
+
+function validWeekCohort(value: string): boolean {
+  const day = WEEK_COHORT_PATTERN.exec(value)?.[1];
+  return day !== undefined && calendarDateSchema.safeParse(day).success;
 }
 
 function validDimensionCohort(value: string): boolean {
@@ -352,6 +390,10 @@ function validDimensionCohort(value: string): boolean {
   if (validIdCohort(value, 'state', new Set(['other']))) return true;
   if (validIdCohort(value, 'project', new Set(['none', 'other']))) return true;
   if (validIdCohort(value, 'outlier', new Set())) return true;
+  if (validIdCohort(value, 'assignee', new Set(['none']))) return true;
+  if (validIdCohort(value, 'label', new Set(['none']))) return true;
+  if (validIdCohort(value, 'sprint', new Set(['none']))) return true;
+  if (validWeekCohort(value)) return true;
   const priority = /^priority:(\d+)$/.exec(value);
   return priority !== null && PRIORITIES.some((entry) => String(entry) === priority[1]);
 }

--- a/packages/core/src/analytics/index.ts
+++ b/packages/core/src/analytics/index.ts
@@ -2,6 +2,7 @@ export * from './burndown.ts';
 export * from './distribution.ts';
 export * from './drilldown.ts';
 export * from './filter.ts';
+export * from './insights.ts';
 export * from './math.ts';
 export * from './overview.ts';
 export * from './people.ts';

--- a/packages/core/src/analytics/insights.ts
+++ b/packages/core/src/analytics/insights.ts
@@ -1,4 +1,5 @@
 import { and, db, isNotNull, schema, sql } from '@orbit/db';
+import { STATE_CATEGORY_LABELS, type StateCategory } from '@orbit/shared/constants';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan } from '@orbit/shared/policy';
 import type {
@@ -253,7 +254,9 @@ function rankByValue<T extends { readonly value: number }>(
 
 function resolveLabel(kind: InsightSlice, id: string, rawLabel: string): string {
   if (id === 'other') return rawLabel;
-  return kind === 'priority' ? priorityLabel(Number(id)) : rawLabel;
+  if (kind === 'priority') return priorityLabel(Number(id));
+  if (kind === 'state_category') return STATE_CATEGORY_LABELS[id as StateCategory] ?? rawLabel;
+  return rawLabel;
 }
 
 function capSegments(

--- a/packages/core/src/analytics/insights.ts
+++ b/packages/core/src/analytics/insights.ts
@@ -27,7 +27,7 @@ export interface InsightBucket {
   readonly label: string;
   readonly value: number;
   readonly segments: readonly InsightSegmentValue[];
-  readonly cohort: AnalyticsDrilldownCohort;
+  readonly cohort: AnalyticsDrilldownCohort | null;
 }
 
 export interface InsightScatterPoint {
@@ -122,58 +122,82 @@ const SLICE_JOIN: Partial<Record<InsightSlice, JoinKind>> = {
   label: 'label',
 };
 
-function joinsFor(insight: InsightConfig): SQL<unknown> {
+function joinsForKinds(kinds: readonly InsightSlice[]): SQL<unknown> {
   const joins = new Set<JoinKind>();
-  const sliceJoin = SLICE_JOIN[insight.slice];
-  if (sliceJoin !== undefined) joins.add(sliceJoin);
-  if (insight.segment !== undefined) {
-    const segmentJoin = SLICE_JOIN[insight.segment];
-    if (segmentJoin !== undefined) joins.add(segmentJoin);
+  for (const kind of kinds) {
+    const join = SLICE_JOIN[kind];
+    if (join !== undefined) joins.add(join);
   }
   const fragments = JOIN_ORDER.filter((join) => joins.has(join)).map((join) => JOIN_SQL[join]);
   return fragments.length === 0 ? sql`` : sql.join(fragments, sql` `);
 }
 
-function usesCompletedWeek(insight: InsightConfig): boolean {
-  return insight.slice === 'completed_week' || insight.segment === 'completed_week';
-}
-
-interface BarRow {
+interface SliceTotalRow {
   readonly [key: string]: unknown;
   readonly slice_id: string;
   readonly slice_label: string;
-  readonly segment_id: string | null;
-  readonly segment_label: string | null;
   readonly value: number | string;
 }
 
-async function barsRows(
+interface SegmentRow {
+  readonly [key: string]: unknown;
+  readonly slice_id: string;
+  readonly segment_id: string;
+  readonly segment_label: string;
+  readonly value: number | string;
+}
+
+async function sliceTotalsRows(
   principal: Principal,
   resolved: ResolvedAnalyticsQuery,
   insight: InsightConfig,
-): Promise<readonly BarRow[]> {
+): Promise<readonly SliceTotalRow[]> {
   const base = baseAnalyticsPredicate(principal, resolved);
   const sliceDef = SLICE_SQL[insight.slice];
-  const segmentDef = insight.segment === undefined ? null : SLICE_SQL[insight.segment];
-  const segmentIdSql = segmentDef === null ? sql`null::text` : segmentDef.id;
-  const segmentLabelSql = segmentDef === null ? sql`null::text` : segmentDef.label;
   const weight = insight.measure === 'points' ? sql`coalesce(${schema.issue.estimate}, 1)` : sql`1`;
   const filters: SQL<unknown>[] = [base];
-  if (usesCompletedWeek(insight)) filters.push(isNotNull(schema.issue.completedAt));
+  if (insight.slice === 'completed_week') filters.push(isNotNull(schema.issue.completedAt));
   const where = and(...filters) ?? sql`false`;
-  return await db.execute<BarRow>(sql`
+  return await db.execute<SliceTotalRow>(sql`
     select
       ${sliceDef.id} as slice_id,
       ${sliceDef.label} as slice_label,
-      ${segmentIdSql} as segment_id,
-      ${segmentLabelSql} as segment_label,
       sum(${weight}) as value
     from issue
     join workflow_state on workflow_state.id = issue.state_id
-    ${joinsFor(insight)}
+    ${joinsForKinds([insight.slice])}
     where ${where}
-    group by ${sliceDef.id}, ${sliceDef.label}, ${segmentIdSql}, ${segmentLabelSql}
+    group by ${sliceDef.id}, ${sliceDef.label}
     order by value desc
+  `);
+}
+
+async function segmentRows(
+  principal: Principal,
+  resolved: ResolvedAnalyticsQuery,
+  insight: InsightConfig,
+  segment: InsightSlice,
+): Promise<readonly SegmentRow[]> {
+  const base = baseAnalyticsPredicate(principal, resolved);
+  const sliceDef = SLICE_SQL[insight.slice];
+  const segmentDef = SLICE_SQL[segment];
+  const weight = insight.measure === 'points' ? sql`coalesce(${schema.issue.estimate}, 1)` : sql`1`;
+  const filters: SQL<unknown>[] = [base];
+  if (insight.slice === 'completed_week' || segment === 'completed_week') {
+    filters.push(isNotNull(schema.issue.completedAt));
+  }
+  const where = and(...filters) ?? sql`false`;
+  return await db.execute<SegmentRow>(sql`
+    select
+      ${sliceDef.id} as slice_id,
+      ${segmentDef.id} as segment_id,
+      ${segmentDef.label} as segment_label,
+      sum(${weight}) as value
+    from issue
+    join workflow_state on workflow_state.id = issue.state_id
+    ${joinsForKinds([insight.slice, segment])}
+    where ${where}
+    group by ${sliceDef.id}, ${segmentDef.id}, ${segmentDef.label}
   `);
 }
 
@@ -185,31 +209,38 @@ interface SegmentAccumulator {
 interface SliceAccumulator {
   readonly id: string;
   readonly label: string;
-  value: number;
+  readonly value: number;
   readonly segments: Map<string, SegmentAccumulator>;
 }
 
-function accumulateBars(rows: readonly BarRow[]): Map<string, SliceAccumulator> {
+function buildSliceMap(rows: readonly SliceTotalRow[]): Map<string, SliceAccumulator> {
   const slices = new Map<string, SliceAccumulator>();
   for (const row of rows) {
-    const value = Number(row.value);
-    let slice = slices.get(row.slice_id);
-    if (slice === undefined) {
-      slice = { id: row.slice_id, label: row.slice_label, value: 0, segments: new Map() };
-      slices.set(row.slice_id, slice);
-    }
-    slice.value += value;
-    if (row.segment_id !== null) {
-      const segmentLabel = row.segment_label ?? row.segment_id;
-      const segment = slice.segments.get(row.segment_id);
-      if (segment === undefined) {
-        slice.segments.set(row.segment_id, { label: segmentLabel, value });
-      } else {
-        segment.value += value;
-      }
-    }
+    slices.set(row.slice_id, {
+      id: row.slice_id,
+      label: row.slice_label,
+      value: Number(row.value),
+      segments: new Map(),
+    });
   }
   return slices;
+}
+
+function applySegments(
+  slices: ReadonlyMap<string, SliceAccumulator>,
+  rows: readonly SegmentRow[],
+): void {
+  for (const row of rows) {
+    const slice = slices.get(row.slice_id);
+    if (slice === undefined) continue;
+    const value = Number(row.value);
+    const existing = slice.segments.get(row.segment_id);
+    if (existing === undefined) {
+      slice.segments.set(row.segment_id, { label: row.segment_label, value });
+    } else {
+      existing.value += value;
+    }
+  }
 }
 
 function rankByValue<T extends { readonly value: number }>(
@@ -258,8 +289,10 @@ function mergeSegmentMaps(
   return merged;
 }
 
-function buildBuckets(insight: InsightConfig, rows: readonly BarRow[]): readonly InsightBucket[] {
-  const slices = accumulateBars(rows);
+function buildBuckets(
+  insight: InsightConfig,
+  slices: ReadonlyMap<string, SliceAccumulator>,
+): readonly InsightBucket[] {
   const ranked = rankByValue(slices);
   const kept = ranked.slice(0, SLICE_CAP);
   const overflow = ranked.slice(SLICE_CAP);
@@ -279,7 +312,7 @@ function buildBuckets(insight: InsightConfig, rows: readonly BarRow[]): readonly
       label: 'Other',
       value: overflowValue,
       segments: insight.segment === undefined ? [] : capSegments(mergedSegments, insight.segment),
-      cohort: { cohort: `${cohortPrefix}:other` },
+      cohort: null,
     });
   }
   return buckets;
@@ -290,11 +323,16 @@ async function loadBars(
   resolved: ResolvedAnalyticsQuery,
   insight: InsightConfig,
 ): Promise<InsightResult> {
-  const rows = await barsRows(principal, resolved, insight);
+  const totals = await sliceTotalsRows(principal, resolved, insight);
+  const slices = buildSliceMap(totals);
+  if (insight.segment !== undefined) {
+    const rows = await segmentRows(principal, resolved, insight, insight.segment);
+    applySegments(slices, rows);
+  }
   return {
     kind: 'bars',
     unit: insight.measure === 'points' ? 'points' : 'issues',
-    buckets: buildBuckets(insight, rows),
+    buckets: buildBuckets(insight, slices),
   };
 }
 
@@ -314,7 +352,11 @@ function scatterDuration(measure: ScatterMeasure, resolved: ResolvedAnalyticsQue
 function scatterWhere(measure: ScatterMeasure, base: SQL<unknown>): SQL<unknown> {
   const filters: SQL<unknown>[] = [base];
   if (measure === 'cycle_time') {
-    filters.push(isNotNull(schema.issue.startedAt), isNotNull(schema.issue.completedAt));
+    filters.push(
+      isNotNull(schema.issue.startedAt),
+      isNotNull(schema.issue.completedAt),
+      sql`${schema.issue.completedAt} >= ${schema.issue.startedAt}`,
+    );
   } else if (measure === 'lead_time') {
     filters.push(isNotNull(schema.issue.completedAt));
   } else {

--- a/packages/core/src/analytics/insights.ts
+++ b/packages/core/src/analytics/insights.ts
@@ -1,0 +1,388 @@
+import { and, db, isNotNull, schema, sql } from '@orbit/db';
+import type { Principal } from '@orbit/shared/policy';
+import { assertCan } from '@orbit/shared/policy';
+import type {
+  AnalyticsDrilldownCohort,
+  AnalyticsQuery,
+  InsightConfig,
+  InsightSlice,
+} from '@orbit/shared/validators';
+import type { SQL } from 'drizzle-orm';
+import { baseAnalyticsPredicate, priorityLabel, resolveOverviewQuery } from './drilldown.ts';
+import { type InsightPercentiles, percentilesOf } from './math.ts';
+import type { ResolvedAnalyticsQuery } from './types.ts';
+
+const SLICE_CAP = 30;
+const SEGMENT_CAP = 8;
+const SCATTER_CAP = 500;
+
+export interface InsightSegmentValue {
+  readonly id: string;
+  readonly label: string;
+  readonly value: number;
+}
+
+export interface InsightBucket {
+  readonly id: string;
+  readonly label: string;
+  readonly value: number;
+  readonly segments: readonly InsightSegmentValue[];
+  readonly cohort: AnalyticsDrilldownCohort;
+}
+
+export interface InsightScatterPoint {
+  readonly issueId: string;
+  readonly identifier: string;
+  readonly title: string;
+  readonly days: number;
+}
+
+export type InsightResult =
+  | {
+      readonly kind: 'bars';
+      readonly unit: 'issues' | 'points';
+      readonly buckets: readonly InsightBucket[];
+    }
+  | {
+      readonly kind: 'scatter';
+      readonly unit: 'days';
+      readonly points: readonly InsightScatterPoint[];
+      readonly percentiles: InsightPercentiles | null;
+    };
+
+interface SliceDimension {
+  readonly id: SQL<unknown>;
+  readonly label: SQL<unknown>;
+  readonly cohortPrefix: string;
+}
+
+const SLICE_SQL: Record<InsightSlice, SliceDimension> = {
+  assignee: {
+    id: sql`coalesce(${schema.issue.assigneeId}, 'none')`,
+    label: sql`coalesce("user".name, 'Unassigned')`,
+    cohortPrefix: 'assignee',
+  },
+  state: {
+    id: sql`${schema.issue.stateId}`,
+    label: sql`workflow_state.name`,
+    cohortPrefix: 'state',
+  },
+  state_category: {
+    id: sql`workflow_state.category::text`,
+    label: sql`workflow_state.category::text`,
+    cohortPrefix: 'state-category',
+  },
+  project: {
+    id: sql`coalesce(${schema.issue.projectId}, 'none')`,
+    label: sql`coalesce(project.name, 'No project')`,
+    cohortPrefix: 'project',
+  },
+  label: {
+    id: sql`coalesce(issue_label.label_id, 'none')`,
+    label: sql`coalesce(label.name, 'No label')`,
+    cohortPrefix: 'label',
+  },
+  priority: {
+    id: sql`${schema.issue.priority}::text`,
+    label: sql`${schema.issue.priority}::text`,
+    cohortPrefix: 'priority',
+  },
+  sprint: {
+    id: sql`coalesce(${schema.issue.cycleId}, 'none')`,
+    label: sql`coalesce(cycle.name, 'No sprint')`,
+    cohortPrefix: 'sprint',
+  },
+  created_week: {
+    id: sql`to_char(date_trunc('week', ${schema.issue.createdAt}), 'YYYY-MM-DD')`,
+    label: sql`to_char(date_trunc('week', ${schema.issue.createdAt}), 'YYYY-MM-DD')`,
+    cohortPrefix: 'created-week',
+  },
+  completed_week: {
+    id: sql`to_char(date_trunc('week', ${schema.issue.completedAt}), 'YYYY-MM-DD')`,
+    label: sql`to_char(date_trunc('week', ${schema.issue.completedAt}), 'YYYY-MM-DD')`,
+    cohortPrefix: 'completed-week',
+  },
+};
+
+type JoinKind = 'user' | 'project' | 'cycle' | 'label';
+
+const JOIN_SQL: Record<JoinKind, SQL<unknown>> = {
+  user: sql`left join "user" on "user".id = ${schema.issue.assigneeId}`,
+  project: sql`left join project on project.id = ${schema.issue.projectId}`,
+  cycle: sql`left join cycle on cycle.id = ${schema.issue.cycleId}`,
+  label: sql`left join issue_label on issue_label.issue_id = ${schema.issue.id} left join label on label.id = issue_label.label_id`,
+};
+
+const JOIN_ORDER: readonly JoinKind[] = ['user', 'project', 'cycle', 'label'];
+
+const SLICE_JOIN: Partial<Record<InsightSlice, JoinKind>> = {
+  assignee: 'user',
+  project: 'project',
+  sprint: 'cycle',
+  label: 'label',
+};
+
+function joinsFor(insight: InsightConfig): SQL<unknown> {
+  const joins = new Set<JoinKind>();
+  const sliceJoin = SLICE_JOIN[insight.slice];
+  if (sliceJoin !== undefined) joins.add(sliceJoin);
+  if (insight.segment !== undefined) {
+    const segmentJoin = SLICE_JOIN[insight.segment];
+    if (segmentJoin !== undefined) joins.add(segmentJoin);
+  }
+  const fragments = JOIN_ORDER.filter((join) => joins.has(join)).map((join) => JOIN_SQL[join]);
+  return fragments.length === 0 ? sql`` : sql.join(fragments, sql` `);
+}
+
+function usesCompletedWeek(insight: InsightConfig): boolean {
+  return insight.slice === 'completed_week' || insight.segment === 'completed_week';
+}
+
+interface BarRow {
+  readonly [key: string]: unknown;
+  readonly slice_id: string;
+  readonly slice_label: string;
+  readonly segment_id: string | null;
+  readonly segment_label: string | null;
+  readonly value: number | string;
+}
+
+async function barsRows(
+  principal: Principal,
+  resolved: ResolvedAnalyticsQuery,
+  insight: InsightConfig,
+): Promise<readonly BarRow[]> {
+  const base = baseAnalyticsPredicate(principal, resolved);
+  const sliceDef = SLICE_SQL[insight.slice];
+  const segmentDef = insight.segment === undefined ? null : SLICE_SQL[insight.segment];
+  const segmentIdSql = segmentDef === null ? sql`null::text` : segmentDef.id;
+  const segmentLabelSql = segmentDef === null ? sql`null::text` : segmentDef.label;
+  const weight = insight.measure === 'points' ? sql`coalesce(${schema.issue.estimate}, 1)` : sql`1`;
+  const filters: SQL<unknown>[] = [base];
+  if (usesCompletedWeek(insight)) filters.push(isNotNull(schema.issue.completedAt));
+  const where = and(...filters) ?? sql`false`;
+  return await db.execute<BarRow>(sql`
+    select
+      ${sliceDef.id} as slice_id,
+      ${sliceDef.label} as slice_label,
+      ${segmentIdSql} as segment_id,
+      ${segmentLabelSql} as segment_label,
+      sum(${weight}) as value
+    from issue
+    join workflow_state on workflow_state.id = issue.state_id
+    ${joinsFor(insight)}
+    where ${where}
+    group by ${sliceDef.id}, ${sliceDef.label}, ${segmentIdSql}, ${segmentLabelSql}
+    order by value desc
+  `);
+}
+
+interface SegmentAccumulator {
+  readonly label: string;
+  value: number;
+}
+
+interface SliceAccumulator {
+  readonly id: string;
+  readonly label: string;
+  value: number;
+  readonly segments: Map<string, SegmentAccumulator>;
+}
+
+function accumulateBars(rows: readonly BarRow[]): Map<string, SliceAccumulator> {
+  const slices = new Map<string, SliceAccumulator>();
+  for (const row of rows) {
+    const value = Number(row.value);
+    let slice = slices.get(row.slice_id);
+    if (slice === undefined) {
+      slice = { id: row.slice_id, label: row.slice_label, value: 0, segments: new Map() };
+      slices.set(row.slice_id, slice);
+    }
+    slice.value += value;
+    if (row.segment_id !== null) {
+      const segmentLabel = row.segment_label ?? row.segment_id;
+      const segment = slice.segments.get(row.segment_id);
+      if (segment === undefined) {
+        slice.segments.set(row.segment_id, { label: segmentLabel, value });
+      } else {
+        segment.value += value;
+      }
+    }
+  }
+  return slices;
+}
+
+function rankByValue<T extends { readonly value: number }>(
+  entries: ReadonlyMap<string, T>,
+): readonly (readonly [string, T])[] {
+  return [...entries.entries()].sort(
+    (left, right) => right[1].value - left[1].value || left[0].localeCompare(right[0]),
+  );
+}
+
+function resolveLabel(kind: InsightSlice, id: string, rawLabel: string): string {
+  if (id === 'other') return rawLabel;
+  return kind === 'priority' ? priorityLabel(Number(id)) : rawLabel;
+}
+
+function capSegments(
+  segments: ReadonlyMap<string, SegmentAccumulator>,
+  kind: InsightSlice,
+): readonly InsightSegmentValue[] {
+  const ranked = rankByValue(segments);
+  const kept = ranked.slice(0, SEGMENT_CAP).map(([id, segment]) => ({
+    id,
+    label: resolveLabel(kind, id, segment.label),
+    value: segment.value,
+  }));
+  const overflow = ranked.slice(SEGMENT_CAP);
+  if (overflow.length === 0) return kept;
+  const overflowValue = overflow.reduce((sum, [, segment]) => sum + segment.value, 0);
+  return [...kept, { id: 'other', label: 'Other', value: overflowValue }];
+}
+
+function mergeSegmentMaps(
+  maps: readonly ReadonlyMap<string, SegmentAccumulator>[],
+): Map<string, SegmentAccumulator> {
+  const merged = new Map<string, SegmentAccumulator>();
+  for (const map of maps) {
+    for (const [id, segment] of map) {
+      const existing = merged.get(id);
+      if (existing === undefined) {
+        merged.set(id, { label: segment.label, value: segment.value });
+      } else {
+        existing.value += segment.value;
+      }
+    }
+  }
+  return merged;
+}
+
+function buildBuckets(insight: InsightConfig, rows: readonly BarRow[]): readonly InsightBucket[] {
+  const slices = accumulateBars(rows);
+  const ranked = rankByValue(slices);
+  const kept = ranked.slice(0, SLICE_CAP);
+  const overflow = ranked.slice(SLICE_CAP);
+  const cohortPrefix = SLICE_SQL[insight.slice].cohortPrefix;
+  const buckets: InsightBucket[] = kept.map(([id, slice]) => ({
+    id,
+    label: resolveLabel(insight.slice, id, slice.label),
+    value: slice.value,
+    segments: insight.segment === undefined ? [] : capSegments(slice.segments, insight.segment),
+    cohort: { cohort: `${cohortPrefix}:${id}` },
+  }));
+  if (overflow.length > 0) {
+    const overflowValue = overflow.reduce((sum, [, slice]) => sum + slice.value, 0);
+    const mergedSegments = mergeSegmentMaps(overflow.map(([, slice]) => slice.segments));
+    buckets.push({
+      id: 'other',
+      label: 'Other',
+      value: overflowValue,
+      segments: insight.segment === undefined ? [] : capSegments(mergedSegments, insight.segment),
+      cohort: { cohort: `${cohortPrefix}:other` },
+    });
+  }
+  return buckets;
+}
+
+async function loadBars(
+  principal: Principal,
+  resolved: ResolvedAnalyticsQuery,
+  insight: InsightConfig,
+): Promise<InsightResult> {
+  const rows = await barsRows(principal, resolved, insight);
+  return {
+    kind: 'bars',
+    unit: insight.measure === 'points' ? 'points' : 'issues',
+    buckets: buildBuckets(insight, rows),
+  };
+}
+
+type ScatterMeasure = 'cycle_time' | 'lead_time' | 'age';
+
+function scatterDuration(measure: ScatterMeasure, resolved: ResolvedAnalyticsQuery): SQL<unknown> {
+  switch (measure) {
+    case 'cycle_time':
+      return sql`extract(epoch from (${schema.issue.completedAt} - ${schema.issue.startedAt})) / 86400`;
+    case 'lead_time':
+      return sql`extract(epoch from (${schema.issue.completedAt} - ${schema.issue.createdAt})) / 86400`;
+    case 'age':
+      return sql`extract(epoch from (${resolved.asOf.toISOString()}::timestamptz - ${schema.issue.createdAt})) / 86400`;
+  }
+}
+
+function scatterWhere(measure: ScatterMeasure, base: SQL<unknown>): SQL<unknown> {
+  const filters: SQL<unknown>[] = [base];
+  if (measure === 'cycle_time') {
+    filters.push(isNotNull(schema.issue.startedAt), isNotNull(schema.issue.completedAt));
+  } else if (measure === 'lead_time') {
+    filters.push(isNotNull(schema.issue.completedAt));
+  } else {
+    filters.push(sql`workflow_state.category not in ('completed', 'canceled')`);
+  }
+  return and(...filters) ?? sql`false`;
+}
+
+interface DurationRow {
+  readonly [key: string]: unknown;
+  readonly days: number | string;
+}
+
+interface ScatterRow {
+  readonly [key: string]: unknown;
+  readonly id: string;
+  readonly identifier: string;
+  readonly title: string;
+  readonly days: number | string;
+}
+
+async function loadScatter(
+  principal: Principal,
+  resolved: ResolvedAnalyticsQuery,
+  measure: ScatterMeasure,
+): Promise<InsightResult> {
+  const base = baseAnalyticsPredicate(principal, resolved);
+  const duration = scatterDuration(measure, resolved);
+  const where = scatterWhere(measure, base);
+  const [durations, points] = await Promise.all([
+    db.execute<DurationRow>(sql`
+      select ${duration} as days
+      from issue
+      join workflow_state on workflow_state.id = issue.state_id
+      where ${where}
+    `),
+    db.execute<ScatterRow>(sql`
+      select issue.id, issue.identifier, issue.title, ${duration} as days
+      from issue
+      join workflow_state on workflow_state.id = issue.state_id
+      where ${where}
+      order by days desc
+      limit ${SCATTER_CAP}
+    `),
+  ]);
+  return {
+    kind: 'scatter',
+    unit: 'days',
+    points: points.map((row) => ({
+      issueId: row.id,
+      identifier: row.identifier,
+      title: row.title,
+      days: Number(row.days),
+    })),
+    percentiles: percentilesOf(durations.map((row) => Number(row.days))),
+  };
+}
+
+export async function loadAnalyticsInsights(
+  principal: Principal,
+  query: AnalyticsQuery,
+  insight: InsightConfig,
+  context: { readonly now: Date; readonly timezone?: string },
+): Promise<InsightResult> {
+  assertCan(principal, 'analytics:read');
+  const resolved = await resolveOverviewQuery(principal, query, context);
+  if (insight.measure === 'count' || insight.measure === 'points') {
+    return loadBars(principal, resolved, insight);
+  }
+  return loadScatter(principal, resolved, insight.measure);
+}

--- a/packages/core/src/analytics/math.ts
+++ b/packages/core/src/analytics/math.ts
@@ -46,6 +46,23 @@ export interface ChurnTotals {
   readonly removed: number;
 }
 
+export interface InsightPercentiles {
+  readonly p25: number;
+  readonly p50: number;
+  readonly p75: number;
+  readonly p95: number;
+}
+
+export function percentilesOf(values: readonly number[]): InsightPercentiles | null {
+  if (values.length === 0) return null;
+  return {
+    p25: percentile(values, 0.25),
+    p50: percentile(values, 0.5),
+    p75: percentile(values, 0.75),
+    p95: percentile(values, 0.95),
+  };
+}
+
 export function churnFromScopeSeries(scopeByDay: readonly number[]): ChurnTotals {
   let added = 0;
   let removed = 0;

--- a/packages/core/src/analytics/overview.ts
+++ b/packages/core/src/analytics/overview.ts
@@ -159,7 +159,7 @@ async function healthCards(
   resolved: ResolvedAnalyticsQuery,
 ): Promise<HealthRow> {
   const base = baseAnalyticsPredicate(principal, resolved);
-  const weight = resolved.measure === 'points' ? sql`coalesce(issue.estimate, 0)` : sql`1`;
+  const weight = resolved.measure === 'points' ? sql`coalesce(issue.estimate, 1)` : sql`1`;
   const wip = cohortPredicate(resolved, { cohort: 'wip' });
   const blocked = cohortPredicate(resolved, { cohort: 'blocked' });
   const overdue = cohortPredicate(resolved, { cohort: 'overdue' });
@@ -202,7 +202,7 @@ async function throughputCards(
   const base = baseAnalyticsPredicate(principal, resolved);
   const current = cohortPredicate(resolved, { cohort: 'throughput' });
   const comparison = cohortPredicate(resolved, { cohort: 'comparison-throughput' });
-  const weight = resolved.measure === 'points' ? sql`coalesce(issue.estimate, 0)` : sql`1`;
+  const weight = resolved.measure === 'points' ? sql`coalesce(issue.estimate, 1)` : sql`1`;
   const duration = sql`extract(epoch from (issue.completed_at - issue.started_at)) / 86400`;
   const validCycle = sql`issue.started_at is not null and issue.completed_at >= issue.started_at`;
   const [row] = await db.execute<CardRow>(sql`
@@ -246,7 +246,7 @@ async function distributions(
   resolved: ResolvedAnalyticsQuery,
 ): Promise<readonly DistributionRow[]> {
   const base = baseAnalyticsPredicate(principal, resolved);
-  const weight = resolved.measure === 'points' ? sql`coalesce(issue.estimate, 0)` : sql`1`;
+  const weight = resolved.measure === 'points' ? sql`coalesce(issue.estimate, 1)` : sql`1`;
   return await db.execute<DistributionRow>(sql`
     with filtered as materialized (
       select workflow_state.category::text as state_id,
@@ -293,7 +293,7 @@ async function deliverySeries(
   resolved: ResolvedAnalyticsQuery,
 ): Promise<readonly DeliveryRow[]> {
   const base = baseAnalyticsPredicate(principal, resolved);
-  const weight = resolved.measure === 'points' ? sql`coalesce(issue.estimate, 0)` : sql`1`;
+  const weight = resolved.measure === 'points' ? sql`coalesce(issue.estimate, 1)` : sql`1`;
   const starts = bucketDates(resolved.resolvedRange, resolved.bucket);
   const rows = starts.map((start, index) => {
     const end = starts[index + 1] ?? resolved.to;

--- a/packages/core/src/analytics/people.ts
+++ b/packages/core/src/analytics/people.ts
@@ -830,7 +830,7 @@ function formulas(): PeopleFormulaMetadata {
     attribution:
       'Captured close outcomes are preferred, assignment activity reconstructs the assignee at completion next, and current-assignee is the labeled fallback when neither fact exists.',
     points:
-      'Null estimates contribute zero points and remain counted in the unestimated issue total. Counts and points are planning signals, not measures of employee value or effort.',
+      'Unestimated work counts as 1 point until estimated. Counts and points are planning signals, not measures of employee value or effort.',
   };
 }
 

--- a/packages/core/src/analytics/people.ts
+++ b/packages/core/src/analytics/people.ts
@@ -367,9 +367,9 @@ async function currentStats(
   const rows = await db.execute<CurrentStatRow>(sql`
     select ${personIdSql()} as person_id,
       count(*) filter (where ${open}) as current_assignments,
-      coalesce(sum(coalesce(issue.estimate, 0)) filter (where ${open}), 0) as current_points,
+      coalesce(sum(coalesce(issue.estimate, 1)) filter (where ${open}), 0) as current_points,
       count(*) filter (where ${wip}) as current_wip,
-      coalesce(sum(coalesce(issue.estimate, 0)) filter (where ${wip}), 0) as current_wip_points,
+      coalesce(sum(coalesce(issue.estimate, 1)) filter (where ${wip}), 0) as current_wip_points,
       count(*) filter (where ${wip} and issue.state_entered_at <= ${resolved.asOf.toISOString()}::timestamptz) as wip_age_valid,
       percentile_cont(0.5) within group (
         order by extract(epoch from (${resolved.asOf.toISOString()}::timestamptz - issue.state_entered_at)) / 86400

--- a/packages/core/src/analytics/people.ts
+++ b/packages/core/src/analytics/people.ts
@@ -432,7 +432,7 @@ async function completionStats(
     )
     select person_id,
       count(*) as completed_issues,
-      coalesce(sum(coalesce(estimate, 0)), 0) as completed_points,
+      coalesce(sum(coalesce(estimate, 1)), 0) as completed_points,
       count(*) filter (where started_at is not null and completed_at >= started_at) as cycle_valid,
       percentile_cont(0.5) within group (
         order by extract(epoch from (completed_at - started_at)) / 86400
@@ -664,22 +664,22 @@ async function focusGroups(
         and workflow_state.category not in ('completed', 'canceled')
     ), dimensions as (
       select 'project'::text as dimension, project.id, project.name,
-        count(*) as issues, coalesce(sum(coalesce(current_work.estimate, 0)), 0) as points
+        count(*) as issues, coalesce(sum(coalesce(current_work.estimate, 1)), 0) as points
       from current_work join project on project.id = current_work.project_id
       group by project.id, project.name
       union all
       select 'milestone', milestone.id, milestone.name, count(*),
-        coalesce(sum(coalesce(current_work.estimate, 0)), 0)
+        coalesce(sum(coalesce(current_work.estimate, 1)), 0)
       from current_work join milestone on milestone.id = current_work.milestone_id
       group by milestone.id, milestone.name
       union all
       select 'sprint', cycle.id, case when cycle.name = '' then 'Sprint ' || cycle.number else cycle.name end,
-        count(*), coalesce(sum(coalesce(current_work.estimate, 0)), 0)
+        count(*), coalesce(sum(coalesce(current_work.estimate, 1)), 0)
       from current_work join cycle on cycle.id = current_work.cycle_id
       group by cycle.id, cycle.name, cycle.number
       union all
       select 'state', workflow_state.id, workflow_state.name, count(*),
-        coalesce(sum(coalesce(current_work.estimate, 0)), 0)
+        coalesce(sum(coalesce(current_work.estimate, 1)), 0)
       from current_work join workflow_state on workflow_state.id = current_work.state_id
       group by workflow_state.id, workflow_state.name
     ), ranked as (
@@ -748,12 +748,12 @@ async function focusTimeline(
         and assignments.created_at < buckets.bucket_end
     ), assignment_bucket as (
       select assignment_issue_bucket.date, count(*) as issues,
-        coalesce(sum(assignment_issue_bucket.estimate), 0) as points
+        coalesce(sum(coalesce(assignment_issue_bucket.estimate, 1)), 0) as points
       from assignment_issue_bucket
       group by assignment_issue_bucket.date
     ), completion_bucket as (
       select buckets.date, count(distinct completions.id) as issues,
-        coalesce(sum(completions.estimate), 0) as points
+        coalesce(sum(coalesce(completions.estimate, 1)), 0) as points
       from buckets
       join completions on completions.completed_at >= buckets.bucket_start
         and completions.completed_at < buckets.bucket_end

--- a/packages/core/src/analytics/projects.ts
+++ b/packages/core/src/analytics/projects.ts
@@ -449,7 +449,7 @@ async function projectAddedStats(
     )
     select project_id,
       count(*) as scope_added_issues,
-      coalesce(sum(coalesce(estimate, 0)), 0) as scope_added_points,
+      coalesce(sum(coalesce(estimate, 1)), 0) as scope_added_points,
       count(*) filter (where current_project_entry) as current_project_entries
     from deduplicated
     group by project_id
@@ -655,9 +655,9 @@ async function milestoneRows(
       select milestone.id, milestone.name, milestone.target_date, milestone.sort_order,
         milestone.created_at,
         count(filtered.id) as scope_issues,
-        coalesce(sum(coalesce(filtered.estimate, 0)), 0) as scope_points,
+        coalesce(sum(case when filtered.id is null then 0 else coalesce(filtered.estimate, 1) end), 0) as scope_points,
         count(filtered.id) filter (where filtered.category = 'completed') as completed_issues,
-        coalesce(sum(coalesce(filtered.estimate, 0)) filter (
+        coalesce(sum(coalesce(filtered.estimate, 1)) filter (
           where filtered.category = 'completed'
         ), 0) as completed_points
       from milestone

--- a/packages/core/src/analytics/projects.ts
+++ b/packages/core/src/analytics/projects.ts
@@ -370,13 +370,13 @@ async function projectStats(
   const rows = await db.execute<ProjectStatRow>(sql`
     select issue.project_id,
       count(*) as scope_issues,
-      coalesce(sum(coalesce(issue.estimate, 0)), 0) as scope_points,
+      coalesce(sum(coalesce(issue.estimate, 1)), 0) as scope_points,
       count(*) filter (where ${open}) as open_issues,
-      coalesce(sum(coalesce(issue.estimate, 0)) filter (where ${open}), 0) as open_points,
+      coalesce(sum(coalesce(issue.estimate, 1)) filter (where ${open}), 0) as open_points,
       count(*) filter (where ${wip}) as wip_issues,
-      coalesce(sum(coalesce(issue.estimate, 0)) filter (where ${wip}), 0) as wip_points,
+      coalesce(sum(coalesce(issue.estimate, 1)) filter (where ${wip}), 0) as wip_points,
       count(*) filter (where ${completed}) as completed_issues,
-      coalesce(sum(coalesce(issue.estimate, 0)) filter (where ${completed}), 0) as completed_points,
+      coalesce(sum(coalesce(issue.estimate, 1)) filter (where ${completed}), 0) as completed_points,
       count(*) filter (where ${blocked}) as blocked,
       count(*) filter (where ${overdue}) as overdue,
       count(*) filter (where ${open} and issue.updated_at < ${staleBefore}::timestamptz) as stale,
@@ -386,7 +386,7 @@ async function projectStats(
         where issue.completed_at >= ${from.toISOString()}::timestamptz
           and issue.completed_at < ${to.toISOString()}::timestamptz
       ) as completed_range_issues,
-      coalesce(sum(coalesce(issue.estimate, 0)) filter (
+      coalesce(sum(coalesce(issue.estimate, 1)) filter (
         where issue.completed_at >= ${from.toISOString()}::timestamptz
           and issue.completed_at < ${to.toISOString()}::timestamptz
       ), 0) as completed_range_points

--- a/packages/core/src/analytics/saved-view.ts
+++ b/packages/core/src/analytics/saved-view.ts
@@ -45,10 +45,12 @@ export function normalizeSavedAnalyticsConfig(
   config: Record<string, unknown>,
 ): SavedDashboardConfig {
   const query = config['query'];
+  const insight = config['insight'];
   return savedDashboardConfigSchema.parse({
     kind: 'dashboard',
     version: 1,
     query: analyticsQuerySchema.parse(typeof query === 'object' && query !== null ? query : config),
+    ...(insight === undefined ? {} : { insight }),
     pinned: config['pinned'] === true,
   });
 }

--- a/packages/core/src/analytics/schemas.ts
+++ b/packages/core/src/analytics/schemas.ts
@@ -1,4 +1,4 @@
-import { analyticsQuerySchema } from '@orbit/shared/validators';
+import { analyticsQuerySchema, insightConfigSchema } from '@orbit/shared/validators';
 import { z } from 'zod';
 
 export const MEASURES = ['issues', 'points'] as const;
@@ -49,6 +49,7 @@ export const savedDashboardConfigSchema = z.object({
   kind: z.literal('dashboard'),
   version: z.literal(1),
   query: analyticsQuerySchema,
+  insight: insightConfigSchema.optional(),
   pinned: z.boolean().default(false),
 });
 export type SavedDashboardConfig = z.infer<typeof savedDashboardConfigSchema>;

--- a/packages/core/src/analytics/sprints.ts
+++ b/packages/core/src/analytics/sprints.ts
@@ -52,7 +52,14 @@ export interface SprintBurnPoint {
   readonly removed: number;
   readonly ideal: number;
   readonly available: boolean;
+  readonly future: boolean;
   readonly coverage: AnalyticsCoverage['kind'];
+}
+
+export interface SprintBaseline {
+  readonly date: string;
+  readonly scope: number;
+  readonly retroactive: boolean;
 }
 
 export interface SprintMeasureSummary {
@@ -105,6 +112,8 @@ export interface SprintDetail {
   readonly sprint: SprintSummary;
   readonly measure: AnalyticsQuery['measure'];
   readonly summary: SprintMeasureSummary;
+  readonly baseline: SprintBaseline | null;
+  readonly counterpart: SprintMeasureSummary;
   readonly scopeChanges: SprintScopeChanges;
   readonly burn: readonly SprintBurnPoint[];
   readonly cohorts: SprintCohorts;
@@ -390,7 +399,7 @@ function startedAt(fact: IssueFact): Date | null {
 
 function valueAt(fact: IssueFact, at: Date, measure: AnalyticsQuery['measure']): number {
   if (measure === 'issues') return 1;
-  return estimateAt(fact, at) ?? 0;
+  return estimateAt(fact, at) ?? 1;
 }
 
 function coverageOf(facts: SprintFacts, now: Date): AnalyticsCoverage {
@@ -462,6 +471,7 @@ function burnFor(
 ): SprintBurnPoint[] {
   const startDay = dateText(facts.cycle.startsAt, facts.cycle.timezone);
   const lastDay = dateText(new Date(endOfFacts(facts, now).getTime() - 1), facts.cycle.timezone);
+  const sprintFinalDay = dateText(new Date(facts.cycle.endsAt.getTime() - 1), facts.cycle.timezone);
   const coverage = coverageOf(facts, now).kind;
   const observedMemberships = facts.issues
     .flatMap((fact) => fact.memberships)
@@ -548,23 +558,42 @@ function burnFor(
       removed,
       ideal: 0,
       available,
+      future: false,
       coverage,
     });
   }
-  const baseline = points.find((point) => point.available);
+  if (lastDay < sprintFinalDay) {
+    let day = addDate(lastDay, 1);
+    while (day <= sprintFinalDay) {
+      const working = isWorkingDay(day);
+      points.push({
+        date: day,
+        calendarDay: calendarDaysBetween(startDay, day),
+        workingDay: working ? workingDaysBetween(startDay, day) : null,
+        scope: 0,
+        started: 0,
+        completed: 0,
+        remaining: 0,
+        added: 0,
+        removed: 0,
+        ideal: 0,
+        available: false,
+        future: true,
+        coverage,
+      });
+      day = addDate(day, 1);
+    }
+  }
+  const baseline = points.find((point) => point.available && !point.future);
   const initialScope = baseline?.scope ?? 0;
-  const baselineDay = baseline?.date ?? startDay;
-  const sprintFinalDay = dateText(new Date(facts.cycle.endsAt.getTime() - 1), facts.cycle.timezone);
-  const plannedWorkingDays = Math.max(1, workingDaysBetween(baselineDay, sprintFinalDay));
+  const plannedWorkingDays = Math.max(1, workingDaysBetween(startDay, sprintFinalDay));
   return points.map((point) => ({
     ...point,
-    ideal: point.available
-      ? idealRemaining(
-          initialScope,
-          workingDaysBetween(baselineDay, point.date) - 1,
-          plannedWorkingDays - 1,
-        )
-      : 0,
+    ideal: idealRemaining(
+      initialScope,
+      workingDaysBetween(startDay, point.date) - 1,
+      plannedWorkingDays - 1,
+    ),
   }));
 }
 
@@ -656,6 +685,7 @@ function summaryFor(
   now: Date,
   personId: string | null,
   teamId: string | null = null,
+  options: { readonly baselineScope: number | null } = { baselineScope: null },
 ): SprintMeasureSummary {
   const at = endOfFacts(facts, now);
   const personFacts = facts.issues.filter(
@@ -667,7 +697,7 @@ function summaryFor(
     personFacts
       .filter((fact) => ids.includes(fact.issueId))
       .reduce((sum, fact) => sum + valueAt(fact, at, measure), 0);
-  const last = burn.at(-1);
+  const last = burn.filter((point) => !point.future).at(-1);
   const events = membershipEvents(facts, now);
   const attributedEvents = (rows: readonly MembershipRow[]): MembershipRow[] =>
     rows.filter((row) => {
@@ -686,8 +716,9 @@ function summaryFor(
   const currentFacts = personFacts.filter(
     (fact) => committedAt(fact, facts, at, now) && insideAt(fact, at),
   );
+  const captured = sumCohort(cohorts.planned);
   return {
-    planned: sumCohort(cohorts.planned),
+    planned: captured > 0 ? captured : (options.baselineScope ?? 0),
     currentScope: last?.scope ?? 0,
     completed: last?.completed ?? 0,
     remaining: last?.remaining ?? 0,
@@ -725,6 +756,10 @@ function flowFor(facts: SprintFacts): SprintFlowDistributions {
   };
 }
 
+function baselinePointOf(burn: readonly SprintBurnPoint[]): SprintBurnPoint | undefined {
+  return burn.find((point) => point.available && !point.future);
+}
+
 function detailFor(
   facts: SprintFacts,
   measure: AnalyticsQuery['measure'],
@@ -733,7 +768,25 @@ function detailFor(
 ): SprintDetail {
   const burn = burnFor(facts, measure, now, null);
   const cohorts = cohortsOf(facts, now);
-  const summary = summaryFor(facts, burn, cohorts, measure, now, null);
+  const baselinePoint = baselinePointOf(burn);
+  const at = endOfFacts(facts, now);
+  const capturedPlanned = facts.issues
+    .filter((fact) => cohorts.planned.includes(fact.issueId))
+    .reduce((sum, fact) => sum + valueAt(fact, at, measure), 0);
+  const baseline =
+    baselinePoint === undefined
+      ? null
+      : {
+          date: baselinePoint.date,
+          scope: baselinePoint.scope,
+          retroactive: capturedPlanned === 0 && baselinePoint.scope > 0,
+        };
+  const summary = summaryFor(facts, burn, cohorts, measure, now, null, null, {
+    baselineScope: baselinePoint?.scope ?? null,
+  });
+  const otherMeasure = measure === 'issues' ? ('points' as const) : ('issues' as const);
+  const counterpartBurn = burnFor(facts, otherMeasure, now, null);
+  const counterpart = summaryFor(facts, counterpartBurn, cohorts, otherMeasure, now, null);
   const personIds = unique(
     facts.issues.flatMap((fact) => [
       ...(fact.assigneeId === null ? [] : [fact.assigneeId]),
@@ -747,11 +800,14 @@ function detailFor(
   );
   const people = personIds.map((personId) => {
     const personBurn = burnFor(facts, measure, now, personId);
+    const personBaseline = baselinePointOf(personBurn);
     return {
       personId,
       name: names.get(personId) ?? 'Former member',
       burn: personBurn,
-      summary: summaryFor(facts, personBurn, cohorts, measure, now, personId),
+      summary: summaryFor(facts, personBurn, cohorts, measure, now, personId, null, {
+        baselineScope: personBaseline?.scope ?? null,
+      }),
       coverage: coverageOf(facts, now),
     };
   });
@@ -764,15 +820,20 @@ function detailFor(
   );
   const teams = teamIds.map((teamId) => {
     const teamBurn = burnFor(facts, measure, now, null, teamId);
+    const teamBaseline = baselinePointOf(teamBurn);
     return {
       id: teamId,
-      summary: summaryFor(facts, teamBurn, cohorts, measure, now, null, teamId),
+      summary: summaryFor(facts, teamBurn, cohorts, measure, now, null, teamId, {
+        baselineScope: teamBaseline?.scope ?? null,
+      }),
     };
   });
   return {
     sprint: summaryOf(facts.cycle),
     measure,
     summary,
+    baseline,
+    counterpart,
     scopeChanges: { added: summary.added, removed: summary.removed },
     burn,
     cohorts,
@@ -961,13 +1022,12 @@ function formulas(): SprintFormulaMetadata {
       'Captured sprint membership entered before the sprint start or within 24 hours after it. Known triage, backlog, or canceled state at commitment is excluded; missing state-at-entry coverage is retained as membership-planned rather than inferred from current state.',
     scope:
       'Membership active at the observation time, excluding triage, backlog, or canceled work only where a state transition or observation establishes that category.',
-    burn: 'Remaining equals scope minus completed on each sprint local calendar day. Dates before an observed membership baseline are unavailable rather than zero. Observed bootstrap membership establishes the baseline and is not counted as added scope. The ideal line begins at the first reliable scope baseline. State-transition facts preserve completion and reopen episodes; current-day values include captured facts after the latest snapshot.',
+    burn: 'Remaining equals scope minus completed on each sprint local calendar day. Dates before an observed membership baseline are unavailable rather than zero. Observed bootstrap membership establishes the baseline and is not counted as added scope. The ideal line starts at sprint day 1 using the first reliable scope baseline and holds flat over weekends. State-transition facts preserve completion and reopen episodes; current-day values include captured facts after the latest snapshot.',
     leadTime:
       'Current issue-row creation to durable completion for issues whose creation row remains available; deleted rows are unavailable.',
     cycleTime:
       'Current mutable startedAt column to completion. Completed sprint values are labeled reconstructed-current-column, never frozen, because close outcomes do not retain first start.',
-    points:
-      'Null estimates contribute zero points and remain counted in the explicit unestimated issue total.',
+    points: 'Unestimated work counts as 1 point until estimated.',
     coverage:
       'Captured requires captured active membership facts, observed includes bootstrap or missing entry-state facts, frozen requires outcomes for every relevant issue plus a final snapshot, and completed partial history is reconstructed.',
   };

--- a/packages/core/src/analytics/sprints.ts
+++ b/packages/core/src/analytics/sprints.ts
@@ -531,7 +531,7 @@ function burnFor(
       )
       .reduce((sum, entry) => {
         if (measure === 'issues') return sum + 1;
-        return sum + (entry.estimateAtAdd ?? 0);
+        return sum + (entry.estimateAtAdd ?? 1);
       }, 0);
     const removed = facts.issues
       .flatMap((fact) => fact.memberships)
@@ -544,7 +544,7 @@ function burnFor(
       )
       .reduce((sum, entry) => {
         if (measure === 'issues') return sum + 1;
-        return sum + (entry.estimateAtAdd ?? 0);
+        return sum + (entry.estimateAtAdd ?? 1);
       }, 0);
     points.push({
       date: day,
@@ -711,7 +711,7 @@ function summaryFor(
     });
   const eventValue = (rows: readonly MembershipRow[]): number =>
     attributedEvents(rows).reduce(
-      (sum, row) => sum + (measure === 'issues' ? 1 : (row.estimateAtAdd ?? 0)),
+      (sum, row) => sum + (measure === 'issues' ? 1 : (row.estimateAtAdd ?? 1)),
       0,
     );
   const currentFacts = personFacts.filter(

--- a/packages/core/src/analytics/sprints.ts
+++ b/packages/core/src/analytics/sprints.ts
@@ -562,8 +562,9 @@ function burnFor(
       coverage,
     });
   }
-  if (lastDay < sprintFinalDay) {
-    let day = addDate(lastDay, 1);
+  const lastObservedDay = points.at(-1)?.date ?? startDay;
+  if (lastObservedDay < sprintFinalDay) {
+    let day = addDate(lastObservedDay, 1);
     while (day <= sprintFinalDay) {
       const working = isWorkingDay(day);
       points.push({
@@ -786,7 +787,10 @@ function detailFor(
   });
   const otherMeasure = measure === 'issues' ? ('points' as const) : ('issues' as const);
   const counterpartBurn = burnFor(facts, otherMeasure, now, null);
-  const counterpart = summaryFor(facts, counterpartBurn, cohorts, otherMeasure, now, null);
+  const counterpartBaseline = baselinePointOf(counterpartBurn);
+  const counterpart = summaryFor(facts, counterpartBurn, cohorts, otherMeasure, now, null, null, {
+    baselineScope: counterpartBaseline?.scope ?? null,
+  });
   const personIds = unique(
     facts.issues.flatMap((fact) => [
       ...(fact.assigneeId === null ? [] : [fact.assigneeId]),

--- a/packages/core/tests/analytics/burndown.test.ts
+++ b/packages/core/tests/analytics/burndown.test.ts
@@ -116,6 +116,10 @@ describe('cycleBurndown', () => {
     );
     expect(future.every((point) => point.isFuture)).toBe(true);
     expect(burndown.points.every((point) => Number.isFinite(point.ideal))).toBe(true);
+
+    const lastObserved = burndown.points.filter((point) => !point.isFuture).at(-1);
+    expect(future.every((point) => point.scope === lastObserved?.scope)).toBe(true);
+    expect(future[0]?.ideal).toBeGreaterThan(0);
   });
 
   it('uses the sprint calendar for boundaries and the current day', async () => {

--- a/packages/core/tests/analytics/drilldown.test.ts
+++ b/packages/core/tests/analytics/drilldown.test.ts
@@ -6,7 +6,14 @@ import {
   analyticsQuerySchema,
 } from '@orbit/shared';
 import { listAnalyticsDrilldown } from '../../src/analytics/drilldown.ts';
-import { createWorkspace, resetDatabase, type Workspace } from '../../src/test-support.ts';
+import { createLabel, insertLabelOn } from '../../src/analytics/test-fixtures.ts';
+import { newId } from '../../src/internal.ts';
+import {
+  addMember,
+  createWorkspace,
+  resetDatabase,
+  type Workspace,
+} from '../../src/test-support.ts';
 import { createIssue } from '../../src/work/issue-service.ts';
 
 const now = new Date('2026-08-13T12:00:00.000Z');
@@ -235,6 +242,148 @@ describe('listAnalyticsDrilldown', () => {
     expect(page.issues.map((entry) => entry.title)).toEqual(['Running']);
   });
 
+  it('drills into an assignee cohort, including the unassigned bucket', async () => {
+    const member = await addMember(workspace, 'member', { name: 'Nadia' });
+    const assigned = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Assigned',
+      assigneeId: member.user.id,
+    });
+    await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Unassigned',
+      assigneeId: null,
+    });
+
+    const assignedPage = await listAnalyticsDrilldown(
+      workspace.admin,
+      { query: query(), cohort: { cohort: `assignee:${member.user.id}` }, limit: 10 },
+      { now, timezone: 'UTC' },
+    );
+    const nonePage = await listAnalyticsDrilldown(
+      workspace.admin,
+      { query: query(), cohort: { cohort: 'assignee:none' }, limit: 10 },
+      { now, timezone: 'UTC' },
+    );
+
+    expect(assignedPage.issues.map((entry) => entry.title)).toEqual(['Assigned']);
+    expect(assignedPage.issues[0]?.id).toBe(assigned.issue.id);
+    expect(nonePage.issues.map((entry) => entry.title)).toEqual(['Unassigned']);
+  });
+
+  it('drills into a label cohort, including the unlabeled bucket', async () => {
+    const labelId = await createLabel(workspace, 'Bug');
+    const labeled = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Labeled',
+    });
+    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Unlabeled' });
+    await insertLabelOn(labeled.issue.id, labelId);
+
+    const labeledPage = await listAnalyticsDrilldown(
+      workspace.admin,
+      { query: query(), cohort: { cohort: `label:${labelId}` }, limit: 10 },
+      { now, timezone: 'UTC' },
+    );
+    const nonePage = await listAnalyticsDrilldown(
+      workspace.admin,
+      { query: query(), cohort: { cohort: 'label:none' }, limit: 10 },
+      { now, timezone: 'UTC' },
+    );
+
+    expect(labeledPage.issues.map((entry) => entry.title)).toEqual(['Labeled']);
+    expect(nonePage.issues.map((entry) => entry.title)).toEqual(['Unlabeled']);
+  });
+
+  it('drills into a sprint cohort, including the no-sprint bucket', async () => {
+    const cycleId = newId();
+    await db.insert(schema.cycle).values({
+      id: cycleId,
+      organizationId: workspace.organizationId,
+      number: 2,
+      name: 'Sprint 2',
+      timezone: 'UTC',
+      startsAt: new Date('2026-08-01T00:00:00.000Z'),
+      endsAt: new Date('2026-08-08T00:00:00.000Z'),
+    });
+    const inSprint = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'In sprint',
+      cycleId,
+    });
+    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'No sprint' });
+
+    const sprintPage = await listAnalyticsDrilldown(
+      workspace.admin,
+      { query: query(), cohort: { cohort: `sprint:${cycleId}` }, limit: 10 },
+      { now, timezone: 'UTC' },
+    );
+    const nonePage = await listAnalyticsDrilldown(
+      workspace.admin,
+      { query: query(), cohort: { cohort: 'sprint:none' }, limit: 10 },
+      { now, timezone: 'UTC' },
+    );
+
+    expect(sprintPage.issues.map((entry) => entry.title)).toEqual(['In sprint']);
+    expect(sprintPage.issues[0]?.id).toBe(inSprint.issue.id);
+    expect(nonePage.issues.map((entry) => entry.title)).toEqual(['No sprint']);
+  });
+
+  it('drills into a created-week cohort by the date_trunc week bucket', async () => {
+    const inWeek = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'In week',
+    });
+    const outOfWeek = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Out of week',
+    });
+    await db
+      .update(schema.issue)
+      .set({ createdAt: new Date('2026-08-10T12:00:00.000Z') })
+      .where(eq(schema.issue.id, inWeek.issue.id));
+    await db
+      .update(schema.issue)
+      .set({ createdAt: new Date('2026-08-17T12:00:00.000Z') })
+      .where(eq(schema.issue.id, outOfWeek.issue.id));
+
+    const page = await listAnalyticsDrilldown(
+      workspace.admin,
+      { query: query(), cohort: { cohort: 'created-week:2026-08-10' }, limit: 10 },
+      { now, timezone: 'UTC' },
+    );
+
+    expect(page.issues.map((entry) => entry.title)).toEqual(['In week']);
+  });
+
+  it('drills into a completed-week cohort and excludes open issues implicitly', async () => {
+    const completedInWeek = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Completed in week',
+    });
+    const completedOtherWeek = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Completed other week',
+    });
+    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Still open' });
+    await db
+      .update(schema.issue)
+      .set({ completedAt: new Date('2026-08-10T12:00:00.000Z') })
+      .where(eq(schema.issue.id, completedInWeek.issue.id));
+    await db
+      .update(schema.issue)
+      .set({ completedAt: new Date('2026-08-17T12:00:00.000Z') })
+      .where(eq(schema.issue.id, completedOtherWeek.issue.id));
+
+    const page = await listAnalyticsDrilldown(
+      workspace.admin,
+      { query: query(), cohort: { cohort: 'completed-week:2026-08-10' }, limit: 10 },
+      { now, timezone: 'UTC' },
+    );
+
+    expect(page.issues.map((entry) => entry.title)).toEqual(['Completed in week']);
+  });
+
   it('rejects malformed semantic cohort keys before executing SQL', async () => {
     const invalidCohorts = [
       '',
@@ -254,6 +403,11 @@ describe('listAnalyticsDrilldown', () => {
       'outlier:none',
       'outlier:not-an-id',
       'current:extra',
+      'assignee:',
+      'label:not-an-id',
+      'sprint:',
+      'created-week:junk',
+      'completed-week:2026-13-99',
     ];
 
     for (const cohort of invalidCohorts) {

--- a/packages/core/tests/analytics/insights.test.ts
+++ b/packages/core/tests/analytics/insights.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { type AnalyticsQuery, analyticsQuerySchema, insightConfigSchema } from '@orbit/shared';
+import { loadAnalyticsInsights } from '../../src/analytics/insights.ts';
+import { createLabel, insertIssue, insertLabelOn } from '../../src/analytics/test-fixtures.ts';
+import {
+  createWorkspace,
+  resetDatabase,
+  stateNamed,
+  type Workspace,
+} from '../../src/test-support.ts';
+
+const now = new Date('2026-08-13T12:00:00.000Z');
+
+let workspace: Workspace;
+
+function query(): AnalyticsQuery {
+  return analyticsQuerySchema.parse({
+    range: { preset: 'custom', from: '2026-08-01', to: '2026-08-10' },
+    compare: 'none',
+  });
+}
+
+beforeEach(async () => {
+  await resetDatabase();
+  workspace = await createWorkspace('Nova');
+});
+
+describe('loadAnalyticsInsights', () => {
+  it('aggregates bars by slice and segment with cohort keys and sums', async () => {
+    const todo = stateNamed(workspace, 'Todo');
+    const inProgress = stateNamed(workspace, 'In Progress');
+    await insertIssue(workspace, { number: 1, state: 'Todo', priority: 1 });
+    await insertIssue(workspace, { number: 2, state: 'Todo', priority: 1 });
+    await insertIssue(workspace, { number: 3, state: 'Todo', priority: 2 });
+    await insertIssue(workspace, { number: 4, state: 'In Progress', priority: 1 });
+
+    const result = await loadAnalyticsInsights(
+      workspace.admin,
+      query(),
+      insightConfigSchema.parse({ measure: 'count', slice: 'state', segment: 'priority' }),
+      { now, timezone: 'UTC' },
+    );
+
+    if (result.kind !== 'bars') throw new Error('Expected a bars result.');
+    expect(result.unit).toBe('issues');
+    expect(result.buckets.map((bucket) => bucket.id)).toEqual([todo.id, inProgress.id]);
+
+    const todoBucket = result.buckets.find((bucket) => bucket.id === todo.id);
+    const inProgressBucket = result.buckets.find((bucket) => bucket.id === inProgress.id);
+    if (todoBucket === undefined || inProgressBucket === undefined) {
+      throw new Error('Missing expected buckets.');
+    }
+
+    expect(todoBucket.value).toBe(3);
+    expect(todoBucket.label).toBe('Todo');
+    expect(todoBucket.cohort).toEqual({ cohort: `state:${todo.id}` });
+    expect(todoBucket.segments.find((segment) => segment.id === '1')).toEqual({
+      id: '1',
+      label: 'Urgent',
+      value: 2,
+    });
+    expect(todoBucket.segments.find((segment) => segment.id === '2')).toEqual({
+      id: '2',
+      label: 'High',
+      value: 1,
+    });
+
+    expect(inProgressBucket.value).toBe(1);
+    expect(inProgressBucket.cohort).toEqual({ cohort: `state:${inProgress.id}` });
+    expect(inProgressBucket.segments).toEqual([{ id: '1', label: 'Urgent', value: 1 }]);
+  });
+
+  it('weighs bars by points, treating an unestimated issue as one point', async () => {
+    await insertIssue(workspace, { number: 5, state: 'Todo', estimate: 3 });
+    await insertIssue(workspace, { number: 6, state: 'Todo', estimate: null });
+
+    const result = await loadAnalyticsInsights(
+      workspace.admin,
+      query(),
+      insightConfigSchema.parse({ measure: 'points', slice: 'state' }),
+      { now, timezone: 'UTC' },
+    );
+
+    if (result.kind !== 'bars') throw new Error('Expected a bars result.');
+    expect(result.unit).toBe('points');
+    const todo = stateNamed(workspace, 'Todo');
+    expect(result.buckets.find((bucket) => bucket.id === todo.id)?.value).toBe(4);
+  });
+
+  it('counts an issue under every label it carries', async () => {
+    const bugId = await createLabel(workspace, 'Bug');
+    const featureId = await createLabel(workspace, 'Feature');
+    const dual = await insertIssue(workspace, { number: 10, state: 'Todo' });
+    await insertLabelOn(dual, bugId);
+    await insertLabelOn(dual, featureId);
+    await insertIssue(workspace, { number: 11, state: 'Todo' });
+    const bugOnly = await insertIssue(workspace, { number: 12, state: 'Todo' });
+    await insertLabelOn(bugOnly, bugId);
+
+    const result = await loadAnalyticsInsights(
+      workspace.admin,
+      query(),
+      insightConfigSchema.parse({ measure: 'count', slice: 'label' }),
+      { now, timezone: 'UTC' },
+    );
+
+    if (result.kind !== 'bars') throw new Error('Expected a bars result.');
+    const bugBucket = result.buckets.find((bucket) => bucket.id === bugId);
+    const featureBucket = result.buckets.find((bucket) => bucket.id === featureId);
+    const noneBucket = result.buckets.find((bucket) => bucket.id === 'none');
+    if (bugBucket === undefined || featureBucket === undefined || noneBucket === undefined) {
+      throw new Error('Missing expected label buckets.');
+    }
+
+    expect(bugBucket.value).toBe(2);
+    expect(bugBucket.label).toBe('Bug');
+    expect(featureBucket.value).toBe(1);
+    expect(featureBucket.label).toBe('Feature');
+    expect(noneBucket.value).toBe(1);
+    expect(noneBucket.label).toBe('No label');
+  });
+
+  it('rolls segments beyond the cap into an other bucket', async () => {
+    const labelIds: string[] = [];
+    for (let index = 0; index < 9; index += 1) {
+      const labelId = await createLabel(workspace, `Label ${String(index).padStart(2, '0')}`);
+      labelIds.push(labelId);
+      const issueId = await insertIssue(workspace, { number: 100 + index, state: 'Todo' });
+      await insertLabelOn(issueId, labelId);
+    }
+
+    const result = await loadAnalyticsInsights(
+      workspace.admin,
+      query(),
+      insightConfigSchema.parse({ measure: 'count', slice: 'state_category', segment: 'label' }),
+      { now, timezone: 'UTC' },
+    );
+
+    if (result.kind !== 'bars') throw new Error('Expected a bars result.');
+    const bucket = result.buckets.find((entry) => entry.id === 'unstarted');
+    if (bucket === undefined) throw new Error('Missing the unstarted bucket.');
+    expect(bucket.segments).toHaveLength(9);
+    const other = bucket.segments.find((segment) => segment.id === 'other');
+    if (other === undefined) throw new Error('Missing the other segment.');
+    expect(other.value).toBe(1);
+    const sortedIds = [...labelIds].sort((left, right) => left.localeCompare(right));
+    const overflowLabelId = sortedIds.at(-1);
+    expect(bucket.segments.some((segment) => segment.id === overflowLabelId)).toBe(false);
+  });
+
+  it('produces scatter points and exact percentiles for cycle time', async () => {
+    const shortId = await insertIssue(workspace, {
+      number: 20,
+      state: 'Done',
+      startedAt: new Date('2026-08-01T00:00:00.000Z'),
+      completedAt: new Date('2026-08-03T00:00:00.000Z'),
+    });
+    const longId = await insertIssue(workspace, {
+      number: 21,
+      state: 'Done',
+      startedAt: new Date('2026-08-01T00:00:00.000Z'),
+      completedAt: new Date('2026-08-07T00:00:00.000Z'),
+    });
+
+    const result = await loadAnalyticsInsights(
+      workspace.admin,
+      query(),
+      insightConfigSchema.parse({ measure: 'cycle_time' }),
+      { now, timezone: 'UTC' },
+    );
+
+    if (result.kind !== 'scatter') throw new Error('Expected a scatter result.');
+    expect(result.unit).toBe('days');
+    expect(result.points.map((point) => point.issueId)).toEqual([longId, shortId]);
+    expect(result.points[0]?.days).toBeCloseTo(6, 5);
+    expect(result.points[1]?.days).toBeCloseTo(2, 5);
+    expect(result.percentiles).not.toBeNull();
+    expect(result.percentiles?.p25).toBeCloseTo(3, 5);
+    expect(result.percentiles?.p50).toBeCloseTo(4, 5);
+    expect(result.percentiles?.p75).toBeCloseTo(5, 5);
+    expect(result.percentiles?.p95).toBeCloseTo(5.8, 5);
+  });
+});

--- a/packages/core/tests/analytics/insights.test.ts
+++ b/packages/core/tests/analytics/insights.test.ts
@@ -120,6 +120,59 @@ describe('loadAnalyticsInsights', () => {
     expect(noneBucket.label).toBe('No label');
   });
 
+  it('keeps a bucket total independent of segment fanout for multi-label issues', async () => {
+    const todo = stateNamed(workspace, 'Todo');
+    const bugId = await createLabel(workspace, 'Bug');
+    const featureId = await createLabel(workspace, 'Feature');
+    const dual = await insertIssue(workspace, { number: 30, state: 'Todo' });
+    await insertLabelOn(dual, bugId);
+    await insertLabelOn(dual, featureId);
+
+    const result = await loadAnalyticsInsights(
+      workspace.admin,
+      query(),
+      insightConfigSchema.parse({ measure: 'count', slice: 'state', segment: 'label' }),
+      { now, timezone: 'UTC' },
+    );
+
+    if (result.kind !== 'bars') throw new Error('Expected a bars result.');
+    const todoBucket = result.buckets.find((bucket) => bucket.id === todo.id);
+    if (todoBucket === undefined) throw new Error('Missing the Todo bucket.');
+    expect(todoBucket.value).toBe(1);
+    expect(todoBucket.segments.find((segment) => segment.id === bugId)?.value).toBe(1);
+    expect(todoBucket.segments.find((segment) => segment.id === featureId)?.value).toBe(1);
+  });
+
+  it('rolls slices beyond the cap into a non-drillable other bucket', async () => {
+    const labelIds: string[] = [];
+    for (let index = 0; index < 31; index += 1) {
+      const labelId = await createLabel(workspace, `Slice ${String(index).padStart(2, '0')}`);
+      labelIds.push(labelId);
+      const issueId = await insertIssue(workspace, { number: 200 + index, state: 'Todo' });
+      await insertLabelOn(issueId, labelId);
+    }
+
+    const result = await loadAnalyticsInsights(
+      workspace.admin,
+      query(),
+      insightConfigSchema.parse({ measure: 'count', slice: 'label' }),
+      { now, timezone: 'UTC' },
+    );
+
+    if (result.kind !== 'bars') throw new Error('Expected a bars result.');
+    expect(result.buckets).toHaveLength(31);
+
+    const other = result.buckets.find((bucket) => bucket.id === 'other');
+    if (other === undefined) throw new Error('Missing the other bucket.');
+    expect(other.cohort).toBeNull();
+    expect(other.value).toBe(1);
+
+    const named = result.buckets.find((bucket) => bucket.id !== 'other');
+    if (named === undefined) throw new Error('Missing a named bucket.');
+    expect(named.cohort).not.toBeNull();
+    expect(named.cohort).toEqual({ cohort: `label:${named.id}` });
+  });
+
   it('rolls segments beyond the cap into an other bucket', async () => {
     const labelIds: string[] = [];
     for (let index = 0; index < 9; index += 1) {
@@ -161,6 +214,12 @@ describe('loadAnalyticsInsights', () => {
       startedAt: new Date('2026-08-01T00:00:00.000Z'),
       completedAt: new Date('2026-08-07T00:00:00.000Z'),
     });
+    await insertIssue(workspace, {
+      number: 22,
+      state: 'Done',
+      startedAt: new Date('2026-08-05T00:00:00.000Z'),
+      completedAt: new Date('2026-08-01T00:00:00.000Z'),
+    });
 
     const result = await loadAnalyticsInsights(
       workspace.admin,
@@ -171,6 +230,7 @@ describe('loadAnalyticsInsights', () => {
 
     if (result.kind !== 'scatter') throw new Error('Expected a scatter result.');
     expect(result.unit).toBe('days');
+    expect(result.points).toHaveLength(2);
     expect(result.points.map((point) => point.issueId)).toEqual([longId, shortId]);
     expect(result.points[0]?.days).toBeCloseTo(6, 5);
     expect(result.points[1]?.days).toBeCloseTo(2, 5);

--- a/packages/core/tests/analytics/insights.test.ts
+++ b/packages/core/tests/analytics/insights.test.ts
@@ -201,6 +201,27 @@ describe('loadAnalyticsInsights', () => {
     expect(bucket.segments.some((segment) => segment.id === overflowLabelId)).toBe(false);
   });
 
+  it('labels state category buckets for people instead of the raw enum value', async () => {
+    await insertIssue(workspace, { number: 40, state: 'Todo' });
+    await insertIssue(workspace, { number: 41, state: 'In Progress' });
+
+    const result = await loadAnalyticsInsights(
+      workspace.admin,
+      query(),
+      insightConfigSchema.parse({ measure: 'count', slice: 'state_category' }),
+      { now, timezone: 'UTC' },
+    );
+
+    if (result.kind !== 'bars') throw new Error('Expected a bars result.');
+    const started = result.buckets.find((bucket) => bucket.id === 'started');
+    const unstarted = result.buckets.find((bucket) => bucket.id === 'unstarted');
+    if (started === undefined || unstarted === undefined) {
+      throw new Error('Missing expected state category buckets.');
+    }
+    expect(started.label).toBe('Started');
+    expect(unstarted.label).toBe('Unstarted');
+  });
+
   it('produces scatter points and exact percentiles for cycle time', async () => {
     const shortId = await insertIssue(workspace, {
       number: 20,

--- a/packages/core/tests/analytics/math.test.ts
+++ b/packages/core/tests/analytics/math.test.ts
@@ -4,6 +4,7 @@ import {
   distributionOf,
   idealRemaining,
   percentile,
+  percentilesOf,
 } from '../../src/analytics/math.ts';
 
 describe('percentile', () => {
@@ -24,6 +25,21 @@ describe('percentile', () => {
   it('clamps out of range quantiles', () => {
     expect(percentile([1, 2, 3], -1)).toBe(1);
     expect(percentile([1, 2, 3], 5)).toBe(3);
+  });
+});
+
+describe('percentilesOf', () => {
+  it('returns null for an empty set', () => {
+    expect(percentilesOf([])).toBeNull();
+  });
+
+  it('interpolates p25, p50, p75 and p95 on a known set', () => {
+    const result = percentilesOf([1, 2, 3, 4]);
+    expect(result).not.toBeNull();
+    expect(result?.p25).toBeCloseTo(1.75, 5);
+    expect(result?.p50).toBeCloseTo(2.5, 5);
+    expect(result?.p75).toBeCloseTo(3.25, 5);
+    expect(result?.p95).toBeCloseTo(3.85, 5);
   });
 });
 

--- a/packages/core/tests/analytics/overview.test.ts
+++ b/packages/core/tests/analytics/overview.test.ts
@@ -354,6 +354,44 @@ describe('loadAnalyticsOverview', () => {
     expect(card(overview, 'unestimated')).toMatchObject({ value: 1, unit: 'issues' });
   });
 
+  it('weights unestimated work as 1 point everywhere in points mode, matching the drilldown total', async () => {
+    const started = stateNamed(workspace, 'In Progress');
+    await issue(
+      workspace.admin,
+      { title: 'Unestimated in progress', stateId: started.id, estimate: null },
+      {
+        createdAt: new Date('2026-08-02T00:00:00.000Z'),
+        startedAt: new Date('2026-08-02T00:00:00.000Z'),
+      },
+    );
+    await issue(
+      workspace.admin,
+      { title: 'Estimated in progress', stateId: started.id, estimate: 3 },
+      {
+        createdAt: new Date('2026-08-02T00:00:00.000Z'),
+        startedAt: new Date('2026-08-02T00:00:00.000Z'),
+      },
+    );
+
+    const overview = await loadAnalyticsOverview(workspace.admin, query('points'), {
+      now,
+      timezone: 'UTC',
+    });
+
+    expect(card(overview, 'wip').value).toBe(4);
+    const startedBucket = overview.state.find((bucket) => bucket.id === 'started');
+    expect(startedBucket?.value).toBe(4);
+    const createdPoint = overview.delivery.find((point) => point.date === '2026-08-02');
+    expect(createdPoint?.created).toBe(4);
+
+    const drilldown = await listAnalyticsDrilldown(
+      workspace.admin,
+      { query: query('points'), cohort: { cohort: 'wip' }, limit: 100 },
+      { now, timezone: 'UTC' },
+    );
+    expect(drilldown.totalValue).toBe(4);
+  });
+
   it('bounds project distribution and reconciles the Other cohort', async () => {
     for (let index = 0; index < 10; index += 1) {
       const { project } = await createProject(workspace.admin, {

--- a/packages/core/tests/analytics/people.test.ts
+++ b/packages/core/tests/analytics/people.test.ts
@@ -279,6 +279,39 @@ describe('loadPeopleAnalytics', () => {
     }
   });
 
+  it('weights an unestimated current issue as 1 point in the focused work groups', async () => {
+    const engineer = await addMember(workspace, 'member', { name: 'Grouped Person' });
+    const project = await createProject(workspace.admin, {
+      name: 'Grouping',
+      teamIds: [workspace.teamId],
+    });
+    const started = stateNamed(workspace, 'In Progress');
+    await issue(
+      workspace.admin,
+      {
+        title: 'Unestimated current work',
+        assigneeId: engineer.user.id,
+        projectId: project.project.id,
+        stateId: started.id,
+        estimate: null,
+      },
+      { createdAt: new Date('2026-08-02T00:00:00.000Z') },
+    );
+
+    const result = await loadPeopleAnalytics(
+      workspace.admin,
+      query({ personId: engineer.user.id }),
+      { now, timezone: 'UTC' },
+    );
+
+    expect(result.focused?.projects).toEqual([
+      expect.objectContaining({ id: project.project.id, issues: 1, points: 1 }),
+    ]);
+    expect(result.focused?.states).toEqual([
+      expect.objectContaining({ id: started.id, issues: 1, points: 1 }),
+    ]);
+  });
+
   it('labels captured, reconstructed, and current-assignee completion attribution', async () => {
     const captured = await addMember(workspace, 'member', { name: 'Captured Person' });
     const reconstructed = await addMember(workspace, 'member', { name: 'Reconstructed Person' });
@@ -607,6 +640,43 @@ describe('loadPeopleAnalytics', () => {
       { now, timezone: 'UTC', cursorSecret: 'people-analytics-secret' },
     );
     expect(drilldown.total).toBe(point.assignedIssues);
+  });
+
+  it('weights an unestimated issue as 1 point in the assignment and completion timeline', async () => {
+    const engineer = await addMember(workspace, 'member', { name: 'Timeline Person' });
+    const assignedWork = await issue(
+      workspace.admin,
+      { title: 'Unestimated assignment', assigneeId: engineer.user.id, estimate: null },
+      { createdAt: new Date('2026-08-01T00:00:00.000Z') },
+    );
+    await assignmentActivity(assignedWork, null, engineer.user, '2026-08-04T09:00:00.000Z');
+    await issue(
+      workspace.admin,
+      {
+        title: 'Unestimated completion',
+        assigneeId: engineer.user.id,
+        stateId: stateNamed(workspace, 'Done').id,
+        estimate: null,
+      },
+      {
+        createdAt: new Date('2026-08-01T00:00:00.000Z'),
+        completedAt: new Date('2026-08-04T00:00:00.000Z'),
+      },
+    );
+
+    const result = await loadPeopleAnalytics(
+      workspace.admin,
+      query({ personId: engineer.user.id }),
+      { now, timezone: 'UTC' },
+    );
+
+    const point = result.focused?.timeline.find((entry) => entry.date === '2026-08-04');
+    expect(point).toMatchObject({
+      assignedIssues: 1,
+      assignedPoints: 1,
+      completedIssues: 1,
+      completedPoints: 1,
+    });
   });
 
   it('retains unassigned and deleted-user-safe evidence and caps the workspace list', async () => {

--- a/packages/core/tests/analytics/people.test.ts
+++ b/packages/core/tests/analytics/people.test.ts
@@ -240,7 +240,7 @@ describe('loadPeopleAnalytics', () => {
 
     expect(row).toMatchObject({
       currentAssignments: 1,
-      currentPoints: 0,
+      currentPoints: 1,
       completedIssues: 2,
       completedPoints: 8,
       activeWeeks: 2,

--- a/packages/core/tests/analytics/projects.test.ts
+++ b/packages/core/tests/analytics/projects.test.ts
@@ -526,7 +526,7 @@ describe('loadProjectAnalytics', () => {
       healthSource: 'manual',
       status: 'in_progress',
       scopeIssues: 4,
-      scopePoints: 10,
+      scopePoints: 11,
       openIssues: 3,
       completedIssues: 1,
       blocked: 1,
@@ -681,12 +681,12 @@ describe('loadProjectAnalytics', () => {
 
     expect(row).toMatchObject({
       scopeIssues: 2,
-      scopePoints: 8,
+      scopePoints: 9,
       unestimated: 1,
       estimateCoverage: 'mixed',
     });
     expect(drilldown.total).toBe(2);
-    expect(drilldown.totalValue).toBe(8);
+    expect(drilldown.totalValue).toBe(9);
   });
 
   it('lets every workspace role inspect projects across teams without crossing organizations', async () => {

--- a/packages/core/tests/analytics/projects.test.ts
+++ b/packages/core/tests/analytics/projects.test.ts
@@ -367,6 +367,94 @@ describe('loadProjectAnalytics', () => {
     }
   });
 
+  it('weights an unestimated issue moved into scope as 1 point', async () => {
+    const alpha = await createProject(workspace.admin, {
+      name: 'Alpha added points',
+      teamIds: [workspace.teamId],
+    });
+    const beta = await createProject(workspace.admin, {
+      name: 'Beta added points',
+      teamIds: [workspace.teamId],
+    });
+    const movedIn = await issue(
+      workspace.admin,
+      { title: 'Unestimated moved in', projectId: beta.project.id, estimate: null },
+      { createdAt: new Date('2026-07-01T00:00:00.000Z') },
+    );
+    await projectActivity(movedIn, alpha.project, beta.project, '2026-08-05T00:00:00.000Z');
+
+    const result = await loadProjectAnalytics(workspace.admin, query({ measure: 'points' }), {
+      now,
+      timezone: 'UTC',
+    });
+    const betaRow = projectRow(result, beta.project.id);
+
+    expect(betaRow.scopeAddedIssues).toBe(1);
+    expect(betaRow.scopeAddedPoints).toBe(1);
+  });
+
+  it('weights an unestimated issue as 1 milestone point, leaving an empty milestone at zero', async () => {
+    const project = await createProject(workspace.admin, {
+      name: 'Milestone points',
+      teamIds: [workspace.teamId],
+    });
+    const populated = await createMilestone(workspace.admin, {
+      projectId: project.project.id,
+      name: 'Populated',
+    });
+    const empty = await createMilestone(workspace.admin, {
+      projectId: project.project.id,
+      name: 'Empty',
+    });
+    await issue(
+      workspace.admin,
+      {
+        title: 'Unestimated milestone work',
+        projectId: project.project.id,
+        milestoneId: populated.milestone.id,
+        estimate: null,
+      },
+      { createdAt: new Date('2026-08-02T00:00:00.000Z') },
+    );
+    await issue(
+      workspace.admin,
+      {
+        title: 'Estimated completed milestone work',
+        projectId: project.project.id,
+        milestoneId: populated.milestone.id,
+        stateId: stateNamed(workspace, 'Done').id,
+        estimate: 3,
+      },
+      {
+        createdAt: new Date('2026-08-01T00:00:00.000Z'),
+        completedAt: new Date('2026-08-03T00:00:00.000Z'),
+      },
+    );
+
+    const result = await loadProjectAnalytics(
+      workspace.admin,
+      query({ measure: 'points', focusProjectId: project.project.id }),
+      { now, timezone: 'UTC' },
+    );
+
+    expect(result.focused?.milestones).toEqual([
+      expect.objectContaining({
+        id: populated.milestone.id,
+        scopeIssues: 2,
+        scopePoints: 4,
+        completedIssues: 1,
+        completedPoints: 3,
+      }),
+      expect.objectContaining({
+        id: empty.milestone.id,
+        scopeIssues: 0,
+        scopePoints: 0,
+        completedIssues: 0,
+        completedPoints: 0,
+      }),
+    ]);
+  });
+
   it('labels delivery buckets in the reporting calendar and reconciles bucket completions', async () => {
     const project = await createProject(workspace.admin, {
       name: 'Calendar launch',

--- a/packages/core/tests/analytics/saved-view.test.ts
+++ b/packages/core/tests/analytics/saved-view.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import { analyticsQuerySchema } from '@orbit/shared/validators';
+import { analyticsQuerySchema, insightConfigSchema } from '@orbit/shared/validators';
 import {
   createCheckpoint,
   createSavedAnalyticsView,
@@ -76,6 +76,27 @@ describe('saved analytics views', () => {
       version: 1,
       query,
       pinned: true,
+    });
+  });
+
+  it('keeps the insight config alongside the query for an insights lens view', async () => {
+    const query = analyticsQuerySchema.parse({ lens: 'insights' });
+    const insight = insightConfigSchema.parse({
+      measure: 'points',
+      slice: 'assignee',
+      segment: 'state',
+    });
+    const { view } = await createSavedAnalyticsView(workspace.admin, {
+      name: 'Points by assignee',
+      config: { kind: 'dashboard', version: 1, query, insight, pinned: false },
+    });
+
+    expect(savedAnalyticsQuery(view)).toEqual({
+      kind: 'dashboard',
+      version: 1,
+      query,
+      insight,
+      pinned: false,
     });
   });
 

--- a/packages/core/tests/analytics/sprints.test.ts
+++ b/packages/core/tests/analytics/sprints.test.ts
@@ -181,8 +181,14 @@ describe('loadSprintAnalytics', () => {
       now: new Date('2026-03-08T12:00:00.000Z'),
     });
 
-    expect(currentOf(result).burn.map((point) => point.date)).toEqual(['2026-03-07', '2026-03-08']);
-    expect(currentOf(result).burn.map((point) => point.remaining)).toEqual([1, 0]);
+    expect(currentOf(result).burn.map((point) => point.date)).toEqual([
+      '2026-03-07',
+      '2026-03-08',
+      '2026-03-09',
+      '2026-03-10',
+      '2026-03-11',
+    ]);
+    expect(currentOf(result).burn.map((point) => point.remaining)).toEqual([1, 0, 0, 0, 0]);
     expect(currentOf(result).burn[1]?.completed).toBe(1);
     expect(result.formulas.burn).toContain('local calendar day');
   });
@@ -205,12 +211,14 @@ describe('loadSprintAnalytics', () => {
       now: new Date('2026-08-14T12:00:00.000Z'),
     });
     const burn = currentOf(result).burn;
+    const past = burn.filter((point) => !point.future);
 
-    expect(burn.map((point) => point.available)).toEqual([false, false, false, true]);
+    expect(past.map((point) => point.available)).toEqual([false, false, false, true]);
     expect(burn.slice(0, 3).map((point) => point.scope)).toEqual([0, 0, 0]);
     expect(burn[3]?.scope).toBe(1);
     expect(burn[3]?.added).toBe(0);
-    expect(burn[3]?.ideal).toBe(1);
+    expect(burn[0]?.ideal).toBe(1);
+    expect(burn[3]?.ideal).toBeCloseTo(6 / 9, 5);
     expect(currentOf(result).scopeChanges.added).toBe(0);
     expect(result.formulas.burn).toContain('unavailable rather than zero');
   });
@@ -251,7 +259,12 @@ describe('loadSprintAnalytics', () => {
     const adaBurn = currentOf(result).people.find((entry) => entry.personId === ada.user.id)?.burn;
 
     expect(adaBurn).toBeDefined();
-    expect(adaBurn?.map((point) => point.available)).toEqual([false, false, false, true]);
+    expect(adaBurn?.filter((point) => !point.future).map((point) => point.available)).toEqual([
+      false,
+      false,
+      false,
+      true,
+    ]);
   });
 
   it('reaches zero ideal remaining on the final included sprint day', async () => {
@@ -389,10 +402,12 @@ describe('loadSprintAnalytics', () => {
       now: new Date('2026-08-14T12:00:00.000Z'),
     });
     const burn = currentOf(result).burn;
+    const past = burn.filter((point) => !point.future);
 
-    expect(burn.length).toBeLessThanOrEqual(120);
+    expect(past.length).toBeLessThanOrEqual(120);
     expect(burn[0]?.date).toBe('2020-01-01');
-    expect(burn.at(-1)?.date).toBe('2026-08-14');
+    expect(past.at(-1)?.date).toBe('2026-08-14');
+    expect(burn.at(-1)?.date).toBe('2029-12-31');
   });
 
   it('keeps removal history, counts net-zero churn, and supports re-addition intervals', async () => {
@@ -424,7 +439,7 @@ describe('loadSprintAnalytics', () => {
     });
 
     expect(currentOf(result).scopeChanges).toMatchObject({ added: 2, removed: 2 });
-    expect(currentOf(result).burn.map((point) => point.scope)).toEqual([1, 1, 1, 2, 1, 1]);
+    expect(currentOf(result).burn.map((point) => point.scope)).toEqual([1, 1, 1, 2, 1, 1, 0]);
     expect(currentOf(result).cohorts.removed).toContain(moved);
   });
 
@@ -445,7 +460,7 @@ describe('loadSprintAnalytics', () => {
       now: new Date('2026-01-05T12:00:00.000Z'),
     });
 
-    expect(currentOf(result).burn.map((point) => point.scope)).toEqual([1, 1, 0, 0, 0]);
+    expect(currentOf(result).burn.map((point) => point.scope)).toEqual([1, 1, 0, 0, 0, 0, 0]);
   });
 
   it('enters committed scope only when a known backlog issue moves to Todo', async () => {
@@ -465,7 +480,7 @@ describe('loadSprintAnalytics', () => {
       now: new Date('2026-01-05T12:00:00.000Z'),
     });
 
-    expect(currentOf(result).burn.map((point) => point.scope)).toEqual([0, 0, 1, 1, 1]);
+    expect(currentOf(result).burn.map((point) => point.scope)).toEqual([0, 0, 1, 1, 1, 0, 0]);
   });
 
   it('shows a completion episode and burns back up when the issue reopens', async () => {
@@ -487,8 +502,8 @@ describe('loadSprintAnalytics', () => {
       now: new Date('2026-01-05T12:00:00.000Z'),
     });
 
-    expect(currentOf(result).burn.map((point) => point.completed)).toEqual([0, 1, 1, 0, 0]);
-    expect(currentOf(result).burn.map((point) => point.remaining)).toEqual([1, 0, 0, 1, 1]);
+    expect(currentOf(result).burn.map((point) => point.completed)).toEqual([0, 1, 1, 0, 0, 0, 0]);
+    expect(currentOf(result).burn.map((point) => point.remaining)).toEqual([1, 0, 0, 1, 1, 0, 0]);
   });
 
   it('applies captured 24-hour planning, excludes uncommitted work, and exposes null estimates', async () => {
@@ -544,7 +559,7 @@ describe('loadSprintAnalytics', () => {
     });
     expect(currentOf(points).summary).toMatchObject({
       planned: 13,
-      currentScope: 8,
+      currentScope: 9,
       unestimated: 1,
     });
     expect([...currentOf(issues).cohorts.planned].sort()).toEqual([planned, backlog].sort());
@@ -588,7 +603,7 @@ describe('loadSprintAnalytics', () => {
     });
 
     expect(currentOf(result).cohorts.planned).toEqual([]);
-    expect(currentOf(result).summary.planned).toBe(0);
+    expect(currentOf(result).summary.planned).toBe(1);
   });
 
   it('aligns previous burn and freezes completed outcomes while preserving person attribution', async () => {
@@ -644,7 +659,7 @@ describe('loadSprintAnalytics', () => {
     expect(result.previous?.burn[0]?.workingDay).toBe(1);
     expect(result.previous?.summary.carryover).toBe(1);
     expect(result.focus?.personId).toBe(person.user.id);
-    expect(result.focus?.burn.at(-1)?.remaining).toBe(1);
+    expect(result.focus?.burn.filter((point) => !point.future).at(-1)?.remaining).toBe(1);
     expect(currentOf(result).cohorts.carryover).toContain(previousIssue);
   });
 
@@ -786,8 +801,8 @@ describe('loadSprintAnalytics', () => {
       now: new Date('2026-01-04T12:00:00.000Z'),
     });
 
-    expect(firstResult.focus?.burn.map((point) => point.remaining)).toEqual([1, 1, 0, 0]);
-    expect(secondResult.focus?.burn.map((point) => point.remaining)).toEqual([0, 0, 1, 1]);
+    expect(firstResult.focus?.burn.map((point) => point.remaining)).toEqual([1, 1, 0, 0, 0, 0, 0]);
+    expect(secondResult.focus?.burn.map((point) => point.remaining)).toEqual([0, 0, 1, 1, 0, 0, 0]);
     expect(secondResult.focus?.summary.currentScope).toBe(1);
   });
 
@@ -935,6 +950,89 @@ describe('loadSprintAnalytics', () => {
 
     expect(result.coverage.kind).not.toBe('frozen');
     expect(result.flow.cycleTimeCoverage).not.toBe('frozen');
+  });
+
+  it('extends the burn with ideal-only future points through sprint end', async () => {
+    const cycleId = await cycle(1, '2026-08-11T00:00:00.000Z', '2026-08-25T00:00:00.000Z');
+    const issueId = await insertIssue(workspace, {
+      number: 1,
+      state: 'Todo',
+      cycleId,
+      createdAt: new Date('2026-08-01T00:00:00.000Z'),
+    });
+    await membership(cycleId, issueId, {
+      addedAt: '2026-08-14T07:00:00.000Z',
+      coverage: 'observed',
+      entryKind: 'bootstrap',
+    });
+
+    const result = await loadSprintAnalytics(workspace.admin, sprintQuery(cycleId), {
+      now: new Date('2026-08-14T12:00:00.000Z'),
+    });
+    const burn = currentOf(result).burn;
+    const past = burn.filter((point) => !point.future);
+    const future = burn.filter((point) => point.future);
+
+    expect(burn.at(-1)?.date).toBe('2026-08-24');
+    expect(past.map((point) => point.date).at(-1)).toBe('2026-08-14');
+    expect(future.every((point) => point.scope === 0 && point.remaining === 0)).toBe(true);
+    expect(future.at(-1)?.ideal).toBe(0);
+  });
+
+  it('draws the ideal from day 1 at the retroactive baseline scope', async () => {
+    const cycleId = await cycle(1, '2026-08-11T00:00:00.000Z', '2026-08-25T00:00:00.000Z');
+    const issueId = await insertIssue(workspace, {
+      number: 1,
+      state: 'Todo',
+      cycleId,
+      createdAt: new Date('2026-08-01T00:00:00.000Z'),
+    });
+    await membership(cycleId, issueId, {
+      addedAt: '2026-08-14T07:00:00.000Z',
+      coverage: 'observed',
+      entryKind: 'bootstrap',
+    });
+
+    const result = await loadSprintAnalytics(workspace.admin, sprintQuery(cycleId), {
+      now: new Date('2026-08-14T12:00:00.000Z'),
+    });
+    const burn = currentOf(result).burn;
+
+    expect(burn[0]?.ideal).toBe(1);
+    expect(burn[3]?.ideal).toBeCloseTo(6 / 9, 5);
+    expect(currentOf(result).baseline).toEqual({
+      date: '2026-08-14',
+      scope: 1,
+      retroactive: true,
+    });
+    expect(currentOf(result).summary.planned).toBe(1);
+  });
+
+  it('reports the counterpart measure summary alongside the requested one', async () => {
+    const cycleId = await cycle(1, '2026-08-11T00:00:00.000Z', '2026-08-25T00:00:00.000Z');
+    const estimated = await insertIssue(workspace, {
+      number: 1,
+      state: 'Todo',
+      cycleId,
+      estimate: 5,
+      createdAt: new Date('2026-08-01T00:00:00.000Z'),
+    });
+    const unestimated = await insertIssue(workspace, {
+      number: 2,
+      state: 'Todo',
+      cycleId,
+      createdAt: new Date('2026-08-01T00:00:00.000Z'),
+    });
+    await membership(cycleId, estimated, { addedAt: '2026-08-11T00:00:00.000Z', estimate: 5 });
+    await membership(cycleId, unestimated, { addedAt: '2026-08-11T00:00:00.000Z' });
+
+    const result = await loadSprintAnalytics(workspace.admin, sprintQuery(cycleId), {
+      now: new Date('2026-08-12T12:00:00.000Z'),
+    });
+
+    expect(currentOf(result).summary.currentScope).toBe(2);
+    expect(currentOf(result).counterpart.currentScope).toBe(6);
+    expect(result.formulas.points).toContain('counts as 1 point');
   });
 
   it('does not call completed outcomes frozen when a relevant membership is observed', async () => {

--- a/packages/core/tests/analytics/sprints.test.ts
+++ b/packages/core/tests/analytics/sprints.test.ts
@@ -221,6 +221,9 @@ describe('loadSprintAnalytics', () => {
     expect(burn[3]?.ideal).toBeCloseTo(6 / 9, 5);
     expect(currentOf(result).scopeChanges.added).toBe(0);
     expect(result.formulas.burn).toContain('unavailable rather than zero');
+    expect(burn.map((point) => point.calendarDay)).toEqual(
+      Array.from({ length: burn.length }, (_, index) => index + 1),
+    );
   });
 
   it('holds the capture baseline cycle wide for a person scoped burn', async () => {
@@ -441,6 +444,32 @@ describe('loadSprintAnalytics', () => {
     expect(currentOf(result).scopeChanges).toMatchObject({ added: 2, removed: 2 });
     expect(currentOf(result).burn.map((point) => point.scope)).toEqual([1, 1, 1, 2, 1, 1, 0]);
     expect(currentOf(result).cohorts.removed).toContain(moved);
+  });
+
+  it('weights an unestimated membership addition as 1 point, matching the points-mode rule', async () => {
+    const cycleId = await cycle(1, '2026-01-01T00:00:00.000Z', '2026-01-08T00:00:00.000Z');
+    const estimated = await insertIssue(workspace, {
+      number: 1,
+      state: 'Todo',
+      cycleId,
+      estimate: 3,
+    });
+    const unestimated = await insertIssue(workspace, {
+      number: 2,
+      state: 'Todo',
+      cycleId,
+      estimate: null,
+    });
+    await membership(cycleId, estimated, { addedAt: '2026-01-02T00:00:00.000Z', estimate: 3 });
+    await membership(cycleId, unestimated, { addedAt: '2026-01-03T00:00:00.000Z', estimate: null });
+
+    const result = await loadSprintAnalytics(workspace.admin, sprintQuery(cycleId, 'points'), {
+      now: new Date('2026-01-04T12:00:00.000Z'),
+    });
+
+    expect(currentOf(result).scopeChanges.added).toBe(4);
+    const addDay = currentOf(result).burn.find((point) => point.date === '2026-01-03');
+    expect(addDay?.added).toBe(1);
   });
 
   it('changes committed scope at known state transitions without applying current backlog backward', async () => {

--- a/packages/core/tests/analytics/sprints.test.ts
+++ b/packages/core/tests/analytics/sprints.test.ts
@@ -1035,6 +1035,56 @@ describe('loadSprintAnalytics', () => {
     expect(result.formulas.points).toContain('counts as 1 point');
   });
 
+  it('does not duplicate the sprint start date when now predates the sprint start', async () => {
+    const cycleId = await cycle(1, '2026-09-01T00:00:00.000Z', '2026-09-08T00:00:00.000Z');
+    const issueId = await insertIssue(workspace, {
+      number: 1,
+      state: 'Todo',
+      cycleId,
+      createdAt: new Date('2026-08-01T00:00:00.000Z'),
+    });
+    await membership(cycleId, issueId, { addedAt: '2026-08-25T00:00:00.000Z' });
+
+    const result = await loadSprintAnalytics(workspace.admin, sprintQuery(cycleId), {
+      now: new Date('2026-08-20T12:00:00.000Z'),
+      selectedSprintId: cycleId,
+    });
+    const burn = currentOf(result).burn;
+    const dates = burn.map((point) => point.date);
+
+    expect(new Set(dates).size).toBe(dates.length);
+    expect(dates[0]).toBe('2026-09-01');
+    expect(dates.at(-1)).toBe('2026-09-07');
+    expect(dates.every((date) => date >= '2026-09-01')).toBe(true);
+  });
+
+  it('adopts each person own retroactive baseline for their planned total', async () => {
+    const cycleId = await cycle(1, '2026-08-11T00:00:00.000Z', '2026-08-25T00:00:00.000Z');
+    const member = await addMember(workspace, 'member', { name: 'Priya' });
+    const issueId = await insertIssue(workspace, {
+      number: 1,
+      state: 'Todo',
+      cycleId,
+      createdAt: new Date('2026-08-01T00:00:00.000Z'),
+      assigneeId: member.user.id,
+    });
+    await membership(cycleId, issueId, {
+      addedAt: '2026-08-14T07:00:00.000Z',
+      coverage: 'observed',
+      entryKind: 'bootstrap',
+      assigneeId: member.user.id,
+    });
+
+    const result = await loadSprintAnalytics(workspace.admin, sprintQuery(cycleId), {
+      now: new Date('2026-08-14T12:00:00.000Z'),
+    });
+    const personSummary = currentOf(result).people.find(
+      (entry) => entry.personId === member.user.id,
+    )?.summary;
+
+    expect(personSummary?.planned).toBe(1);
+  });
+
   it('does not call completed outcomes frozen when a relevant membership is observed', async () => {
     const cycleId = await cycle(1, '2026-01-01T00:00:00.000Z', '2026-01-08T00:00:00.000Z', {
       completedAt: '2026-01-08T00:00:00.000Z',

--- a/packages/shared/src/validators/analytics.ts
+++ b/packages/shared/src/validators/analytics.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { filterGroupQuerySchema } from '../filters/index.ts';
 import { idSchema } from './common.ts';
 
-export const ANALYTICS_LENSES = ['overview', 'sprints', 'projects', 'people'] as const;
+export const ANALYTICS_LENSES = ['overview', 'sprints', 'projects', 'people', 'insights'] as const;
 export const ANALYTICS_MEASURES = ['issues', 'points'] as const;
 export const ANALYTICS_COMPARE = ['auto', 'none', 'previous_period', 'previous_sprint'] as const;
 export const ANALYTICS_RANGE_PRESETS = [
@@ -70,6 +70,33 @@ export const analyticsDrilldownQuerySchema = analyticsQuerySchema.extend({
   limit: z.coerce.number().int().min(1).max(200).default(50),
 });
 
+export const INSIGHT_MEASURES = ['count', 'points', 'cycle_time', 'lead_time', 'age'] as const;
+export const INSIGHT_SLICES = [
+  'assignee',
+  'state',
+  'state_category',
+  'project',
+  'label',
+  'priority',
+  'sprint',
+  'created_week',
+  'completed_week',
+] as const;
+export const insightConfigSchema = z
+  .object({
+    measure: z.enum(INSIGHT_MEASURES).default('count'),
+    slice: z.enum(INSIGHT_SLICES).default('state_category'),
+    segment: z.enum(INSIGHT_SLICES).optional(),
+    cumulative: z.boolean().default(false),
+  })
+  .refine((config) => config.segment !== config.slice, {
+    message: 'Segment must differ from slice.',
+    path: ['segment'],
+  });
+export const analyticsInsightsQuerySchema = analyticsQuerySchema.extend({
+  insight: insightConfigSchema.prefault({}),
+});
+
 export type AnalyticsLens = (typeof ANALYTICS_LENSES)[number];
 export type AnalyticsMeasure = (typeof ANALYTICS_MEASURES)[number];
 export type AnalyticsRange = z.infer<typeof analyticsRangeSchema>;
@@ -78,3 +105,7 @@ export type AnalyticsFocus = z.infer<typeof analyticsFocusSchema>;
 export type AnalyticsDrilldownCohort = z.infer<typeof analyticsDrilldownCohortSchema>;
 export type AnalyticsQuery = z.infer<typeof analyticsQuerySchema>;
 export type AnalyticsDrilldownQuery = z.infer<typeof analyticsDrilldownQuerySchema>;
+export type InsightMeasure = (typeof INSIGHT_MEASURES)[number];
+export type InsightSlice = (typeof INSIGHT_SLICES)[number];
+export type InsightConfig = z.infer<typeof insightConfigSchema>;
+export type AnalyticsInsightsQuery = z.infer<typeof analyticsInsightsQuerySchema>;

--- a/packages/shared/tests/validators/analytics.test.ts
+++ b/packages/shared/tests/validators/analytics.test.ts
@@ -44,6 +44,10 @@ describe('insightConfigSchema', () => {
     expect(() => insightConfigSchema.parse({ slice: 'assignee', segment: 'assignee' })).toThrow();
   });
 
+  it('rejects a segment equal to the defaulted slice when slice is omitted', () => {
+    expect(() => insightConfigSchema.parse({ segment: 'state_category' })).toThrow();
+  });
+
   it('allows a segment that differs from the slice', () => {
     expect(insightConfigSchema.parse({ slice: 'assignee', segment: 'project' })).toMatchObject({
       slice: 'assignee',

--- a/packages/shared/tests/validators/analytics.test.ts
+++ b/packages/shared/tests/validators/analytics.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test';
-import { analyticsQuerySchema } from '../../src/validators/analytics.ts';
+import {
+  analyticsInsightsQuerySchema,
+  analyticsQuerySchema,
+  insightConfigSchema,
+} from '../../src/validators/analytics.ts';
 
 describe('analyticsQuerySchema', () => {
   it('fills the clean URL defaults', () => {
@@ -20,5 +24,56 @@ describe('analyticsQuerySchema', () => {
         range: { preset: 'custom', from: '2026-08-11', to: '2026-08-01' },
       }),
     ).toThrow();
+  });
+
+  it('accepts insights as a valid lens', () => {
+    expect(analyticsQuerySchema.parse({ lens: 'insights' })).toMatchObject({ lens: 'insights' });
+  });
+});
+
+describe('insightConfigSchema', () => {
+  it('fills the insight defaults', () => {
+    expect(insightConfigSchema.parse({})).toMatchObject({
+      measure: 'count',
+      slice: 'state_category',
+      cumulative: false,
+    });
+  });
+
+  it('rejects a segment equal to the slice', () => {
+    expect(() => insightConfigSchema.parse({ slice: 'assignee', segment: 'assignee' })).toThrow();
+  });
+
+  it('allows a segment that differs from the slice', () => {
+    expect(insightConfigSchema.parse({ slice: 'assignee', segment: 'project' })).toMatchObject({
+      slice: 'assignee',
+      segment: 'project',
+    });
+  });
+});
+
+describe('analyticsInsightsQuerySchema', () => {
+  it('fills the insight query defaults when the insight object is present', () => {
+    expect(analyticsInsightsQuerySchema.parse({ insight: {} })).toMatchObject({
+      version: 1,
+      lens: 'overview',
+      insight: {
+        measure: 'count',
+        slice: 'state_category',
+        cumulative: false,
+      },
+    });
+  });
+
+  it('fills the insight query defaults when the insight key is omitted entirely', () => {
+    expect(analyticsInsightsQuerySchema.parse({})).toMatchObject({
+      version: 1,
+      lens: 'overview',
+      insight: {
+        measure: 'count',
+        slice: 'state_category',
+        cumulative: false,
+      },
+    });
   });
 });


### PR DESCRIPTION
## What this changes

Rebuilds the sprint analytics experience to cycle-graph quality and adds a Measure by Slice by Segment Insights lens, per the approved spec at docs/superpowers/specs/2026-08-15-sprint-analytics-redesign-design.md.

Phase 1, the sprint graph:

- Charts render at native pixel scale from a measured container width. The stretched 640x260 viewBox that scaled 11px labels to 29px is gone.
- The burn chart spans the whole sprint on a calendar-day domain: weekend bands, a tick per day, per-day tooltips listing every series, keyboard day navigation, and a pivoted one-row-per-day data table.
- Retroactive baseline for sprints adopted mid-flight: the first captured scope anchors the ideal from day 1, Planned adopts the baseline instead of reading 0, and one caption states when capture began. Pre-capture days draw no fabricated zeros.
- The ideal line holds flat across weekends and reaches zero on the last working day. A dotted forecast extends from today's remaining when three declining working days exist, clamped to the frame with the true date in the stat strip.
- A dense stat strip replaces the four summary cards: scope in both measures, completed and started percentages, churn, needed versus actual pace per working day, forecast date with late coloring, and people count.
- Personal burn charts share the same full-span frame with their own day-1-anchored ideal.
- Velocity renders paired planned versus completed bars per closed sprint, an average line, and the current sprint as a dimmed in-progress pair.
- Unestimated issues count as 1 point in points mode, labeled.

Phase 2, the Insights lens:

- A new Insights tab over the filtered dataset: Measure (count, points, cycle time, lead time, age) by Slice (assignee, state, state category, project, label, priority, sprint, created week, completed week) by optional Segment rendered as stacked bars.
- Duration measures render a percentile scatterplot (p25/p50/p75/p95 lines, one point per issue, click or keyboard through to the issue).
- Week slices offer a cumulative running-total line.
- Every named bucket drills into the exact matching issues through the existing cohort machinery, extended with assignee, label, sprint, and week cohorts. Overflow rollup buckets are honestly non-clickable.
- Saved views persist and restore the insight configuration.

## How you know it works

- bun run verify: green on every gate; the web suite's 14 full-process failures are the documented pre-existing DOM-leak and load-contention signature on main, and all 14 pass 81/81 when their files run in isolation
- Production build: clean
- Playwright analytics spec extended and run against a live stack: green, including the new insights journey
- 171 core analytics tests and 135 web analytics tests, all green
- Light and dark screenshots of both lenses at 1680x1000 captured during verification

## Checklist

- [x] bun run verify green modulo documented pre-existing flakes, with isolation evidence
- [x] Tests added at every layer and verified to fail without their features
- [x] No comments in code, no em-dash characters
- [x] No any, no non-null assertions
- [x] External input parsed with shared Zod schemas, including the new insights query
- [x] Authorization enforced server-side (analytics:read gates the new route and aggregation)
- [x] No database schema change; no migration needed

## Anything reviewers should know

- The sprint interval stays half-open: the endsAt day belongs to the next sprint. Pace and forecast anchor on the last working day, so Monday-to-Monday sprints ending on a weekend read correctly.
- Insight bucket totals are computed in a separate query from segment values, so an issue with two labels segments under both without inflating its bucket's total.
- Temporary click-to-filter chips from the spec's interactivity section are deliberately deferred; bars uniformly open the drilldown dialog. A follow-up can add chips.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR rebuilds sprint analytics around full-span calendar burn charts and adds a configurable Insights lens.
- Adds planning-grade sprint burn, forecast, pace, velocity, and personal-burn presentations.
- Adds count, points, and duration insights grouped by configurable slices and segments.
- Extends drilldown cohorts, saved-view persistence, query state, responsive chart primitives, and analytics test coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/(app)/analytics/page.tsx | Restores validated pinned Insights configuration and hydrates the matching analytics query. |
| apps/web/src/features/analytics/analytics-cockpit.tsx | Coordinates standard and Insights lens state, fetching, saved views, URL persistence, loading, and error states. |
| apps/web/src/features/analytics/insights-lens.tsx | Renders configurable bar, cumulative, and duration-scatter insights with drilldown behavior. |
| packages/core/src/analytics/insights.ts | Implements authorized slice, segment, points, and duration aggregations for the Insights lens. |
| packages/core/src/analytics/drilldown.ts | Adds Insights cohort predicates and consistently weights unestimated drilldown issues as one point. |
| packages/core/src/analytics/sprints.ts | Produces full-span sprint burn, baseline, velocity, personal-burn, and planning statistics. |
| apps/web/src/features/analytics/charts/bar-plot.tsx | Expands responsive bar rendering with paired and segmented modes, keyboard interaction, tooltips, and accessible tables. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant P as Analytics Page
  participant C as Analytics Cockpit
  participant A as Analytics API
  participant Q as Core Analytics
  participant D as Database
  U->>P: Open analytics URL
  P->>P: Resolve URL or pinned saved view
  P->>A: Prefetch selected lens
  A->>Q: Load authorized analytics
  Q->>D: Aggregate filtered issues
  D-->>Q: Analytics rows
  Q-->>A: Lens result
  A-->>P: Hydration state
  P-->>C: Initial query and insight config
  U->>C: Change lens, measure, slice, or segment
  C->>A: Fetch canonical analytics query
  A->>Q: Resolve and aggregate
  Q-->>C: Chart and drilldown cohorts
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(analytics): use singular wording for..."](https://github.com/noveum/orbit/commit/1ca972d2c4e36dc1ab13fb1dbd89e76411edaf0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53617535)</sub>

<!-- /greptile_comment -->