### PR TITLE
chore(web): use path alias and describe/it for registry tests

### DIFF
--- a/apps/web/tests/lib/keyboard/registry.test.ts
+++ b/apps/web/tests/lib/keyboard/registry.test.ts
@@ -1,9 +1,5 @@
-import { expect, test } from 'bun:test';
-import {
-  HOTKEY_PRIORITY,
-  type HotkeyEntryInput,
-  HotkeyRegistry,
-} from '../../../src/lib/keyboard/registry.ts';
+import { describe, expect, it } from 'bun:test';
+import { HOTKEY_PRIORITY, type HotkeyEntryInput, HotkeyRegistry } from '@/lib/keyboard/registry.ts';
 
 function createDummyEntry(id: string, binding: string, priority: number): HotkeyEntryInput {
   return {
@@ -20,63 +16,55 @@ function createDummyEntry(id: string, binding: string, priority: number): Hotkey
     run: () => true,
   };
 }
+describe('HotkeyRegistry collision detection', () => {
+  it('warns on duplicate bindings with the same priority', () => {
+    const registry = new HotkeyRegistry();
+    let warningMessage = '';
+    const originalWarn = console.warn;
+    try {
+      console.warn = (msg: string) => {
+        warningMessage = msg;
+      };
+      registry.register(createDummyEntry('cmd:one', 'shift+d', HOTKEY_PRIORITY.global));
+      registry.register(createDummyEntry('cmd:two', 'shift+d', HOTKEY_PRIORITY.global));
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(warningMessage).toContain('Duplicate hotkey collision');
+    expect(warningMessage).toContain('shift+d');
+    expect(warningMessage).toContain('cmd:one');
+    expect(warningMessage).toContain('cmd:two');
+  });
 
-test('HotkeyRegistry warns on duplicate bindings with the same priority', () => {
-  const registry = new HotkeyRegistry();
+  it('HotkeyRegistry does not warn if priorities are different', () => {
+    const registry = new HotkeyRegistry();
+    let warned = false;
+    const originalWarn = console.warn;
+    try {
+      console.warn = () => {
+        warned = true;
+      };
+      registry.register(createDummyEntry('cmd:global', 'shift+d', HOTKEY_PRIORITY.global));
+      registry.register(createDummyEntry('cmd:surface', 'shift+d', HOTKEY_PRIORITY.surface));
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(warned).toBe(false);
+  });
 
-  let warningMessage = '';
-  const originalWarn = console.warn;
-
-  try {
-    console.warn = (msg: string) => {
-      warningMessage = msg;
-    };
-    registry.register(createDummyEntry('cmd:one', 'shift+d', HOTKEY_PRIORITY.global));
-    registry.register(createDummyEntry('cmd:two', 'shift+d', HOTKEY_PRIORITY.global));
-  } finally {
-    console.warn = originalWarn;
-  }
-
-  expect(warningMessage).toContain('Duplicate hotkey collision');
-  expect(warningMessage).toContain('shift+d');
-  expect(warningMessage).toContain('cmd:one');
-  expect(warningMessage).toContain('cmd:two');
-});
-
-test('HotkeyRegistry does not warn if priorities are different', () => {
-  const registry = new HotkeyRegistry();
-
-  let warned = false;
-  const originalWarn = console.warn;
-
-  try {
-    console.warn = () => {
-      warned = true;
-    };
-    registry.register(createDummyEntry('cmd:global', 'shift+d', HOTKEY_PRIORITY.global));
-    registry.register(createDummyEntry('cmd:surface', 'shift+d', HOTKEY_PRIORITY.surface));
-  } finally {
-    console.warn = originalWarn;
-  }
-
-  expect(warned).toBe(false);
-});
-
-test('HotkeyRegistry warns on colliding shift specificity with different shift locations', () => {
-  const registry = new HotkeyRegistry();
-
-  let warningMessage = '';
-  const originalWarn = console.warn;
-
-  try {
-    console.warn = (msg: string) => {
-      warningMessage = msg;
-    };
-    registry.register(createDummyEntry('cmd:one', 'shift+a b', HOTKEY_PRIORITY.global));
-    registry.register(createDummyEntry('cmd:two', 'a shift+b', HOTKEY_PRIORITY.global));
-  } finally {
-    console.warn = originalWarn;
-  }
-
-  expect(warningMessage).toContain('Duplicate hotkey collision');
+  it('HotkeyRegistry warns on colliding shift specificity with different shift locations', () => {
+    const registry = new HotkeyRegistry();
+    let warningMessage = '';
+    const originalWarn = console.warn;
+    try {
+      console.warn = (msg: string) => {
+        warningMessage = msg;
+      };
+      registry.register(createDummyEntry('cmd:one', 'shift+a b', HOTKEY_PRIORITY.global));
+      registry.register(createDummyEntry('cmd:two', 'a shift+b', HOTKEY_PRIORITY.global));
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(warningMessage).toContain('Duplicate hotkey collision');
+  });
 });

--- a/apps/web/tests/lib/keyboard/registry.test.ts
+++ b/apps/web/tests/lib/keyboard/registry.test.ts
@@ -36,7 +36,7 @@ describe('HotkeyRegistry collision detection', () => {
     expect(warningMessage).toContain('cmd:two');
   });
 
-  it('HotkeyRegistry does not warn if priorities are different', () => {
+  it('does not warn if priorities are different', () => {
     const registry = new HotkeyRegistry();
     let warned = false;
     const originalWarn = console.warn;
@@ -52,7 +52,7 @@ describe('HotkeyRegistry collision detection', () => {
     expect(warned).toBe(false);
   });
 
-  it('HotkeyRegistry warns on colliding shift specificity with different shift locations', () => {
+  it('warns on colliding shift specificity with different shift locations', () => {
     const registry = new HotkeyRegistry();
     let warningMessage = '';
     const originalWarn = console.warn;


### PR DESCRIPTION
### Summary

A quick follow-up to address the minor feedback from PR #334.

* Refactored `apps/web/tests/lib/keyboard/registry.test.ts` to use `describe` and `it` instead of bare `test` blocks.
* Swapped the relative `../../../src/lib...` import to use the `@/` path alias as requested in `AGENTS.md`.

No logic changes!

### Verification

I ran the specific test file locally to verify the refactored suite still passes cleanly:

```bash
$ bun test apps/web/tests/lib/keyboard/registry.test.ts
bun test v1.3.14 (0d9b296a)

apps\web\tests\lib\keyboard\registry.test.ts:
✓ HotkeyRegistry collision detection > warns on duplicate bindings with the same priority [2.90ms]
✓ HotkeyRegistry collision detection > does not warn if priorities are different [1.13ms]
✓ HotkeyRegistry collision detection > warns on colliding shift specificity with different shift locations [0.28ms]

 3 pass
 0 fail
 6 expect() calls
Ran 3 tests across 1 file. [101.00ms]

```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the keyboard registry tests to follow repository conventions without changing test logic.
- Replaces the relative registry import with the configured `@/` path alias.
- Groups the existing collision-detection cases under `describe` and uses `it` for each case.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the refactor preserves test behavior and uses the configured web path alias.

The test bodies and assertions remain unchanged, while the new alias is supported by the web TypeScript configuration and already used throughout the web test suite.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/tests/lib/keyboard/registry.test.ts | Refactors test organization and import style while preserving all three existing test scenarios and assertions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(web): refactor registry tests to u..."](https://github.com/noveum/orbit/commit/9c89d3aa40738921e22390e01e71b5b8407dcd38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54682444)</sub>

<!-- /greptile_comment -->