### PR TITLE
test(e2e): make the filter history round trip deterministic

### DIFF
--- a/apps/web/e2e/filters.spec.ts
+++ b/apps/web/e2e/filters.spec.ts
@@ -77,11 +77,12 @@ test('filters narrow the list, round trip through the url and save as a view', a
     .poll(async () => Number(await page.getByTestId('issue-count').innerText()))
     .toBe(twoFilters);
 
+  const restoredUrl = page.url();
   await page.goto(`${BASE}/my-issues`);
   await expect(page.getByTestId('issue-count')).toBeVisible();
 
   await page.goBack();
-  await expect(page).toHaveURL(/filter=/);
+  await expect(page).toHaveURL(restoredUrl);
   await expect(page.getByTestId('filter-chip-assignee')).toBeVisible();
   await expect(page.getByTestId('filter-chip-priority')).toBeVisible();
 

--- a/apps/web/e2e/filters.spec.ts
+++ b/apps/web/e2e/filters.spec.ts
@@ -77,9 +77,13 @@ test('filters narrow the list, round trip through the url and save as a view', a
     .poll(async () => Number(await page.getByTestId('issue-count').innerText()))
     .toBe(twoFilters);
 
+  await page.goto(`${BASE}/my-issues`);
+  await expect(page.getByTestId('issue-count')).toBeVisible();
+
   await page.goBack();
-  await page.goForward();
+  await expect(page).toHaveURL(/filter=/);
   await expect(page.getByTestId('filter-chip-assignee')).toBeVisible();
+  await expect(page.getByTestId('filter-chip-priority')).toBeVisible();
 
   await page.getByTestId('display-menu-trigger').first().click();
   await expect(page.getByTestId('display-menu')).toBeVisible();


### PR DESCRIPTION
## What broke

CI on `main` went red on 792c0fab, a commit that added only `.github/workflows/links.yml`. Every job passed except End-to-end (Playwright), where exactly one test out of 31 failed:

```
✘ e2e/filters.spec.ts:17 › filters narrow the list, round trip through the url and save as a view
Error: goForward: Protocol error (Page.getNavigationHistory): Not attached to an active page
```

The same test failed the same way on `main` on 2026-08-14 (run 31789408789) and on the unrelated `ci/add-links-check` branch (run 31834005491). It is a long standing flake that lands on whichever commit happens to be pushed.

## Root cause

The trace from the failed run shows two causes compounding.

`page.goBack()` and `page.goForward()` fired 50ms apart with nothing between them. `goForward()` is a single shot CDP call: it sends `Page.getNavigationHistory` once and throws if the page is still swapping, while `expect()` polls and retries. The call landed inside that window.

The entry `goBack()` reached was not stable either. Filters are written with `window.history.replaceState` in `use-view-config.ts`, so a filter change never pushes an entry, and the previous entry was whatever earlier navigations left behind: `/my-issues` locally, but a duplicate of the filtered page on CI. Neither the test nor the assertion after it depended on which one it got, which is why the race went unnoticed.

## The change

Navigate to `/my-issues` explicitly so the entry behind the filtered page is one this test created, then step back to it once. Every history move is now preceded by a polling assertion, so no single shot call runs against a page that is still swapping.

The step also asserts the restored URL and both chips rather than one, so it verifies the round trip it is named for.

`goForward()` is gone. The app restores filter state from the URL and does not distinguish forward from back, so the behaviour it covered is the behaviour `goBack()` now covers, with stronger assertions.

## Verification

The test ran five times in a row without failure, the whole spec file passes, and `lint`, `typecheck` and the comment policy are clean. Local runs were made against a throwaway database, because `e2e/global-setup.ts` seeds and truncates whatever `DATABASE_URL` points at.

The race is rare and specific to CI timing, so local runs cannot prove its absence. What they do show is that the unsynchronized call the trace identified is gone and the rewritten step is stable.

## Left alone deliberately

Three things worth a separate look, none of them changed here:

- The e2e job boots the app with `next dev` rather than a build, so routes compile on demand, 9s to 19s each on a cold runner. That is what makes this suite timing sensitive.
- `retries` is unset in `apps/web/playwright.config.ts`, so it defaults to 0 and one flake reddens `main`.
- In run 31834005491 the same test failed differently: after `reload()` the issue count sat at 0 for 45s where 2 was expected. That may be a real problem with filtered results after a reload and deserves its own investigation rather than a guess bundled into this one.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the filter-history end-to-end test deterministic by creating a known history entry, returning to the filtered URL with one back navigation, and polling for restoration of the exact URL and both filter chips.
- Removes the back-to-back forward navigation that raced with page attachment.
- Strengthens the round-trip assertions to cover the complete filtered URL and both active filters.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/e2e/filters.spec.ts | Reworks the history round trip around a known `/my-issues` entry and verifies exact URL and filter-state restoration without introducing a supported defect. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(e2e): assert the exact url restored..."](https://github.com/noveum/orbit/commit/a0140d35cafc3adde6188ee0aa1c2d3153e8a9f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53732610)</sub>

<!-- /greptile_comment -->