### PR TITLE
feat(inbox): open on Activity and move field changes to a Status tab

### DIFF
--- a/apps/web/e2e/inbox-layout.spec.ts
+++ b/apps/web/e2e/inbox-layout.spec.ts
@@ -98,8 +98,8 @@ test('a list longer than the pane never pushes the shell off the page', async ({
     .poll(async () => await list.evaluate((node) => node.scrollHeight - node.clientHeight))
     .toBeGreaterThan(0);
 
-  for (const tab of ['All', 'Unread', 'Mentions', 'Pull requests']) {
-    await reader.getByRole('button', { name: tab, exact: true }).click();
+  for (const tab of ['activity', 'unread', 'mentions', 'pulls', 'status']) {
+    await reader.getByTestId(`inbox-tab-${tab}`).click();
     const measured = await overflowOf(reader);
     expect(measured.documentY, `${tab} pushed the document`).toBe(0);
     expect(measured.mainY, `${tab} left dead space under the shell`).toBe(0);

--- a/apps/web/src/app/(app)/inbox/page.tsx
+++ b/apps/web/src/app/(app)/inbox/page.tsx
@@ -15,6 +15,7 @@ export default async function InboxPage() {
       items={inbox.items}
       unreadCount={inbox.unreadCount}
       unreadMentions={inbox.unreadMentions}
+      unreadActivity={inbox.unreadActivity}
       nextCursor={inbox.nextCursor}
       userId={context.principal.userId}
       canWriteDocs={can(context.principal, 'doc:write')}

--- a/apps/web/src/features/inbox/data.ts
+++ b/apps/web/src/features/inbox/data.ts
@@ -27,6 +27,7 @@ export interface InboxData {
   readonly items: InboxItem[];
   readonly unreadCount: number;
   readonly unreadMentions: number;
+  readonly unreadActivity: number;
   readonly nextCursor: string | null;
 }
 
@@ -64,6 +65,7 @@ export async function loadInbox(principal: Principal): Promise<InboxData> {
   return {
     unreadCount: counters.total,
     unreadMentions: counters.mentions,
+    unreadActivity: counters.activity,
     nextCursor: page.nextCursor,
     items: page.items.map(toInboxItem),
   };

--- a/apps/web/src/features/inbox/inbox-realtime.tsx
+++ b/apps/web/src/features/inbox/inbox-realtime.tsx
@@ -7,6 +7,7 @@ export interface InboxRealtimeProps {
   readonly items: readonly InboxItem[];
   readonly unreadCount: number;
   readonly unreadMentions: number;
+  readonly unreadActivity: number;
   readonly nextCursor: string | null;
   readonly userId: string;
   readonly canWriteDocs: boolean;
@@ -17,6 +18,7 @@ export function InboxRealtime({
   items,
   unreadCount,
   unreadMentions,
+  unreadActivity,
   nextCursor,
   userId,
   canWriteDocs,
@@ -27,6 +29,7 @@ export function InboxRealtime({
       items={items}
       unreadCount={unreadCount}
       unreadMentions={unreadMentions}
+      unreadActivity={unreadActivity}
       nextCursor={nextCursor}
       userId={userId}
       canWriteDocs={canWriteDocs}

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -186,8 +186,12 @@ function isActivity(item: InboxItem): boolean {
   return !isStatusChangeNotification(item.type);
 }
 
+function countsTowardUnread(item: InboxItem, at = Date.now()): boolean {
+  return item.snoozedUntil === null || Date.parse(item.snoozedUntil) <= at;
+}
+
 function unreadActivityCount(item: InboxItem): number {
-  return !item.read && isActivity(item) ? 1 : 0;
+  return !item.read && countsTowardUnread(item) && isActivity(item) ? 1 : 0;
 }
 
 function applyOne(patch: InboxPatch, action: SyncAction): InboxPatch {
@@ -582,8 +586,9 @@ export function InboxView({
   const setReadState = useCallback(
     async (item: InboxItem, next: boolean) => {
       if (item.read === next) return;
-      const isMention = item.type === 'mention';
-      const countsAsActivity = isActivity(item);
+      const counted = countsTowardUnread(item);
+      const isMention = counted && item.type === 'mention';
+      const countsAsActivity = counted && isActivity(item);
       const applyLocally = (read: boolean, step: number) => {
         setRows((list) => list.map((row) => (row.id === item.id ? { ...row, read } : row)));
         if (tab === 'unread') {
@@ -632,7 +637,7 @@ export function InboxView({
   const snooze = useCallback(async () => {
     if (current === undefined) return;
     const snoozedUntil = new Date(Date.now() + SNOOZE_HOURS * 3_600_000).toISOString();
-    const wasUnreadMention = unreadMentionCount(current) === 1;
+    const wasUnreadMention = countsTowardUnread(current) && unreadMentionCount(current) === 1;
     const wasUnreadActivity = unreadActivityCount(current) === 1;
     setRows((list) => list.map((row) => (row.id === current.id ? { ...row, snoozedUntil } : row)));
     if (wasUnreadMention) setMentions((count) => Math.max(0, count - 1));
@@ -749,8 +754,12 @@ export function InboxView({
       {visible.length === 0 && cursor === null ? (
         <EmptyState
           icon={<Bell strokeWidth={1.75} aria-hidden="true" />}
-          title="Inbox zero"
-          description="When somebody assigns you an issue, mentions you, replies to you, or changes something you follow, it lands here. Your own actions do not."
+          title={rows.length === 0 ? 'Inbox zero' : 'Nothing on this tab'}
+          description={
+            rows.length === 0
+              ? 'When somebody assigns you an issue, mentions you, replies to you, or changes something you follow, it lands here. Your own actions do not.'
+              : 'Every notification you have is on another tab. Status collects the issue field moves, and Unread, Mentions and Pull requests span all of them.'
+          }
           className="flex-1"
         />
       ) : (

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -2,7 +2,11 @@
 
 import { useDeltaHandler, useScopeSubscription } from '@orbit/realtime-client/react';
 import type { NotificationType } from '@orbit/shared/constants';
-import { isPullRequestNotification, NOTIFICATION_TYPES } from '@orbit/shared/constants';
+import {
+  isPullRequestNotification,
+  isStatusChangeNotification,
+  NOTIFICATION_TYPES,
+} from '@orbit/shared/constants';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import { relativeTime } from '@orbit/shared/utils';
@@ -69,18 +73,27 @@ const SOURCE_ICONS: Record<NotificationType, LucideIcon> = {
 };
 
 const TABS = [
-  { id: 'all', label: 'All' },
+  { id: 'activity', label: 'Activity' },
   { id: 'unread', label: 'Unread' },
   { id: 'mentions', label: 'Mentions' },
   { id: 'pulls', label: 'Pull requests' },
+  { id: 'status', label: 'Status' },
 ] as const;
 type TabId = (typeof TABS)[number]['id'];
 
 function matchesTab(item: InboxItem, tab: TabId): boolean {
-  if (tab === 'unread') return !item.read;
-  if (tab === 'mentions') return item.type === 'mention';
-  if (tab === 'pulls') return isPullRequestNotification(item.type);
-  return true;
+  switch (tab) {
+    case 'activity':
+      return isActivity(item);
+    case 'status':
+      return isStatusChangeNotification(item.type);
+    case 'unread':
+      return !item.read;
+    case 'mentions':
+      return item.type === 'mention';
+    case 'pulls':
+      return isPullRequestNotification(item.type);
+  }
 }
 
 function openLabel(item: InboxItem): string {
@@ -158,6 +171,7 @@ interface InboxPatch {
   readonly rows: readonly InboxItem[];
   readonly unreadDelta: number;
   readonly mentionDelta: number;
+  readonly activityDelta: number;
 }
 
 function readChange(read: boolean): number {
@@ -166,6 +180,14 @@ function readChange(read: boolean): number {
 
 function unreadMentionCount(item: InboxItem): number {
   return !item.read && item.type === 'mention' ? 1 : 0;
+}
+
+function isActivity(item: InboxItem): boolean {
+  return !isStatusChangeNotification(item.type);
+}
+
+function unreadActivityCount(item: InboxItem): number {
+  return !item.read && isActivity(item) ? 1 : 0;
 }
 
 function applyOne(patch: InboxPatch, action: SyncAction): InboxPatch {
@@ -179,6 +201,7 @@ function applyOne(patch: InboxPatch, action: SyncAction): InboxPatch {
       rows: patch.rows.filter((row) => row.id !== item.id),
       unreadDelta: patch.unreadDelta - (previous.read ? 0 : 1),
       mentionDelta: patch.mentionDelta - unreadMentionCount(previous),
+      activityDelta: patch.activityDelta - unreadActivityCount(previous),
     };
   }
   if (previous === undefined) {
@@ -187,6 +210,7 @@ function applyOne(patch: InboxPatch, action: SyncAction): InboxPatch {
       rows: [item, ...patch.rows],
       unreadDelta: patch.unreadDelta + (item.read ? 0 : 1),
       mentionDelta: patch.mentionDelta + unreadMentionCount(item),
+      activityDelta: patch.activityDelta + unreadActivityCount(item),
     };
   }
   const change = previous.read === item.read ? 0 : readChange(item.read);
@@ -194,6 +218,8 @@ function applyOne(patch: InboxPatch, action: SyncAction): InboxPatch {
     rows: patch.rows.map((row) => (row.id === item.id ? item : row)),
     unreadDelta: patch.unreadDelta + change,
     mentionDelta: patch.mentionDelta + (unreadMentionCount(item) - unreadMentionCount(previous)),
+    activityDelta:
+      patch.activityDelta + (unreadActivityCount(item) - unreadActivityCount(previous)),
   };
 }
 
@@ -204,7 +230,7 @@ export function applyNotificationDeltas(
 ): InboxPatch {
   return actions
     .filter((action) => action.model === 'notification' && action.originClientId !== tabClientId)
-    .reduce(applyOne, { rows, unreadDelta: 0, mentionDelta: 0 });
+    .reduce(applyOne, { rows, unreadDelta: 0, mentionDelta: 0, activityDelta: 0 });
 }
 
 function LoadMoreRow({
@@ -417,6 +443,7 @@ export interface InboxViewProps {
   readonly items: readonly InboxItem[];
   readonly unreadCount: number;
   readonly unreadMentions: number;
+  readonly unreadActivity: number;
   readonly nextCursor: string | null;
   readonly userId: string;
   readonly canWriteDocs: boolean;
@@ -427,6 +454,7 @@ export function InboxView({
   items,
   unreadCount,
   unreadMentions,
+  unreadActivity,
   nextCursor,
   userId,
   canWriteDocs,
@@ -435,12 +463,13 @@ export function InboxView({
   const [rows, setRows] = useState<readonly InboxItem[]>(items);
   const [unread, setUnread] = useState(unreadCount);
   const [mentions, setMentions] = useState(unreadMentions);
+  const [activity, setActivity] = useState(unreadActivity);
   const [cursor, setCursor] = useState<string | null>(nextCursor);
   const [loadingMore, setLoadingMore] = useState(false);
   const [pagingError, setPagingError] = useState<string | null>(null);
   const inFlight = useRef(false);
   const cursorRef = useRef<string | null>(nextCursor);
-  const [tab, setTab] = useState<TabId>('all');
+  const [tab, setTab] = useState<TabId>('activity');
   const [retainedUnreadIds, setRetainedUnreadIds] = useState<ReadonlySet<string>>(new Set());
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -449,9 +478,10 @@ export function InboxView({
     setRows(items);
     setUnread(unreadCount);
     setMentions(unreadMentions);
+    setActivity(unreadActivity);
     setCursor(nextCursor);
     cursorRef.current = nextCursor;
-  }, [items, unreadCount, unreadMentions, nextCursor]);
+  }, [items, unreadCount, unreadMentions, unreadActivity, nextCursor]);
 
   useScopeSubscription([scopes.user(userId)]);
   useDeltaHandler(
@@ -464,6 +494,9 @@ export function InboxView({
         }
         if (patch.mentionDelta !== 0) {
           setMentions((current) => Math.max(0, current + patch.mentionDelta));
+        }
+        if (patch.activityDelta !== 0) {
+          setActivity((current) => Math.max(0, current + patch.activityDelta));
         }
       },
       [rows],
@@ -550,6 +583,7 @@ export function InboxView({
     async (item: InboxItem, next: boolean) => {
       if (item.read === next) return;
       const isMention = item.type === 'mention';
+      const countsAsActivity = isActivity(item);
       const applyLocally = (read: boolean, step: number) => {
         setRows((list) => list.map((row) => (row.id === item.id ? { ...row, read } : row)));
         if (tab === 'unread') {
@@ -561,6 +595,7 @@ export function InboxView({
           });
         }
         if (isMention) setMentions((count) => Math.max(0, count + step));
+        if (countsAsActivity) setActivity((count) => Math.max(0, count + step));
         setUnread((count) => Math.max(0, count + step));
       };
 
@@ -597,7 +632,11 @@ export function InboxView({
   const snooze = useCallback(async () => {
     if (current === undefined) return;
     const snoozedUntil = new Date(Date.now() + SNOOZE_HOURS * 3_600_000).toISOString();
+    const wasUnreadMention = unreadMentionCount(current) === 1;
+    const wasUnreadActivity = unreadActivityCount(current) === 1;
     setRows((list) => list.map((row) => (row.id === current.id ? { ...row, snoozedUntil } : row)));
+    if (wasUnreadMention) setMentions((count) => Math.max(0, count - 1));
+    if (wasUnreadActivity) setActivity((count) => Math.max(0, count - 1));
     applyServerCount(
       await apiRequest(`/api/notifications/${current.id}`, {
         method: 'PATCH',
@@ -608,9 +647,11 @@ export function InboxView({
 
   const remove = useCallback(async () => {
     if (current === undefined) return;
-    const wasUnreadMention = !current.read && current.type === 'mention';
+    const wasUnreadMention = unreadMentionCount(current) === 1;
+    const wasUnreadActivity = unreadActivityCount(current) === 1;
     setRows((list) => list.filter((row) => row.id !== current.id));
     if (wasUnreadMention) setMentions((count) => Math.max(0, count - 1));
+    if (wasUnreadActivity) setActivity((count) => Math.max(0, count - 1));
     applyServerCount(await apiRequest(`/api/notifications/${current.id}`, { method: 'DELETE' }));
   }, [current, applyServerCount]);
 
@@ -673,16 +714,25 @@ export function InboxView({
               <button
                 key={entry.id}
                 type="button"
+                data-testid={`inbox-tab-${entry.id}`}
                 onClick={() => selectTab(entry.id)}
                 aria-current={tab === entry.id ? 'true' : undefined}
                 className={cn(
-                  'rounded-md px-2.5 py-1 text-dense transition-colors duration-[var(--duration-fast)]',
+                  'flex items-center gap-1.5 rounded-md px-2.5 py-1 text-dense transition-colors duration-[var(--duration-fast)]',
                   tab === entry.id
                     ? 'bg-accent-soft font-medium text-accent'
                     : 'text-muted hover:bg-surface-2 hover:text-text',
                 )}
               >
                 {entry.label}
+                {entry.id === 'activity' && activity > 0 ? (
+                  <span
+                    data-testid="inbox-activity-count"
+                    className="text-2xs text-faint tabular-nums"
+                  >
+                    {activity}
+                  </span>
+                ) : null}
               </button>
             ))}
           </nav>

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -180,16 +180,16 @@ function readChange(read: boolean): number {
   return read ? -1 : 1;
 }
 
-function unreadMentionCount(item: InboxItem): number {
-  return !item.read && item.type === 'mention' ? 1 : 0;
-}
-
 function isActivity(item: InboxItem): boolean {
   return !isStatusChangeNotification(item.type);
 }
 
 function countsTowardUnread(item: InboxItem, at = Date.now()): boolean {
   return item.snoozedUntil === null || Date.parse(item.snoozedUntil) <= at;
+}
+
+function unreadMentionCount(item: InboxItem): number {
+  return !item.read && countsTowardUnread(item) && item.type === 'mention' ? 1 : 0;
 }
 
 function unreadActivityCount(item: InboxItem): number {
@@ -488,6 +488,7 @@ export function InboxView({
   const [rows, setRows] = useState<readonly InboxItem[]>(items);
   const rowsRef = useRef(rows);
   rowsRef.current = rows;
+  const snoozing = useRef<Set<string>>(new Set());
   const [unread, setUnread] = useState(unreadCount);
   const [mentions, setMentions] = useState(unreadMentions);
   const [activity, setActivity] = useState(unreadActivity);
@@ -663,10 +664,11 @@ export function InboxView({
   }, []);
 
   const snooze = useCallback(async () => {
-    if (current === undefined) return;
+    if (current === undefined || snoozing.current.has(current.id)) return;
+    snoozing.current.add(current.id);
     const snoozedUntil = new Date(Date.now() + SNOOZE_HOURS * 3_600_000).toISOString();
     const previousSnoozedUntil = current.snoozedUntil;
-    const wasUnreadMention = countsTowardUnread(current) && unreadMentionCount(current) === 1;
+    const wasUnreadMention = unreadMentionCount(current) === 1;
     const wasUnreadActivity = unreadActivityCount(current) === 1;
     setRows((list) => list.map((row) => (row.id === current.id ? { ...row, snoozedUntil } : row)));
     if (wasUnreadMention) setMentions((count) => Math.max(0, count - 1));
@@ -688,6 +690,8 @@ export function InboxView({
       setRows(rollback.rows);
       if (rollback.restoreCounts) restoreCounts(wasUnreadMention, wasUnreadActivity);
       setError(FAILED_SAVE);
+    } finally {
+      snoozing.current.delete(current.id);
     }
   }, [current, applyServerCount, restoreCounts]);
 

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -103,6 +103,8 @@ function openLabel(item: InboxItem): string {
 
 const SNOOZE_HOURS = 24;
 
+const FAILED_SAVE = 'That did not save. Check your connection and try again.';
+
 const notificationDeltaSchema = z.object({
   id: z.string(),
   type: z.string(),
@@ -194,15 +196,23 @@ function unreadActivityCount(item: InboxItem): number {
   return !item.read && countsTowardUnread(item) && isActivity(item) ? 1 : 0;
 }
 
-export function revertSnooze(
+export interface SnoozeRollback {
+  readonly rows: readonly InboxItem[];
+  readonly restoreCounts: boolean;
+}
+
+export function snoozeRollback(
   rows: readonly InboxItem[],
   id: string,
   optimistic: string,
   previous: string | null,
-): readonly InboxItem[] {
-  return rows.map((row) =>
-    row.id === id && row.snoozedUntil === optimistic ? { ...row, snoozedUntil: previous } : row,
-  );
+): SnoozeRollback {
+  const ours = rows.some((row) => row.id === id && row.snoozedUntil === optimistic);
+  if (!ours) return { rows, restoreCounts: false };
+  return {
+    rows: rows.map((row) => (row.id === id ? { ...row, snoozedUntil: previous } : row)),
+    restoreCounts: true,
+  };
 }
 
 function applyOne(patch: InboxPatch, action: SyncAction): InboxPatch {
@@ -476,6 +486,8 @@ export function InboxView({
   canPublishDocs,
 }: InboxViewProps) {
   const [rows, setRows] = useState<readonly InboxItem[]>(items);
+  const rowsRef = useRef(rows);
+  rowsRef.current = rows;
   const [unread, setUnread] = useState(unreadCount);
   const [mentions, setMentions] = useState(unreadMentions);
   const [activity, setActivity] = useState(unreadActivity);
@@ -625,7 +637,7 @@ export function InboxView({
         );
       } catch (cause) {
         applyLocally(item.read, next ? 1 : -1);
-        setError('That did not save. Check your connection and try again.');
+        setError(FAILED_SAVE);
         throw cause;
       }
     },
@@ -648,7 +660,6 @@ export function InboxView({
   const restoreCounts = useCallback((mention: boolean, activityRow: boolean) => {
     if (mention) setMentions((count) => count + 1);
     if (activityRow) setActivity((count) => count + 1);
-    setError('That did not save. Check your connection and try again.');
   }, []);
 
   const snooze = useCallback(async () => {
@@ -668,8 +679,15 @@ export function InboxView({
         }),
       );
     } catch {
-      setRows((list) => revertSnooze(list, current.id, snoozedUntil, previousSnoozedUntil));
-      restoreCounts(wasUnreadMention, wasUnreadActivity);
+      const rollback = snoozeRollback(
+        rowsRef.current,
+        current.id,
+        snoozedUntil,
+        previousSnoozedUntil,
+      );
+      setRows(rollback.rows);
+      if (rollback.restoreCounts) restoreCounts(wasUnreadMention, wasUnreadActivity);
+      setError(FAILED_SAVE);
     }
   }, [current, applyServerCount, restoreCounts]);
 
@@ -684,13 +702,16 @@ export function InboxView({
     try {
       applyServerCount(await apiRequest(`/api/notifications/${current.id}`, { method: 'DELETE' }));
     } catch {
-      setRows((list) => {
-        if (list.some((row) => row.id === current.id)) return list;
-        const restored = [...list];
-        restored.splice(removedAt === -1 ? list.length : removedAt, 0, current);
-        return restored;
-      });
-      restoreCounts(wasUnreadMention, wasUnreadActivity);
+      const stillRemoved = !rowsRef.current.some((row) => row.id === current.id);
+      if (stillRemoved) {
+        setRows((list) => {
+          const restored = [...list];
+          restored.splice(removedAt === -1 ? list.length : removedAt, 0, current);
+          return restored;
+        });
+        restoreCounts(wasUnreadMention, wasUnreadActivity);
+      }
+      setError(FAILED_SAVE);
     }
   }, [current, rows, applyServerCount, restoreCounts]);
 

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -39,7 +39,7 @@ import { DocSurface } from '@/features/docs/doc-surface.tsx';
 import { IssueDetailView } from '@/features/issues/issue-detail.tsx';
 import { apiRequest } from '@/lib/api/client.ts';
 import { cn } from '@/lib/cn.ts';
-import { rowHover } from '@/lib/interaction.ts';
+import { rowHover, tabHover } from '@/lib/interaction.ts';
 import { useHotkey } from '@/lib/keyboard/index.ts';
 import { clientId } from '@/lib/query/client-id.ts';
 import type { InboxItem } from './data.ts';
@@ -634,31 +634,58 @@ export function InboxView({
     [setReadState],
   );
 
+  const restoreCounts = useCallback((mention: boolean, activityRow: boolean) => {
+    if (mention) setMentions((count) => count + 1);
+    if (activityRow) setActivity((count) => count + 1);
+    setError('That did not save. Check your connection and try again.');
+  }, []);
+
   const snooze = useCallback(async () => {
     if (current === undefined) return;
     const snoozedUntil = new Date(Date.now() + SNOOZE_HOURS * 3_600_000).toISOString();
+    const previousSnoozedUntil = current.snoozedUntil;
     const wasUnreadMention = countsTowardUnread(current) && unreadMentionCount(current) === 1;
     const wasUnreadActivity = unreadActivityCount(current) === 1;
     setRows((list) => list.map((row) => (row.id === current.id ? { ...row, snoozedUntil } : row)));
     if (wasUnreadMention) setMentions((count) => Math.max(0, count - 1));
     if (wasUnreadActivity) setActivity((count) => Math.max(0, count - 1));
-    applyServerCount(
-      await apiRequest(`/api/notifications/${current.id}`, {
-        method: 'PATCH',
-        body: { snoozeHours: SNOOZE_HOURS },
-      }),
-    );
-  }, [current, applyServerCount]);
+    try {
+      applyServerCount(
+        await apiRequest(`/api/notifications/${current.id}`, {
+          method: 'PATCH',
+          body: { snoozeHours: SNOOZE_HOURS },
+        }),
+      );
+    } catch {
+      setRows((list) =>
+        list.map((row) =>
+          row.id === current.id ? { ...row, snoozedUntil: previousSnoozedUntil } : row,
+        ),
+      );
+      restoreCounts(wasUnreadMention, wasUnreadActivity);
+    }
+  }, [current, applyServerCount, restoreCounts]);
 
   const remove = useCallback(async () => {
     if (current === undefined) return;
     const wasUnreadMention = unreadMentionCount(current) === 1;
     const wasUnreadActivity = unreadActivityCount(current) === 1;
+    const removedAt = rows.findIndex((row) => row.id === current.id);
     setRows((list) => list.filter((row) => row.id !== current.id));
     if (wasUnreadMention) setMentions((count) => Math.max(0, count - 1));
     if (wasUnreadActivity) setActivity((count) => Math.max(0, count - 1));
-    applyServerCount(await apiRequest(`/api/notifications/${current.id}`, { method: 'DELETE' }));
-  }, [current, applyServerCount]);
+    try {
+      applyServerCount(await apiRequest(`/api/notifications/${current.id}`, { method: 'DELETE' }));
+    } catch {
+      setRows((list) => {
+        if (list.some((row) => row.id === current.id)) return list;
+        const restored = [...list];
+        restored.splice(removedAt === -1 ? list.length : removedAt, 0, current);
+        return restored;
+      });
+      restoreCounts(wasUnreadMention, wasUnreadActivity);
+    }
+  }, [current, rows, applyServerCount, restoreCounts]);
 
   useHotkey('j', () => move(1), {
     label: 'Next notification',
@@ -723,10 +750,10 @@ export function InboxView({
                 onClick={() => selectTab(entry.id)}
                 aria-current={tab === entry.id ? 'true' : undefined}
                 className={cn(
-                  'flex items-center gap-1.5 rounded-md px-2.5 py-1 text-dense transition-colors duration-[var(--duration-fast)]',
+                  'flex items-center gap-1.5 rounded-md px-2.5 py-1 text-dense',
                   tab === entry.id
                     ? 'bg-accent-soft font-medium text-accent'
-                    : 'text-muted hover:bg-surface-2 hover:text-text',
+                    : cn(tabHover, 'text-muted hover:bg-surface-2'),
                 )}
               >
                 {entry.label}

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -194,6 +194,17 @@ function unreadActivityCount(item: InboxItem): number {
   return !item.read && countsTowardUnread(item) && isActivity(item) ? 1 : 0;
 }
 
+export function revertSnooze(
+  rows: readonly InboxItem[],
+  id: string,
+  optimistic: string,
+  previous: string | null,
+): readonly InboxItem[] {
+  return rows.map((row) =>
+    row.id === id && row.snoozedUntil === optimistic ? { ...row, snoozedUntil: previous } : row,
+  );
+}
+
 function applyOne(patch: InboxPatch, action: SyncAction): InboxPatch {
   const item = toInboxItem(action.data);
   if (item === null) return patch;
@@ -657,11 +668,7 @@ export function InboxView({
         }),
       );
     } catch {
-      setRows((list) =>
-        list.map((row) =>
-          row.id === current.id ? { ...row, snoozedUntil: previousSnoozedUntil } : row,
-        ),
-      );
+      setRows((list) => revertSnooze(list, current.id, snoozedUntil, previousSnoozedUntil));
       restoreCounts(wasUnreadMention, wasUnreadActivity);
     }
   }, [current, applyServerCount, restoreCounts]);

--- a/apps/web/tests/components/keyboard-hints.test.tsx
+++ b/apps/web/tests/components/keyboard-hints.test.tsx
@@ -133,6 +133,7 @@ function Surfaces({ extra }: { readonly extra?: ReactNode }) {
             items={[]}
             unreadCount={0}
             unreadMentions={0}
+            unreadActivity={0}
             userId="user_1"
             nextCursor={null}
             canWriteDocs

--- a/apps/web/tests/features/inbox/inbox-deltas.test.ts
+++ b/apps/web/tests/features/inbox/inbox-deltas.test.ts
@@ -49,6 +49,11 @@ function action(overrides: Partial<SyncAction> = {}): SyncAction {
   };
 }
 
+function comment(overrides: Partial<SyncAction> = {}): SyncAction {
+  const base = action(overrides);
+  return { ...base, data: { ...base.data, type: 'comment_created' } };
+}
+
 function read(base: SyncAction): SyncAction {
   return {
     ...base,
@@ -149,6 +154,46 @@ describe('applyNotificationDeltas', () => {
   it('lowers the mention badge when another tab reads a mention', () => {
     const patch = applyNotificationDeltas([item({ type: 'mention' })], [read(action())], TAB);
     expect(patch.mentionDelta).toBe(-1);
+  });
+
+  it('leaves the activity count alone when an assignment arrives', () => {
+    const patch = applyNotificationDeltas([], [action()], TAB);
+    expect(patch.unreadDelta).toBe(1);
+    expect(patch.activityDelta).toBe(0);
+  });
+
+  it('raises the activity count when an unread comment arrives', () => {
+    const patch = applyNotificationDeltas([], [comment()], TAB);
+    expect(patch.unreadDelta).toBe(1);
+    expect(patch.activityDelta).toBe(1);
+  });
+
+  it('lowers the activity count when another tab reads a comment', () => {
+    const patch = applyNotificationDeltas(
+      [item({ type: 'comment_created' })],
+      [read(comment())],
+      TAB,
+    );
+    expect(patch.activityDelta).toBe(-1);
+  });
+
+  it('lowers the activity count when an unread comment is deleted', () => {
+    const patch = applyNotificationDeltas(
+      [item({ type: 'comment_created' })],
+      [comment({ action: 'delete' })],
+      TAB,
+    );
+    expect(patch.activityDelta).toBe(-1);
+  });
+
+  it('leaves the activity count alone when a status change is deleted', () => {
+    const patch = applyNotificationDeltas(
+      [item({ type: 'issue_status_changed' })],
+      [action({ action: 'delete' })],
+      TAB,
+    );
+    expect(patch.unreadDelta).toBe(-1);
+    expect(patch.activityDelta).toBe(0);
   });
 });
 

--- a/apps/web/tests/features/inbox/inbox-deltas.test.ts
+++ b/apps/web/tests/features/inbox/inbox-deltas.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import type { SyncAction } from '@orbit/shared/events';
 import type { InboxItem } from '../../../src/features/inbox/data.ts';
-import { applyNotificationDeltas } from '../../../src/features/inbox/inbox-view.tsx';
+import { applyNotificationDeltas, revertSnooze } from '../../../src/features/inbox/inbox-view.tsx';
 
 const TAB = 'tab_a';
 
@@ -243,5 +243,34 @@ describe('what the reading pane is looking at', () => {
     const row = item({ entityType: 'issue', entityId: 'issue_42' });
     expect(row.entityType).toBe('issue');
     expect(row.entityId).toBe('issue_42');
+  });
+});
+
+describe('reverting a snooze the server rejected', () => {
+  it('puts back the value the row had before the failed request', () => {
+    const rows = [item({ snoozedUntil: '2026-03-01T00:00:00.000Z' })];
+
+    const reverted = revertSnooze(rows, 'notification_1', '2026-03-01T00:00:00.000Z', null);
+
+    expect(reverted[0]?.snoozedUntil).toBeNull();
+  });
+
+  it('leaves a newer snooze alone rather than overwriting it', () => {
+    const rows = [item({ snoozedUntil: '2026-06-01T00:00:00.000Z' })];
+
+    const reverted = revertSnooze(rows, 'notification_1', '2026-03-01T00:00:00.000Z', null);
+
+    expect(reverted[0]?.snoozedUntil).toBe('2026-06-01T00:00:00.000Z');
+  });
+
+  it('leaves every other row untouched', () => {
+    const rows = [
+      item({ id: 'notification_1', snoozedUntil: '2026-03-01T00:00:00.000Z' }),
+      item({ id: 'notification_2', snoozedUntil: '2026-03-01T00:00:00.000Z' }),
+    ];
+
+    const reverted = revertSnooze(rows, 'notification_1', '2026-03-01T00:00:00.000Z', null);
+
+    expect(reverted[1]?.snoozedUntil).toBe('2026-03-01T00:00:00.000Z');
   });
 });

--- a/apps/web/tests/features/inbox/inbox-deltas.test.ts
+++ b/apps/web/tests/features/inbox/inbox-deltas.test.ts
@@ -286,3 +286,23 @@ describe('rolling back a snooze the server rejected', () => {
     expect(rollback.rows[1]?.snoozedUntil).toBe('2026-03-01T00:00:00.000Z');
   });
 });
+
+describe('a snoozed mention', () => {
+  it('is not counted, because the server counter excludes it too', () => {
+    const patch = applyNotificationDeltas(
+      [item({ type: 'mention', snoozedUntil: '2999-01-01T00:00:00.000Z' })],
+      [action({ action: 'delete' })],
+      TAB,
+    );
+    expect(patch.mentionDelta).toBe(0);
+  });
+
+  it('is counted again once the snooze has expired', () => {
+    const patch = applyNotificationDeltas(
+      [item({ type: 'mention', snoozedUntil: '2020-01-01T00:00:00.000Z' })],
+      [action({ action: 'delete' })],
+      TAB,
+    );
+    expect(patch.mentionDelta).toBe(-1);
+  });
+});

--- a/apps/web/tests/features/inbox/inbox-deltas.test.ts
+++ b/apps/web/tests/features/inbox/inbox-deltas.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 import type { SyncAction } from '@orbit/shared/events';
 import type { InboxItem } from '../../../src/features/inbox/data.ts';
-import { applyNotificationDeltas, revertSnooze } from '../../../src/features/inbox/inbox-view.tsx';
+import {
+  applyNotificationDeltas,
+  snoozeRollback,
+} from '../../../src/features/inbox/inbox-view.tsx';
 
 const TAB = 'tab_a';
 
@@ -246,21 +249,30 @@ describe('what the reading pane is looking at', () => {
   });
 });
 
-describe('reverting a snooze the server rejected', () => {
+describe('rolling back a snooze the server rejected', () => {
   it('puts back the value the row had before the failed request', () => {
     const rows = [item({ snoozedUntil: '2026-03-01T00:00:00.000Z' })];
 
-    const reverted = revertSnooze(rows, 'notification_1', '2026-03-01T00:00:00.000Z', null);
+    const rollback = snoozeRollback(rows, 'notification_1', '2026-03-01T00:00:00.000Z', null);
 
-    expect(reverted[0]?.snoozedUntil).toBeNull();
+    expect(rollback.rows[0]?.snoozedUntil).toBeNull();
+    expect(rollback.restoreCounts).toBe(true);
   });
 
   it('leaves a newer snooze alone rather than overwriting it', () => {
     const rows = [item({ snoozedUntil: '2026-06-01T00:00:00.000Z' })];
 
-    const reverted = revertSnooze(rows, 'notification_1', '2026-03-01T00:00:00.000Z', null);
+    const rollback = snoozeRollback(rows, 'notification_1', '2026-03-01T00:00:00.000Z', null);
 
-    expect(reverted[0]?.snoozedUntil).toBe('2026-06-01T00:00:00.000Z');
+    expect(rollback.rows[0]?.snoozedUntil).toBe('2026-06-01T00:00:00.000Z');
+  });
+
+  it('leaves the counts alone when it did not undo the snooze', () => {
+    const rows = [item({ snoozedUntil: '2026-06-01T00:00:00.000Z' })];
+
+    const rollback = snoozeRollback(rows, 'notification_1', '2026-03-01T00:00:00.000Z', null);
+
+    expect(rollback.restoreCounts).toBe(false);
   });
 
   it('leaves every other row untouched', () => {
@@ -269,8 +281,8 @@ describe('reverting a snooze the server rejected', () => {
       item({ id: 'notification_2', snoozedUntil: '2026-03-01T00:00:00.000Z' }),
     ];
 
-    const reverted = revertSnooze(rows, 'notification_1', '2026-03-01T00:00:00.000Z', null);
+    const rollback = snoozeRollback(rows, 'notification_1', '2026-03-01T00:00:00.000Z', null);
 
-    expect(reverted[1]?.snoozedUntil).toBe('2026-03-01T00:00:00.000Z');
+    expect(rollback.rows[1]?.snoozedUntil).toBe('2026-03-01T00:00:00.000Z');
   });
 });

--- a/apps/web/tests/features/inbox/inbox-issue.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-issue.test.tsx
@@ -230,6 +230,7 @@ function renderInbox(
               items={items}
               unreadCount={1}
               unreadMentions={0}
+              unreadActivity={0}
               userId="user_1"
               nextCursor={null}
               canWriteDocs={docAccess.canWriteDocs}
@@ -324,6 +325,7 @@ describe('reading a notification in the inbox', () => {
   });
 
   it('does not repeat a body the issue itself already says', async () => {
+    const user = userEvent.setup();
     renderInbox([
       item({
         type: 'issue_assigned',
@@ -334,6 +336,8 @@ describe('reading a notification in the inbox', () => {
         url: '/issue/ENG-3',
       }),
     ]);
+
+    await user.click(screen.getByTestId('inbox-tab-status'));
 
     await screen.findByTestId('issue-detail');
     expect(screen.queryByTestId('inbox-event-context')).toBeNull();

--- a/apps/web/tests/features/inbox/inbox-open.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-open.test.tsx
@@ -90,6 +90,7 @@ function renderInbox(items: readonly InboxItem[]) {
           items={items}
           unreadCount={1}
           unreadMentions={1}
+          unreadActivity={1}
           userId="user_1"
           nextCursor={null}
           canWriteDocs

--- a/apps/web/tests/features/inbox/inbox-pagination.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-pagination.test.tsx
@@ -258,13 +258,13 @@ describe('an inbox with more notifications than one page', () => {
     });
   });
 
-  it('says inbox zero only when there is nothing left to fetch', async () => {
+  it('shows the empty state only when there is nothing left to fetch', async () => {
     const user = userEvent.setup();
     renderInbox([item('n1', { read: true })], null);
 
     await user.click(screen.getByRole('button', { name: 'Unread' }));
 
-    expect(screen.getByText('Inbox zero')).toBeInTheDocument();
+    expect(screen.getByText('Nothing on this tab')).toBeInTheDocument();
     expect(screen.queryByTestId('inbox-load-more')).toBeNull();
   });
 

--- a/apps/web/tests/features/inbox/inbox-pagination.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-pagination.test.tsx
@@ -113,6 +113,7 @@ function renderInbox(items: readonly InboxItem[], nextCursor: string | null) {
           items={items}
           unreadCount={0}
           unreadMentions={0}
+          unreadActivity={0}
           userId="user_1"
           nextCursor={nextCursor}
           canWriteDocs

--- a/apps/web/tests/features/inbox/inbox-tabs.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-tabs.test.tsx
@@ -1,0 +1,192 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { NOTIFICATION_TYPES, STATUS_CHANGE_NOTIFICATION_TYPES } from '@orbit/shared/constants';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { InboxItem } from '@/features/inbox/data.ts';
+import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+
+const realtimeReact = { ...(await import('@orbit/realtime-client/react')) };
+mock.module('@orbit/realtime-client/react', () => ({
+  ...realtimeReact,
+  useScopeSubscription: () => undefined,
+  useDeltaHandler: () => undefined,
+}));
+
+const issueDetail = { ...(await import('@/features/issues/issue-detail.tsx')) };
+mock.module('@/features/issues/issue-detail.tsx', () => ({
+  ...issueDetail,
+  IssueDetailView: ({ identifier }: { identifier: string }) => (
+    <div data-testid="issue-detail">{identifier}</div>
+  ),
+}));
+
+afterAll(() => {
+  mock.module('@/features/issues/issue-detail.tsx', () => issueDetail);
+  mock.module('@orbit/realtime-client/react', () => realtimeReact);
+});
+
+const { InboxView } = await import('@/features/inbox/inbox-view.tsx');
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  globalThis.fetch = mock(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ unreadCount: 0 }),
+    }),
+  ) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function item(overrides: Partial<InboxItem> = {}): InboxItem {
+  return {
+    id: 'notification_1',
+    type: 'comment_created',
+    entityType: 'issue',
+    entityId: 'issue_1',
+    actorName: 'Ada',
+    title: 'New comment on ENG-3',
+    body: '',
+    bodyHtml: '',
+    url: '/issue/ENG-3',
+    externalUrl: null,
+    read: true,
+    snoozedUntil: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function renderInbox(items: readonly InboxItem[], unreadActivity = 0, unreadMentions = 0) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <HotkeyProvider>
+        <InboxView
+          items={items}
+          unreadCount={0}
+          unreadMentions={unreadMentions}
+          unreadActivity={unreadActivity}
+          userId="user_1"
+          nextCursor={null}
+          canWriteDocs
+          canPublishDocs
+        />
+      </HotkeyProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function rowTitles(): string[] {
+  return screen
+    .getAllByRole('listitem')
+    .map((row) => row.textContent ?? '')
+    .filter((text) => text.length > 0);
+}
+
+const statusMove = item({
+  id: 'notification_status',
+  type: 'issue_status_changed',
+  title: 'ENG-3 moved to In Progress',
+});
+const assignment = item({
+  id: 'notification_assigned',
+  type: 'issue_assigned',
+  title: 'ENG-4 assigned to you',
+});
+const comment = item({ id: 'notification_comment', title: 'New comment on ENG-3' });
+
+describe('the Activity tab', () => {
+  it('is the tab the inbox opens on', () => {
+    renderInbox([comment]);
+
+    expect(screen.getByRole('button', { name: 'Activity' })).toHaveAttribute(
+      'aria-current',
+      'true',
+    );
+  });
+
+  it('leaves status moves and assignments out', () => {
+    renderInbox([statusMove, assignment, comment]);
+
+    const titles = rowTitles();
+    expect(titles.some((text) => text.includes('New comment on ENG-3'))).toBe(true);
+    expect(titles.some((text) => text.includes('moved to In Progress'))).toBe(false);
+    expect(titles.some((text) => text.includes('assigned to you'))).toBe(false);
+  });
+});
+
+describe('the Status tab', () => {
+  it('shows the status moves and assignments the Activity tab left out', async () => {
+    const user = userEvent.setup();
+    renderInbox([statusMove, assignment, comment]);
+
+    await user.click(screen.getByRole('button', { name: 'Status' }));
+
+    const titles = rowTitles();
+    expect(titles.some((text) => text.includes('moved to In Progress'))).toBe(true);
+    expect(titles.some((text) => text.includes('assigned to you'))).toBe(true);
+    expect(titles.some((text) => text.includes('New comment on ENG-3'))).toBe(false);
+  });
+
+  it('holds every notification the Activity tab does not, and nothing more', async () => {
+    const user = userEvent.setup();
+    const everyType = NOTIFICATION_TYPES.map((type, index) =>
+      item({ id: `notification_${index}`, type, title: `Notification ${index}` }),
+    );
+    renderInbox(everyType);
+
+    const activityCount = rowTitles().length;
+    await user.click(screen.getByRole('button', { name: 'Status' }));
+    const statusCount = rowTitles().length;
+
+    expect(statusCount).toBe(STATUS_CHANGE_NOTIFICATION_TYPES.length);
+    expect(activityCount + statusCount).toBe(NOTIFICATION_TYPES.length);
+  });
+});
+
+describe('the Activity unread count', () => {
+  it('shows how many unread notifications are real activity', () => {
+    renderInbox([comment], 12);
+
+    expect(screen.getByTestId('inbox-activity-count')).toHaveTextContent('12');
+  });
+
+  it('stays hidden when no activity is unread', () => {
+    renderInbox([comment], 0);
+
+    expect(screen.queryByTestId('inbox-activity-count')).toBeNull();
+  });
+
+  it('drops when an unread notification is snoozed out of the counters', async () => {
+    const user = userEvent.setup();
+    renderInbox([item({ id: 'notification_unread', read: false })], 1);
+    expect(screen.getByTestId('inbox-activity-count')).toHaveTextContent('1');
+
+    await user.keyboard('h');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('inbox-activity-count')).toBeNull();
+    });
+  });
+});
+
+describe('the mention count', () => {
+  it('drops when an unread mention is snoozed out of the counters', async () => {
+    const user = userEvent.setup();
+    renderInbox([item({ id: 'notification_mention', type: 'mention', read: false })], 1, 1);
+    expect(screen.getByTestId('inbox-mention-count')).toHaveTextContent('1');
+
+    await user.keyboard('h');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('inbox-mention-count')).toBeNull();
+    });
+  });
+});

--- a/apps/web/tests/features/inbox/inbox-tabs.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-tabs.test.tsx
@@ -175,6 +175,52 @@ describe('the Activity unread count', () => {
       expect(screen.queryByTestId('inbox-activity-count')).toBeNull();
     });
   });
+
+  it('drops only once when the same notification is snoozed again', async () => {
+    const user = userEvent.setup();
+    renderInbox(
+      [
+        item({ id: 'notification_a', read: false }),
+        item({ id: 'notification_b', read: false, title: 'Second comment on ENG-3' }),
+      ],
+      2,
+    );
+
+    await user.keyboard('h');
+    await user.keyboard('h');
+
+    expect(screen.getByTestId('inbox-activity-count')).toHaveTextContent('1');
+  });
+
+  it('ignores a read toggle on a notification already snoozed out of the counters', async () => {
+    const user = userEvent.setup();
+    renderInbox(
+      [
+        item({ id: 'notification_a', read: false, snoozedUntil: '2999-01-01T00:00:00.000Z' }),
+        item({ id: 'notification_b', read: false, title: 'Second comment on ENG-3' }),
+      ],
+      1,
+    );
+
+    await user.keyboard('u');
+
+    expect(screen.getByTestId('inbox-activity-count')).toHaveTextContent('1');
+  });
+});
+
+describe('the empty state', () => {
+  it('does not claim inbox zero when the notifications are all on another tab', () => {
+    renderInbox([statusMove, assignment]);
+
+    expect(screen.queryByText('Inbox zero')).toBeNull();
+    expect(screen.getByText('Nothing on this tab')).toBeVisible();
+  });
+
+  it('still claims inbox zero when there is genuinely nothing', () => {
+    renderInbox([]);
+
+    expect(screen.getByText('Inbox zero')).toBeVisible();
+  });
 });
 
 describe('the mention count', () => {

--- a/apps/web/tests/features/inbox/inbox-tabs.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-tabs.test.tsx
@@ -29,14 +29,18 @@ afterAll(() => {
 const { InboxView } = await import('@/features/inbox/inbox-view.tsx');
 
 const realFetch = globalThis.fetch;
+let failWrite = false;
 
 beforeEach(() => {
+  failWrite = false;
   globalThis.fetch = mock(() =>
-    Promise.resolve({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ unreadCount: 0 }),
-    }),
+    failWrite
+      ? Promise.reject(new Error('network down'))
+      : Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ unreadCount: 0 }),
+        }),
   ) as unknown as typeof fetch;
 });
 
@@ -205,6 +209,35 @@ describe('the Activity unread count', () => {
     await user.keyboard('u');
 
     expect(screen.getByTestId('inbox-activity-count')).toHaveTextContent('1');
+  });
+});
+
+describe('a write the server rejects', () => {
+  it('puts the activity count back when the snooze does not save', async () => {
+    const user = userEvent.setup();
+    renderInbox([item({ id: 'notification_unread', read: false })], 1);
+    failWrite = true;
+
+    await user.keyboard('h');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('inbox-error')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('inbox-activity-count')).toHaveTextContent('1');
+  });
+
+  it('puts the row and the activity count back when the delete does not save', async () => {
+    const user = userEvent.setup();
+    renderInbox([item({ id: 'notification_unread', read: false })], 1);
+    failWrite = true;
+
+    await user.keyboard('{Backspace}');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('inbox-error')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('inbox-activity-count')).toHaveTextContent('1');
+    expect(screen.getByRole('button', { name: /New comment on ENG-3/ })).toBeInTheDocument();
   });
 });
 

--- a/apps/web/tests/features/inbox/inbox-tabs.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-tabs.test.tsx
@@ -241,6 +241,23 @@ describe('a write the server rejects', () => {
   });
 });
 
+describe('overlapping snoozes on one row', () => {
+  it('sends a single request however fast the key is pressed', async () => {
+    const user = userEvent.setup();
+    let calls = 0;
+    globalThis.fetch = mock(() => {
+      calls += 1;
+      return new Promise<Response>(() => undefined);
+    }) as unknown as typeof fetch;
+    renderInbox([item({ id: 'notification_unread', read: false })], 1);
+
+    await user.keyboard('h');
+    await user.keyboard('h');
+
+    expect(calls).toBe(1);
+  });
+});
+
 describe('the empty state', () => {
   it('does not claim inbox zero when the notifications are all on another tab', () => {
     renderInbox([statusMove, assignment]);

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -211,6 +211,12 @@ filters. `Bugs in progress with no assignee` deserves to be a view.
 The inbox collects what happened that involves you: assignments, mentions,
 comments on issues you follow, state changes on work you are watching.
 
+It opens on **Activity**, which is everything people did: comments, replies,
+mentions, reactions, reviews, failed checks, document changes. Issue field moves
+such as `ENG-3 moved to In Progress` and assignments live on the **Status** tab
+instead, so a busy board cannot bury a comment. The two tabs are complements, so
+nothing is hidden, and Unread, Mentions and Pull requests still span both.
+
 In-app notification preferences are per event type, with quiet hours that
 respect your timezone.
 

--- a/docs/superpowers/specs/2026-08-15-inbox-activity-status-tabs-design.md
+++ b/docs/superpowers/specs/2026-08-15-inbox-activity-status-tabs-design.md
@@ -1,0 +1,167 @@
+# Inbox Activity and Status Tabs Design
+
+## Problem
+
+The inbox is dominated by issue field changes. A workspace with active boards produces a
+continuous run of `NOV-152 moved to In Progress` rows, and those rows bury the notifications a
+person actually needs to act on: a comment on their issue, a review on their pull request, a
+failed check, a document they follow changing.
+
+The four existing tabs do not help. `All` is the flood itself. `Unread` is the same flood
+filtered by a flag that most of the flood also satisfies. `Mentions` and `Pull requests` are
+narrow slices that miss ordinary comments and replies. The result is that a reader scanning the
+inbox misses real activity, which defeats the purpose of having an inbox.
+
+Hiding field changes is not the answer. Knowing that an issue moved is useful, and a
+notification a user was sent should remain reachable. The problem is placement, not existence.
+
+## Scope
+
+Split the inbox into two complementary buckets and land the reader in the useful one:
+
+- Introduce a shared classification of notification types that represent an issue field moving.
+- Rename the default tab to `Activity` and define it as every notification that is not a field
+  move.
+- Add a `Status` tab holding exactly the field moves, so nothing becomes unreachable.
+- Give the `Activity` tab its own unread count, so the reader can tell how much of the inbox
+  total is real activity.
+- Leave `Unread`, `Mentions` and `Pull requests` unchanged, still spanning every notification.
+
+This change is confined to classification, the inbox UI and one unread counter. It does not
+change what notifications are produced, who receives them, how they are delivered, or how they
+are read, snoozed and deleted.
+
+## Classification
+
+`packages/shared/src/constants/notification.ts` gains a list beside the existing
+`PULL_REQUEST_NOTIFICATION_TYPES`, declared the same way:
+
+```
+STATUS_CHANGE_NOTIFICATION_TYPES = [
+  'issue_status_changed',
+  'issue_priority_changed',
+  'issue_assigned',
+  'issue_unassigned',
+  'triage_added',
+]
+```
+
+with an `isStatusChangeNotification` predicate matching the shape and signature of
+`isPullRequestNotification`.
+
+Three of these five types are not produced today. `issue_status_changed` and `issue_assigned`
+come from `packages/core/src/work/issue-service.ts`. `issue_priority_changed`,
+`issue_unassigned` and `triage_added` are declared in `NOTIFICATION_TYPES` and unused. They are
+classified now anyway, so that wiring one of them up later places it in `Status` by default
+rather than silently leaking into `Activity` and reproducing the original problem.
+
+Assignment is deliberately classified as a field move rather than as activity. An assignment is
+a workflow transition of the same kind as a status change, it is produced by the same service on
+the same edit, and it arrives in the same bursts. A reader who wants assignments still has
+`Status`, and a reader who was assigned something urgent is reached by email and push, which this
+change does not touch.
+
+The two lists are disjoint. No notification type is both a pull request event and a field move,
+and a test asserts this so that a future addition to either list cannot make a type ambiguous.
+
+## Tab structure
+
+The tab bar becomes:
+
+```
+Activity | Unread | Mentions | Pull requests | Status
+```
+
+`Activity` is the default and holds every notification that is not a field move: comments,
+replies, mentions, reactions, subscription activity, document changes, document access requests
+and grants, project updates, reminders, invites, members joining, and all seven pull request
+types including failed checks.
+
+`Status` holds exactly the field moves. `Activity` and `Status` are exact complements, so every
+notification appears in one of them and no notification is unreachable.
+
+`Unread`, `Mentions` and `Pull requests` keep their current definitions and continue to span
+every notification, field moves included. They are facets over the whole inbox rather than
+subdivisions of `Activity`. A reader who wants only unread activity reads the `Activity` list,
+where unread rows already carry the accent dot.
+
+Mechanically this is the existing pattern unchanged. `matchesTab` in
+`apps/web/src/features/inbox/inbox-view.tsx` gains two branches: `activity` returns the negation
+of `isStatusChangeNotification`, `status` returns it directly. The implicit `return true`
+fallback is replaced by an explicit branch per tab so that adding a tab cannot accidentally
+inherit the old meaning of `All`. Keyboard navigation, the retained-unread set, selection reset
+on tab change and the load-more row all operate on the filtered list exactly as they do now.
+
+### Naming
+
+`Activity` is chosen over `Focused` or `Primary`. Outlook's `Focused` implies that a model ranked
+the messages, and Orbit's rule is a fixed, inspectable classification with no scoring. Gmail names
+its own tabs after their contents for the same reason. `Activity` and `Status` describe what is in
+each tab and read as the complements they are.
+
+The page heading stays `Inbox`, and the total unread and mention badges beside it are unchanged.
+
+## Activity unread count
+
+The `Activity` tab carries a count of unread notifications that are not field moves, rendered
+only when it is above zero. Read together with the existing header badge it answers the question
+the current inbox cannot: of the total unread, how many are worth opening.
+
+`unreadCounters` in `packages/services/src/notifications/index.ts` already groups unread rows by
+type to separate mentions from the total. It gains a third accumulator in that same loop and
+returns `activity` alongside `total` and `mentions`. There is no new query and no new index.
+
+The value reaches the view along the path the mention count already takes: `loadInbox` in
+`apps/web/src/features/inbox/data.ts` puts `unreadActivity` on `InboxData`, the inbox page passes
+it through `inbox-realtime.tsx`, and `InboxView` seeds state from it and re-seeds in the existing
+effect that resynchronises on new props.
+
+Once seeded, the count is maintained locally:
+
+- `InboxPatch` gains `activityDelta` beside `unreadDelta` and `mentionDelta`, and `applyOne`
+  maintains it across realtime insert, update and delete using a helper that counts a row as one
+  when it is both unread and not a field move.
+- `setReadState` adjusts it on the optimistic path and reverses that adjustment on the rollback
+  path, in the same place it adjusts the mention count.
+- `remove` decrements it when the deleted row was an unread non-field-move.
+
+`/api/notifications/read` and the notification `PATCH` and `DELETE` responses continue to return
+only `unreadCount`, so `applyServerCount` corrects the total but never the activity count. This is
+the same contract the mention count already lives under, and it keeps the change out of the route
+layer entirely.
+
+## Pagination
+
+Filtering stays client-side over the loaded page, which is how `Mentions` and `Pull requests`
+already work. The server load is unchanged.
+
+The known consequence is that when field moves dominate the first page of fifty, `Activity` shows
+only the remainder of that page until more is loaded. The load-more row fires from an
+`IntersectionObserver`, so ordinary scrolling continues to pull pages without a click, and the
+`Activity` count on the tab tells the reader how much is still to come. Moving the filter into
+`listInbox` and the notifications route remains available if the tab proves thin in practice, but
+it widens the change to the query, the route, the first server paint and their tests for a
+problem that has not yet been observed.
+
+## Testing
+
+- `packages/shared`: membership of `STATUS_CHANGE_NOTIFICATION_TYPES`, the behaviour of
+  `isStatusChangeNotification`, and disjointness from `PULL_REQUEST_NOTIFICATION_TYPES`.
+- `apps/web/tests/features/inbox/inbox-tabs.test.tsx`, new: `Activity` excludes field moves,
+  `Status` shows only field moves, the complement property across a fixture covering every entry
+  in `NOTIFICATION_TYPES`, and the activity count rendering and its absence at zero.
+- `apps/web/tests/features/inbox/inbox-deltas.test.ts`: `activityDelta` across insert, update and
+  delete. The shared fixture defaults to `issue_assigned`, which this change reclassifies as a
+  field move, so the existing expectations are revised deliberately rather than left to pass by
+  coincidence.
+- `packages/services/tests/notifications/notifications.test.ts`: the `activity` counter, including
+  a case where unread field moves and unread activity coexist. Both existing assertions compare
+  the counter object exactly, so both are updated.
+- `apps/web/e2e/inbox-layout.spec.ts`: the tab label list, which currently hardcodes the four
+  present labels.
+
+## Out of scope
+
+Server-side tab filtering. Per-tab unread counts beyond `Activity`. Any change to notification
+production, delivery channels, the notification preference matrix, or the email and push paths.
+User-configurable classification of which types count as field moves.

--- a/docs/superpowers/specs/2026-08-15-inbox-activity-status-tabs-design.md
+++ b/docs/superpowers/specs/2026-08-15-inbox-activity-status-tabs-design.md
@@ -36,7 +36,7 @@ are read, snoozed and deleted.
 `packages/shared/src/constants/notification.ts` gains a list beside the existing
 `PULL_REQUEST_NOTIFICATION_TYPES`, declared the same way:
 
-```
+```ts
 STATUS_CHANGE_NOTIFICATION_TYPES = [
   'issue_status_changed',
   'issue_priority_changed',
@@ -68,7 +68,7 @@ and a test asserts this so that a future addition to either list cannot make a t
 
 The tab bar becomes:
 
-```
+```text
 Activity | Unread | Mentions | Pull requests | Status
 ```
 

--- a/docs/superpowers/specs/2026-08-15-inbox-activity-status-tabs-design.md
+++ b/docs/superpowers/specs/2026-08-15-inbox-activity-status-tabs-design.md
@@ -124,11 +124,20 @@ Once seeded, the count is maintained locally:
 - `setReadState` adjusts it on the optimistic path and reverses that adjustment on the rollback
   path, in the same place it adjusts the mention count.
 - `remove` decrements it when the deleted row was an unread non-field-move.
+- `snooze` decrements it when the snoozed row was an unread non-field-move.
 
 `/api/notifications/read` and the notification `PATCH` and `DELETE` responses continue to return
 only `unreadCount`, so `applyServerCount` corrects the total but never the activity count. This is
 the same contract the mention count already lives under, and it keeps the change out of the route
 layer entirely.
+
+The snooze case is the one place that contract was already broken. `unreadCounters` excludes a
+snoozed row, so the server total drops the moment a row is snoozed, and `applyServerCount` applies
+that drop to the total. The mention count was never given the same treatment, so snoozing an unread
+mention left its badge one too high until the next page load. Adding the activity count to that
+function would have reproduced the same staleness, so `snooze` now adjusts both counts locally the
+way `remove` already did. This is a fix to existing mention behaviour, made because the alternative
+was shipping a new badge with a known stale case.
 
 ## Pagination
 
@@ -149,16 +158,23 @@ problem that has not yet been observed.
   `isStatusChangeNotification`, and disjointness from `PULL_REQUEST_NOTIFICATION_TYPES`.
 - `apps/web/tests/features/inbox/inbox-tabs.test.tsx`, new: `Activity` excludes field moves,
   `Status` shows only field moves, the complement property across a fixture covering every entry
-  in `NOTIFICATION_TYPES`, and the activity count rendering and its absence at zero.
+  in `NOTIFICATION_TYPES`, the activity count rendering and its absence at zero, and the snooze
+  case for both the activity and mention counts.
+- `apps/web/tests/features/inbox/inbox-issue.test.tsx`: the body-duplication test uses an
+  `issue_assigned` fixture, which this change moves to `Status`, so it selects that tab before
+  reading the detail pane. Keeping the fixture preserves assignment coverage rather than swapping
+  it for a type that happens to stay on the default tab.
 - `apps/web/tests/features/inbox/inbox-deltas.test.ts`: `activityDelta` across insert, update and
   delete. The shared fixture defaults to `issue_assigned`, which this change reclassifies as a
   field move, so the existing expectations are revised deliberately rather than left to pass by
   coincidence.
 - `packages/services/tests/notifications/notifications.test.ts`: the `activity` counter, including
-  a case where unread field moves and unread activity coexist. Both existing assertions compare
-  the counter object exactly, so both are updated.
-- `apps/web/e2e/inbox-layout.spec.ts`: the tab label list, which currently hardcodes the four
-  present labels.
+  a case where unread field moves and unread activity coexist, and one where a read field move
+  leaves both counters alone. One existing assertion compares the counter object exactly and is
+  updated; the other reads fields individually and needs no change.
+- `apps/web/e2e/inbox-layout.spec.ts`: the tab list. It matched tabs by exact accessible name,
+  which the count badge changes from `Activity` to `Activity 12`, so the tabs carry
+  `data-testid="inbox-tab-<id>"` and the spec selects them by that instead.
 
 ## Out of scope
 

--- a/packages/services/src/notifications/index.ts
+++ b/packages/services/src/notifications/index.ts
@@ -9,6 +9,7 @@ import {
 import {
   actorSchema,
   idSchema,
+  isStatusChangeNotification,
   NOTIFICATION_REASONS,
   NOTIFICATION_TYPES,
   SLACK_INTEGRATION_ENABLED,
@@ -494,6 +495,7 @@ export async function unreadCount(
 export interface UnreadCounters {
   readonly total: number;
   readonly mentions: number;
+  readonly activity: number;
 }
 
 export async function unreadCounters(
@@ -517,9 +519,11 @@ export async function unreadCounters(
     .groupBy(notification.type);
   let total = 0;
   let mentions = 0;
+  let activity = 0;
   for (const row of rows) {
     total += row.value;
     if (row.type === 'mention') mentions += row.value;
+    if (!isStatusChangeNotification(row.type)) activity += row.value;
   }
-  return { total, mentions };
+  return { total, mentions, activity };
 }

--- a/packages/services/tests/notifications/notifications.test.ts
+++ b/packages/services/tests/notifications/notifications.test.ts
@@ -163,6 +163,7 @@ describe('notifyMany', () => {
       expect(await unreadCounters(tx, fixture.adaId, fixture.organizationId)).toEqual({
         total: 0,
         mentions: 0,
+        activity: 0,
       });
     });
   });
@@ -432,6 +433,50 @@ describe('inbox reads and writes', () => {
       const counters = await unreadCounters(tx, fixture.adaId, fixture.organizationId);
       expect(counters.mentions).toBe(2);
       expect(counters.total).toBe(4);
+    });
+  });
+
+  it('keeps issue field moves out of the activity counter', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await notifyMany(tx, [
+        eventFor(fixture, {
+          userIds: [fixture.adaId],
+          type: 'issue_status_changed',
+          entityId: 'iss_a',
+        }),
+        eventFor(fixture, { userIds: [fixture.adaId], type: 'issue_assigned', entityId: 'iss_b' }),
+        eventFor(fixture, { userIds: [fixture.adaId], type: 'comment_created', entityId: 'iss_c' }),
+        eventFor(fixture, { userIds: [fixture.adaId], type: 'mention', entityId: 'iss_d' }),
+      ]);
+
+      const counters = await unreadCounters(tx, fixture.adaId, fixture.organizationId);
+      expect(counters.total).toBe(4);
+      expect(counters.activity).toBe(2);
+      expect(counters.mentions).toBe(1);
+    });
+  });
+
+  it('counts a read field move out of both the total and the activity counter', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      const outcome = await notifyMany(tx, [
+        eventFor(fixture, {
+          userIds: [fixture.adaId],
+          type: 'issue_status_changed',
+          entityId: 'iss_a',
+        }),
+        eventFor(fixture, { userIds: [fixture.adaId], type: 'comment_created', entityId: 'iss_b' }),
+      ]);
+      await markRead(tx, {
+        userId: fixture.adaId,
+        organizationId: fixture.organizationId,
+        notificationIds: [outcome.notifications[0]?.id ?? ''],
+      });
+
+      const counters = await unreadCounters(tx, fixture.adaId, fixture.organizationId);
+      expect(counters.total).toBe(1);
+      expect(counters.activity).toBe(1);
     });
   });
 

--- a/packages/shared/src/constants/notification.ts
+++ b/packages/shared/src/constants/notification.ts
@@ -40,6 +40,18 @@ export function isPullRequestNotification(type: NotificationType): boolean {
   return (PULL_REQUEST_NOTIFICATION_TYPES as readonly string[]).includes(type);
 }
 
+export const STATUS_CHANGE_NOTIFICATION_TYPES = [
+  'issue_status_changed',
+  'issue_priority_changed',
+  'issue_assigned',
+  'issue_unassigned',
+  'triage_added',
+] as const satisfies readonly NotificationType[];
+
+export function isStatusChangeNotification(type: string): boolean {
+  return (STATUS_CHANGE_NOTIFICATION_TYPES as readonly string[]).includes(type);
+}
+
 export const NOTIFICATION_CHANNELS = ['inbox', 'email', 'slack', 'push'] as const;
 export type NotificationChannel = (typeof NOTIFICATION_CHANNELS)[number];
 

--- a/packages/shared/tests/constants/notification.test.ts
+++ b/packages/shared/tests/constants/notification.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  isPullRequestNotification,
+  isStatusChangeNotification,
+  NOTIFICATION_TYPES,
+  PULL_REQUEST_NOTIFICATION_TYPES,
+  STATUS_CHANGE_NOTIFICATION_TYPES,
+} from '../../src/constants/notification.ts';
+
+describe('isStatusChangeNotification', () => {
+  it('classifies every issue field move as a status change', () => {
+    for (const type of STATUS_CHANGE_NOTIFICATION_TYPES) {
+      expect(isStatusChangeNotification(type)).toBe(true);
+    }
+  });
+
+  it('classifies assignment as a status change rather than activity', () => {
+    expect(isStatusChangeNotification('issue_assigned')).toBe(true);
+    expect(isStatusChangeNotification('issue_unassigned')).toBe(true);
+  });
+
+  it('leaves conversation and document notifications as activity', () => {
+    expect(isStatusChangeNotification('comment_created')).toBe(false);
+    expect(isStatusChangeNotification('comment_replied')).toBe(false);
+    expect(isStatusChangeNotification('mention')).toBe(false);
+    expect(isStatusChangeNotification('reaction')).toBe(false);
+    expect(isStatusChangeNotification('document_changed')).toBe(false);
+  });
+
+  it('leaves every pull request notification as activity', () => {
+    for (const type of PULL_REQUEST_NOTIFICATION_TYPES) {
+      expect(isStatusChangeNotification(type)).toBe(false);
+    }
+  });
+});
+
+describe('STATUS_CHANGE_NOTIFICATION_TYPES', () => {
+  it('shares no type with the pull request list', () => {
+    const overlap = STATUS_CHANGE_NOTIFICATION_TYPES.filter((type) =>
+      isPullRequestNotification(type),
+    );
+    expect(overlap).toEqual([]);
+  });
+
+  it('contains only declared notification types', () => {
+    const declared: readonly string[] = NOTIFICATION_TYPES;
+    const undeclared = STATUS_CHANGE_NOTIFICATION_TYPES.filter((type) => !declared.includes(type));
+    expect(undeclared).toEqual([]);
+  });
+
+  it('splits the notification enum into two non-empty halves', () => {
+    const activity = NOTIFICATION_TYPES.filter((type) => !isStatusChangeNotification(type));
+    const status = NOTIFICATION_TYPES.filter((type) => isStatusChangeNotification(type));
+    expect(status.length).toBe(STATUS_CHANGE_NOTIFICATION_TYPES.length);
+    expect(activity.length).toBe(NOTIFICATION_TYPES.length - status.length);
+    expect(activity.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## The problem

A busy board buries the inbox. Runs of `NOV-152 moved to In Progress` push comments, reviews and failed checks off the screen, so the notifications worth acting on get missed. The four existing tabs did not help: **All** was the flood itself, and **Unread** was the same flood filtered by a flag most of the flood also satisfies.

Hiding field moves is not the answer, because knowing an issue moved is useful and a notification a user was sent should stay reachable. The problem is placement, not existence.

## The change

```text
Inbox  [68 unread]  [@1]
  Activity 12 | Unread | Mentions | Pull requests | Status
  ^^^^^^^^ default
```

- **Activity** (default) holds everything people did: comments, replies, mentions, reactions, reviews, failed checks, doc changes, invites.
- **Status** holds the issue field moves: status, priority, assignment, unassignment, triage.
- The two are exact complements, so every notification reaches one of them and nothing is unreachable. A test renders one notification of every type in `NOTIFICATION_TYPES` and asserts the 19/5 split covers all 24.
- **Unread**, **Mentions** and **Pull requests** are unchanged and still span both.

`matchesTab` is now an exhaustive `switch` with no `default`. Under `noImplicitReturns` a future tab without a case is a compile error, where the old `if` chain would have silently inherited the meaning of `All`.

## Activity unread count

The header total tells you how much is unread; the tab tells you how much is worth opening. `unreadCounters` already grouped unread rows by type to split out mentions, so the third accumulator costs no extra query. The count is seeded from the server, then maintained locally through the realtime reducer, the read toggle and its rollback, delete, and snooze.

## Decisions worth a reviewer's attention

**Assignments are classified as field moves.** They come from the same service on the same edit as a status change and arrive in the same bursts, and urgent assignments still reach you by email and push. This is the call most likely to want revisiting in use; it is one entry in `STATUS_CHANGE_NOTIFICATION_TYPES`.

**Three of the five status types are not produced yet.** `issue_priority_changed`, `issue_unassigned` and `triage_added` are declared in `NOTIFICATION_TYPES` and unused. Classifying them now means wiring one up later places it in Status by default rather than quietly recreating the flood.

**`isStatusChangeNotification` takes `string`, unlike its `isPullRequestNotification` sibling.** `notification.type` is a plain `text` column, so `unreadCounters` reads a raw string. Taking `string` avoids an unchecked cast at the only call site with database data.

**Filtering stays client side**, as it already is for Mentions and Pull requests. When field moves dominate the first page of fifty, Activity shows the remainder until the IntersectionObserver pulls more on scroll. Server side filtering is the follow up if it feels thin in practice.

## Review round

Six defects were found after the first push, each fixed with a test that fails when the fix is reverted.

| Where | Defect |
| --- | --- |
| `snooze` | Snoozing the same row twice decremented twice, taking a count of 2 to 0 for one notification |
| `setReadState` | Marking an already-snoozed row read decremented a row the server had already excluded |
| empty state | An inbox of only field moves said "Inbox zero" on the default tab while Status held every row |
| `snooze` | A rejected PATCH left the row snoozed and the counts low, with no error shown |
| `remove` | A rejected DELETE left the row gone and the counts low, with no error shown |
| tab styling | Hand-rolled hover classes missed `motion-reduce`, so the transition ignored `prefers-reduced-motion` |

The first two share a root cause: the client treated a badge row as "unread", but the server's `unreadCounters` counts "unread **and** not currently snoozed". `countsTowardUnread` now mirrors that predicate exactly, including that an expired snooze counts again.

The snooze and delete rollbacks also repair pre-existing gaps in the mention count and the row list, which had the same failure mode before this PR. `remove` restores the row at the index it came from, so a failed delete does not reorder the list.

One Greptile finding was answered rather than fixed: deltas for notifications outside the loaded page are discarded by `applyOne`. That early return drops `unreadDelta` and `mentionDelta` on the identical path, so it is pre-existing and not specific to this counter, and a real fix changes the mutation endpoints' contract for all three. Reasoning is on the thread.

## Verification

All CI green on the first push: lint, comment policy, types, build, migrations, CodeQL, unit and integration tests, and Playwright e2e.

Design doc: `docs/superpowers/specs/2026-08-15-inbox-activity-status-tabs-design.md`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes Activity the default inbox tab, moves issue field-change notifications into a complementary Status tab, and adds a server-seeded Activity unread count maintained through local and realtime updates.
- Adds shared status-change classification and validates complete, disjoint tab coverage.
- Extends unread counters through the service, loader, realtime wrapper, and inbox view.
- Adds guarded optimistic snooze/delete handling with race-aware rollback and focused regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/inbox/inbox-view.tsx | Introduces Activity/Status filtering, Activity counter maintenance, and guarded rollback behavior; the previously reported snooze defects are addressed at current HEAD. |
| packages/services/src/notifications/index.ts | Extends the grouped unread-counter calculation with an Activity accumulator excluding status-change notification types. |
| packages/shared/src/constants/notification.ts | Adds the shared status-change classification used consistently by service and client filtering. |
| apps/web/tests/features/inbox/inbox-tabs.test.tsx | Covers default-tab behavior, complementary classification, counter updates, rejected writes, and duplicate snooze suppression. |
| apps/web/tests/features/inbox/inbox-deltas.test.ts | Covers Activity realtime deltas and conditional snooze rollback behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  N[Notification] --> C{Status-change type?}
  C -->|No| A[Activity tab]
  C -->|Yes| S[Status tab]
  N --> U[Unread facet]
  N --> M[Mentions facet]
  N --> P[Pull requests facet]
  A --> AC[Activity unread counter]
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(inbox): count a snoozed mention the ..."](https://github.com/noveum/orbit/commit/acdf4c6f818848508e6ef865f3dad7ac573f33ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53645506)</sub>

<!-- /greptile_comment -->