### PR TITLE
fix(tests): stop the Slack install test overwriting the auth secret

### DIFF
--- a/apps/web/tests/features/settings/integrations-connect-slack.test.ts
+++ b/apps/web/tests/features/settings/integrations-connect-slack.test.ts
@@ -3,8 +3,6 @@ import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test
 import { and, db, eq, schema } from '@orbit/db';
 import { completeSlackInstall } from '../../../src/features/settings/integrations-connect.ts';
 
-process.env['BETTER_AUTH_SECRET'] = 'slack-install-test-secret-123';
-
 const originalFetch = globalThis.fetch;
 let workspace: Workspace;
 


### PR DESCRIPTION
## What broke

`main` has been red since aa3e922d. One test fails in the `Unit and integration tests` job:

```
(fail) MCP authorize PKCE boundary > binds authorization and refresh tokens to the consented workspace grant
DomainError: That access token is not valid.
  at verifyMcpAccessToken (packages/core/src/auth/mcp-token.ts:76:21)
```

It passes in isolation and fails only in a full-suite run, which is why it survived review on #323.

## Why

`apps/web/tests/features/settings/integrations-connect-slack.test.ts`, added in #323, sets the auth secret at module scope:

```ts
process.env['BETTER_AUTH_SECRET'] = 'slack-install-test-secret-123';
```

Module scope means the whole test process, not that file. Bun loads test files into one process, so from the moment this file is loaded every other test sees the new secret. MCP access tokens are signed with `BETTER_AUTH_SECRET`, so a token issued under the real secret no longer verifies once the file has been loaded, and `verifyMcpAccessToken` correctly rejects it.

The assignment was never needed. `BETTER_AUTH_SECRET` already comes from the repository `.env` locally and from the workflow environment in CI.

## How I confirmed it

Full `apps/web` suite, same lane and same database, only this line varying:

| tree | result |
| --- | --- |
| `a447d5a5`, before the three merges | 16 fail, PKCE **passes** |
| `aa3e922d`, current `main` | 17 fail, PKCE **fails** |
| `aa3e922d` with `integrations-connect-slack.test.ts` removed | 16 fail, PKCE **passes** |
| `aa3e922d` with only this one line removed | 16 fail, PKCE **passes** |

I also ruled out two other candidates on the way: removing the `registry.test.ts` file added by #334 changes nothing, and rewriting `describe.serial` to `describe` changes nothing.

The remaining 16 are the pre-existing full-suite failures that are also present on `a447d5a5` and pass in isolation. They are a separate problem and not touched here.

## Verification

- `apps/web/tests/features/settings/integrations-connect-slack.test.ts` on its own: 4 pass, 0 fail
- `apps/web/tests/app/api/auth` on its own: 15 pass, 0 fail
- Full `apps/web` suite: 2240 pass, 16 fail, matching `a447d5a5`
- `bun run lint` and `bun run check-comments` clean

Worth a follow up separately: a test that mutates `process.env` at module scope can break any other test in the process, and nothing catches it. The 16 remaining full-suite failures are probably worth their own issue too, since they mean a local `bun run verify` cannot be green today.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes an unnecessary module-scope `BETTER_AUTH_SECRET` override from the Slack installation test.
- Prevents the test file from mutating process-wide authentication state.
- Preserves the Slack installation test behavior because its exercised code path does not consume this secret.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the changed test.

The removed environment assignment is unused by the Slack installation path, while its removal prevents unrelated tests from observing an overwritten authentication secret.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/tests/features/settings/integrations-connect-slack.test.ts | Safely removes a process-wide environment mutation that caused order-dependent authentication failures elsewhere in the shared test process. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tests): stop the Slack install test ..."](https://github.com/noveum/orbit/commit/423682cecda353ee1809f2b69197bad55e317bcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54664532)</sub>

<!-- /greptile_comment -->