### PR TITLE
fix(issues): stop a long description covering the new issue properties

### DIFF
--- a/apps/web/e2e/quick-create-layout.spec.ts
+++ b/apps/web/e2e/quick-create-layout.spec.ts
@@ -1,0 +1,72 @@
+import { type BrowserContext, expect, type Page, test } from '@playwright/test';
+import { BASE } from './base-url.ts';
+
+const LONG_DESCRIPTION = Array.from(
+  { length: 14 },
+  (_, index) =>
+    `Paragraph ${index + 1}: the shared packages diverged, so the audit had to walk Cost Explorer, EKS, RDS, EC2 and CloudWatch by hand before anything else could be trusted.`,
+).join('\n');
+
+async function signIn(context: BrowserContext, email: string): Promise<Page> {
+  const page = await context.newPage();
+  await page.goto(`${BASE}/login`);
+  await page.getByTestId(`dev-sign-in-${email}`).click();
+  await page.waitForURL(`${BASE}/my-issues`);
+  return page;
+}
+
+async function composeLongIssue(page: Page): Promise<void> {
+  await page.goto(`${BASE}/team/eng/board`);
+  await expect(page.getByTestId('board-column-Todo')).toBeVisible();
+  await page.keyboard.press('c');
+  await expect(page.getByTestId('quick-create')).toBeVisible();
+  await page.getByTestId('quick-create-title').fill('Audit the AWS bill');
+  await page.getByTestId('quick-create-description').click();
+  await page.keyboard.insertText(LONG_DESCRIPTION);
+}
+
+test('a long description scrolls instead of covering the property row', async ({ browser }) => {
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const author = await signIn(context, 'alex@orbit.example');
+
+  await composeLongIssue(author);
+
+  const laidOut = await author.evaluate(() => {
+    const description = document.querySelector('[data-testid="quick-create-description"]');
+    const properties = document.querySelector('[data-testid="quick-create-properties"]');
+    const scroller = document.querySelector('[data-testid="quick-create-scroll"]');
+    if (description === null || properties === null || scroller === null) {
+      throw new Error('the composer never rendered');
+    }
+    const prose = description.querySelector('.ProseMirror');
+    if (prose === null) throw new Error('the description never rendered');
+    return {
+      descriptionHeight: description.getBoundingClientRect().height,
+      proseHeight: prose.getBoundingClientRect().height,
+      descriptionBottom: description.getBoundingClientRect().bottom,
+      propertiesTop: properties.getBoundingClientRect().top,
+      scrolls: scroller.scrollHeight - scroller.clientHeight,
+    };
+  });
+
+  expect(laidOut.descriptionHeight).toBeGreaterThanOrEqual(laidOut.proseHeight);
+  expect(laidOut.propertiesTop).toBeGreaterThanOrEqual(laidOut.descriptionBottom);
+  expect(laidOut.scrolls).toBeGreaterThan(0);
+
+  await context.close();
+});
+
+test('the estimate picker still opens once the description is long', async ({ browser }) => {
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const author = await signIn(context, 'alex@orbit.example');
+
+  await composeLongIssue(author);
+
+  const estimate = author.getByTestId('quick-create-estimate');
+  await estimate.scrollIntoViewIfNeeded();
+  await estimate.click();
+  await author.getByRole('menuitemradio', { name: '3 points', exact: true }).click();
+  await expect(estimate).toHaveText(/3 points/);
+
+  await context.close();
+});

--- a/apps/web/src/features/issues/quick-create.tsx
+++ b/apps/web/src/features/issues/quick-create.tsx
@@ -378,10 +378,11 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
                 if (event.key === 'Enter' && !event.metaKey && !event.ctrlKey)
                   event.preventDefault();
               }}
-              className="h-9 border-0 px-0 font-medium text-base shadow-none"
+              className="h-9 shrink-0 border-0 px-0 font-medium text-base shadow-none"
             />
             <RichTextEditor
               key={composerKey}
+              className="shrink-0"
               value={description}
               onChange={setDescription}
               members={members}
@@ -391,12 +392,15 @@ export function QuickCreateDialog({ open, onOpenChange, defaultTeamId }: QuickCr
               onUpload={hold}
             />
             {pending.length === 0 ? null : (
-              <output className="text-2xs text-faint" data-testid="quick-create-pending">
+              <output className="shrink-0 text-2xs text-faint" data-testid="quick-create-pending">
                 {pendingLabel(pending.length)}
               </output>
             )}
 
-            <div className="flex flex-wrap items-center gap-1.5">
+            <div
+              className="flex shrink-0 flex-wrap items-center gap-1.5"
+              data-testid="quick-create-properties"
+            >
               <PropertyMenu
                 title="Team"
                 options={teams.map((team) => ({ id: team.id, label: team.name }))}

--- a/apps/web/tests/features/issues/quick-create.test.tsx
+++ b/apps/web/tests/features/issues/quick-create.test.tsx
@@ -650,6 +650,15 @@ describe('the new issue dialog', () => {
     expect(screen.getByTestId('quick-create').className).toContain('max-h-');
   });
 
+  it('holds the description at its natural height so it cannot cover the properties', () => {
+    workspace = buildWorkspace();
+    open();
+
+    expect(screen.getByTestId('quick-create-description').className).toContain('shrink-0');
+    expect(screen.getByTestId('quick-create-properties').className).toContain('shrink-0');
+    expect(screen.getByTestId('quick-create-title').className).toContain('shrink-0');
+  });
+
   it('shows no formatting toolbar above the description, the way Linear does not', () => {
     workspace = buildWorkspace();
     open();


### PR DESCRIPTION
## What this changes

The new issue dialog lays its title, description, property chips and footer out as a flex column inside a scroll region. Every one of those children was still shrinkable, so once the description grew past the height of the dialog, flexbox shrank the description box instead of letting the region scroll. The editor kept rendering at its natural height inside a box roughly half that tall, and the overflow painted straight over the property row: Team, Status, Priority, Assignee, Labels and Project ended up behind the text, and Estimate and Sprint disappeared entirely.

This pins the four children of the scroll region at their natural height with `shrink-0`, so the region scrolls the way it was meant to and the property row keeps its place under the description. The property row also picks up a `quick-create-properties` test id so its position can be asserted.

## Why

Reported internally: with a long description, the pickers for estimate, assignee and the rest vanish from the composer. They are not only hidden, they are unclickable, so a long issue cannot be assigned or estimated at create time without deleting the description first.

## How you know it works

`bun run lint`, `bun run check-comments` and `bun run typecheck` are green. `bun run --filter '@orbit/web' test` reports the same 17 failures as a clean `main`, plus the new test passing.

New tests, each of which fails without the change:

- `apps/web/e2e/quick-create-layout.spec.ts`: with a fourteen paragraph description the description box is at least as tall as its rendered content, the property row starts at or below the bottom of the description, and the scroll region actually scrolls. A second test opens the estimate picker and sets 3 points. Against the unfixed component the first fails at 648px of box for 1338px of content, and the second times out because the chip is covered.
- `apps/web/tests/features/issues/quick-create.test.tsx`: the title, description and property row are all non-shrinking.

Manual check against the seeded demo workspace, both themes.

## Screenshots

New issue dialog, scrolled to the bottom of a long description.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Tanzeelsameen/orbit/pr-assets/pr/quick-create-property-overlap/before/new-issue-dark.png" width="440"> | <img src="https://raw.githubusercontent.com/Tanzeelsameen/orbit/pr-assets/pr/quick-create-property-overlap/after/new-issue-dark.png" width="440"> |
| <img src="https://raw.githubusercontent.com/Tanzeelsameen/orbit/pr-assets/pr/quick-create-property-overlap/before/new-issue-light.png" width="440"> | <img src="https://raw.githubusercontent.com/Tanzeelsameen/orbit/pr-assets/pr/quick-create-property-overlap/after/new-issue-light.png" width="440"> |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents long quick-create descriptions from shrinking over issue properties by preserving the natural height of the title, editor, pending-upload message, and property row.
- Adds `shrink-0` to the quick-create scroll region's principal children.
- Adds a stable test identifier to the property row.
- Adds unit and browser coverage for layout separation, scrolling, and estimate selection after entering a long description.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the layout fix matching the dialog's existing bounded scroll-container design.

The changed flex items retain their natural height inside a viewport-constrained dialog whose `min-h-0` and `overflow-y-auto` chain provides the intended scrolling behavior, and no blocking or independently actionable issue remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/issues/quick-create.tsx | Applies non-shrinking flex behavior to quick-create content while retaining the existing bounded, vertically scrolling dialog layout. |
| apps/web/e2e/quick-create-layout.spec.ts | Adds end-to-end checks that a long description remains above the property row, causes scrolling, and does not block the estimate picker. |
| apps/web/tests/features/issues/quick-create.test.tsx | Adds focused assertions for the non-shrinking classes on the title, editor, and property row. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(issues): cover the composer layout ..."](https://github.com/noveum/orbit/commit/da0b64f2baced5c9f2313bd3ce103b2a3f8539f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54683573)</sub>

<!-- /greptile_comment -->