### PR TITLE
feat(web): add development collision detection for hotkeys

### DIFF
--- a/apps/web/src/lib/keyboard/registry.ts
+++ b/apps/web/src/lib/keyboard/registry.ts
@@ -32,6 +32,23 @@ function shiftSpecificity(entry: HotkeyEntry): number {
   return entry.steps.reduce((total, step) => total + (step.shift ? 1 : 0), 0);
 }
 
+function stepsCollide(a: readonly HotkeyStep[], b: readonly HotkeyStep[]): boolean {
+  if (a.length !== b.length) return false;
+  let shiftA = 0;
+  let shiftB = 0;
+  for (let i = 0; i < a.length; i++) {
+    const stepA = a[i];
+    const stepB = b[i];
+    if (!(stepA && stepB)) return false;
+    if (stepA.key !== stepB.key || stepA.mod !== stepB.mod || stepA.alt !== stepB.alt) {
+      return false;
+    }
+    if (stepA.shift) shiftA++;
+    if (stepB.shift) shiftB++;
+  }
+  return shiftA === shiftB;
+}
+
 function beats(candidate: HotkeyEntry, current: HotkeyEntry): boolean {
   if (candidate.steps.length !== current.steps.length) {
     return candidate.steps.length > current.steps.length;
@@ -61,7 +78,23 @@ export class HotkeyRegistry {
   private snapshot: readonly HotkeyEntry[] = [];
 
   register(input: HotkeyEntryInput): () => void {
-    this.entries.set(input.id, { ...input, steps: parseBinding(input.binding) });
+    const steps = parseBinding(input.binding);
+
+    if (process.env.NODE_ENV !== 'production' && input.advertised) {
+      for (const existing of this.entries.values()) {
+        if (existing.id === input.id) continue;
+        if (
+          existing.advertised &&
+          existing.priority === input.priority &&
+          stepsCollide(existing.steps, steps)
+        ) {
+          console.warn(
+            `Duplicate hotkey collision: "${input.binding}" is advertised by both "${existing.id}" and "${input.id}" at priority ${input.priority}. This will cause silent resolution.`,
+          );
+        }
+      }
+    }
+    this.entries.set(input.id, { ...input, steps });
     this.publish();
     return () => {
       this.entries.delete(input.id);

--- a/apps/web/tests/lib/keyboard/registry.test.ts
+++ b/apps/web/tests/lib/keyboard/registry.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from 'bun:test';
+import {
+  HOTKEY_PRIORITY,
+  type HotkeyEntryInput,
+  HotkeyRegistry,
+} from '../../../src/lib/keyboard/registry.ts';
+
+function createDummyEntry(id: string, binding: string, priority: number): HotkeyEntryInput {
+  return {
+    id,
+    binding,
+    label: 'Test Command',
+    section: 'General',
+    scope: 'global',
+    priority,
+    enabled: true,
+    advertised: true,
+    preventDefault: true,
+    allowInInput: false,
+    run: () => true,
+  };
+}
+
+test('HotkeyRegistry warns on duplicate bindings with the same priority', () => {
+  const registry = new HotkeyRegistry();
+
+  let warningMessage = '';
+  const originalWarn = console.warn;
+
+  try {
+    console.warn = (msg: string) => {
+      warningMessage = msg;
+    };
+    registry.register(createDummyEntry('cmd:one', 'shift+d', HOTKEY_PRIORITY.global));
+    registry.register(createDummyEntry('cmd:two', 'shift+d', HOTKEY_PRIORITY.global));
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  expect(warningMessage).toContain('Duplicate hotkey collision');
+  expect(warningMessage).toContain('shift+d');
+  expect(warningMessage).toContain('cmd:one');
+  expect(warningMessage).toContain('cmd:two');
+});
+
+test('HotkeyRegistry does not warn if priorities are different', () => {
+  const registry = new HotkeyRegistry();
+
+  let warned = false;
+  const originalWarn = console.warn;
+
+  try {
+    console.warn = () => {
+      warned = true;
+    };
+    registry.register(createDummyEntry('cmd:global', 'shift+d', HOTKEY_PRIORITY.global));
+    registry.register(createDummyEntry('cmd:surface', 'shift+d', HOTKEY_PRIORITY.surface));
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  expect(warned).toBe(false);
+});
+
+test('HotkeyRegistry warns on colliding shift specificity with different shift locations', () => {
+  const registry = new HotkeyRegistry();
+
+  let warningMessage = '';
+  const originalWarn = console.warn;
+
+  try {
+    console.warn = (msg: string) => {
+      warningMessage = msg;
+    };
+    registry.register(createDummyEntry('cmd:one', 'shift+a b', HOTKEY_PRIORITY.global));
+    registry.register(createDummyEntry('cmd:two', 'a shift+b', HOTKEY_PRIORITY.global));
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  expect(warningMessage).toContain('Duplicate hotkey collision');
+});


### PR DESCRIPTION
## What this changes

Adds a development-mode warning check inside `HotkeyRegistry.register()` to detect and flag silent hotkey tie collisions, along with a dedicated unit test suite.

## Why

When two advertised shortcuts tie on all three tiebreakers (steps, shift specificity, and priority), the registry silently resolves them based on registration order. This caused issues like #331 where the theme toggle shadowed the due-date menu shortcut. This check ensures developers are loudly warned in non-production environments if a tie occurs. 

Closes #332

## How you know it works

Added a new unit test file at `apps/web/tests/lib/keyboard/registry.test.ts`. 

Ran `bun test apps/web/tests/lib/keyboard/registry.test.ts` to verify that:
1. Identical priorities triggering a duplicate binding correctly fire a `console.warn`.
2. Differing priorities (global vs surface) pass cleanly without warnings.

## Screenshots

*Not applicable.*

## Checklist

- [ ] `bun run verify` is green, all four checks
- [x] Tests added or updated, and they fail without the change
- [ ] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions
- [ ] External input is parsed with a Zod schema from `@orbit/shared`
- [ ] Authorization is enforced on the server through `packages/shared/src/policy`, not only in the UI
- [ ] Docs updated if behaviour, configuration or setup changed
- [ ] `bun run db:release` and `bun run db:check-drift` passed against the target database before this ships

## Anything reviewers should know

Implemented option 2 from the issue description: a non-production `console.warn` inside `HotkeyRegistry.register()` when advertised hotkeys tie on all tiebreakers, allowing existing integration/E2E test runs to surface collisions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds development-only warnings when advertised hotkeys tie on binding structure, Shift specificity, and priority, plus focused registry tests.
- Detects collisions across identical and differently positioned Shift modifiers.
- Avoids warnings where priority resolves the conflict.
- Restores test-level console stubs through exception-safe cleanup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/keyboard/registry.ts | Adds collision detection whose comparison now matches the registry's runtime matching and tie-break semantics. |
| apps/web/tests/lib/keyboard/registry.test.ts | Covers duplicate, priority-separated, and multi-step Shift collisions while restoring console.warn in finally blocks. |

</details>

<sub>Reviews (3): Last reviewed commit: ["feat(web): add development collision det..."](https://github.com/noveum/orbit/commit/ac0b21f26b207feba24f1c679e306be6df795fcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54427382)</sub>

<!-- /greptile_comment -->