### PR TITLE
feat(issues): add accessible keyboard drag and drop to Kanban board

### DIFF
--- a/apps/realtime/src/test-helpers.ts
+++ b/apps/realtime/src/test-helpers.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { db, eq, inArray, schema } from '@orbit/db';
+import { db, eq, inArray, schema, sql } from '@orbit/db';
 import type { ClientMessage, ServerMessage, SyncAction } from '@orbit/shared/events';
 import { serverMessageSchema } from '@orbit/shared/events';
 import { REALTIME_TICKET_TTL_MS, signRealtimeTicket } from '@orbit/shared/events/ticket';
@@ -125,12 +125,18 @@ export async function createIssue(
   teamId: string,
   creatorId: string,
 ): Promise<string> {
+  const [team] = await db
+    .update(schema.team)
+    .set({ issueCounter: sql`${schema.team.issueCounter} + 1` })
+    .where(eq(schema.team.id, teamId))
+    .returning({ issueCounter: schema.team.issueCounter });
+  if (team === undefined) throw new Error('missing realtime test team');
   const stateId = `state_${randomUUID()}`;
   await db.insert(schema.workflowState).values({
     id: stateId,
     organizationId,
     teamId,
-    name: 'Todo',
+    name: `Todo ${stateId.slice(6, 12)}`,
     category: 'unstarted',
     color: '#5A63C8',
   });
@@ -139,7 +145,7 @@ export async function createIssue(
     id: issueId,
     organizationId,
     teamId,
-    number: 1,
+    number: team.issueCounter,
     identifier: `RT-${issueId.slice(6, 12)}`,
     title: 'Realtime issue',
     stateId,
@@ -166,13 +172,14 @@ export async function deleteSessionFor(userId: string): Promise<void> {
 }
 
 export function syncAction(overrides: Partial<SyncAction> & Pick<SyncAction, 'organizationId'>) {
+  const modelId = overrides.modelId ?? 'label_1';
   return {
     syncId: 1,
     scopes: ['org:none'],
     action: 'update',
-    model: 'issue',
-    modelId: 'issue_1',
-    data: { title: 'hello' },
+    model: 'label',
+    modelId,
+    data: { id: modelId, name: 'hello' },
     actor: { type: 'user', id: 'user_1' },
     at: new Date().toISOString(),
     ...overrides,

--- a/apps/realtime/tests/active-organization.test.ts
+++ b/apps/realtime/tests/active-organization.test.ts
@@ -81,7 +81,7 @@ describe('ticket organization', () => {
       syncAction({
         organizationId: orgA,
         scopes: [scopes.team(teamA)],
-        modelId: 'issue_wrong_workspace',
+        modelId: 'label_wrong_workspace',
         syncId: 41,
       }),
     );
@@ -89,19 +89,19 @@ describe('ticket organization', () => {
       syncAction({
         organizationId: orgB,
         scopes: [scopes.team(teamB)],
-        modelId: 'issue_right_workspace',
+        modelId: 'label_right_workspace',
         syncId: 42,
       }),
     );
 
     const delta = await client.waitFor('delta');
-    expect(delta.actions.map((action) => action.modelId)).toEqual(['issue_right_workspace']);
+    expect(delta.actions.map((action) => action.modelId)).toEqual(['label_right_workspace']);
 
     await delay(SETTLE_MS);
     const delivered = client.messages
       .filter((message) => message.type === 'delta')
       .flatMap((message) => message.actions.map((action) => action.modelId));
-    expect(delivered).not.toContain('issue_wrong_workspace');
+    expect(delivered).not.toContain('label_wrong_workspace');
 
     client.close();
   });

--- a/apps/realtime/tests/client-reconnect.test.ts
+++ b/apps/realtime/tests/client-reconnect.test.ts
@@ -73,12 +73,12 @@ it('reconnects and resubscribes after the server drops the socket', async () => 
         syncAction({
           organizationId,
           scopes: [scopes.team(teamId)],
-          modelId: 'issue_after_reconnect',
+          modelId: 'label_after_reconnect',
           syncId: 900,
         }),
       ),
     );
-    await waitUntil(() => received.some((action) => action.modelId === 'issue_after_reconnect'));
+    await waitUntil(() => received.some((action) => action.modelId === 'label_after_reconnect'));
 
     expect(statuses).toContain('reconnecting');
     expect(statuses.at(-1)).toBe('open');

--- a/apps/realtime/tests/node-socket.test.ts
+++ b/apps/realtime/tests/node-socket.test.ts
@@ -104,11 +104,11 @@ describe('the hub over a node websocket', () => {
 
     await publisher.publish(
       DELTA_CHANNEL,
-      JSON.stringify([syncAction({ organizationId, scopes: [scope], modelId: 'issue_node' })]),
+      JSON.stringify([syncAction({ organizationId, scopes: [scope], modelId: 'label_node' })]),
     );
 
     const delta = await client.waitFor('delta');
-    expect(delta.actions[0]?.modelId).toBe('issue_node');
+    expect(delta.actions[0]?.modelId).toBe('label_node');
     client.close();
   });
 

--- a/apps/realtime/tests/server.test.ts
+++ b/apps/realtime/tests/server.test.ts
@@ -143,13 +143,13 @@ describe('fan-out', () => {
       syncAction({
         organizationId: orgA,
         scopes: [scopes.team(teamA)],
-        modelId: 'issue_fanout',
+        modelId: 'label_fanout',
         syncId: 10,
       }),
     );
 
     const delta = await subscribed.waitFor('delta');
-    expect(delta.actions.map((action) => action.modelId)).toEqual(['issue_fanout']);
+    expect(delta.actions.map((action) => action.modelId)).toEqual(['label_fanout']);
     await delay(BATCH_WINDOW_MS * 3);
     expect(other.messages.some((message) => message.type === 'delta')).toBe(false);
 
@@ -167,7 +167,7 @@ describe('fan-out', () => {
       syncAction({
         organizationId: orgA,
         scopes: [scopes.organization(orgB)],
-        modelId: 'issue_cross_org',
+        modelId: 'label_cross_org',
         syncId: 11,
       }),
     );
@@ -183,7 +183,7 @@ describe('fan-out', () => {
     client.send({ type: 'subscribe', scopes: [scopes.team(teamA)] });
     await client.waitFor('subscribed');
 
-    const targets = ['issue_a', 'issue_b', 'issue_c', 'issue_a', 'issue_d'];
+    const targets = ['label_a', 'label_b', 'label_c', 'label_a', 'label_d'];
     let syncId = 100;
     for (const modelId of targets) {
       syncId += 1;
@@ -198,10 +198,10 @@ describe('fan-out', () => {
     const deltas = client.messages.filter((message) => message.type === 'delta');
     expect(deltas).toHaveLength(1);
     expect(delta.actions.map((action) => action.modelId)).toEqual([
-      'issue_b',
-      'issue_c',
-      'issue_a',
-      'issue_d',
+      'label_b',
+      'label_c',
+      'label_a',
+      'label_d',
     ]);
     expect(delta.actions.map((action) => action.syncId)).toEqual([102, 103, 104, 105]);
     client.close();
@@ -223,7 +223,7 @@ describe('multi tab and multi tenant fan-out', () => {
       syncAction({
         organizationId: orgA,
         scopes: [scopes.team(teamA)],
-        modelId: 'issue_two_tabs',
+        modelId: 'label_two_tabs',
         syncId: 400,
       }),
     );
@@ -236,7 +236,7 @@ describe('multi tab and multi tenant fan-out', () => {
       const actions = tab.messages
         .filter((message) => message.type === 'delta')
         .flatMap((message) => message.actions)
-        .filter((action) => action.modelId === 'issue_two_tabs');
+        .filter((action) => action.modelId === 'label_two_tabs');
       expect(actions).toHaveLength(1);
     }
 
@@ -260,7 +260,7 @@ describe('multi tab and multi tenant fan-out', () => {
       syncAction({
         organizationId: orgA,
         scopes: [scopes.organization(orgA), scopes.team(teamA)],
-        modelId: 'issue_tenant_a',
+        modelId: 'label_tenant_a',
         syncId: 410,
       }),
     );
@@ -268,7 +268,7 @@ describe('multi tab and multi tenant fan-out', () => {
       syncAction({
         organizationId: orgB,
         scopes: [scopes.organization(orgB)],
-        modelId: 'issue_tenant_b',
+        modelId: 'label_tenant_b',
         syncId: 411,
       }),
     );
@@ -284,10 +284,10 @@ describe('multi tab and multi tenant fan-out', () => {
       .filter((message) => message.type === 'delta')
       .flatMap((message) => message.actions.map((action) => action.modelId));
 
-    expect(insideIds).toContain('issue_tenant_a');
-    expect(insideIds).not.toContain('issue_tenant_b');
-    expect(outsideIds).toContain('issue_tenant_b');
-    expect(outsideIds).not.toContain('issue_tenant_a');
+    expect(insideIds).toContain('label_tenant_a');
+    expect(insideIds).not.toContain('label_tenant_b');
+    expect(outsideIds).toContain('label_tenant_b');
+    expect(outsideIds).not.toContain('label_tenant_a');
 
     inside.close();
     outside.close();
@@ -303,7 +303,7 @@ describe('multi tab and multi tenant fan-out', () => {
       syncAction({
         organizationId: orgA,
         scopes: [scopes.team(teamA)],
-        modelId: 'issue_already_seen',
+        modelId: 'label_already_seen',
         syncId: 500,
       }),
     );
@@ -311,14 +311,14 @@ describe('multi tab and multi tenant fan-out', () => {
       syncAction({
         organizationId: orgA,
         scopes: [scopes.team(teamA)],
-        modelId: 'issue_after_watermark',
+        modelId: 'label_after_watermark',
         syncId: 501,
       }),
     );
 
     const delta = await client.waitFor('delta');
     await delay(BATCH_WINDOW_MS * 3);
-    expect(delta.actions.map((action) => action.modelId)).toEqual(['issue_after_watermark']);
+    expect(delta.actions.map((action) => action.modelId)).toEqual(['label_after_watermark']);
     client.close();
   });
 });
@@ -378,6 +378,7 @@ describe('authorization', () => {
   });
 
   it('never carries a team issue to somebody who only holds the organization scope', async () => {
+    const issueId = await createIssue(orgA, teamB, bob.userId);
     const listener = await connectClient(server.port, alice);
     await listener.waitFor('ready');
     listener.send({ type: 'subscribe', scopes: [scopes.organization(orgA)] });
@@ -386,8 +387,10 @@ describe('authorization', () => {
     await publish(
       syncAction({
         organizationId: orgA,
-        scopes: [scopes.team(teamB), scopes.issue('issue_secret')],
-        modelId: 'issue_secret',
+        scopes: [scopes.team(teamB), scopes.issue(issueId)],
+        model: 'issue',
+        modelId: issueId,
+        data: { id: issueId, teamId: teamB },
         syncId: 9100,
       }),
     );
@@ -441,7 +444,7 @@ describe('authorization', () => {
       syncAction({
         organizationId: orgA,
         scopes: [scopes.team(teamA)],
-        modelId: 'issue_refused',
+        modelId: 'label_refused',
         syncId: 200,
       }),
     );
@@ -472,7 +475,7 @@ describe('protocol', () => {
       syncAction({
         organizationId: orgA,
         scopes: [scopes.team(teamA)],
-        modelId: 'issue_after_unsubscribe',
+        modelId: 'label_after_unsubscribe',
         syncId: 300,
       }),
     );

--- a/apps/web/e2e/api.ts
+++ b/apps/web/e2e/api.ts
@@ -43,11 +43,12 @@ export async function createIssue(
   page: Page,
   teamId: string,
   title: string,
+  stateId?: string,
 ): Promise<{ id: string; identifier: string }> {
   const body = await json(page, '/api/issues', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ teamId, title }),
+    body: JSON.stringify({ teamId, title, ...(stateId === undefined ? {} : { stateId }) }),
   });
   return issueEnvelopeSchema.parse(body).issue;
 }

--- a/apps/web/e2e/board-drag.spec.ts
+++ b/apps/web/e2e/board-drag.spec.ts
@@ -81,6 +81,39 @@ async function waitForKeyboardDragReady(page: Page, identifier: string): Promise
   );
 }
 
+async function reloadAndWaitForTeamSubscription(page: Page, teamId: string): Promise<void> {
+  const subscribed = new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const handleWebSocket = (socket: import('@playwright/test').WebSocket) => {
+      socket.on('framereceived', ({ payload }) => {
+        if (settled || typeof payload !== 'string') return;
+        let value: unknown;
+        try {
+          value = JSON.parse(payload);
+        } catch {
+          return;
+        }
+        const result = z
+          .object({ type: z.literal('subscribed'), scopes: z.array(z.string()) })
+          .safeParse(value);
+        if (!(result.success && result.data.scopes.includes(`team:${teamId}`))) return;
+        settled = true;
+        clearTimeout(timeout);
+        page.off('websocket', handleWebSocket);
+        resolve();
+      });
+    };
+    const timeout = setTimeout(() => {
+      settled = true;
+      page.off('websocket', handleWebSocket);
+      reject(new Error(`realtime did not subscribe to team:${teamId}`));
+    }, 15_000);
+    page.on('websocket', handleWebSocket);
+  });
+  await page.reload();
+  await subscribed;
+}
+
 test('a card dragged to another column lands there and stays after a reload', async ({
   browser,
 }) => {
@@ -116,6 +149,7 @@ test('a card dragged to another column lands there and stays after a reload', as
 
   await page.reload();
   await page.waitForSelector('[data-testid^="issue-card-"]');
+  await expect(page.getByTestId('board-column-Todo')).toBeVisible();
   await expect
     .poll(async () => await cardsIn(page, 'In Progress'), { timeout: 45_000 })
     .toContain(moving);
@@ -199,6 +233,7 @@ test('a card moved with the keyboard updates the aria-live region and lands in t
     .toContain(moving);
   await expect(cardLocator).toBeFocused();
   await page.reload();
+  await expect(page.getByTestId('board-column-Todo')).toBeVisible();
   await expect
     .poll(async () => await cardsIn(page, 'In Progress'), { timeout: 15_000 })
     .toContain(moving);
@@ -273,7 +308,7 @@ test('a keyboard drag can be cancelled with Escape and returns to the original p
   const todo = await stateIdByName(page, teamId, 'Todo');
   const made = await createIssue(page, teamId, `Keyboard Cancel ${Date.now()}`, todo);
   const moving = made.identifier;
-  await page.reload();
+  await reloadAndWaitForTeamSubscription(page, teamId);
   const cardLocator = page.locator(`li:has([data-testid="issue-card-${moving}"])`);
   await expect(cardLocator).toBeVisible();
   const boardStatus = page.getByTestId('board-drag-status');

--- a/apps/web/e2e/board-drag.spec.ts
+++ b/apps/web/e2e/board-drag.spec.ts
@@ -198,6 +198,11 @@ test('a card moved with the keyboard updates the aria-live region and lands in t
     .poll(async () => await cardsIn(page, 'In Progress'), { timeout: 15_000 })
     .toContain(moving);
   await expect(cardLocator).toBeFocused();
+  await page.reload();
+  await expect
+    .poll(async () => await cardsIn(page, 'In Progress'), { timeout: 15_000 })
+    .toContain(moving);
+  await expect.poll(async () => await cardsIn(page, 'Todo')).not.toContain(moving);
   await context.close();
 });
 
@@ -368,6 +373,7 @@ test('a failed keyboard move announces rollback and leaves the card in place', a
     await sourceCard.focus();
     await page.keyboard.press('Enter');
     await expect(boardStatus).toContainText(`Picked up ${made.identifier}`, { timeout: 10_000 });
+    await waitForKeyboardDragReady(page, made.identifier);
     await page.keyboard.press('ArrowRight');
     await expect(boardStatus).toContainText(`Moved ${made.identifier}`, { timeout: 10_000 });
     await page.keyboard.press('Enter');

--- a/apps/web/e2e/board-drag.spec.ts
+++ b/apps/web/e2e/board-drag.spec.ts
@@ -1,4 +1,5 @@
 import { type BrowserContext, expect, type Page, test } from '@playwright/test';
+import { z } from 'zod';
 import { createIssue, stateIdByName, stateIdOf, teamIdByKey } from './api.ts';
 import { BASE } from './base-url.ts';
 
@@ -32,6 +33,34 @@ async function dragCardToColumn(page: Page, identifier: string, column: string):
   await page.mouse.down();
   await page.mouse.move(to.x + to.width / 2, to.y + 120, { steps: 12 });
   await page.mouse.up();
+}
+
+async function updateIssue(page: Page, issueId: string, patch: Record<string, unknown>) {
+  const response = await page.request.patch(`${BASE}/api/issues/${issueId}`, { data: patch });
+  expect(response.ok()).toBe(true);
+}
+
+async function deleteIssue(page: Page, issueId: string) {
+  const response = await page.request.delete(`${BASE}/api/issues/${issueId}`);
+  expect(response.ok()).toBe(true);
+}
+
+function deferred(): { readonly promise: Promise<void>; readonly resolve: () => void } {
+  let resolvePromise: (() => void) | undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (resolvePromise === undefined) throw new Error('deferred promise did not initialize');
+  return { promise, resolve: resolvePromise };
+}
+
+function filterParam(property: string, values: readonly string[]): string {
+  const tree = {
+    kind: 'group',
+    combinator: 'and',
+    children: [{ kind: 'condition', property, operator: 'in', values, negate: false }],
+  };
+  return `filter=${encodeURIComponent(JSON.stringify(tree))}`;
 }
 
 test('a card dragged to another column lands there and stays after a reload', async ({
@@ -116,21 +145,81 @@ test('a card moved with the keyboard updates the aria-live region and lands in t
   await page.reload();
   const cardLocator = page.locator(`li:has([data-testid="issue-card-${moving}"])`);
   await expect(cardLocator).toBeVisible();
-  const ariaLive = page.locator('[id^="DndLiveRegion-"][aria-live="assertive"]');
   const boardStatus = page.getByTestId('board-drag-status');
 
   await cardLocator.focus();
   await page.keyboard.press('Enter');
-  await expect(ariaLive).toContainText(`Picked up ${moving}`, { timeout: 10000 });
+  await expect(boardStatus).toHaveText(
+    new RegExp(`Picked up ${moving}: .+ in column Todo, position \\d+ of \\d+\\.`),
+    { timeout: 10_000 },
+  );
   await page.keyboard.press('ArrowRight');
-  await expect(ariaLive).toContainText(`Moved ${moving}`, { timeout: 10000 });
+  await expect(boardStatus).toHaveText(
+    new RegExp(`Moved ${moving} to column In Progress, position \\d+ of \\d+\\.`),
+    { timeout: 10_000 },
+  );
   await page.keyboard.press('Enter');
-  await expect(boardStatus).toContainText(`Moved ${moving} from column Todo`, { timeout: 10000 });
-  await expect(boardStatus).toContainText('to column In Progress');
+  await expect(boardStatus).toHaveText(`Moved ${moving} from column Todo to column In Progress.`, {
+    timeout: 10_000,
+  });
 
   await expect
     .poll(async () => await cardsIn(page, 'In Progress'), { timeout: 15_000 })
     .toContain(moving);
+  await expect(cardLocator).toBeFocused();
+  await context.close();
+});
+
+test('a filtered My Issues keyboard move announces success and focuses the destination list', async ({
+  browser,
+}) => {
+  test.setTimeout(120_000);
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const page = await context.newPage();
+  await page.goto(`${BASE}/login?next=${encodeURIComponent('/settings/general')}`);
+  await page.getByTestId('dev-sign-in-alex@orbit.example').click();
+  await page.waitForURL(`${BASE}/settings/general`);
+  const bootstrapResponse = await page.request.get(`${BASE}/api/bootstrap`);
+  expect(bootstrapResponse.ok()).toBe(true);
+  const viewer = z
+    .object({ userId: z.string().min(1) })
+    .parse(await bootstrapResponse.json()).userId;
+  const teamId = await teamIdByKey(page, 'ENG');
+  const todo = await stateIdByName(page, teamId, 'Todo');
+  const made = await createIssue(page, teamId, `Filtered Keyboard Drag ${Date.now()}`, todo);
+  const anchor = await createIssue(page, teamId, `Filtered Keyboard Anchor ${Date.now()}`, todo);
+  await updateIssue(page, made.id, { assigneeId: viewer });
+  await updateIssue(page, anchor.id, { assigneeId: viewer });
+  const preferenceResponse = await page.request.put(`${BASE}/api/view-preferences`, {
+    data: { page: 'my_issues', scope: '', layout: 'board', display: {} },
+  });
+  expect(preferenceResponse.ok()).toBe(true);
+
+  await page.goto(`${BASE}/my-issues?${filterParam('state', [todo])}`);
+  await expect(page.getByTestId('my-issues-board')).toBeVisible();
+  const card = page.getByRole('listitem', { name: new RegExp(`^${made.identifier}:`) });
+  const destinationList = page.getByTestId('board-column-In Progress').locator('ul');
+  const boardStatus = page.getByTestId('board-drag-status');
+  await expect(card).toBeVisible();
+  await expect(destinationList).toBeVisible();
+
+  await card.focus();
+  await page.keyboard.press('Enter');
+  await expect(boardStatus).toContainText(`Picked up ${made.identifier}`, { timeout: 10_000 });
+  await expect(async () => {
+    await page.keyboard.press('ArrowRight');
+    await expect(boardStatus).toContainText(`Moved ${made.identifier} to column In Progress`, {
+      timeout: 2_000,
+    });
+  }).toPass({ timeout: 10_000 });
+  await page.keyboard.press('Enter');
+
+  await expect(boardStatus).toHaveText(
+    `Moved ${made.identifier} from column Todo to column In Progress.`,
+    { timeout: 10_000 },
+  );
+  await expect(card).toHaveCount(0);
+  await expect(destinationList).toBeFocused();
   await context.close();
 });
 
@@ -150,18 +239,62 @@ test('a keyboard drag can be cancelled with Escape and returns to the original p
   await page.reload();
   const cardLocator = page.locator(`li:has([data-testid="issue-card-${moving}"])`);
   await expect(cardLocator).toBeVisible();
-  const ariaLive = page.locator('[id^="DndLiveRegion-"][aria-live="assertive"]');
+  const boardStatus = page.getByTestId('board-drag-status');
+  let moveRequestCount = 0;
+  page.on('request', (request) => {
+    if (request.method() === 'POST' && request.url().endsWith(`/api/issues/${made.id}/move`)) {
+      moveRequestCount += 1;
+    }
+  });
 
   await cardLocator.focus();
   await page.keyboard.press('Space');
-  await expect(ariaLive).toContainText(`Picked up ${moving}`, { timeout: 10000 });
+  await expect(boardStatus).toContainText(`Picked up ${moving}`, { timeout: 10_000 });
   await page.keyboard.press('ArrowRight');
-  await expect(ariaLive).toContainText(`Moved ${moving}`, { timeout: 10000 });
+  await expect(boardStatus).toContainText(`Moved ${moving}`, { timeout: 10_000 });
   await page.keyboard.press('Escape');
-  await expect(ariaLive).toContainText(`Cancelled dragging ${moving}`, { timeout: 10000 });
-  await expect(ariaLive).toContainText('Returned to column Todo');
+  await expect(boardStatus).toContainText(`Cancelled dragging ${moving}`, { timeout: 10_000 });
+  await expect(boardStatus).toContainText('Returned to column Todo');
+  expect(moveRequestCount).toBe(0);
 
   await expect.poll(async () => await cardsIn(page, 'Todo'), { timeout: 15_000 }).toContain(moving);
+
+  const remote = await context.newPage();
+  await remote.goto(`${BASE}/my-issues`);
+  const inProgress = await stateIdByName(remote, teamId, 'In Progress');
+  const cardBox = await page.getByTestId(`issue-card-${moving}`).boundingBox();
+  if (cardBox === null) throw new Error('the card has no box');
+  await page.mouse.move(cardBox.x + cardBox.width / 2, cardBox.y + cardBox.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(cardBox.x + cardBox.width / 2 + 8, cardBox.y + cardBox.height / 2, {
+    steps: 4,
+  });
+  await expect(boardStatus).toContainText(`Picked up ${moving}`);
+  await updateIssue(remote, made.id, { stateId: inProgress });
+  await expect(boardStatus).toContainText(`${moving} moved in the background`, {
+    timeout: 15_000,
+  });
+  await expect(boardStatus).toHaveText(
+    new RegExp(
+      `${moving} moved in the background to column In Progress, position \\d+(?: of \\d+)?\\. Drag cancelled\\.`,
+    ),
+  );
+  await expect(cardLocator).toBeFocused();
+  await page.mouse.up();
+  await page.mouse.move(0, 0);
+  expect(moveRequestCount).toBe(0);
+
+  const regroupedCard = page.locator(`li:has([data-testid="issue-card-${moving}"])`);
+  await regroupedCard.focus();
+  await page.keyboard.press('Enter');
+  await expect(boardStatus).toContainText(`Picked up ${moving}`);
+  await expect(boardStatus).toContainText('in column In Progress');
+  await deleteIssue(remote, made.id);
+  await expect(boardStatus).toHaveText(`${moving} is no longer visible. Drag cancelled.`, {
+    timeout: 15_000,
+  });
+  await expect(regroupedCard).toHaveCount(0);
+  expect(moveRequestCount).toBe(0);
   await context.close();
 });
 
@@ -178,10 +311,11 @@ test('a failed keyboard move announces rollback and leaves the card in place', a
   const made = await createIssue(page, teamId, `Keyboard Rollback ${Date.now()}`, todo);
   await page.reload();
   const cardLocator = page.locator(`li:has([data-testid="issue-card-${made.identifier}"])`);
-  const ariaLive = page.locator('[id^="DndLiveRegion-"][aria-live="assertive"]');
   const boardStatus = page.getByTestId('board-drag-status');
   await expect(cardLocator).toBeVisible();
+  const failure = deferred();
   await page.route(`**/api/issues/${made.id}/move`, async (route) => {
+    await failure.promise;
     await route.fulfill({
       status: 500,
       contentType: 'application/json',
@@ -191,11 +325,19 @@ test('a failed keyboard move announces rollback and leaves the card in place', a
 
   await cardLocator.focus();
   await page.keyboard.press('Enter');
-  await expect(ariaLive).toContainText(`Picked up ${made.identifier}`, { timeout: 10_000 });
+  await expect(boardStatus).toContainText(`Picked up ${made.identifier}`, { timeout: 10_000 });
   await page.keyboard.press('ArrowRight');
-  await expect(ariaLive).toContainText(`Moved ${made.identifier}`, { timeout: 10_000 });
+  await expect(boardStatus).toContainText(`Moved ${made.identifier}`, { timeout: 10_000 });
   await page.keyboard.press('Enter');
 
+  await expect(boardStatus).toContainText(`Dropping ${made.identifier}`, { timeout: 10_000 });
+  await expect
+    .poll(async () => await cardsIn(page, 'In Progress'), { timeout: 15_000 })
+    .toContain(made.identifier);
+  await expect(
+    page.getByRole('listitem', { name: new RegExp(`^${made.identifier}:`) }),
+  ).toHaveAttribute('aria-disabled', 'true');
+  failure.resolve();
   await expect(boardStatus).toContainText(`Failed to move ${made.identifier}`, { timeout: 10_000 });
   await expect(boardStatus).toContainText('Returned to column Todo');
   await expect
@@ -203,6 +345,9 @@ test('a failed keyboard move announces rollback and leaves the card in place', a
     .toContain(made.identifier);
   expect(await cardsIn(page, 'In Progress')).not.toContain(made.identifier);
   expect(await stateIdOf(page, made.identifier)).toBe(todo);
+  await expect(
+    page.getByRole('listitem', { name: new RegExp(`^${made.identifier}:`) }),
+  ).toBeFocused();
   await context.close();
 });
 
@@ -221,7 +366,6 @@ test('a card can be reordered within the same column via keyboard', async ({ bro
   await page.reload();
   const cardLocator = page.locator(`li:has([data-testid="issue-card-${moving}"])`);
   await expect(cardLocator).toBeVisible();
-  const ariaLive = page.locator('[id^="DndLiveRegion-"][aria-live="assertive"]');
   const boardStatus = page.getByTestId('board-drag-status');
 
   await expect
@@ -233,16 +377,15 @@ test('a card can be reordered within the same column via keyboard', async ({ bro
 
   await cardLocator.focus();
   await page.keyboard.press('Space');
-  await expect(ariaLive).toContainText(`Picked up ${moving}`, { timeout: 10000 });
+  await expect(boardStatus).toContainText(`Picked up ${moving}`, { timeout: 10_000 });
   await page.keyboard.press('ArrowDown');
-  await expect(ariaLive).toContainText(`Moved ${moving} to column Todo, position 2`, {
-    timeout: 10000,
+  await expect(boardStatus).toContainText(`Moved ${moving} to column Todo, position 2`, {
+    timeout: 10_000,
   });
   await page.keyboard.press('Enter');
-  await expect(boardStatus).toContainText(`Moved ${moving} from column Todo, position 1`, {
-    timeout: 10000,
+  await expect(boardStatus).toHaveText(`Moved ${moving} from column Todo to column Todo.`, {
+    timeout: 10_000,
   });
-  await expect(boardStatus).toContainText('to column Todo, position 2');
 
   await expect
     .poll(async () => {

--- a/apps/web/e2e/board-drag.spec.ts
+++ b/apps/web/e2e/board-drag.spec.ts
@@ -1,3 +1,4 @@
+import { encodeFilter, inCondition } from '@orbit/shared/filters';
 import { type BrowserContext, expect, type Page, test } from '@playwright/test';
 import { z } from 'zod';
 import { createIssue, stateIdByName, stateIdOf, teamIdByKey } from './api.ts';
@@ -54,13 +55,30 @@ function deferred(): { readonly promise: Promise<void>; readonly resolve: () => 
   return { promise, resolve: resolvePromise };
 }
 
-function filterParam(property: string, values: readonly string[]): string {
-  const tree = {
-    kind: 'group',
-    combinator: 'and',
-    children: [{ kind: 'condition', property, operator: 'in', values, negate: false }],
-  };
-  return `filter=${encodeURIComponent(JSON.stringify(tree))}`;
+function stateAndContentFilterParam(stateId: string, content: string): string {
+  return `filter=${encodeURIComponent(
+    encodeFilter({
+      kind: 'group',
+      combinator: 'and',
+      children: [
+        inCondition('state', [stateId]),
+        {
+          kind: 'condition',
+          property: 'content',
+          operator: 'exact',
+          value: content,
+          negate: false,
+        },
+      ],
+    }),
+  )}`;
+}
+
+async function waitForKeyboardDragReady(page: Page, identifier: string): Promise<void> {
+  await expect(page.getByTestId(`issue-card-${identifier}`)).toHaveCount(2);
+  await page.evaluate(
+    () => new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve())),
+  );
 }
 
 test('a card dragged to another column lands there and stays after a reload', async ({
@@ -158,10 +176,23 @@ test('a card moved with the keyboard updates the aria-live region and lands in t
     new RegExp(`Moved ${moving} to column In Progress, position \\d+ of \\d+\\.`),
     { timeout: 10_000 },
   );
+  await page.keyboard.press('ArrowLeft');
+  await expect(boardStatus).toHaveText(
+    new RegExp(`Moved ${moving} to column Todo, position \\d+ of \\d+\\.`),
+    { timeout: 10_000 },
+  );
+  await page.keyboard.press('ArrowRight');
+  await expect(boardStatus).toHaveText(
+    new RegExp(`Moved ${moving} to column In Progress, position \\d+ of \\d+\\.`),
+    { timeout: 10_000 },
+  );
   await page.keyboard.press('Enter');
-  await expect(boardStatus).toHaveText(`Moved ${moving} from column Todo to column In Progress.`, {
-    timeout: 10_000,
-  });
+  await expect(boardStatus).toHaveText(
+    new RegExp(
+      `Moved ${moving} from column Todo, position \\d+ of \\d+ to column In Progress, position \\d+ of \\d+\\.`,
+    ),
+    { timeout: 10_000 },
+  );
 
   await expect
     .poll(async () => await cardsIn(page, 'In Progress'), { timeout: 15_000 })
@@ -170,7 +201,7 @@ test('a card moved with the keyboard updates the aria-live region and lands in t
   await context.close();
 });
 
-test('a filtered My Issues keyboard move announces success and focuses the destination list', async ({
+test('a last filtered My Issues keyboard move keeps feedback and destination focus', async ({
   browser,
 }) => {
   test.setTimeout(120_000);
@@ -186,36 +217,37 @@ test('a filtered My Issues keyboard move announces success and focuses the desti
     .parse(await bootstrapResponse.json()).userId;
   const teamId = await teamIdByKey(page, 'ENG');
   const todo = await stateIdByName(page, teamId, 'Todo');
-  const made = await createIssue(page, teamId, `Filtered Keyboard Drag ${Date.now()}`, todo);
-  const anchor = await createIssue(page, teamId, `Filtered Keyboard Anchor ${Date.now()}`, todo);
+  const title = `Filtered Keyboard Drag ${Date.now()}`;
+  const made = await createIssue(page, teamId, title, todo);
   await updateIssue(page, made.id, { assigneeId: viewer });
-  await updateIssue(page, anchor.id, { assigneeId: viewer });
   const preferenceResponse = await page.request.put(`${BASE}/api/view-preferences`, {
     data: { page: 'my_issues', scope: '', layout: 'board', display: {} },
   });
   expect(preferenceResponse.ok()).toBe(true);
 
-  await page.goto(`${BASE}/my-issues?${filterParam('state', [todo])}`);
+  await page.goto(`${BASE}/my-issues?${stateAndContentFilterParam(todo, title)}`);
   await expect(page.getByTestId('my-issues-board')).toBeVisible();
   const card = page.getByRole('listitem', { name: new RegExp(`^${made.identifier}:`) });
   const destinationList = page.getByTestId('board-column-In Progress').locator('ul');
   const boardStatus = page.getByTestId('board-drag-status');
   await expect(card).toBeVisible();
+  await expect(page.getByTestId('my-issues-board').getByRole('listitem')).toHaveCount(1);
   await expect(destinationList).toBeVisible();
 
   await card.focus();
   await page.keyboard.press('Enter');
   await expect(boardStatus).toContainText(`Picked up ${made.identifier}`, { timeout: 10_000 });
-  await expect(async () => {
-    await page.keyboard.press('ArrowRight');
-    await expect(boardStatus).toContainText(`Moved ${made.identifier} to column In Progress`, {
-      timeout: 2_000,
-    });
-  }).toPass({ timeout: 10_000 });
+  await waitForKeyboardDragReady(page, made.identifier);
+  await page.keyboard.press('ArrowRight');
+  await expect(boardStatus).toContainText(`Moved ${made.identifier} to column In Progress`, {
+    timeout: 10_000,
+  });
   await page.keyboard.press('Enter');
 
   await expect(boardStatus).toHaveText(
-    `Moved ${made.identifier} from column Todo to column In Progress.`,
+    new RegExp(
+      `Moved ${made.identifier} from column Todo, position \\d+ of \\d+ to column In Progress\\.`,
+    ),
     { timeout: 10_000 },
   );
   await expect(card).toHaveCount(0);
@@ -279,7 +311,7 @@ test('a keyboard drag can be cancelled with Escape and returns to the original p
       `${moving} moved in the background to column In Progress, position \\d+(?: of \\d+)?\\. Drag cancelled\\.`,
     ),
   );
-  await expect(cardLocator).toBeFocused();
+  await expect(cardLocator).not.toBeFocused();
   await page.mouse.up();
   await page.mouse.move(0, 0);
   expect(moveRequestCount).toBe(0);
@@ -313,8 +345,14 @@ test('a failed keyboard move announces rollback and leaves the card in place', a
   const cardLocator = page.locator(`li:has([data-testid="issue-card-${made.identifier}"])`);
   const boardStatus = page.getByTestId('board-drag-status');
   await expect(cardLocator).toBeVisible();
-  const failure = deferred();
+  const normalFailure = deferred();
+  const alternateFailure = deferred();
+  const failures = [normalFailure, alternateFailure];
+  let requestIndex = 0;
   await page.route(`**/api/issues/${made.id}/move`, async (route) => {
+    const failure = failures[requestIndex];
+    if (failure === undefined) throw new Error('unexpected extra move request');
+    requestIndex += 1;
     await failure.promise;
     await route.fulfill({
       status: 500,
@@ -323,21 +361,43 @@ test('a failed keyboard move announces rollback and leaves the card in place', a
     });
   });
 
-  await cardLocator.focus();
-  await page.keyboard.press('Enter');
-  await expect(boardStatus).toContainText(`Picked up ${made.identifier}`, { timeout: 10_000 });
-  await page.keyboard.press('ArrowRight');
-  await expect(boardStatus).toContainText(`Moved ${made.identifier}`, { timeout: 10_000 });
-  await page.keyboard.press('Enter');
+  const beginMove = async () => {
+    const sourceCard = page.getByRole('listitem', {
+      name: new RegExp(`^${made.identifier}:`),
+    });
+    await sourceCard.focus();
+    await page.keyboard.press('Enter');
+    await expect(boardStatus).toContainText(`Picked up ${made.identifier}`, { timeout: 10_000 });
+    await page.keyboard.press('ArrowRight');
+    await expect(boardStatus).toContainText(`Moved ${made.identifier}`, { timeout: 10_000 });
+    await page.keyboard.press('Enter');
+    await expect(boardStatus).toContainText(`Dropping ${made.identifier}`, { timeout: 10_000 });
+    await expect
+      .poll(async () => await cardsIn(page, 'In Progress'), { timeout: 15_000 })
+      .toContain(made.identifier);
+    const optimisticCard = page.getByRole('listitem', {
+      name: new RegExp(`^${made.identifier}:`),
+    });
+    await expect(optimisticCard).toHaveAttribute('aria-disabled', 'true');
+    await expect(optimisticCard).toBeFocused();
+  };
 
-  await expect(boardStatus).toContainText(`Dropping ${made.identifier}`, { timeout: 10_000 });
+  await beginMove();
+  normalFailure.resolve();
+  await expect(boardStatus).toContainText(`Failed to move ${made.identifier}`, { timeout: 10_000 });
+  await expect(boardStatus).toContainText('Returned to column Todo');
   await expect
-    .poll(async () => await cardsIn(page, 'In Progress'), { timeout: 15_000 })
+    .poll(async () => await cardsIn(page, 'Todo'), { timeout: 15_000 })
     .toContain(made.identifier);
   await expect(
     page.getByRole('listitem', { name: new RegExp(`^${made.identifier}:`) }),
-  ).toHaveAttribute('aria-disabled', 'true');
-  failure.resolve();
+  ).toBeFocused();
+
+  await beginMove();
+  const alternateControl = page.getByRole('button', { name: 'Create an issue in Todo' });
+  await alternateControl.focus();
+  await expect(alternateControl).toBeFocused();
+  alternateFailure.resolve();
   await expect(boardStatus).toContainText(`Failed to move ${made.identifier}`, { timeout: 10_000 });
   await expect(boardStatus).toContainText('Returned to column Todo');
   await expect
@@ -345,9 +405,7 @@ test('a failed keyboard move announces rollback and leaves the card in place', a
     .toContain(made.identifier);
   expect(await cardsIn(page, 'In Progress')).not.toContain(made.identifier);
   expect(await stateIdOf(page, made.identifier)).toBe(todo);
-  await expect(
-    page.getByRole('listitem', { name: new RegExp(`^${made.identifier}:`) }),
-  ).toBeFocused();
+  await expect(alternateControl).toBeFocused();
   await context.close();
 });
 
@@ -371,7 +429,9 @@ test('a card can be reordered within the same column via keyboard', async ({ bro
   await expect
     .poll(async () => {
       const rows = await cardsIn(page, 'Todo');
-      return rows.indexOf(second.identifier) < rows.indexOf(first.identifier);
+      const secondIndex = rows.indexOf(second.identifier);
+      const firstIndex = rows.indexOf(first.identifier);
+      return secondIndex !== -1 && firstIndex !== -1 && secondIndex < firstIndex;
     })
     .toBe(true);
 
@@ -383,14 +443,19 @@ test('a card can be reordered within the same column via keyboard', async ({ bro
     timeout: 10_000,
   });
   await page.keyboard.press('Enter');
-  await expect(boardStatus).toHaveText(`Moved ${moving} from column Todo to column Todo.`, {
-    timeout: 10_000,
-  });
+  await expect(boardStatus).toHaveText(
+    new RegExp(
+      `Moved ${moving} from column Todo, position \\d+ of \\d+ to column Todo, position \\d+ of \\d+\\.`,
+    ),
+    { timeout: 10_000 },
+  );
 
   await expect
     .poll(async () => {
       const rows = await cardsIn(page, 'Todo');
-      return rows.indexOf(first.identifier) < rows.indexOf(second.identifier);
+      const firstIndex = rows.indexOf(first.identifier);
+      const secondIndex = rows.indexOf(second.identifier);
+      return firstIndex !== -1 && secondIndex !== -1 && firstIndex < secondIndex;
     })
     .toBe(true);
 
@@ -398,7 +463,9 @@ test('a card can be reordered within the same column via keyboard', async ({ bro
   await expect
     .poll(async () => {
       const rows = await cardsIn(page, 'Todo');
-      return rows.indexOf(first.identifier) < rows.indexOf(second.identifier);
+      const firstIndex = rows.indexOf(first.identifier);
+      const secondIndex = rows.indexOf(second.identifier);
+      return firstIndex !== -1 && secondIndex !== -1 && firstIndex < secondIndex;
     })
     .toBe(true);
   await context.close();

--- a/apps/web/e2e/board-drag.spec.ts
+++ b/apps/web/e2e/board-drag.spec.ts
@@ -30,15 +30,7 @@ async function dragCardToColumn(page: Page, identifier: string, column: string):
 
   await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
   await page.mouse.down();
-  const steps = 12;
-  for (let step = 1; step <= steps; step += 1) {
-    await page.mouse.move(
-      from.x + (to.x + to.width / 2 - from.x) * (step / steps),
-      from.y + (to.y + 120 - from.y) * (step / steps),
-    );
-    await page.waitForTimeout(30);
-  }
-  await page.waitForTimeout(200);
+  await page.mouse.move(to.x + to.width / 2, to.y + 120, { steps: 12 });
   await page.mouse.up();
 }
 
@@ -54,7 +46,8 @@ test('a card dragged to another column lands there and stays after a reload', as
   await page.waitForSelector('[data-testid^="issue-card-"]');
 
   const teamId = await teamIdByKey(page, 'ENG');
-  const made = await createIssue(page, teamId, `Draggable ${Date.now()}`);
+  const todo = await stateIdByName(page, teamId, 'Todo');
+  const made = await createIssue(page, teamId, `Draggable ${Date.now()}`, todo);
   const moving = made.identifier;
 
   await page.reload();
@@ -117,12 +110,14 @@ test('a card moved with the keyboard updates the aria-live region and lands in t
   await expect(page.getByTestId('board-column-Todo')).toBeVisible();
   await page.waitForSelector('[data-testid^="issue-card-"]');
   const teamId = await teamIdByKey(page, 'ENG');
-  const made = await createIssue(page, teamId, `Keyboard Drag ${Date.now()}`);
+  const todo = await stateIdByName(page, teamId, 'Todo');
+  const made = await createIssue(page, teamId, `Keyboard Drag ${Date.now()}`, todo);
   const moving = made.identifier;
   await page.reload();
   const cardLocator = page.locator(`li:has([data-testid="issue-card-${moving}"])`);
   await expect(cardLocator).toBeVisible();
   const ariaLive = page.locator('[id^="DndLiveRegion-"][aria-live="assertive"]');
+  const boardStatus = page.getByTestId('board-drag-status');
 
   await cardLocator.focus();
   await page.keyboard.press('Enter');
@@ -130,9 +125,9 @@ test('a card moved with the keyboard updates the aria-live region and lands in t
   await page.keyboard.press('ArrowRight');
   await expect(ariaLive).toContainText(`Moved ${moving}`, { timeout: 10000 });
   await page.keyboard.press('Enter');
-  await expect(ariaLive).toContainText(`Successfully dropped ${moving}`, { timeout: 10000 });
+  await expect(boardStatus).toContainText(`Moved ${moving} from column Todo`, { timeout: 10000 });
+  await expect(boardStatus).toContainText('to column In Progress');
 
-  await page.waitForTimeout(500);
   await expect
     .poll(async () => await cardsIn(page, 'In Progress'), { timeout: 15_000 })
     .toContain(moving);
@@ -149,7 +144,8 @@ test('a keyboard drag can be cancelled with Escape and returns to the original p
   await expect(page.getByTestId('board-column-Todo')).toBeVisible();
   await page.waitForSelector('[data-testid^="issue-card-"]');
   const teamId = await teamIdByKey(page, 'ENG');
-  const made = await createIssue(page, teamId, `Keyboard Cancel ${Date.now()}`);
+  const todo = await stateIdByName(page, teamId, 'Todo');
+  const made = await createIssue(page, teamId, `Keyboard Cancel ${Date.now()}`, todo);
   const moving = made.identifier;
   await page.reload();
   const cardLocator = page.locator(`li:has([data-testid="issue-card-${moving}"])`);
@@ -163,9 +159,47 @@ test('a keyboard drag can be cancelled with Escape and returns to the original p
   await expect(ariaLive).toContainText(`Moved ${moving}`, { timeout: 10000 });
   await page.keyboard.press('Escape');
   await expect(ariaLive).toContainText(`Cancelled dragging ${moving}`, { timeout: 10000 });
+  await expect(ariaLive).toContainText('Returned to column Todo');
 
-  await page.waitForTimeout(500);
   await expect.poll(async () => await cardsIn(page, 'Todo'), { timeout: 15_000 }).toContain(moving);
+  await context.close();
+});
+
+test('a failed keyboard move announces rollback and leaves the card in place', async ({
+  browser,
+}) => {
+  test.setTimeout(120_000);
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const page = await signIn(context, 'alex@orbit.example');
+  await page.goto(`${BASE}/team/eng/board`);
+  await expect(page.getByTestId('board-column-Todo')).toBeVisible();
+  const teamId = await teamIdByKey(page, 'ENG');
+  const todo = await stateIdByName(page, teamId, 'Todo');
+  const made = await createIssue(page, teamId, `Keyboard Rollback ${Date.now()}`, todo);
+  await page.reload();
+  const cardLocator = page.locator(`li:has([data-testid="issue-card-${made.identifier}"])`);
+  const boardStatus = page.getByTestId('board-drag-status');
+  await expect(cardLocator).toBeVisible();
+  await page.route(`**/api/issues/${made.id}/move`, async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: { code: 'TEST_FAILURE', message: 'Move failed.' } }),
+    });
+  });
+
+  await cardLocator.focus();
+  await page.keyboard.press('Enter');
+  await page.keyboard.press('ArrowRight');
+  await page.keyboard.press('Enter');
+
+  await expect(boardStatus).toContainText(`Failed to move ${made.identifier}`, { timeout: 10_000 });
+  await expect(boardStatus).toContainText('Returned to column Todo');
+  await expect
+    .poll(async () => await cardsIn(page, 'Todo'), { timeout: 15_000 })
+    .toContain(made.identifier);
+  expect(await cardsIn(page, 'In Progress')).not.toContain(made.identifier);
+  expect(await stateIdOf(page, made.identifier)).toBe(todo);
   await context.close();
 });
 
@@ -177,22 +211,49 @@ test('a card can be reordered within the same column via keyboard', async ({ bro
   await expect(page.getByTestId('board-column-Todo')).toBeVisible();
   await page.waitForSelector('[data-testid^="issue-card-"]');
   const teamId = await teamIdByKey(page, 'ENG');
-  await createIssue(page, teamId, `Keyboard Reorder A ${Date.now()}`);
-  const made2 = await createIssue(page, teamId, `Keyboard Reorder B ${Date.now()}`);
-  const moving = made2.identifier;
+  const todo = await stateIdByName(page, teamId, 'Todo');
+  const first = await createIssue(page, teamId, `Keyboard Reorder A ${Date.now()}`, todo);
+  const second = await createIssue(page, teamId, `Keyboard Reorder B ${Date.now()}`, todo);
+  const moving = second.identifier;
   await page.reload();
   const cardLocator = page.locator(`li:has([data-testid="issue-card-${moving}"])`);
   await expect(cardLocator).toBeVisible();
   const ariaLive = page.locator('[id^="DndLiveRegion-"][aria-live="assertive"]');
+  const boardStatus = page.getByTestId('board-drag-status');
+
+  await expect
+    .poll(async () => {
+      const rows = await cardsIn(page, 'Todo');
+      return rows.indexOf(second.identifier) < rows.indexOf(first.identifier);
+    })
+    .toBe(true);
 
   await cardLocator.focus();
   await page.keyboard.press('Space');
   await expect(ariaLive).toContainText(`Picked up ${moving}`, { timeout: 10000 });
-  await page.keyboard.press('ArrowUp');
-  await expect(ariaLive).toContainText(`Moved ${moving}`, { timeout: 10000 });
+  await page.keyboard.press('ArrowDown');
+  await expect(ariaLive).toContainText(`Moved ${moving} to column Todo, position 2`, {
+    timeout: 10000,
+  });
   await page.keyboard.press('Enter');
-  await expect(ariaLive).toContainText(`Successfully dropped ${moving}`, { timeout: 10000 });
+  await expect(boardStatus).toContainText(`Moved ${moving} from column Todo, position 1`, {
+    timeout: 10000,
+  });
+  await expect(boardStatus).toContainText('to column Todo, position 2');
 
-  await page.waitForTimeout(500);
+  await expect
+    .poll(async () => {
+      const rows = await cardsIn(page, 'Todo');
+      return rows.indexOf(first.identifier) < rows.indexOf(second.identifier);
+    })
+    .toBe(true);
+
+  await page.reload();
+  await expect
+    .poll(async () => {
+      const rows = await cardsIn(page, 'Todo');
+      return rows.indexOf(first.identifier) < rows.indexOf(second.identifier);
+    })
+    .toBe(true);
   await context.close();
 });

--- a/apps/web/e2e/board-drag.spec.ts
+++ b/apps/web/e2e/board-drag.spec.ts
@@ -128,7 +128,7 @@ test('a card moved with the keyboard updates the aria-live region and lands in t
   const cardLocator = page.locator(`li:has([data-testid="issue-card-${moving}"])`);
   await expect(cardLocator).toBeVisible();
   
-  const ariaLive = page.locator('[aria-live="assertive"]');
+  const ariaLive = page.locator('[id^="DndLiveRegion-"][aria-live="assertive"]')
 
   await cardLocator.focus();
 

--- a/apps/web/e2e/board-drag.spec.ts
+++ b/apps/web/e2e/board-drag.spec.ts
@@ -107,43 +107,92 @@ test('the command palette finds an issue by its title and opens it', async ({ br
   await context.close();
 });
 
-
 test('a card moved with the keyboard updates the aria-live region and lands in the new column', async ({
   browser,
 }) => {
   test.setTimeout(120_000);
   const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
   const page = await signIn(context, 'alex@orbit.example');
-
   await page.goto(`${BASE}/team/eng/board`);
   await expect(page.getByTestId('board-column-Todo')).toBeVisible();
   await page.waitForSelector('[data-testid^="issue-card-"]');
-
   const teamId = await teamIdByKey(page, 'ENG');
   const made = await createIssue(page, teamId, `Keyboard Drag ${Date.now()}`);
   const moving = made.identifier;
-
   await page.reload();
-  
   const cardLocator = page.locator(`li:has([data-testid="issue-card-${moving}"])`);
   await expect(cardLocator).toBeVisible();
-  
-  const ariaLive = page.locator('[id^="DndLiveRegion-"][aria-live="assertive"]')
+  const ariaLive = page.locator('[id^="DndLiveRegion-"][aria-live="assertive"]');
 
   await cardLocator.focus();
-
-  await page.keyboard.press('Space');
-  await expect(ariaLive).toContainText(`Picked up ${moving}`, { timeout: 5000 });
-
+  await page.keyboard.press('Enter');
+  await expect(ariaLive).toContainText(`Picked up ${moving}`, { timeout: 10000 });
   await page.keyboard.press('ArrowRight');
-  await expect(ariaLive).toContainText(`Moved ${moving} to column In Progress`, { timeout: 5000 });
+  await expect(ariaLive).toContainText(`Moved ${moving}`, { timeout: 10000 });
+  await page.keyboard.press('Enter');
+  await expect(ariaLive).toContainText(`Successfully dropped ${moving}`, { timeout: 10000 });
 
-  await page.keyboard.press('Space');
-  await expect(ariaLive).toContainText(`Dropped ${moving} in column In Progress`, { timeout: 5000 });
-
+  await page.waitForTimeout(500);
   await expect
     .poll(async () => await cardsIn(page, 'In Progress'), { timeout: 15_000 })
     .toContain(moving);
+  await context.close();
+});
 
+test('a keyboard drag can be cancelled with Escape and returns to the original position', async ({
+  browser,
+}) => {
+  test.setTimeout(120_000);
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const page = await signIn(context, 'alex@orbit.example');
+  await page.goto(`${BASE}/team/eng/board`);
+  await expect(page.getByTestId('board-column-Todo')).toBeVisible();
+  await page.waitForSelector('[data-testid^="issue-card-"]');
+  const teamId = await teamIdByKey(page, 'ENG');
+  const made = await createIssue(page, teamId, `Keyboard Cancel ${Date.now()}`);
+  const moving = made.identifier;
+  await page.reload();
+  const cardLocator = page.locator(`li:has([data-testid="issue-card-${moving}"])`);
+  await expect(cardLocator).toBeVisible();
+  const ariaLive = page.locator('[id^="DndLiveRegion-"][aria-live="assertive"]');
+
+  await cardLocator.focus();
+  await page.keyboard.press('Space');
+  await expect(ariaLive).toContainText(`Picked up ${moving}`, { timeout: 10000 });
+  await page.keyboard.press('ArrowRight');
+  await expect(ariaLive).toContainText(`Moved ${moving}`, { timeout: 10000 });
+  await page.keyboard.press('Escape');
+  await expect(ariaLive).toContainText(`Cancelled dragging ${moving}`, { timeout: 10000 });
+
+  await page.waitForTimeout(500);
+  await expect.poll(async () => await cardsIn(page, 'Todo'), { timeout: 15_000 }).toContain(moving);
+  await context.close();
+});
+
+test('a card can be reordered within the same column via keyboard', async ({ browser }) => {
+  test.setTimeout(120_000);
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const page = await signIn(context, 'alex@orbit.example');
+  await page.goto(`${BASE}/team/eng/board`);
+  await expect(page.getByTestId('board-column-Todo')).toBeVisible();
+  await page.waitForSelector('[data-testid^="issue-card-"]');
+  const teamId = await teamIdByKey(page, 'ENG');
+  await createIssue(page, teamId, `Keyboard Reorder A ${Date.now()}`);
+  const made2 = await createIssue(page, teamId, `Keyboard Reorder B ${Date.now()}`);
+  const moving = made2.identifier;
+  await page.reload();
+  const cardLocator = page.locator(`li:has([data-testid="issue-card-${moving}"])`);
+  await expect(cardLocator).toBeVisible();
+  const ariaLive = page.locator('[id^="DndLiveRegion-"][aria-live="assertive"]');
+
+  await cardLocator.focus();
+  await page.keyboard.press('Space');
+  await expect(ariaLive).toContainText(`Picked up ${moving}`, { timeout: 10000 });
+  await page.keyboard.press('ArrowUp');
+  await expect(ariaLive).toContainText(`Moved ${moving}`, { timeout: 10000 });
+  await page.keyboard.press('Enter');
+  await expect(ariaLive).toContainText(`Successfully dropped ${moving}`, { timeout: 10000 });
+
+  await page.waitForTimeout(500);
   await context.close();
 });

--- a/apps/web/e2e/board-drag.spec.ts
+++ b/apps/web/e2e/board-drag.spec.ts
@@ -106,3 +106,44 @@ test('the command palette finds an issue by its title and opens it', async ({ br
   await expect(page).toHaveURL(/\/issue\/[A-Z]+-\d+/);
   await context.close();
 });
+
+
+test('a card moved with the keyboard updates the aria-live region and lands in the new column', async ({
+  browser,
+}) => {
+  test.setTimeout(120_000);
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const page = await signIn(context, 'alex@orbit.example');
+
+  await page.goto(`${BASE}/team/eng/board`);
+  await expect(page.getByTestId('board-column-Todo')).toBeVisible();
+  await page.waitForSelector('[data-testid^="issue-card-"]');
+
+  const teamId = await teamIdByKey(page, 'ENG');
+  const made = await createIssue(page, teamId, `Keyboard Drag ${Date.now()}`);
+  const moving = made.identifier;
+
+  await page.reload();
+  
+  const cardLocator = page.locator(`li:has([data-testid="issue-card-${moving}"])`);
+  await expect(cardLocator).toBeVisible();
+  
+  const ariaLive = page.locator('[aria-live="assertive"]');
+
+  await cardLocator.focus();
+
+  await page.keyboard.press('Space');
+  await expect(ariaLive).toContainText(`Picked up ${moving}`, { timeout: 5000 });
+
+  await page.keyboard.press('ArrowRight');
+  await expect(ariaLive).toContainText(`Moved ${moving} to column In Progress`, { timeout: 5000 });
+
+  await page.keyboard.press('Space');
+  await expect(ariaLive).toContainText(`Dropped ${moving} in column In Progress`, { timeout: 5000 });
+
+  await expect
+    .poll(async () => await cardsIn(page, 'In Progress'), { timeout: 15_000 })
+    .toContain(moving);
+
+  await context.close();
+});

--- a/apps/web/e2e/board-drag.spec.ts
+++ b/apps/web/e2e/board-drag.spec.ts
@@ -178,6 +178,7 @@ test('a failed keyboard move announces rollback and leaves the card in place', a
   const made = await createIssue(page, teamId, `Keyboard Rollback ${Date.now()}`, todo);
   await page.reload();
   const cardLocator = page.locator(`li:has([data-testid="issue-card-${made.identifier}"])`);
+  const ariaLive = page.locator('[id^="DndLiveRegion-"][aria-live="assertive"]');
   const boardStatus = page.getByTestId('board-drag-status');
   await expect(cardLocator).toBeVisible();
   await page.route(`**/api/issues/${made.id}/move`, async (route) => {
@@ -190,7 +191,9 @@ test('a failed keyboard move announces rollback and leaves the card in place', a
 
   await cardLocator.focus();
   await page.keyboard.press('Enter');
+  await expect(ariaLive).toContainText(`Picked up ${made.identifier}`, { timeout: 10_000 });
   await page.keyboard.press('ArrowRight');
+  await expect(ariaLive).toContainText(`Moved ${made.identifier}`, { timeout: 10_000 });
   await page.keyboard.press('Enter');
 
   await expect(boardStatus).toContainText(`Failed to move ${made.identifier}`, { timeout: 10_000 });

--- a/apps/web/src/features/issues/board-sensors.ts
+++ b/apps/web/src/features/issues/board-sensors.ts
@@ -1,0 +1,176 @@
+import {
+  KeyboardCode,
+  type KeyboardCodes,
+  KeyboardSensor,
+  type KeyboardSensorOptions,
+  type KeyboardSensorProps,
+  PointerSensor,
+  type PointerSensorOptions,
+  type PointerSensorProps,
+  type Sensor,
+  type SensorInstance,
+  type SensorProps,
+} from '@dnd-kit/core';
+
+const defaultKeyboardCodes: KeyboardCodes = {
+  start: [KeyboardCode.Space, KeyboardCode.Enter],
+  cancel: [KeyboardCode.Esc],
+  end: [KeyboardCode.Space, KeyboardCode.Enter, KeyboardCode.Tab],
+};
+
+let cancellationSequence = 0;
+
+type CancellationMode = 'context' | 'teardown';
+
+interface SensorRegistration {
+  active: boolean;
+  requested: boolean;
+  mode: CancellationMode | null;
+  cancel: (mode: CancellationMode) => void;
+}
+
+export interface BoardSensorController {
+  readonly Keyboard: Sensor<KeyboardSensorOptions>;
+  readonly Pointer: Sensor<PointerSensorOptions>;
+  readonly mount: () => void;
+  readonly unmount: () => void;
+  readonly cancel: () => void;
+}
+
+export function createBoardSensorController(): BoardSensorController {
+  let current: SensorRegistration | null = null;
+  let mounted = false;
+
+  const release = (registration: SensorRegistration) => {
+    registration.active = false;
+    if (current === registration) current = null;
+  };
+
+  const requestCancellation = (
+    registration: SensorRegistration,
+    mode: CancellationMode,
+  ): boolean => {
+    if (!registration.active) return false;
+    if (mode === 'teardown' || registration.mode === null) registration.mode = mode;
+    if (registration.requested) return false;
+    registration.requested = true;
+    return true;
+  };
+
+  const lifecycleProps = <Options extends object>(
+    props: SensorProps<Options>,
+    registration: SensorRegistration,
+  ): SensorProps<Options> => ({
+    ...props,
+    onAbort(id) {
+      if (!registration.active || registration.mode === 'teardown') return;
+      props.onAbort(id);
+    },
+    onCancel() {
+      if (!registration.active) return;
+      const notify = registration.mode !== 'teardown';
+      release(registration);
+      if (notify) props.onCancel();
+    },
+    onEnd() {
+      if (!registration.active) return;
+      const notify = registration.mode !== 'teardown';
+      release(registration);
+      if (notify) props.onEnd();
+    },
+  });
+
+  const register = (registration: SensorRegistration) => {
+    if (current !== null && current !== registration) current.cancel('teardown');
+    if (!mounted) {
+      registration.cancel('teardown');
+      return;
+    }
+    current = registration;
+  };
+
+  class ControlledPointerSensor implements SensorInstance {
+    static readonly activators = PointerSensor.activators;
+    readonly autoScrollEnabled: boolean;
+
+    constructor(props: PointerSensorProps) {
+      const ownerDocument = props.activeNode.node.current?.ownerDocument ?? document;
+      const ownerWindow = ownerDocument.defaultView ?? window;
+      const registration: SensorRegistration = {
+        active: true,
+        requested: false,
+        mode: null,
+        cancel(mode) {
+          if (!requestCancellation(registration, mode)) return;
+          ownerDocument.dispatchEvent(
+            new ownerWindow.Event('pointercancel', { bubbles: false, cancelable: true }),
+          );
+        },
+      };
+      const delegate = new PointerSensor(lifecycleProps(props, registration));
+      this.autoScrollEnabled = delegate.autoScrollEnabled;
+      register(registration);
+    }
+  }
+
+  class ControlledKeyboardSensor implements SensorInstance {
+    static readonly activators = KeyboardSensor.activators;
+    readonly autoScrollEnabled: boolean;
+
+    constructor(props: KeyboardSensorProps) {
+      cancellationSequence += 1;
+      const cancellationCode = `OrbitBoardCancel${cancellationSequence}`;
+      const ownerDocument = props.activeNode.node.current?.ownerDocument ?? document;
+      const ownerWindow = ownerDocument.defaultView ?? window;
+      const configuredCodes = props.options.keyboardCodes ?? defaultKeyboardCodes;
+      const registration: SensorRegistration = {
+        active: true,
+        requested: false,
+        mode: null,
+        cancel(mode) {
+          if (!requestCancellation(registration, mode)) return;
+          ownerWindow.setTimeout(() => {
+            if (!registration.active) return;
+            ownerDocument.dispatchEvent(
+              new ownerWindow.KeyboardEvent('keydown', {
+                key: 'Unidentified',
+                code: cancellationCode,
+                bubbles: false,
+                cancelable: true,
+              }),
+            );
+          }, 0);
+        },
+      };
+      const wrapped = lifecycleProps(props, registration);
+      const delegate = new KeyboardSensor({
+        ...wrapped,
+        options: {
+          ...wrapped.options,
+          keyboardCodes: {
+            start: [...configuredCodes.start],
+            cancel: [...configuredCodes.cancel, cancellationCode],
+            end: [...configuredCodes.end],
+          },
+        },
+      });
+      this.autoScrollEnabled = delegate.autoScrollEnabled;
+      register(registration);
+    }
+  }
+
+  return {
+    Keyboard: ControlledKeyboardSensor,
+    Pointer: ControlledPointerSensor,
+    mount() {
+      mounted = true;
+    },
+    unmount() {
+      mounted = false;
+      current?.cancel('teardown');
+    },
+    cancel() {
+      current?.cancel('context');
+    },
+  };
+}

--- a/apps/web/src/features/issues/board.tsx
+++ b/apps/web/src/features/issues/board.tsx
@@ -3,13 +3,11 @@
 import {
   type CollisionDetection,
   DndContext,
-  type DragCancelEvent,
   type DragEndEvent,
+  type DragMoveEvent,
   type DragOverEvent,
   DragOverlay,
   type DragStartEvent,
-  KeyboardSensor,
-  PointerSensor,
   pointerWithin,
   rectIntersection,
   useDroppable,
@@ -27,15 +25,27 @@ import type { OrgRole } from '@orbit/shared/constants';
 import type { DisplayOptions, DisplayProperty, GroupByField } from '@orbit/shared/filters';
 import { DEFAULT_DISPLAY_PROPERTIES, emptyFilterGroup } from '@orbit/shared/filters';
 import { permissionsFor } from '@orbit/shared/policy';
+import { useQueryClient } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { applyDisplayFilters, displayFiltersHideRows } from '@/features/filters/display-filter.ts';
 import type { IssueGroup } from '@/features/filters/grouping.ts';
 import { UNGROUPED_ID } from '@/features/filters/grouping.ts';
 import { cn } from '@/lib/cn.ts';
 import type { Cycle, Issue, Label, Member, Project, WorkflowState } from '@/lib/query/schemas.ts';
-import type { IssueQuery, IssueRegrouping, MoveInput } from '@/lib/query/use-issues.ts';
-import { useBoardPage, useColumnIssues, useMoveIssue } from '@/lib/query/use-issues.ts';
+import type {
+  AuthoritativeCachedIssue,
+  IssueQuery,
+  IssueRegrouping,
+  MoveInput,
+} from '@/lib/query/use-issues.ts';
+import {
+  authoritativeCachedIssue,
+  useBoardPage,
+  useColumnIssues,
+  useMoveIssue,
+} from '@/lib/query/use-issues.ts';
+import { createBoardSensorController } from './board-sensors.ts';
 import { GroupGlyph } from './group-glyph.tsx';
 import { IssueCard } from './issue-card.tsx';
 import { IssuePeek } from './issue-peek.tsx';
@@ -79,14 +89,28 @@ export function columnsReadyFor(columnSource: object | undefined, boardPending: 
 export interface BoardPosition {
   readonly column: string;
   readonly position: number;
-  readonly total: number;
+  readonly total?: number;
+}
+
+export interface BoardDestination {
+  readonly column: string;
+  readonly position?: number;
+  readonly total?: number;
+}
+
+export interface BoardSource extends BoardPosition {
+  readonly groupId: string;
+}
+
+export interface BoardTarget extends BoardDestination {
+  readonly groupId: string;
 }
 
 export interface CompletedDrag {
   readonly session: number;
   readonly identifier: string;
   readonly source: BoardPosition;
-  readonly destination: BoardPosition;
+  readonly destination: BoardDestination;
 }
 
 export interface SettledDragStatusInput {
@@ -99,12 +123,32 @@ export interface SettledDragStatusInput {
 export function settledDragStatus(input: SettledDragStatusInput): string | null {
   const { latestSession, activeSession, completed, outcome } = input;
   if (completed.session !== latestSession || activeSession !== null) return null;
-  const source = `column ${completed.source.column}, position ${completed.source.position} of ${completed.source.total}`;
+  const source = `column ${completed.source.column}`;
   if (outcome === 'error') {
     return `Failed to move ${completed.identifier}. Returned to ${source}.`;
   }
-  const destination = `column ${completed.destination.column}, position ${completed.destination.position} of ${completed.destination.total}`;
-  return `Moved ${completed.identifier} from ${source}, to ${destination}.`;
+  const destination = `column ${completed.destination.column}`;
+  return `Moved ${completed.identifier} from ${source} to ${destination}.`;
+}
+
+export function moveResultWasSuperseded(
+  cached: AuthoritativeCachedIssue,
+  settled: Issue | undefined,
+  outcome: SettledDragStatusInput['outcome'],
+): boolean {
+  if (settled === undefined) return true;
+  if (cached.kind === 'missing') return outcome !== 'success';
+  if (cached.kind !== 'found') return true;
+  const current = cached.issue;
+  return (
+    current.syncId !== settled.syncId ||
+    current.stateId !== settled.stateId ||
+    current.cycleId !== settled.cycleId ||
+    current.projectId !== settled.projectId ||
+    current.assigneeId !== settled.assigneeId ||
+    current.priority !== settled.priority ||
+    current.sortOrder !== settled.sortOrder
+  );
 }
 
 export const boardCollision: CollisionDetection = (args) => {
@@ -199,19 +243,117 @@ export function dropPositionFor(
   if (overGroup === undefined) return null;
   const siblings = overGroup.issues.filter((i) => i.id !== activeId);
   const position = dropIndexFor(overGroup, activeId, overId) + 1;
-  return { column: overGroup.title, position, total: siblings.length + 1 };
+  const complete = overGroup.issues.length === overGroup.total;
+  return {
+    column: overGroup.title,
+    position,
+    ...(complete ? { total: siblings.length + 1 } : {}),
+  };
 }
 
-function currentPositionFor(groups: readonly IssueGroup[], issueId: string): BoardPosition | null {
+function currentSourceFor(groups: readonly IssueGroup[], issueId: string): BoardSource | null {
   const group = groups.find((entry) => entry.issues.some((issue) => issue.id === issueId));
   if (group === undefined) return null;
-  const index = group.issues.findIndex((issue) => issue.id === issueId);
-  if (index === -1) return null;
-  return { column: group.title, position: index + 1, total: group.issues.length };
+  const position = positionInGroup(group, issueId);
+  return position === null ? null : { ...position, groupId: group.id };
 }
 
-function boardPositionLabel(position: BoardPosition): string {
-  return `column ${position.column}, position ${position.position} of ${position.total}`;
+function newestIssueFor(groups: readonly IssueGroup[], issueId: string): Issue | undefined {
+  let newest: Issue | undefined;
+  for (const group of groups) {
+    for (const issue of group.issues) {
+      if (issue.id !== issueId) continue;
+      if (newest === undefined || issue.syncId > newest.syncId) newest = issue;
+    }
+  }
+  return newest;
+}
+
+export type DragSourceSnapshot =
+  | { readonly kind: 'missing' }
+  | { readonly kind: 'pending'; readonly issue: Issue }
+  | { readonly kind: 'ambiguous'; readonly issue: Issue }
+  | { readonly kind: 'found'; readonly issue: Issue; readonly source: BoardSource };
+
+function issueBoardFingerprint(issue: Issue): string {
+  return (
+    JSON.stringify([
+      issue.id,
+      issue.teamId,
+      issue.stateId,
+      issue.priority,
+      issue.assigneeId,
+      issue.projectId,
+      issue.cycleId,
+      issue.sortOrder,
+      issue.syncId,
+    ]) ?? ''
+  );
+}
+
+export function dragSourceSnapshotFor(
+  groups: readonly IssueGroup[],
+  issueId: string,
+  groupBy: GroupByField,
+  resolveState: StateResolver | undefined,
+): DragSourceSnapshot {
+  const occurrences = groups.flatMap((group) =>
+    group.issues.flatMap((issue) => (issue.id === issueId ? [{ group, issue }] : [])),
+  );
+  const newestSyncId = occurrences.reduce(
+    (newest, occurrence) => Math.max(newest, occurrence.issue.syncId),
+    Number.NEGATIVE_INFINITY,
+  );
+  const newest = occurrences.filter((occurrence) => occurrence.issue.syncId === newestSyncId);
+  const issue = newest[0]?.issue;
+  if (issue === undefined) return { kind: 'missing' };
+  const fingerprint = issueBoardFingerprint(issue);
+  if (newest.some((occurrence) => issueBoardFingerprint(occurrence.issue) !== fingerprint)) {
+    return { kind: 'ambiguous', issue };
+  }
+
+  let found: { readonly issue: Issue; readonly source: BoardSource } | undefined;
+  for (const occurrence of newest) {
+    if (!groupMatchesIssue(occurrence.group, occurrence.issue, groupBy, resolveState)) continue;
+    const position = positionInGroup(occurrence.group, issueId);
+    if (position === null) continue;
+    const source = { ...position, groupId: occurrence.group.id };
+    if (found === undefined) {
+      found = { issue: occurrence.issue, source };
+      continue;
+    }
+    if (found.source.groupId !== source.groupId) return { kind: 'ambiguous', issue };
+  }
+  return found === undefined ? { kind: 'pending', issue } : { kind: 'found', ...found };
+}
+
+function positionInGroup(group: IssueGroup, issueId: string): BoardPosition | null {
+  const index = group.issues.findIndex((issue) => issue.id === issueId);
+  if (index === -1) return null;
+  return {
+    column: group.title,
+    position: index + 1,
+    ...(group.issues.length === group.total ? { total: group.total } : {}),
+  };
+}
+
+function groupMatchesIssue(
+  group: IssueGroup,
+  issue: Issue,
+  groupBy: GroupByField,
+  resolveState: StateResolver | undefined,
+): boolean {
+  const groupId =
+    groupBy === 'state' && resolveState !== undefined ? resolveState(group.id, issue) : group.id;
+  if (groupId === null) return false;
+  const regrouping = regroupPatch(groupBy, groupId);
+  return regrouping !== null && regroupingLeavesIssue(regrouping, issue);
+}
+
+function boardPositionLabel(position: BoardDestination): string {
+  if (position.position === undefined) return `column ${position.column}`;
+  const total = position.total === undefined ? '' : ` of ${position.total}`;
+  return `column ${position.column}, position ${position.position}${total}`;
 }
 
 function getAdjacentColumnCard(
@@ -309,6 +451,75 @@ export function planDrop(
   };
 }
 
+export interface DragTargetSnapshot {
+  readonly overId: string;
+  readonly destination: BoardTarget;
+  readonly placement: MoveInput;
+}
+
+export type DragTargetSnapshotResult =
+  | { readonly kind: 'missing' }
+  | { readonly kind: 'ambiguous' }
+  | { readonly kind: 'found'; readonly target: DragTargetSnapshot };
+
+export function dragTargetSnapshotFor(
+  groups: readonly IssueGroup[],
+  issue: Issue,
+  overId: string,
+  groupBy: GroupByField,
+  resolveState: StateResolver | undefined,
+  reorderable: boolean,
+): DragTargetSnapshotResult {
+  const directGroup = groups.find((group) => group.id === overId);
+  let candidates: readonly IssueGroup[];
+  if (directGroup === undefined) {
+    const occurrences = groups.flatMap((group) =>
+      group.issues.flatMap((entry) => (entry.id === overId ? [{ group, issue: entry }] : [])),
+    );
+    const newestSyncId = occurrences.reduce(
+      (newest, occurrence) => Math.max(newest, occurrence.issue.syncId),
+      Number.NEGATIVE_INFINITY,
+    );
+    const newest = occurrences.filter((occurrence) => occurrence.issue.syncId === newestSyncId);
+    const targetIssue = newest[0]?.issue;
+    if (targetIssue === undefined) return { kind: 'missing' };
+    const fingerprint = issueBoardFingerprint(targetIssue);
+    if (newest.some((occurrence) => issueBoardFingerprint(occurrence.issue) !== fingerprint)) {
+      return { kind: 'ambiguous' };
+    }
+    candidates = newest
+      .filter((occurrence) =>
+        groupMatchesIssue(occurrence.group, occurrence.issue, groupBy, resolveState),
+      )
+      .map((occurrence) => occurrence.group);
+  } else {
+    candidates = [directGroup];
+  }
+
+  const targets = new Map<string, DragTargetSnapshot>();
+  for (const group of candidates) {
+    const placement = planDrop(
+      [group],
+      [issue, ...group.issues],
+      issue.id,
+      overId,
+      groupBy,
+      resolveState,
+      reorderable,
+    );
+    const position = dropPositionFor([group], issue.id, overId);
+    if (placement === null || position === null) continue;
+    const destination: BoardTarget = reorderable
+      ? { ...position, groupId: group.id }
+      : { column: position.column, groupId: group.id };
+    if (!targets.has(group.id)) targets.set(group.id, { overId, destination, placement });
+  }
+  if (targets.size === 0) return { kind: 'missing' };
+  if (targets.size > 1) return { kind: 'ambiguous' };
+  const target = targets.values().next().value;
+  return target === undefined ? { kind: 'missing' } : { kind: 'found', target };
+}
+
 export function regroupingLeavesIssue(regrouping: IssueRegrouping, issue: Issue): boolean {
   const entries = Object.entries(regrouping) as [keyof IssueRegrouping, unknown][];
   return entries.every(([field, value]) => issue[field as keyof Issue] === value);
@@ -355,12 +566,16 @@ function SortableCard({
   issue,
   lookups,
   properties,
+  disabled,
   onOpen,
+  onNode,
 }: {
   issue: Issue;
   lookups: CardLookups;
   properties: readonly DisplayProperty[];
+  disabled: boolean;
   onOpen: (id: string) => void;
+  onNode: (id: string, node: HTMLLIElement | null) => void;
 }) {
   const {
     attributes,
@@ -373,14 +588,16 @@ function SortableCard({
   } = useSortable({
     id: issue.id,
     data: { stateId: issue.stateId },
+    disabled,
     attributes: { role: 'listitem' },
   });
   const setCardNode = useCallback(
     (node: HTMLLIElement | null) => {
       setNodeRef(node);
       setActivatorNodeRef(node);
+      onNode(issue.id, node);
     },
-    [setNodeRef, setActivatorNodeRef],
+    [issue.id, onNode, setNodeRef, setActivatorNodeRef],
   );
 
   return (
@@ -397,6 +614,7 @@ function SortableCard({
           : 'cursor-grab active:cursor-grabbing',
       )}
       {...attributes}
+      aria-label={`${issue.identifier}: ${issue.title}`}
       {...listeners}
     >
       <IssueCardView issue={issue} lookups={lookups} properties={properties} onOpen={onOpen} />
@@ -407,8 +625,107 @@ function SortableCard({
 interface ActiveDragSession {
   readonly session: number;
   readonly issueId: string;
-  readonly source: BoardPosition;
-  readonly overId?: string;
+  readonly source: BoardSource;
+  readonly keyboard: boolean;
+  readonly target?: DragTargetSnapshot;
+}
+
+interface DragDelta {
+  readonly x: number;
+  readonly y: number;
+}
+
+interface BoardFocusTarget {
+  readonly issueId: string;
+  readonly fallbackGroupId?: string;
+  readonly requireIssueInFallback?: boolean;
+}
+
+interface BoardFocusOwnership {
+  readonly request: number;
+  readonly target: BoardFocusTarget;
+  readonly expectedSession?: number;
+  readonly node: HTMLElement;
+}
+
+function registeredBoardFocusNode(
+  target: BoardFocusTarget,
+  cardNodes: ReadonlyMap<string, HTMLLIElement>,
+  columnNodes: ReadonlyMap<string, HTMLUListElement>,
+): HTMLElement | undefined {
+  const card = cardNodes.get(target.issueId);
+  const fallback =
+    target.fallbackGroupId === undefined ? undefined : columnNodes.get(target.fallbackGroupId);
+  if (
+    target.requireIssueInFallback === true &&
+    card !== undefined &&
+    fallback !== undefined &&
+    !fallback.contains(card)
+  ) {
+    return fallback;
+  }
+  return card ?? fallback;
+}
+
+function boardFocusRequestIsCurrent(
+  request: number,
+  latestRequest: number,
+  expectedSession: number | undefined,
+  latestSession: number,
+  active: boolean,
+): boolean {
+  return (
+    request === latestRequest &&
+    (expectedSession === undefined || expectedSession === latestSession) &&
+    !active
+  );
+}
+
+function sameDragDelta(left: DragDelta, right: DragDelta): boolean {
+  return left.x === right.x && left.y === right.y;
+}
+
+export function sameBoardSource(left: BoardTarget, right: BoardTarget): boolean {
+  return left.groupId === right.groupId && left.position === right.position;
+}
+
+type DragEndTarget =
+  | { readonly kind: 'source' }
+  | { readonly kind: 'destination'; readonly overId: string }
+  | { readonly kind: 'invalid' };
+
+type DragSourceState =
+  | { readonly kind: 'missing' }
+  | { readonly kind: 'pending'; readonly issue: Issue }
+  | { readonly kind: 'ambiguous'; readonly issue: Issue }
+  | { readonly kind: 'moved'; readonly issue: Issue; readonly source: BoardSource }
+  | { readonly kind: 'current'; readonly issue: Issue; readonly source: BoardSource };
+
+function dragSourceStateFor(
+  groups: readonly IssueGroup[],
+  session: ActiveDragSession,
+  groupBy: GroupByField,
+  resolveState: StateResolver | undefined,
+): DragSourceState {
+  const snapshot = dragSourceSnapshotFor(groups, session.issueId, groupBy, resolveState);
+  if (snapshot.kind !== 'found') return snapshot;
+  return sameBoardSource(snapshot.source, session.source)
+    ? { kind: 'current', issue: snapshot.issue, source: snapshot.source }
+    : { kind: 'moved', issue: snapshot.issue, source: snapshot.source };
+}
+
+function dragEndTargetFor(
+  session: ActiveDragSession,
+  dragId: string,
+  eventOverId: string | null,
+): DragEndTarget {
+  if (eventOverId === null) return { kind: 'invalid' };
+  if (session.target === undefined) {
+    return dragId === eventOverId ? { kind: 'source' } : { kind: 'invalid' };
+  }
+  return session.target.overId === eventOverId
+    ? { kind: 'destination', overId: session.target.overId }
+    : { kind: 'invalid' };
 }
 
 export function Board({
@@ -424,23 +741,206 @@ export function Board({
   resolveState,
 }: BoardProps) {
   const { labelById, memberById, stateById, projects, cycles, openQuickCreate } = useWorkspace();
+  const queryClient = useQueryClient();
   const move = useMoveIssue();
   const boardPage = useBoardPage(columnSource ?? EMPTY_COLUMN, columnSource !== undefined);
   const columnsReady = columnsReadyFor(columnSource, boardPage.isPending);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [dragStatus, setDragStatus] = useState('');
   const [peekId, setPeekId] = useState<string | null>(null);
-  const [, setRowRevision] = useState(0);
+  const [loadedRowMap, setLoadedRowMap] = useState<ReadonlyMap<string, readonly Issue[]>>(
+    new Map(),
+  );
+  const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(new Set());
   const latestSession = useRef(0);
+  const latestFocusRequest = useRef(0);
+  const boardFocusOwnership = useRef<BoardFocusOwnership | undefined>(undefined);
   const activeSession = useRef<ActiveDragSession | undefined>(undefined);
-
   const columnRows = useRef<Map<string, readonly Issue[]>>(new Map());
+  const dragDelta = useRef<DragDelta>({ x: 0, y: 0 });
+  const suppressedOverDelta = useRef<DragDelta | undefined>(undefined);
+  const pendingIssueIds = useRef<Set<string>>(new Set());
+  const cardNodes = useRef<Map<string, HTMLLIElement>>(new Map());
+  const columnNodes = useRef<Map<string, HTMLUListElement>>(new Map());
+  const dragged = useRef<Issue | undefined>(undefined);
+  const sensorController = useMemo(() => createBoardSensorController(), []);
+
+  useLayoutEffect(() => {
+    if (!draggable) {
+      activeSession.current = undefined;
+      dragged.current = undefined;
+      suppressedOverDelta.current = undefined;
+      latestSession.current += 1;
+      latestFocusRequest.current += 1;
+      boardFocusOwnership.current = undefined;
+      setActiveId(null);
+      setDragStatus('');
+      return;
+    }
+    sensorController.mount();
+    return () => sensorController.unmount();
+  }, [draggable, sensorController]);
+
+  const setIssuePending = useCallback((issueId: string, pending: boolean) => {
+    if (pending) pendingIssueIds.current.add(issueId);
+    else pendingIssueIds.current.delete(issueId);
+    setPendingIds(new Set(pendingIssueIds.current));
+  }, []);
+
+  const scheduleBoardFocus = useCallback((target: BoardFocusTarget, expectedSession?: number) => {
+    const request = latestFocusRequest.current + 1;
+    latestFocusRequest.current = request;
+    boardFocusOwnership.current = undefined;
+    window.requestAnimationFrame(() => {
+      if (
+        !boardFocusRequestIsCurrent(
+          request,
+          latestFocusRequest.current,
+          expectedSession,
+          latestSession.current,
+          activeSession.current !== undefined,
+        )
+      ) {
+        return;
+      }
+      const node = registeredBoardFocusNode(target, cardNodes.current, columnNodes.current);
+      if (node === undefined || !node.isConnected) return;
+      const ownership: BoardFocusOwnership = {
+        request,
+        target,
+        node,
+        ...(expectedSession === undefined ? {} : { expectedSession }),
+      };
+      boardFocusOwnership.current = ownership;
+      node.addEventListener(
+        'blur',
+        (event) => {
+          if (event.relatedTarget !== null) {
+            if (boardFocusOwnership.current === ownership) {
+              boardFocusOwnership.current = undefined;
+            }
+            return;
+          }
+          window.requestAnimationFrame(() => {
+            if (node.isConnected && boardFocusOwnership.current === ownership) {
+              boardFocusOwnership.current = undefined;
+            }
+          });
+        },
+        { once: true },
+      );
+      node.focus();
+      if (document.activeElement !== node && boardFocusOwnership.current === ownership) {
+        boardFocusOwnership.current = undefined;
+      }
+    });
+  }, []);
+
+  const registerColumnNode = useCallback(
+    (groupId: string, node: HTMLUListElement | null) => {
+      if (node !== null) {
+        columnNodes.current.set(groupId, node);
+        return;
+      }
+      const previous = columnNodes.current.get(groupId);
+      columnNodes.current.delete(groupId);
+      const ownership = boardFocusOwnership.current;
+      if (
+        previous === undefined ||
+        ownership === undefined ||
+        ownership.node !== previous ||
+        ownership.target.fallbackGroupId !== groupId ||
+        (document.activeElement !== previous && document.activeElement !== document.body) ||
+        !boardFocusRequestIsCurrent(
+          ownership.request,
+          latestFocusRequest.current,
+          ownership.expectedSession,
+          latestSession.current,
+          activeSession.current !== undefined,
+        )
+      ) {
+        return;
+      }
+      scheduleBoardFocus(
+        { ...ownership.target, requireIssueInFallback: true },
+        ownership.expectedSession,
+      );
+    },
+    [scheduleBoardFocus],
+  );
+
+  const registerCardNode = useCallback(
+    (issueId: string, node: HTMLLIElement | null) => {
+      if (node !== null) {
+        cardNodes.current.set(issueId, node);
+        return;
+      }
+      const previous = cardNodes.current.get(issueId);
+      cardNodes.current.delete(issueId);
+      const ownership = boardFocusOwnership.current;
+      if (
+        previous === undefined ||
+        ownership === undefined ||
+        ownership.node !== previous ||
+        ownership.target.issueId !== issueId ||
+        ownership.target.fallbackGroupId === undefined ||
+        (document.activeElement !== previous && document.activeElement !== document.body) ||
+        !boardFocusRequestIsCurrent(
+          ownership.request,
+          latestFocusRequest.current,
+          ownership.expectedSession,
+          latestSession.current,
+          activeSession.current !== undefined,
+        )
+      ) {
+        return;
+      }
+      scheduleBoardFocus(
+        {
+          issueId,
+          fallbackGroupId: ownership.target.fallbackGroupId,
+          requireIssueInFallback: true,
+        },
+        ownership.expectedSession,
+      );
+    },
+    [scheduleBoardFocus],
+  );
+
+  const resetDndSensor = useCallback(
+    (status: string, focusTarget?: BoardFocusTarget) => {
+      sensorController.cancel();
+      if (focusTarget !== undefined) scheduleBoardFocus(focusTarget);
+      setDragStatus(status);
+    },
+    [scheduleBoardFocus, sensorController],
+  );
+
+  const cancelActiveDrag = useCallback(
+    (status: string, focusTarget?: BoardFocusTarget) => {
+      const session = activeSession.current;
+      activeSession.current = undefined;
+      dragged.current = undefined;
+      suppressedOverDelta.current = undefined;
+      latestSession.current += 1;
+      latestFocusRequest.current += 1;
+      boardFocusOwnership.current = undefined;
+      setActiveId(null);
+      const keyboardTarget =
+        session?.keyboard === true
+          ? { issueId: session.issueId, fallbackGroupId: session.source.groupId }
+          : undefined;
+      resetDndSensor(status, focusTarget ?? keyboardTarget);
+    },
+    [resetDndSensor],
+  );
+
   const publishRows = useCallback(
     (groupId: string, rows: readonly Issue[]) => {
       if (columnSource === undefined) return;
       if (columnRows.current.get(groupId) === rows) return;
       columnRows.current.set(groupId, rows);
-      setRowRevision((revision) => revision + 1);
+      setLoadedRowMap(new Map(columnRows.current));
     },
     [columnSource],
   );
@@ -448,10 +948,10 @@ export function Board({
   const loadedGroups = useCallback(() => {
     if (columnSource === undefined) return groups;
     return groups.map((group) => {
-      const rows = columnRows.current.get(group.id);
+      const rows = loadedRowMap.get(group.id);
       return rows === undefined || rows === group.issues ? group : { ...group, issues: rows };
     });
-  }, [groups, columnSource]);
+  }, [groups, columnSource, loadedRowMap]);
 
   const issuesInPlay = useCallback(
     () => loadedGroups().flatMap((group) => [...group.issues]),
@@ -480,44 +980,103 @@ export function Board({
   useBoardAutoScroll(activeId !== null);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    useSensor(sensorController.Pointer, { activationConstraint: { distance: 4 } }),
+    useSensor(sensorController.Keyboard, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
-  const dragged = useRef<Issue | undefined>(undefined);
   const peekIssue =
     peekId === null ? undefined : issuesInPlay().find((issue) => issue.id === peekId);
   const activeIssue = activeId === null ? undefined : dragged.current;
   const liveActiveIssue =
-    activeId === null ? undefined : issuesInPlay().find((i) => i.id === activeId);
+    activeId === null ? undefined : newestIssueFor([...loadedGroups(), ...groups], activeId);
   useEffect(() => {
-    if (
-      activeId !== null &&
-      dragged.current !== undefined &&
-      liveActiveIssue !== undefined &&
-      dragged.current.syncId !== liveActiveIssue.syncId
-    ) {
-      dragged.current = liveActiveIssue;
-      const overId = activeSession.current?.overId;
-      const heldPosition =
-        overId === undefined
-          ? currentPositionFor(loadedGroups(), liveActiveIssue.id)
-          : dropPositionFor(loadedGroups(), liveActiveIssue.id, overId);
-      const location =
-        heldPosition === null
-          ? 'at its current board position'
-          : `in ${boardPositionLabel(heldPosition)}`;
-      setDragStatus(
-        `${liveActiveIssue.identifier} was updated in the background. Still holding it ${location}.`,
+    if (activeId === null || dragged.current === undefined || liveActiveIssue !== undefined) return;
+    const identifier = dragged.current.identifier;
+    const timeout = window.setTimeout(() => {
+      if (issuesInPlay().some((issue) => issue.id === activeId)) return;
+      cancelActiveDrag(`${identifier} is no longer visible. Drag cancelled.`);
+    }, 500);
+    return () => window.clearTimeout(timeout);
+  }, [activeId, liveActiveIssue, issuesInPlay, cancelActiveDrag]);
+
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: fail-closed drag reconciliation keeps each outcome explicit
+  useEffect(() => {
+    if (activeId === null || dragged.current === undefined || liveActiveIssue === undefined) return;
+
+    const previousIssue = dragged.current;
+    const session = activeSession.current;
+    if (session === undefined) return;
+    const reconciliationGroups = [...loadedGroups(), ...groups];
+    const sourceState = dragSourceStateFor(reconciliationGroups, session, groupBy, resolveState);
+    if (sourceState.kind === 'pending' || sourceState.kind === 'missing') return;
+    if (sourceState.kind === 'ambiguous') {
+      cancelActiveDrag(
+        `${sourceState.issue.identifier}'s position changed in the background. Drag cancelled.`,
       );
+      return;
     }
-  }, [activeId, liveActiveIssue, loadedGroups]);
+    if (sourceState.kind === 'moved') {
+      cancelActiveDrag(
+        `${sourceState.issue.identifier} moved in the background to ${boardPositionLabel(sourceState.source)}. Drag cancelled.`,
+        { issueId: sourceState.issue.id, fallbackGroupId: sourceState.source.groupId },
+      );
+      return;
+    }
+    dragged.current = sourceState.issue;
+    if (previousIssue.syncId !== sourceState.issue.syncId) {
+      suppressedOverDelta.current = { ...dragDelta.current };
+    }
+    const previousTarget = session.target;
+    const targetState =
+      previousTarget === undefined
+        ? undefined
+        : dragTargetSnapshotFor(
+            reconciliationGroups,
+            sourceState.issue,
+            previousTarget.overId,
+            groupBy,
+            resolveState,
+            reorderable,
+          );
+    if (
+      previousTarget !== undefined &&
+      (targetState?.kind !== 'found' ||
+        !sameBoardSource(previousTarget.destination, targetState.target.destination))
+    ) {
+      cancelActiveDrag(
+        `${sourceState.issue.identifier}'s drop target changed in the background. Drag cancelled at ${boardPositionLabel(sourceState.source)}.`,
+        { issueId: sourceState.issue.id, fallbackGroupId: sourceState.source.groupId },
+      );
+      return;
+    }
+    activeSession.current = {
+      session: session.session,
+      issueId: session.issueId,
+      source: sourceState.source,
+      keyboard: session.keyboard,
+      ...(targetState?.kind === 'found' ? { target: targetState.target } : {}),
+    };
+  }, [
+    activeId,
+    liveActiveIssue,
+    loadedGroups,
+    groups,
+    groupBy,
+    resolveState,
+    reorderable,
+    cancelActiveDrag,
+  ]);
 
   const onDragStart = (event: DragStartEvent) => {
     const id = String(event.active.id);
+    if (pendingIssueIds.current.has(id)) return;
     const issue = issuesInPlay().find((entry) => entry.id === id);
-    const source = currentPositionFor(loadedGroups(), id);
+    const source = currentSourceFor(loadedGroups(), id);
     latestSession.current += 1;
+    latestFocusRequest.current += 1;
+    boardFocusOwnership.current = undefined;
+    dragDelta.current = { x: 0, y: 0 };
+    suppressedOverDelta.current = undefined;
     activeSession.current =
       issue === undefined || source === null
         ? undefined
@@ -525,94 +1084,268 @@ export function Board({
             session: latestSession.current,
             issueId: issue.id,
             source,
+            keyboard: event.activatorEvent.type === 'keydown',
           };
     dragged.current = issue;
-    setDragStatus('');
     setActiveId(id);
+    if (issue !== undefined && source !== null) {
+      setDragStatus(
+        `Picked up ${issue.identifier}: ${issue.title} in ${boardPositionLabel(source)}.`,
+      );
+    }
+  };
+
+  const handleDragMove = (event: DragMoveEvent) => {
+    dragDelta.current = { ...event.delta };
   };
 
   const handleDragOver = (event: DragOverEvent) => {
     const session = activeSession.current;
     if (session === undefined || session.issueId !== String(event.active.id)) return;
+    const suppressedDelta = suppressedOverDelta.current;
+    if (suppressedDelta !== undefined && sameDragDelta(suppressedDelta, event.delta)) return;
+    suppressedOverDelta.current = undefined;
+    const currentGroups = loadedGroups();
+    const currentIssues = issuesInPlay();
+    const title = currentIssues.find((issue) => issue.id === session.issueId)?.identifier ?? 'item';
     if (event.over === null) {
       activeSession.current = {
         session: session.session,
         issueId: session.issueId,
         source: session.source,
+        keyboard: session.keyboard,
+      };
+      setDragStatus(`Moving ${title} outside of the board.`);
+      return;
+    }
+    const overId = String(event.over.id);
+    if (overId === session.issueId) {
+      activeSession.current = {
+        session: session.session,
+        issueId: session.issueId,
+        source: session.source,
+        keyboard: session.keyboard,
       };
       return;
     }
-    const overId = String(event.over.id);
-    const destination = dropPositionFor(loadedGroups(), session.issueId, overId);
-    activeSession.current =
-      destination === null
-        ? {
-            session: session.session,
-            issueId: session.issueId,
-            source: session.source,
-          }
-        : { ...session, overId };
+    const heldIssue = currentIssues.find((issue) => issue.id === session.issueId);
+    const targetState =
+      heldIssue === undefined
+        ? { kind: 'missing' as const }
+        : dragTargetSnapshotFor(
+            currentGroups,
+            heldIssue,
+            overId,
+            groupBy,
+            resolveState,
+            reorderable,
+          );
+    if (targetState.kind !== 'found') {
+      activeSession.current = {
+        session: session.session,
+        issueId: session.issueId,
+        source: session.source,
+        keyboard: session.keyboard,
+      };
+      setDragStatus(`Cannot move ${title} here.`);
+      return;
+    }
+    activeSession.current = { ...session, target: targetState.target };
+    setDragStatus(`Moved ${title} to ${boardPositionLabel(targetState.target.destination)}.`);
   };
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: fail-closed drag completion keeps each outcome explicit
   const handleDragEnd = (event: DragEndEvent) => {
     const dragId = String(event.active.id);
     const session = activeSession.current;
-    activeSession.current = undefined;
-    setActiveId(null);
+    const heldIssue = dragged.current;
+    const title = heldIssue?.identifier ?? 'item';
 
-    if (event.over === null) return;
-    const overId = String(event.over.id);
-    if (dragId === overId) return;
-
-    const placement = planDrop(
-      loadedGroups(),
-      issuesInPlay(),
-      dragId,
-      overId,
-      groupBy,
-      resolveState,
-      reorderable,
-    );
-
-    const issue = issuesInPlay().find((i) => i.id === dragId);
-    const title = issue?.identifier ?? 'item';
-
-    if (placement === null) {
-      if (session !== undefined) {
-        setDragStatus(
-          `Cannot place ${title} here. Returned to ${boardPositionLabel(session.source)}.`,
-        );
-      }
+    if (session === undefined || session.session !== latestSession.current) {
+      activeSession.current = undefined;
+      suppressedOverDelta.current = undefined;
+      setActiveId(null);
+      dragged.current = undefined;
       return;
     }
+    const reconciliationGroups = [...loadedGroups(), ...groups];
+    const sourceState = dragSourceStateFor(reconciliationGroups, session, groupBy, resolveState);
+    const target = dragEndTargetFor(
+      session,
+      dragId,
+      event.over === null ? null : String(event.over.id),
+    );
+    const currentTarget =
+      sourceState.kind === 'current' && target.kind === 'destination'
+        ? dragTargetSnapshotFor(
+            reconciliationGroups,
+            sourceState.issue,
+            target.overId,
+            groupBy,
+            resolveState,
+            reorderable,
+          )
+        : undefined;
 
-    const destination = dropPositionFor(loadedGroups(), dragId, overId);
-    if (session === undefined || destination === null) return;
+    activeSession.current = undefined;
+    suppressedOverDelta.current = undefined;
+    setActiveId(null);
+    dragged.current = undefined;
+
+    if (sourceState.kind === 'missing') {
+      latestSession.current += 1;
+      if (session.keyboard) {
+        scheduleBoardFocus({ issueId: session.issueId, fallbackGroupId: session.source.groupId });
+      }
+      setDragStatus(`${title} is no longer visible. Drag cancelled.`);
+      return;
+    }
+    if (sourceState.kind === 'pending' || sourceState.kind === 'ambiguous') {
+      latestSession.current += 1;
+      if (session.keyboard) {
+        scheduleBoardFocus({ issueId: session.issueId, fallbackGroupId: session.source.groupId });
+      }
+      setDragStatus(`${sourceState.issue.identifier}'s position changed. Drag cancelled.`);
+      return;
+    }
+    if (sourceState.kind === 'moved') {
+      latestSession.current += 1;
+      scheduleBoardFocus({
+        issueId: sourceState.issue.id,
+        fallbackGroupId: sourceState.source.groupId,
+      });
+      setDragStatus(
+        `${sourceState.issue.identifier} moved in the background to ${boardPositionLabel(sourceState.source)}. Drag cancelled.`,
+      );
+      return;
+    }
+    const currentTitle = sourceState.issue.identifier;
+    if (target.kind === 'invalid') {
+      if (session.keyboard) {
+        scheduleBoardFocus(
+          { issueId: sourceState.issue.id, fallbackGroupId: session.source.groupId },
+          session.session,
+        );
+      }
+      setDragStatus(
+        `Could not drop ${currentTitle}. Returned to ${boardPositionLabel(session.source)}.`,
+      );
+      return;
+    }
+    if (target.kind === 'source') {
+      if (session.keyboard) {
+        scheduleBoardFocus(
+          { issueId: sourceState.issue.id, fallbackGroupId: session.source.groupId },
+          session.session,
+        );
+      }
+      setDragStatus(`Dropped ${currentTitle} in ${boardPositionLabel(session.source)}.`);
+      return;
+    }
+    if (
+      currentTarget?.kind !== 'found' ||
+      session.target === undefined ||
+      !sameBoardSource(session.target.destination, currentTarget.target.destination)
+    ) {
+      latestSession.current += 1;
+      scheduleBoardFocus({
+        issueId: sourceState.issue.id,
+        fallbackGroupId: sourceState.source.groupId,
+      });
+      setDragStatus(
+        `${currentTitle}'s drop target changed in the background. Drag cancelled at ${boardPositionLabel(sourceState.source)}.`,
+      );
+      return;
+    }
+    const placement = currentTarget.target.placement;
+    const destination = currentTarget.target.destination;
+
     const completed: CompletedDrag = {
       session: session.session,
-      identifier: title,
+      identifier: currentTitle,
       source: session.source,
       destination,
     };
-    const publishResult = (outcome: SettledDragStatusInput['outcome']) => {
+    const publishResult = (
+      outcome: SettledDragStatusInput['outcome'],
+      settled: Issue | undefined,
+    ) => {
+      const cached = authoritativeCachedIssue(queryClient, dragId);
       const status = settledDragStatus({
         latestSession: latestSession.current,
         activeSession: activeSession.current?.session ?? null,
         completed,
         outcome,
       });
-      if (status !== null) setDragStatus(status);
+      if (status === null) return;
+      if (moveResultWasSuperseded(cached, settled, outcome)) {
+        setDragStatus(
+          `${currentTitle} changed again while the move finished. Showing the latest version.`,
+        );
+        return;
+      }
+      setDragStatus(status);
     };
 
-    move.mutate(placement, {
-      onSuccess: () => publishResult('success'),
-      onError: () => publishResult('error'),
-    });
+    const restoreCompletedKeyboardFocus = (fallbackGroupId: string) => {
+      if (
+        session.keyboard &&
+        latestSession.current === completed.session &&
+        activeSession.current === undefined
+      ) {
+        scheduleBoardFocus(
+          {
+            issueId: dragId,
+            fallbackGroupId,
+            requireIssueInFallback: true,
+          },
+          completed.session,
+        );
+      }
+    };
+    setIssuePending(dragId, true);
+    setDragStatus(
+      `Dropping ${currentTitle} from ${boardPositionLabel(session.source)} to ${boardPositionLabel(destination)}.`,
+    );
+    move
+      .mutateAsync(placement)
+      .then(
+        (moved) => {
+          publishResult(
+            'success',
+            moved.find((issue) => issue.id === dragId),
+          );
+          setIssuePending(dragId, false);
+          restoreCompletedKeyboardFocus(destination.groupId);
+        },
+        () => {
+          publishResult('error', placement.issue);
+          setIssuePending(dragId, false);
+          restoreCompletedKeyboardFocus(session.source.groupId);
+        },
+      )
+      .catch(() => undefined);
   };
 
   const handleDragCancel = () => {
+    const session = activeSession.current;
+    const issue = dragged.current;
+    if (session === undefined && issue === undefined) return;
     activeSession.current = undefined;
+    dragged.current = undefined;
+    suppressedOverDelta.current = undefined;
     setActiveId(null);
+    if (session !== undefined && issue !== undefined) {
+      if (session.keyboard) {
+        scheduleBoardFocus(
+          { issueId: issue.id, fallbackGroupId: session.source.groupId },
+          session.session,
+        );
+      }
+      setDragStatus(
+        `Cancelled dragging ${issue.identifier}. Returned to ${boardPositionLabel(session.source)}.`,
+      );
+    }
   };
 
   const handleBoardKeyDown = (e: React.KeyboardEvent) => {
@@ -634,67 +1367,18 @@ export function Board({
   const accessibility = useMemo(
     () => ({
       announcements: {
-        onDragStart({ active }: DragStartEvent) {
-          const issue = issuesInPlay().find((i) => i.id === active.id);
-          if (issue === undefined) return 'Picked up item.';
-          const source = currentPositionFor(loadedGroups(), String(active.id));
-          const location = source === null ? '' : ` in ${boardPositionLabel(source)}`;
-          return `Picked up ${issue.identifier}: ${issue.title}${location}.`;
-        },
-        onDragOver({ active, over }: DragOverEvent) {
-          if (over === null) return 'Moving item outside of board.';
-          if (active.id === over.id) return undefined;
-
-          const dragId = String(active.id);
-          const overId = String(over.id);
-          const issue = issuesInPlay().find((i) => i.id === dragId);
-          const title = issue === undefined ? 'item' : issue.identifier;
-
-          const placement = planDrop(
-            loadedGroups(),
-            issuesInPlay(),
-            dragId,
-            overId,
-            groupBy,
-            resolveState,
-            reorderable,
-          );
-
-          if (placement === null) return `Cannot move ${title} here.`;
-
-          const info = dropPositionFor(loadedGroups(), dragId, overId);
-          if (info !== null) {
-            return `Moved ${title} to column ${info.column}, position ${info.position} of ${info.total}.`;
-          }
-          return `Moved ${title}.`;
-        },
-        onDragEnd({ active, over }: DragEndEvent) {
-          const title = issuesInPlay().find((i) => i.id === active.id)?.identifier ?? 'item';
-          const source = currentPositionFor(loadedGroups(), String(active.id));
-          const sourceLabel =
-            source === null ? 'its original position' : boardPositionLabel(source);
-          if (over === null) return `Could not drop ${title}. Returned to ${sourceLabel}.`;
-          if (active.id === over.id) return `Dropped ${title} in ${sourceLabel}.`;
-          const destination = dropPositionFor(loadedGroups(), String(active.id), String(over.id));
-          if (destination === null) {
-            return `Could not drop ${title}. Returned to ${sourceLabel}.`;
-          }
-          return `Dropping ${title} from ${sourceLabel} to ${boardPositionLabel(destination)}.`;
-        },
-        onDragCancel({ active }: DragCancelEvent) {
-          const issue = issuesInPlay().find((i) => i.id === active.id);
-          if (issue === undefined) return 'Cancelled drag.';
-          const source = currentPositionFor(loadedGroups(), String(active.id));
-          const location = source === null ? 'its original position' : boardPositionLabel(source);
-          return `Cancelled dragging ${issue.identifier}. Returned to ${location}.`;
-        },
+        onDragStart: () => undefined,
+        onDragOver: () => undefined,
+        onDragEnd: () => undefined,
+        onDragCancel: () => undefined,
       },
+      restoreFocus: false,
       screenReaderInstructions: {
         draggable:
           'To pick up this issue, press Space or Enter. While dragging, use the arrow keys to move it. Press Space or Enter again to drop, or Escape to cancel.',
       },
     }),
-    [issuesInPlay, loadedGroups, groupBy, resolveState, reorderable],
+    [],
   );
 
   const columns = (
@@ -712,7 +1396,10 @@ export function Board({
           onLoadMore={onLoadMore}
           columnSource={columnSource}
           columnsReady={columnsReady}
+          pendingIssueIds={pendingIds}
           onCreate={() => openQuickCreate()}
+          onCardNode={registerCardNode}
+          onColumnNode={registerColumnNode}
           onOpen={setPeekId}
           onRows={publishRows}
         />
@@ -737,6 +1424,7 @@ export function Board({
       collisionDetection={boardCollision}
       accessibility={accessibility}
       onDragStart={onDragStart}
+      onDragMove={handleDragMove}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
@@ -774,7 +1462,10 @@ interface BoardColumnProps {
   readonly onLoadMore: (() => void) | undefined;
   readonly columnSource: BoardColumnSource | undefined;
   readonly columnsReady: boolean;
+  readonly pendingIssueIds: ReadonlySet<string>;
   readonly onCreate: () => void;
+  readonly onCardNode: (id: string, node: HTMLLIElement | null) => void;
+  readonly onColumnNode: (id: string, node: HTMLUListElement | null) => void;
   readonly onOpen: (id: string) => void;
   readonly onRows: (groupId: string, issues: readonly Issue[]) => void;
 }
@@ -789,7 +1480,10 @@ function BoardColumn({
   onLoadMore,
   columnSource,
   columnsReady,
+  pendingIssueIds,
   onCreate,
+  onCardNode,
+  onColumnNode,
   onOpen,
   onRows,
 }: BoardColumnProps) {
@@ -809,7 +1503,7 @@ function BoardColumn({
     [ownsData, columnSource, fetched, group.issues, stateById],
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     onRows(group.id, issues);
   }, [onRows, group.id, issues]);
   const columnHasMore = ownsData ? owned.hasNextPage : hasMore;
@@ -867,9 +1561,10 @@ function BoardColumn({
   const setScrollNode = useCallback(
     (node: HTMLUListElement | null) => {
       scrollRef.current = node;
+      onColumnNode(group.id, node);
       if (draggable) setNodeRef(node);
     },
-    [draggable, setNodeRef],
+    [draggable, group.id, onColumnNode, setNodeRef],
   );
 
   const cards = visibleIssues.map((issue) =>
@@ -879,6 +1574,8 @@ function BoardColumn({
         issue={issue}
         lookups={lookups}
         properties={properties}
+        disabled={pendingIssueIds.has(issue.id)}
+        onNode={onCardNode}
         onOpen={onOpen}
       />
     ) : (
@@ -899,7 +1596,8 @@ function BoardColumn({
     </>
   );
 
-  const listClass = 'flex min-h-24 flex-1 flex-col gap-2 overflow-y-auto p-2 pt-0';
+  const listClass =
+    'flex min-h-24 flex-1 flex-col gap-2 overflow-y-auto rounded-b-lg p-2 pt-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent';
 
   return (
     <section
@@ -932,13 +1630,25 @@ function BoardColumn({
           items={visibleIssues.map((issue) => issue.id)}
           strategy={verticalListSortingStrategy}
         >
-          <ul ref={setScrollNode} onScroll={markScrolled} className={listClass}>
+          <ul
+            ref={setScrollNode}
+            onScroll={markScrolled}
+            className={listClass}
+            tabIndex={-1}
+            aria-label={`${group.title} issues`}
+          >
             {cards}
             {footer}
           </ul>
         </SortableContext>
       ) : (
-        <ul ref={scrollRef} onScroll={markScrolled} className={listClass}>
+        <ul
+          ref={setScrollNode}
+          onScroll={markScrolled}
+          className={listClass}
+          tabIndex={-1}
+          aria-label={`${group.title} issues`}
+        >
           {cards}
           {footer}
         </ul>

--- a/apps/web/src/features/issues/board.tsx
+++ b/apps/web/src/features/issues/board.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import {
-type CollisionDetection,
+  type CollisionDetection,
   DndContext,
-  type DragEndEvent,
-  type DragStartEvent,
-  type DragOverEvent,
   type DragCancelEvent,
+  type DragEndEvent,
+  type DragOverEvent,
   DragOverlay,
+  type DragStartEvent,
   KeyboardSensor,
   PointerSensor,
   pointerWithin,
@@ -148,6 +148,65 @@ function neighboursIn(
     before: insertAt === 0 ? null : (siblings[insertAt - 1] ?? null),
     after: siblings[insertAt] ?? null,
   };
+}
+
+function getNewPosition(
+  groups: readonly IssueGroup[],
+  activeId: string,
+  overId: string,
+): { column: string; pos: number; total: number } | null {
+  const overGroup = targetGroupFor(groups, overId);
+  if (overGroup === undefined) return null;
+  const siblings = overGroup.issues.filter((i) => i.id !== activeId);
+  let overIndex = siblings.findIndex((i) => i.id === overId);
+  if (overGroup.id === overId) overIndex = siblings.length;
+  const pos = (overIndex === -1 ? siblings.length : overIndex) + 1;
+  return { column: overGroup.title, pos, total: siblings.length + 1 };
+}
+
+function getAdjacentColumnCard(
+  columns: Element[],
+  targetColIndex: number,
+  currentCardIndex: number,
+): HTMLElement | null {
+  const col = columns[targetColIndex];
+  if (col === undefined) return null;
+  const cards = Array.from(col.querySelectorAll('li[tabindex]'));
+  if (cards.length === 0) return null;
+  const safeIndex = Math.max(0, Math.min(currentCardIndex, cards.length - 1));
+  return (cards[safeIndex] ?? null) as HTMLElement | null;
+}
+
+function getDOMIndices(currentFocus: Element): {
+  cols: Element[];
+  colIndex: number;
+  cardsInCol: Element[];
+  cardIndex: number;
+} | null {
+  const currentCol = currentFocus.closest('[data-testid^="board-column-"]');
+  if (currentCol === null) return null;
+  const cols = Array.from(document.querySelectorAll('[data-testid^="board-column-"]'));
+  const cardsInCol = Array.from(currentCol.querySelectorAll('li[tabindex]'));
+  return {
+    cols,
+    colIndex: cols.indexOf(currentCol),
+    cardsInCol,
+    cardIndex: cardsInCol.indexOf(currentFocus),
+  };
+}
+
+function getNextCardTarget(
+  key: string,
+  cols: Element[],
+  colIndex: number,
+  cardsInCol: Element[],
+  cardIndex: number,
+): HTMLElement | null {
+  if (key === 'ArrowDown') return (cardsInCol[cardIndex + 1] ?? null) as HTMLElement | null;
+  if (key === 'ArrowUp') return (cardsInCol[cardIndex - 1] ?? null) as HTMLElement | null;
+  if (key === 'ArrowRight') return getAdjacentColumnCard(cols, colIndex + 1, cardIndex);
+  if (key === 'ArrowLeft') return getAdjacentColumnCard(cols, colIndex - 1, cardIndex);
+  return null;
 }
 
 export function planDrop(
@@ -345,6 +404,22 @@ export function Board({
   const peekIssue =
     peekId === null ? undefined : issuesInPlay().find((issue) => issue.id === peekId);
   const activeIssue = activeId === null ? undefined : dragged.current;
+  const liveActiveIssue =
+    activeId === null ? undefined : issuesInPlay().find((i) => i.id === activeId);
+  useEffect(() => {
+    if (
+      activeId !== null &&
+      dragged.current !== undefined &&
+      liveActiveIssue !== undefined &&
+      dragged.current.updatedAt !== liveActiveIssue.updatedAt
+    ) {
+      dragged.current = liveActiveIssue;
+      const el = document.querySelector('[id^="DndLiveRegion-"][aria-live="assertive"]');
+      if (el !== null) {
+        el.textContent = `Note: ${liveActiveIssue.identifier} was updated in the background.`;
+      }
+    }
+  }, [activeId, liveActiveIssue]);
 
   const onDragStart = (event: DragStartEvent) => {
     const id = String(event.active.id);
@@ -352,22 +427,65 @@ export function Board({
     setActiveId(id);
   };
 
-  const onDragEnd = (event: DragEndEvent) => {
+  const handleDragEnd = (event: DragEndEvent) => {
+    const dragId = String(event.active.id);
     setActiveId(null);
+
+    const announce = (msg: string) => {
+      setTimeout(() => {
+        const el = document.querySelector('[id^="DndLiveRegion-"][aria-live="assertive"]');
+        if (el !== null) el.textContent = msg;
+      }, 50);
+    };
+
     if (event.over === null) return;
+    const overId = String(event.over.id);
+    if (dragId === overId) return;
+
     const placement = planDrop(
       loadedGroups(),
       issuesInPlay(),
-      String(event.active.id),
-      String(event.over.id),
+      dragId,
+      overId,
       groupBy,
       resolveState,
       reorderable,
     );
-    if (placement !== null) move.mutate(placement);
+
+    const issue = issuesInPlay().find((i) => i.id === dragId);
+    const title = issue?.identifier ?? 'item';
+
+    if (placement === null) {
+      announce(`Cannot place ${title} here. Returned to original position.`);
+      return;
+    }
+
+    const info = getNewPosition(loadedGroups(), dragId, overId);
+    const dest = info === null ? 'new position' : `column ${info.column}, position ${info.pos}`;
+
+    move.mutate(placement, {
+      onSuccess: () => announce(`Successfully dropped ${title} in ${dest}.`),
+      onError: () => announce(`Failed to move ${title}. Returned to original position.`),
+    });
   };
 
-const accessibility = useMemo(
+  const handleBoardKeyDown = (e: React.KeyboardEvent) => {
+    if (activeId !== null) return;
+    if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+
+    const currentFocus = document.activeElement;
+    if (currentFocus === null) return;
+    const dom = getDOMIndices(currentFocus);
+    if (dom === null) return;
+
+    e.preventDefault();
+    const { cols, colIndex, cardsInCol, cardIndex } = dom;
+
+    const nextFocus = getNextCardTarget(e.key, cols, colIndex, cardsInCol, cardIndex);
+    if (nextFocus !== null) nextFocus.focus();
+  };
+
+  const accessibility = useMemo(
     () => ({
       announcements: {
         onDragStart({ active }: DragStartEvent) {
@@ -375,82 +493,42 @@ const accessibility = useMemo(
           if (issue === undefined) return 'Picked up item.';
           const group = loadedGroups().find((g) => g.issues.some((r) => r.id === active.id));
           const groupName = group === undefined ? '' : ` in column ${group.title}`;
-          return `Picked up ${issue.identifier}: ${issue.title}${groupName}.`;
+          const siblings = group?.issues ?? [];
+          const pos = siblings.findIndex((i) => i.id === active.id) + 1;
+          return `Picked up ${issue.identifier}: ${issue.title}${groupName}, position ${pos} of ${siblings.length}.`;
         },
         onDragOver({ active, over }: DragOverEvent) {
-          if (over === null) return 'Moving item.';
-          const activeId = String(active.id);
+          if (over === null) return 'Moving item outside of board.';
+          if (active.id === over.id) return undefined;
+
+          const dragId = String(active.id);
           const overId = String(over.id);
-          const issue = issuesInPlay().find((i) => i.id === activeId);
+          const issue = issuesInPlay().find((i) => i.id === dragId);
           const title = issue === undefined ? 'item' : issue.identifier;
-
-          const overGroup = loadedGroups().find((g) => g.id === g.id && g.id === overId) ?? targetGroupFor(loadedGroups(), overId);
-          if (overGroup !== undefined) {
-            const placement = planDrop(
-              loadedGroups(),
-              issuesInPlay(),
-              activeId,
-              overId,
-              groupBy,
-              resolveState,
-              reorderable,
-            );
-            if (placement === null) {
-              return `Cannot move ${title} to column ${overGroup.title}.`;
-            }
-            return `Moved ${title} to column ${overGroup.title}.`;
-          }
-
-          const overIssue = issuesInPlay().find((i) => i.id === overId);
-          if (overIssue !== undefined) {
-            const group = loadedGroups().find((g) =>
-              g.issues.some((row) => row.id === overIssue.id)
-            );
-            if (group !== undefined) {
-              return `Moved ${title} over ${overIssue.identifier} in column ${group.title}.`;
-            }
-          }
-
-          return `Moved ${title}.`;
-        },
-        onDragEnd({ active, over }: DragEndEvent) {
-          const activeId = String(active.id);
-          const issue = issuesInPlay().find((i) => i.id === activeId);
-          const title = issue === undefined ? 'item' : issue.identifier;
-
-          if (over === null) return `Dropped ${title}.`;
-          const overId = String(over.id);
 
           const placement = planDrop(
             loadedGroups(),
             issuesInPlay(),
-            activeId,
+            dragId,
             overId,
             groupBy,
             resolveState,
             reorderable,
           );
 
-          if (placement === null) {
-            return `Cannot place ${title} here. Released ${title}.`;
-          }
+          if (placement === null) return `Cannot move ${title} here.`;
 
-          const overGroup = loadedGroups().find((g) => g.id === overId);
-          if (overGroup !== undefined) {
-            return `Dropped ${title} in column ${overGroup.title}.`;
+          const info = getNewPosition(loadedGroups(), dragId, overId);
+          if (info !== null) {
+            return `Moved ${title} to column ${info.column}, position ${info.pos} of ${info.total}.`;
           }
-
-          const overIssue = issuesInPlay().find((i) => i.id === overId);
-          if (overIssue !== undefined) {
-            const group = loadedGroups().find((g) =>
-              g.issues.some((row) => row.id === overIssue.id)
-            );
-            if (group !== undefined) {
-              return `Dropped ${title} in column ${group.title}.`;
-            }
-          }
-
-          return `Dropped ${title}.`;
+          return `Moved ${title}.`;
+        },
+        onDragEnd({ active, over }: DragEndEvent) {
+          const title = issuesInPlay().find((i) => i.id === active.id)?.identifier ?? 'item';
+          if (over === null) return `Could not drop ${title}. Returned to original position.`;
+          if (active.id === over.id) return `Dropped ${title} in original position.`;
+          return `Dropping ${title}...`;
         },
         onDragCancel({ active }: DragCancelEvent) {
           const issue = issuesInPlay().find((i) => i.id === active.id);
@@ -463,12 +541,12 @@ const accessibility = useMemo(
           'To pick up this issue, press Space or Enter. While dragging, use the arrow keys to move it. Press Space or Enter again to drop, or Escape to cancel.',
       },
     }),
-    [issuesInPlay, loadedGroups, groupBy, resolveState, reorderable]
+    [issuesInPlay, loadedGroups, groupBy, resolveState, reorderable],
   );
 
-
   const columns = (
-    <div className="flex h-full min-h-0 gap-3 overflow-x-auto p-3">
+    // biome-ignore lint/a11y/noStaticElementInteractions: event delegation for focus management
+    <div className="flex h-full min-h-0 gap-3 overflow-x-auto p-3" onKeyDown={handleBoardKeyDown}>
       {groups.map((group) => (
         <BoardColumn
           key={group.id}
@@ -502,11 +580,11 @@ const accessibility = useMemo(
 
   return (
     <DndContext
-     sensors={sensors}
+      sensors={sensors}
       collisionDetection={boardCollision}
       accessibility={accessibility}
       onDragStart={onDragStart}
-      onDragEnd={onDragEnd}
+      onDragEnd={handleDragEnd}
       onDragCancel={() => setActiveId(null)}
     >
       {columns}

--- a/apps/web/src/features/issues/board.tsx
+++ b/apps/web/src/features/issues/board.tsx
@@ -76,6 +76,37 @@ export function columnsReadyFor(columnSource: object | undefined, boardPending: 
   return columnSource === undefined || !boardPending;
 }
 
+export interface BoardPosition {
+  readonly column: string;
+  readonly position: number;
+  readonly total: number;
+}
+
+export interface CompletedDrag {
+  readonly session: number;
+  readonly identifier: string;
+  readonly source: BoardPosition;
+  readonly destination: BoardPosition;
+}
+
+export interface SettledDragStatusInput {
+  readonly latestSession: number;
+  readonly activeSession: number | null;
+  readonly completed: CompletedDrag;
+  readonly outcome: 'success' | 'error';
+}
+
+export function settledDragStatus(input: SettledDragStatusInput): string | null {
+  const { latestSession, activeSession, completed, outcome } = input;
+  if (completed.session !== latestSession || activeSession !== null) return null;
+  const source = `column ${completed.source.column}, position ${completed.source.position} of ${completed.source.total}`;
+  if (outcome === 'error') {
+    return `Failed to move ${completed.identifier}. Returned to ${source}.`;
+  }
+  const destination = `column ${completed.destination.column}, position ${completed.destination.position} of ${completed.destination.total}`;
+  return `Moved ${completed.identifier} from ${source}, to ${destination}.`;
+}
+
 export const boardCollision: CollisionDetection = (args) => {
   const under = pointerWithin(args);
   return under.length > 0 ? under : rectIntersection(args);
@@ -142,26 +173,45 @@ function neighboursIn(
   overId: string,
 ): { before: Issue | null; after: Issue | null } {
   const siblings = group.issues.filter((issue) => issue.id !== dragged.id);
-  const overIndex = siblings.findIndex((issue) => issue.id === overId);
-  const insertAt = overIndex === -1 ? siblings.length : overIndex;
+  const insertAt = dropIndexFor(group, dragged.id, overId);
   return {
     before: insertAt === 0 ? null : (siblings[insertAt - 1] ?? null),
     after: siblings[insertAt] ?? null,
   };
 }
 
-function getNewPosition(
+function dropIndexFor(group: IssueGroup, activeId: string, overId: string): number {
+  const activeIndex = group.issues.findIndex((issue) => issue.id === activeId);
+  const targetIndex = group.issues.findIndex((issue) => issue.id === overId);
+  const siblings = group.issues.filter((issue) => issue.id !== activeId);
+  const targetWithoutActive = siblings.findIndex((issue) => issue.id === overId);
+  if (targetWithoutActive === -1) return siblings.length;
+  const movingDown = activeIndex !== -1 && targetIndex !== -1 && activeIndex < targetIndex;
+  return targetWithoutActive + (movingDown ? 1 : 0);
+}
+
+export function dropPositionFor(
   groups: readonly IssueGroup[],
   activeId: string,
   overId: string,
-): { column: string; pos: number; total: number } | null {
+): BoardPosition | null {
   const overGroup = targetGroupFor(groups, overId);
   if (overGroup === undefined) return null;
   const siblings = overGroup.issues.filter((i) => i.id !== activeId);
-  let overIndex = siblings.findIndex((i) => i.id === overId);
-  if (overGroup.id === overId) overIndex = siblings.length;
-  const pos = (overIndex === -1 ? siblings.length : overIndex) + 1;
-  return { column: overGroup.title, pos, total: siblings.length + 1 };
+  const position = dropIndexFor(overGroup, activeId, overId) + 1;
+  return { column: overGroup.title, position, total: siblings.length + 1 };
+}
+
+function currentPositionFor(groups: readonly IssueGroup[], issueId: string): BoardPosition | null {
+  const group = groups.find((entry) => entry.issues.some((issue) => issue.id === issueId));
+  if (group === undefined) return null;
+  const index = group.issues.findIndex((issue) => issue.id === issueId);
+  if (index === -1) return null;
+  return { column: group.title, position: index + 1, total: group.issues.length };
+}
+
+function boardPositionLabel(position: BoardPosition): string {
+  return `column ${position.column}, position ${position.position} of ${position.total}`;
 }
 
 function getAdjacentColumnCard(
@@ -187,11 +237,13 @@ function getDOMIndices(currentFocus: Element): {
   if (currentCol === null) return null;
   const cols = Array.from(document.querySelectorAll('[data-testid^="board-column-"]'));
   const cardsInCol = Array.from(currentCol.querySelectorAll('li[tabindex]'));
+  const cardIndex = cardsInCol.indexOf(currentFocus);
+  if (cardIndex === -1) return null;
   return {
     cols,
     colIndex: cols.indexOf(currentCol),
     cardsInCol,
-    cardIndex: cardsInCol.indexOf(currentFocus),
+    cardIndex,
   };
 }
 
@@ -310,14 +362,30 @@ function SortableCard({
   properties: readonly DisplayProperty[];
   onOpen: (id: string) => void;
 }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
     id: issue.id,
     data: { stateId: issue.stateId },
+    attributes: { role: 'listitem' },
   });
+  const setCardNode = useCallback(
+    (node: HTMLLIElement | null) => {
+      setNodeRef(node);
+      setActivatorNodeRef(node);
+    },
+    [setNodeRef, setActivatorNodeRef],
+  );
 
   return (
     <li
-      ref={setNodeRef}
+      ref={setCardNode}
       style={{
         transform: CSS.Translate.toString(transform),
         transition: transition ?? 'transform 140ms var(--ease-out-orbit)',
@@ -334,6 +402,13 @@ function SortableCard({
       <IssueCardView issue={issue} lookups={lookups} properties={properties} onOpen={onOpen} />
     </li>
   );
+}
+
+interface ActiveDragSession {
+  readonly session: number;
+  readonly issueId: string;
+  readonly source: BoardPosition;
+  readonly overId?: string;
 }
 
 export function Board({
@@ -353,21 +428,30 @@ export function Board({
   const boardPage = useBoardPage(columnSource ?? EMPTY_COLUMN, columnSource !== undefined);
   const columnsReady = columnsReadyFor(columnSource, boardPage.isPending);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [dragStatus, setDragStatus] = useState('');
   const [peekId, setPeekId] = useState<string | null>(null);
+  const [, setRowRevision] = useState(0);
+  const latestSession = useRef(0);
+  const activeSession = useRef<ActiveDragSession | undefined>(undefined);
 
   const columnRows = useRef<Map<string, readonly Issue[]>>(new Map());
-  const publishRows = useCallback((groupId: string, rows: readonly Issue[]) => {
-    columnRows.current.set(groupId, rows);
-  }, []);
-
-  const loadedGroups = useCallback(
-    () =>
-      groups.map((group) => {
-        const rows = columnRows.current.get(group.id);
-        return rows === undefined || rows === group.issues ? group : { ...group, issues: rows };
-      }),
-    [groups],
+  const publishRows = useCallback(
+    (groupId: string, rows: readonly Issue[]) => {
+      if (columnSource === undefined) return;
+      if (columnRows.current.get(groupId) === rows) return;
+      columnRows.current.set(groupId, rows);
+      setRowRevision((revision) => revision + 1);
+    },
+    [columnSource],
   );
+
+  const loadedGroups = useCallback(() => {
+    if (columnSource === undefined) return groups;
+    return groups.map((group) => {
+      const rows = columnRows.current.get(group.id);
+      return rows === undefined || rows === group.issues ? group : { ...group, issues: rows };
+    });
+  }, [groups, columnSource]);
 
   const issuesInPlay = useCallback(
     () => loadedGroups().flatMap((group) => [...group.issues]),
@@ -411,32 +495,70 @@ export function Board({
       activeId !== null &&
       dragged.current !== undefined &&
       liveActiveIssue !== undefined &&
-      dragged.current.updatedAt !== liveActiveIssue.updatedAt
+      dragged.current.syncId !== liveActiveIssue.syncId
     ) {
       dragged.current = liveActiveIssue;
-      const el = document.querySelector('[id^="DndLiveRegion-"][aria-live="assertive"]');
-      if (el !== null) {
-        el.textContent = `Note: ${liveActiveIssue.identifier} was updated in the background.`;
-      }
+      const overId = activeSession.current?.overId;
+      const heldPosition =
+        overId === undefined
+          ? currentPositionFor(loadedGroups(), liveActiveIssue.id)
+          : dropPositionFor(loadedGroups(), liveActiveIssue.id, overId);
+      const location =
+        heldPosition === null
+          ? 'at its current board position'
+          : `in ${boardPositionLabel(heldPosition)}`;
+      setDragStatus(
+        `${liveActiveIssue.identifier} was updated in the background. Still holding it ${location}.`,
+      );
     }
-  }, [activeId, liveActiveIssue]);
+  }, [activeId, liveActiveIssue, loadedGroups]);
 
   const onDragStart = (event: DragStartEvent) => {
     const id = String(event.active.id);
-    dragged.current = issuesInPlay().find((issue) => issue.id === id);
+    const issue = issuesInPlay().find((entry) => entry.id === id);
+    const source = currentPositionFor(loadedGroups(), id);
+    latestSession.current += 1;
+    activeSession.current =
+      issue === undefined || source === null
+        ? undefined
+        : {
+            session: latestSession.current,
+            issueId: issue.id,
+            source,
+          };
+    dragged.current = issue;
+    setDragStatus('');
     setActiveId(id);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    const session = activeSession.current;
+    if (session === undefined || session.issueId !== String(event.active.id)) return;
+    if (event.over === null) {
+      activeSession.current = {
+        session: session.session,
+        issueId: session.issueId,
+        source: session.source,
+      };
+      return;
+    }
+    const overId = String(event.over.id);
+    const destination = dropPositionFor(loadedGroups(), session.issueId, overId);
+    activeSession.current =
+      destination === null
+        ? {
+            session: session.session,
+            issueId: session.issueId,
+            source: session.source,
+          }
+        : { ...session, overId };
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
     const dragId = String(event.active.id);
+    const session = activeSession.current;
+    activeSession.current = undefined;
     setActiveId(null);
-
-    const announce = (msg: string) => {
-      setTimeout(() => {
-        const el = document.querySelector('[id^="DndLiveRegion-"][aria-live="assertive"]');
-        if (el !== null) el.textContent = msg;
-      }, 50);
-    };
 
     if (event.over === null) return;
     const overId = String(event.over.id);
@@ -456,17 +578,41 @@ export function Board({
     const title = issue?.identifier ?? 'item';
 
     if (placement === null) {
-      announce(`Cannot place ${title} here. Returned to original position.`);
+      if (session !== undefined) {
+        setDragStatus(
+          `Cannot place ${title} here. Returned to ${boardPositionLabel(session.source)}.`,
+        );
+      }
       return;
     }
 
-    const info = getNewPosition(loadedGroups(), dragId, overId);
-    const dest = info === null ? 'new position' : `column ${info.column}, position ${info.pos}`;
+    const destination = dropPositionFor(loadedGroups(), dragId, overId);
+    if (session === undefined || destination === null) return;
+    const completed: CompletedDrag = {
+      session: session.session,
+      identifier: title,
+      source: session.source,
+      destination,
+    };
+    const publishResult = (outcome: SettledDragStatusInput['outcome']) => {
+      const status = settledDragStatus({
+        latestSession: latestSession.current,
+        activeSession: activeSession.current?.session ?? null,
+        completed,
+        outcome,
+      });
+      if (status !== null) setDragStatus(status);
+    };
 
     move.mutate(placement, {
-      onSuccess: () => announce(`Successfully dropped ${title} in ${dest}.`),
-      onError: () => announce(`Failed to move ${title}. Returned to original position.`),
+      onSuccess: () => publishResult('success'),
+      onError: () => publishResult('error'),
     });
+  };
+
+  const handleDragCancel = () => {
+    activeSession.current = undefined;
+    setActiveId(null);
   };
 
   const handleBoardKeyDown = (e: React.KeyboardEvent) => {
@@ -491,11 +637,9 @@ export function Board({
         onDragStart({ active }: DragStartEvent) {
           const issue = issuesInPlay().find((i) => i.id === active.id);
           if (issue === undefined) return 'Picked up item.';
-          const group = loadedGroups().find((g) => g.issues.some((r) => r.id === active.id));
-          const groupName = group === undefined ? '' : ` in column ${group.title}`;
-          const siblings = group?.issues ?? [];
-          const pos = siblings.findIndex((i) => i.id === active.id) + 1;
-          return `Picked up ${issue.identifier}: ${issue.title}${groupName}, position ${pos} of ${siblings.length}.`;
+          const source = currentPositionFor(loadedGroups(), String(active.id));
+          const location = source === null ? '' : ` in ${boardPositionLabel(source)}`;
+          return `Picked up ${issue.identifier}: ${issue.title}${location}.`;
         },
         onDragOver({ active, over }: DragOverEvent) {
           if (over === null) return 'Moving item outside of board.';
@@ -518,22 +662,31 @@ export function Board({
 
           if (placement === null) return `Cannot move ${title} here.`;
 
-          const info = getNewPosition(loadedGroups(), dragId, overId);
+          const info = dropPositionFor(loadedGroups(), dragId, overId);
           if (info !== null) {
-            return `Moved ${title} to column ${info.column}, position ${info.pos} of ${info.total}.`;
+            return `Moved ${title} to column ${info.column}, position ${info.position} of ${info.total}.`;
           }
           return `Moved ${title}.`;
         },
         onDragEnd({ active, over }: DragEndEvent) {
           const title = issuesInPlay().find((i) => i.id === active.id)?.identifier ?? 'item';
-          if (over === null) return `Could not drop ${title}. Returned to original position.`;
-          if (active.id === over.id) return `Dropped ${title} in original position.`;
-          return `Dropping ${title}...`;
+          const source = currentPositionFor(loadedGroups(), String(active.id));
+          const sourceLabel =
+            source === null ? 'its original position' : boardPositionLabel(source);
+          if (over === null) return `Could not drop ${title}. Returned to ${sourceLabel}.`;
+          if (active.id === over.id) return `Dropped ${title} in ${sourceLabel}.`;
+          const destination = dropPositionFor(loadedGroups(), String(active.id), String(over.id));
+          if (destination === null) {
+            return `Could not drop ${title}. Returned to ${sourceLabel}.`;
+          }
+          return `Dropping ${title} from ${sourceLabel} to ${boardPositionLabel(destination)}.`;
         },
         onDragCancel({ active }: DragCancelEvent) {
           const issue = issuesInPlay().find((i) => i.id === active.id);
           if (issue === undefined) return 'Cancelled drag.';
-          return `Cancelled dragging ${issue.identifier}. Returned to original position.`;
+          const source = currentPositionFor(loadedGroups(), String(active.id));
+          const location = source === null ? 'its original position' : boardPositionLabel(source);
+          return `Cancelled dragging ${issue.identifier}. Returned to ${location}.`;
         },
       },
       screenReaderInstructions: {
@@ -584,8 +737,9 @@ export function Board({
       collisionDetection={boardCollision}
       accessibility={accessibility}
       onDragStart={onDragStart}
+      onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
-      onDragCancel={() => setActiveId(null)}
+      onDragCancel={handleDragCancel}
     >
       {columns}
 
@@ -594,6 +748,16 @@ export function Board({
           <IssueCardView issue={activeIssue} lookups={lookups} properties={properties} dragging />
         )}
       </DragOverlay>
+
+      <div
+        data-testid="board-drag-status"
+        className="sr-only"
+        role="status"
+        aria-live="assertive"
+        aria-atomic="true"
+      >
+        {dragStatus}
+      </div>
 
       {peek}
     </DndContext>

--- a/apps/web/src/features/issues/board.tsx
+++ b/apps/web/src/features/issues/board.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import {
-  type CollisionDetection,
+type CollisionDetection,
   DndContext,
   type DragEndEvent,
-  DragOverlay,
   type DragStartEvent,
+  type DragOverEvent,
+  type DragCancelEvent,
+  DragOverlay,
   KeyboardSensor,
   PointerSensor,
   pointerWithin,
@@ -365,6 +367,106 @@ export function Board({
     if (placement !== null) move.mutate(placement);
   };
 
+const accessibility = useMemo(
+    () => ({
+      announcements: {
+        onDragStart({ active }: DragStartEvent) {
+          const issue = issuesInPlay().find((i) => i.id === active.id);
+          if (issue === undefined) return 'Picked up item.';
+          const group = loadedGroups().find((g) => g.issues.some((r) => r.id === active.id));
+          const groupName = group === undefined ? '' : ` in column ${group.title}`;
+          return `Picked up ${issue.identifier}: ${issue.title}${groupName}.`;
+        },
+        onDragOver({ active, over }: DragOverEvent) {
+          if (over === null) return 'Moving item.';
+          const activeId = String(active.id);
+          const overId = String(over.id);
+          const issue = issuesInPlay().find((i) => i.id === activeId);
+          const title = issue === undefined ? 'item' : issue.identifier;
+
+          const overGroup = loadedGroups().find((g) => g.id === g.id && g.id === overId) ?? targetGroupFor(loadedGroups(), overId);
+          if (overGroup !== undefined) {
+            const placement = planDrop(
+              loadedGroups(),
+              issuesInPlay(),
+              activeId,
+              overId,
+              groupBy,
+              resolveState,
+              reorderable,
+            );
+            if (placement === null) {
+              return `Cannot move ${title} to column ${overGroup.title}.`;
+            }
+            return `Moved ${title} to column ${overGroup.title}.`;
+          }
+
+          const overIssue = issuesInPlay().find((i) => i.id === overId);
+          if (overIssue !== undefined) {
+            const group = loadedGroups().find((g) =>
+              g.issues.some((row) => row.id === overIssue.id)
+            );
+            if (group !== undefined) {
+              return `Moved ${title} over ${overIssue.identifier} in column ${group.title}.`;
+            }
+          }
+
+          return `Moved ${title}.`;
+        },
+        onDragEnd({ active, over }: DragEndEvent) {
+          const activeId = String(active.id);
+          const issue = issuesInPlay().find((i) => i.id === activeId);
+          const title = issue === undefined ? 'item' : issue.identifier;
+
+          if (over === null) return `Dropped ${title}.`;
+          const overId = String(over.id);
+
+          const placement = planDrop(
+            loadedGroups(),
+            issuesInPlay(),
+            activeId,
+            overId,
+            groupBy,
+            resolveState,
+            reorderable,
+          );
+
+          if (placement === null) {
+            return `Cannot place ${title} here. Released ${title}.`;
+          }
+
+          const overGroup = loadedGroups().find((g) => g.id === overId);
+          if (overGroup !== undefined) {
+            return `Dropped ${title} in column ${overGroup.title}.`;
+          }
+
+          const overIssue = issuesInPlay().find((i) => i.id === overId);
+          if (overIssue !== undefined) {
+            const group = loadedGroups().find((g) =>
+              g.issues.some((row) => row.id === overIssue.id)
+            );
+            if (group !== undefined) {
+              return `Dropped ${title} in column ${group.title}.`;
+            }
+          }
+
+          return `Dropped ${title}.`;
+        },
+        onDragCancel({ active }: DragCancelEvent) {
+          const issue = issuesInPlay().find((i) => i.id === active.id);
+          if (issue === undefined) return 'Cancelled drag.';
+          return `Cancelled dragging ${issue.identifier}. Returned to original position.`;
+        },
+      },
+      screenReaderInstructions: {
+        draggable:
+          'To pick up this issue, press Space or Enter. While dragging, use the arrow keys to move it. Press Space or Enter again to drop, or Escape to cancel.',
+      },
+    }),
+    [issuesInPlay, loadedGroups, groupBy, resolveState, reorderable]
+  );
+
+
   const columns = (
     <div className="flex h-full min-h-0 gap-3 overflow-x-auto p-3">
       {groups.map((group) => (
@@ -400,8 +502,9 @@ export function Board({
 
   return (
     <DndContext
-      sensors={sensors}
+     sensors={sensors}
       collisionDetection={boardCollision}
+      accessibility={accessibility}
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
       onDragCancel={() => setActiveId(null)}

--- a/apps/web/src/features/issues/board.tsx
+++ b/apps/web/src/features/issues/board.tsx
@@ -25,16 +25,19 @@ import type { OrgRole } from '@orbit/shared/constants';
 import type { DisplayOptions, DisplayProperty, GroupByField } from '@orbit/shared/filters';
 import { DEFAULT_DISPLAY_PROPERTIES, emptyFilterGroup } from '@orbit/shared/filters';
 import { permissionsFor } from '@orbit/shared/policy';
-import { useQueryClient } from '@tanstack/react-query';
+import { type QueryClient, useQueryClient } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { applyDisplayFilters, displayFiltersHideRows } from '@/features/filters/display-filter.ts';
 import type { IssueGroup } from '@/features/filters/grouping.ts';
 import { UNGROUPED_ID } from '@/features/filters/grouping.ts';
+import type { ViewConfig } from '@/features/filters/view-config.ts';
 import { cn } from '@/lib/cn.ts';
+import { issueDeletionGeneration } from '@/lib/query/issue-cache-generation.ts';
 import type { Cycle, Issue, Label, Member, Project, WorkflowState } from '@/lib/query/schemas.ts';
 import type {
   AuthoritativeCachedIssue,
+  IssueMoveSettlement,
   IssueQuery,
   IssueRegrouping,
   MoveInput,
@@ -72,6 +75,8 @@ export interface BoardProps {
   readonly onLoadMore?: (() => void) | undefined;
   readonly columnSource?: BoardColumnSource | undefined;
   readonly groupBy?: GroupByField;
+  readonly filtered?: boolean;
+  readonly onVisibilityActivityStart?: () => () => void;
 }
 
 const EMPTY_QUERY: IssueQuery = { filter: emptyFilterGroup(), orderBy: 'manual' };
@@ -109,8 +114,8 @@ export interface BoardTarget extends BoardDestination {
 export interface CompletedDrag {
   readonly session: number;
   readonly identifier: string;
-  readonly source: BoardPosition;
-  readonly destination: BoardDestination;
+  readonly source: BoardSource;
+  readonly destination: BoardTarget;
 }
 
 export interface SettledDragStatusInput {
@@ -118,26 +123,105 @@ export interface SettledDragStatusInput {
   readonly activeSession: number | null;
   readonly completed: CompletedDrag;
   readonly outcome: 'success' | 'error';
+  readonly settledPosition: BoardPosition | null;
+}
+
+export interface CompletedDragResult extends SettledDragStatusInput {
+  readonly superseded: boolean;
+  readonly deleted?: boolean;
+}
+
+export interface CompletedDragResultOutput {
+  readonly status: string | null;
+  readonly focusGroupId: string | null;
+}
+
+interface CurrentCompletedDragResultInput {
+  readonly queryClient: QueryClient;
+  readonly dragId: string;
+  readonly deletionGeneration: number;
+  readonly settlement: IssueMoveSettlement | undefined;
+  readonly outcome: SettledDragStatusInput['outcome'];
+  readonly settled: Issue | undefined;
+  readonly completed: CompletedDrag;
+  readonly filtered: boolean;
+  readonly latestSession: number;
+  readonly activeSession: number | null;
+  readonly cardNodes: ReadonlyMap<string, HTMLLIElement>;
+  readonly columnNodes: ReadonlyMap<string, HTMLUListElement>;
 }
 
 export function settledDragStatus(input: SettledDragStatusInput): string | null {
-  const { latestSession, activeSession, completed, outcome } = input;
+  const { latestSession, activeSession, completed, outcome, settledPosition } = input;
   if (completed.session !== latestSession || activeSession !== null) return null;
-  const source = `column ${completed.source.column}`;
   if (outcome === 'error') {
-    return `Failed to move ${completed.identifier}. Returned to ${source}.`;
+    const returned = settledPosition ?? { column: completed.source.column };
+    return `Failed to move ${completed.identifier}. Returned to ${boardPositionLabel(returned)}.`;
   }
-  const destination = `column ${completed.destination.column}`;
-  return `Moved ${completed.identifier} from ${source} to ${destination}.`;
+  const destination = settledPosition ?? { column: completed.destination.column };
+  return `Moved ${completed.identifier} from ${boardPositionLabel(completed.source)} to ${boardPositionLabel(destination)}.`;
+}
+
+export function completedDragResult(input: CompletedDragResult): CompletedDragResultOutput {
+  const status = settledDragStatus(input);
+  if (status === null) return { status: null, focusGroupId: null };
+  if (input.deleted === true) {
+    return {
+      status: `${input.completed.identifier} was deleted while the move finished.`,
+      focusGroupId:
+        input.outcome === 'success'
+          ? input.completed.destination.groupId
+          : input.completed.source.groupId,
+    };
+  }
+  if (input.superseded) {
+    return {
+      status: `${input.completed.identifier} changed again while the move finished. Showing the latest version.`,
+      focusGroupId: null,
+    };
+  }
+  return {
+    status,
+    focusGroupId:
+      input.outcome === 'success'
+        ? input.completed.destination.groupId
+        : input.completed.source.groupId,
+  };
+}
+
+function currentCompletedDragResult(
+  input: CurrentCompletedDragResultInput,
+): CompletedDragResultOutput {
+  const endpoint =
+    input.outcome === 'success' ? input.completed.destination : input.completed.source;
+  const deleted =
+    input.settlement?.issueWasDeletedDuringSettlement === true ||
+    issueDeletionGeneration(input.queryClient, input.dragId) !== input.deletionGeneration;
+  const settledPosition = input.filtered
+    ? null
+    : registeredBoardPosition(input.dragId, endpoint, input.cardNodes, input.columnNodes);
+  const cached = authoritativeCachedIssue(input.queryClient, input.dragId);
+  return completedDragResult({
+    latestSession: input.latestSession,
+    activeSession: input.activeSession,
+    completed: input.completed,
+    outcome: input.outcome,
+    settledPosition,
+    superseded: moveResultWasSuperseded(cached, input.settled, input.outcome, deleted),
+    deleted,
+  });
 }
 
 export function moveResultWasSuperseded(
   cached: AuthoritativeCachedIssue,
   settled: Issue | undefined,
   outcome: SettledDragStatusInput['outcome'],
+  issueWasDeletedDuringSettlement = false,
 ): boolean {
   if (settled === undefined) return true;
-  if (cached.kind === 'missing') return outcome !== 'success';
+  if (cached.kind === 'missing') {
+    return outcome !== 'success' || issueWasDeletedDuringSettlement;
+  }
   if (cached.kind !== 'found') return true;
   const current = cached.issue;
   return (
@@ -148,6 +232,21 @@ export function moveResultWasSuperseded(
     current.assigneeId !== settled.assigneeId ||
     current.priority !== settled.priority ||
     current.sortOrder !== settled.sortOrder
+  );
+}
+
+export function focusRemainsBoardOwned(
+  focused: Element | null,
+  body: HTMLElement,
+  ownedCard: Element | undefined,
+  ownedColumn: Element | undefined,
+  alternateOwnedColumn?: Element | undefined,
+): boolean {
+  return (
+    focused === body ||
+    focused === ownedCard ||
+    focused === ownedColumn ||
+    focused === alternateOwnedColumn
   );
 }
 
@@ -182,6 +281,83 @@ export function canRegroup(groupBy: GroupByField): boolean {
 
 export function canDragBoard(role: OrgRole, groupBy: GroupByField): boolean {
   return canRegroup(groupBy) && permissionsFor(role).includes('issue:update');
+}
+
+export function boardPositionsAreIncomplete(
+  filtered: boolean,
+  display: DisplayOptions | undefined,
+): boolean {
+  return filtered || (display !== undefined && displayFiltersHideRows(display));
+}
+
+export function boardVisibilityConfig(config: ViewConfig) {
+  return {
+    filter: config.filter,
+    groupBy: config.groupBy,
+    subGroupBy: config.subGroupBy,
+    orderBy: config.orderBy,
+    display: {
+      showSubIssues: config.display.showSubIssues,
+      showEmptyGroups: config.display.showEmptyGroups,
+      showCompleted: config.display.showCompleted,
+    },
+  };
+}
+
+interface BoardVisibilityActivity {
+  readonly generation: number;
+  readonly count: number;
+  readonly latched: boolean;
+}
+
+export function useBoardVisibilityHold(contextKey: string, empty: boolean) {
+  const context = useRef({ key: contextKey, generation: 0 });
+  if (context.current.key !== contextKey) {
+    context.current = { key: contextKey, generation: context.current.generation + 1 };
+  }
+  const generation = context.current.generation;
+  const latestEmpty = useRef(empty);
+  latestEmpty.current = empty;
+  const [activity, setActivity] = useState<BoardVisibilityActivity>({
+    generation,
+    count: 0,
+    latched: false,
+  });
+  useLayoutEffect(() => {
+    if (empty) return;
+    setActivity((current) =>
+      current.generation === generation && current.latched
+        ? { ...current, latched: false }
+        : current,
+    );
+  }, [empty, generation]);
+  const start = useCallback(() => {
+    let ended = false;
+    setActivity((current) => ({
+      generation,
+      count: current.generation === generation ? current.count + 1 : 1,
+      latched: current.generation === generation && current.latched,
+    }));
+    return () => {
+      if (ended) return;
+      ended = true;
+      setActivity((current) => {
+        if (current.generation !== generation || current.count === 0) return current;
+        const count = current.count - 1;
+        return {
+          generation,
+          count,
+          latched: current.latched || (count === 0 && latestEmpty.current),
+        };
+      });
+    };
+  }, [generation]);
+  const current = activity.generation === generation ? activity : undefined;
+  return {
+    key: `${generation}:${contextKey}`,
+    held: current !== undefined && (current.count > 0 || current.latched),
+    start,
+  };
 }
 
 export function regroupPatch(groupBy: GroupByField, groupId: string): IssueRegrouping | null {
@@ -356,6 +532,28 @@ function boardPositionLabel(position: BoardDestination): string {
   return `column ${position.column}, position ${position.position}${total}`;
 }
 
+export function registeredBoardPosition(
+  issueId: string,
+  target: BoardSource | BoardTarget,
+  cardNodes: ReadonlyMap<string, HTMLLIElement>,
+  columnNodes: ReadonlyMap<string, HTMLUListElement>,
+): BoardPosition | null {
+  const card = cardNodes.get(issueId);
+  const column = columnNodes.get(target.groupId);
+  if (card === undefined || column === undefined || !column.contains(card)) return null;
+  const cards = Array.from(column.querySelectorAll('li[tabindex]'));
+  const index = cards.indexOf(card);
+  if (index === -1) return null;
+  const incomplete = Array.from(column.children).some((child) =>
+    child.matches('li[aria-hidden="true"]'),
+  );
+  return {
+    column: target.column,
+    position: index + 1,
+    ...(incomplete ? {} : { total: cards.length }),
+  };
+}
+
 function getAdjacentColumnCard(
   columns: Element[],
   targetColIndex: number,
@@ -364,23 +562,28 @@ function getAdjacentColumnCard(
   const col = columns[targetColIndex];
   if (col === undefined) return null;
   const cards = Array.from(col.querySelectorAll('li[tabindex]'));
-  if (cards.length === 0) return null;
+  if (cards.length === 0) return col.querySelector('ul');
   const safeIndex = Math.max(0, Math.min(currentCardIndex, cards.length - 1));
   return (cards[safeIndex] ?? null) as HTMLElement | null;
 }
 
-function getDOMIndices(currentFocus: Element): {
+function getDOMIndices(
+  currentFocus: Element,
+  board: HTMLElement,
+): {
   cols: Element[];
   colIndex: number;
   cardsInCol: Element[];
   cardIndex: number;
 } | null {
+  if (!board.contains(currentFocus)) return null;
   const currentCol = currentFocus.closest('[data-testid^="board-column-"]');
-  if (currentCol === null) return null;
-  const cols = Array.from(document.querySelectorAll('[data-testid^="board-column-"]'));
+  if (currentCol === null || !board.contains(currentCol)) return null;
+  const cols = Array.from(board.querySelectorAll('[data-testid^="board-column-"]'));
   const cardsInCol = Array.from(currentCol.querySelectorAll('li[tabindex]'));
   const cardIndex = cardsInCol.indexOf(currentFocus);
-  if (cardIndex === -1) return null;
+  const columnNode = currentCol.querySelector('ul');
+  if (cardIndex === -1 && currentFocus !== columnNode) return null;
   return {
     cols,
     colIndex: cols.indexOf(currentCol),
@@ -397,7 +600,10 @@ function getNextCardTarget(
   cardIndex: number,
 ): HTMLElement | null {
   if (key === 'ArrowDown') return (cardsInCol[cardIndex + 1] ?? null) as HTMLElement | null;
-  if (key === 'ArrowUp') return (cardsInCol[cardIndex - 1] ?? null) as HTMLElement | null;
+  if (key === 'ArrowUp') {
+    const targetIndex = cardIndex === -1 ? cardsInCol.length - 1 : cardIndex - 1;
+    return (cardsInCol[targetIndex] ?? null) as HTMLElement | null;
+  }
   if (key === 'ArrowRight') return getAdjacentColumnCard(cols, colIndex + 1, cardIndex);
   if (key === 'ArrowLeft') return getAdjacentColumnCard(cols, colIndex - 1, cardIndex);
   return null;
@@ -575,7 +781,7 @@ function SortableCard({
   properties: readonly DisplayProperty[];
   disabled: boolean;
   onOpen: (id: string) => void;
-  onNode: (id: string, node: HTMLLIElement | null) => void;
+  onNode: (id: string, node: HTMLLIElement | null, previousNode: HTMLLIElement | null) => void;
 }) {
   const {
     attributes,
@@ -591,11 +797,14 @@ function SortableCard({
     disabled,
     attributes: { role: 'listitem' },
   });
+  const registeredNode = useRef<HTMLLIElement | null>(null);
   const setCardNode = useCallback(
     (node: HTMLLIElement | null) => {
+      const previousNode = registeredNode.current;
+      registeredNode.current = node;
       setNodeRef(node);
       setActivatorNodeRef(node);
-      onNode(issue.id, node);
+      onNode(issue.id, node, previousNode);
     },
     [issue.id, onNode, setNodeRef, setActivatorNodeRef],
   );
@@ -627,7 +836,28 @@ interface ActiveDragSession {
   readonly issueId: string;
   readonly source: BoardSource;
   readonly keyboard: boolean;
+  readonly departedSource: boolean;
+  readonly endVisibilityActivity: () => void;
   readonly target?: DragTargetSnapshot;
+}
+
+interface PendingDragSettlement {
+  readonly endVisibilityActivity: () => void;
+  readonly frameId?: number;
+}
+
+interface BoardLifecycle {
+  readonly generation: number;
+  readonly mounted: boolean;
+}
+
+function dragSourceReturnStatus(
+  session: ActiveDragSession,
+  title: string,
+  current: string,
+): string {
+  if (!session.departedSource && session.target === undefined) return current;
+  return `Moved ${title} to ${boardPositionLabel(session.source)}.`;
 }
 
 interface DragDelta {
@@ -645,7 +875,34 @@ interface BoardFocusOwnership {
   readonly request: number;
   readonly target: BoardFocusTarget;
   readonly expectedSession?: number;
+  readonly focusAllowed?: () => boolean;
   readonly node: HTMLElement;
+}
+
+function boardFocusArrivalMayQueue(
+  focused: Element | null,
+  body: HTMLElement,
+  arrivingCard: Element,
+  fallbackColumn: Element | undefined,
+  ownership: BoardFocusOwnership,
+  latestRequest: number,
+  latestSession: number,
+  active: boolean,
+): boolean {
+  return (
+    fallbackColumn !== undefined &&
+    ownership.node === fallbackColumn &&
+    fallbackColumn.contains(arrivingCard) &&
+    (focused === ownership.node || focused === body) &&
+    boardFocusRequestMayRun(
+      ownership.request,
+      latestRequest,
+      ownership.expectedSession,
+      latestSession,
+      active,
+      ownership.focusAllowed?.() !== false,
+    )
+  );
 }
 
 function registeredBoardFocusNode(
@@ -667,7 +924,26 @@ function registeredBoardFocusNode(
   return card ?? fallback;
 }
 
-function boardFocusRequestIsCurrent(
+export function boardFocusRequestMayRun(
+  request: number,
+  latestRequest: number,
+  expectedSession: number | undefined,
+  latestSession: number,
+  active: boolean,
+  focusAllowed = true,
+): boolean {
+  return (
+    request === latestRequest &&
+    (expectedSession === undefined || expectedSession === latestSession) &&
+    !active &&
+    focusAllowed
+  );
+}
+
+export function boardFocusRemountMayQueue(
+  focused: Element | null,
+  body: HTMLElement,
+  previous: Element,
   request: number,
   latestRequest: number,
   expectedSession: number | undefined,
@@ -675,9 +951,8 @@ function boardFocusRequestIsCurrent(
   active: boolean,
 ): boolean {
   return (
-    request === latestRequest &&
-    (expectedSession === undefined || expectedSession === latestSession) &&
-    !active
+    (focused === previous || focused === body) &&
+    boardFocusRequestMayRun(request, latestRequest, expectedSession, latestSession, active)
   );
 }
 
@@ -739,10 +1014,13 @@ export function Board({
   columnSource,
   groupBy = 'state',
   resolveState,
+  filtered = false,
+  onVisibilityActivityStart,
 }: BoardProps) {
   const { labelById, memberById, stateById, projects, cycles, openQuickCreate } = useWorkspace();
   const queryClient = useQueryClient();
   const move = useMoveIssue();
+  const positionsIncomplete = boardPositionsAreIncomplete(filtered, columnSource?.display);
   const boardPage = useBoardPage(columnSource ?? EMPTY_COLUMN, columnSource !== undefined);
   const columnsReady = columnsReadyFor(columnSource, boardPage.isPending);
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -756,17 +1034,57 @@ export function Board({
   const latestFocusRequest = useRef(0);
   const boardFocusOwnership = useRef<BoardFocusOwnership | undefined>(undefined);
   const activeSession = useRef<ActiveDragSession | undefined>(undefined);
+  const pendingSettlements = useRef<Map<number, PendingDragSettlement>>(new Map());
+  const lifecycle = useRef<BoardLifecycle>({ generation: 0, mounted: false });
   const columnRows = useRef<Map<string, readonly Issue[]>>(new Map());
   const dragDelta = useRef<DragDelta>({ x: 0, y: 0 });
   const suppressedOverDelta = useRef<DragDelta | undefined>(undefined);
   const pendingIssueIds = useRef<Set<string>>(new Set());
   const cardNodes = useRef<Map<string, HTMLLIElement>>(new Map());
   const columnNodes = useRef<Map<string, HTMLUListElement>>(new Map());
+  const boardNode = useRef<HTMLDivElement | null>(null);
   const dragged = useRef<Issue | undefined>(undefined);
   const sensorController = useMemo(() => createBoardSensorController(), []);
+  const groupShells = useRef<readonly IssueGroup[]>([]);
+  if (groups.length > 0) {
+    groupShells.current = groups.map((group) => ({
+      ...group,
+      issues: [],
+      subGroups: [],
+      total: 0,
+    }));
+  }
+  const renderedGroups = groups.length > 0 ? groups : groupShells.current;
+
+  const releasePendingSettlement = useCallback((session: number, cancelFrame: boolean) => {
+    const pending = pendingSettlements.current.get(session);
+    if (pending === undefined) return;
+    pendingSettlements.current.delete(session);
+    if (cancelFrame && pending.frameId !== undefined) {
+      window.cancelAnimationFrame(pending.frameId);
+    }
+    pending.endVisibilityActivity();
+  }, []);
+
+  useLayoutEffect(() => {
+    const generation = lifecycle.current.generation + 1;
+    lifecycle.current = { generation, mounted: true };
+    return () => {
+      lifecycle.current = { generation: generation + 1, mounted: false };
+      latestSession.current += 1;
+      latestFocusRequest.current += 1;
+      boardFocusOwnership.current = undefined;
+      activeSession.current?.endVisibilityActivity();
+      activeSession.current = undefined;
+      for (const session of [...pendingSettlements.current.keys()]) {
+        releasePendingSettlement(session, true);
+      }
+    };
+  }, [releasePendingSettlement]);
 
   useLayoutEffect(() => {
     if (!draggable) {
+      activeSession.current?.endVisibilityActivity();
       activeSession.current = undefined;
       dragged.current = undefined;
       suppressedOverDelta.current = undefined;
@@ -778,7 +1096,10 @@ export function Board({
       return;
     }
     sensorController.mount();
-    return () => sensorController.unmount();
+    return () => {
+      activeSession.current?.endVisibilityActivity();
+      sensorController.unmount();
+    };
   }, [draggable, sensorController]);
 
   const setIssuePending = useCallback((issueId: string, pending: boolean) => {
@@ -787,54 +1108,67 @@ export function Board({
     setPendingIds(new Set(pendingIssueIds.current));
   }, []);
 
-  const scheduleBoardFocus = useCallback((target: BoardFocusTarget, expectedSession?: number) => {
-    const request = latestFocusRequest.current + 1;
-    latestFocusRequest.current = request;
-    boardFocusOwnership.current = undefined;
-    window.requestAnimationFrame(() => {
-      if (
-        !boardFocusRequestIsCurrent(
+  const scheduleBoardFocus = useCallback(
+    (target: BoardFocusTarget, expectedSession?: number, focusAllowed?: () => boolean) => {
+      const request = latestFocusRequest.current + 1;
+      const lifecycleGeneration = lifecycle.current.generation;
+      latestFocusRequest.current = request;
+      boardFocusOwnership.current = undefined;
+      window.requestAnimationFrame(() => {
+        if (
+          !lifecycle.current.mounted ||
+          lifecycle.current.generation !== lifecycleGeneration ||
+          !boardFocusRequestMayRun(
+            request,
+            latestFocusRequest.current,
+            expectedSession,
+            latestSession.current,
+            activeSession.current !== undefined,
+            focusAllowed?.() !== false,
+          )
+        ) {
+          return;
+        }
+        const node = registeredBoardFocusNode(target, cardNodes.current, columnNodes.current);
+        if (node === undefined || !node.isConnected) return;
+        const ownership: BoardFocusOwnership = {
           request,
-          latestFocusRequest.current,
-          expectedSession,
-          latestSession.current,
-          activeSession.current !== undefined,
-        )
-      ) {
-        return;
-      }
-      const node = registeredBoardFocusNode(target, cardNodes.current, columnNodes.current);
-      if (node === undefined || !node.isConnected) return;
-      const ownership: BoardFocusOwnership = {
-        request,
-        target,
-        node,
-        ...(expectedSession === undefined ? {} : { expectedSession }),
-      };
-      boardFocusOwnership.current = ownership;
-      node.addEventListener(
-        'blur',
-        (event) => {
-          if (event.relatedTarget !== null) {
-            if (boardFocusOwnership.current === ownership) {
-              boardFocusOwnership.current = undefined;
+          target,
+          node,
+          ...(expectedSession === undefined ? {} : { expectedSession }),
+          ...(focusAllowed === undefined ? {} : { focusAllowed }),
+        };
+        boardFocusOwnership.current = ownership;
+        node.addEventListener(
+          'blur',
+          (event) => {
+            if (event.relatedTarget !== null) {
+              if (boardFocusOwnership.current === ownership) {
+                boardFocusOwnership.current = undefined;
+              }
+              return;
             }
-            return;
-          }
-          window.requestAnimationFrame(() => {
-            if (node.isConnected && boardFocusOwnership.current === ownership) {
-              boardFocusOwnership.current = undefined;
-            }
-          });
-        },
-        { once: true },
-      );
-      node.focus();
-      if (document.activeElement !== node && boardFocusOwnership.current === ownership) {
-        boardFocusOwnership.current = undefined;
-      }
-    });
-  }, []);
+            window.requestAnimationFrame(() => {
+              if (
+                lifecycle.current.mounted &&
+                lifecycle.current.generation === lifecycleGeneration &&
+                node.isConnected &&
+                boardFocusOwnership.current === ownership
+              ) {
+                boardFocusOwnership.current = undefined;
+              }
+            });
+          },
+          { once: true },
+        );
+        node.focus();
+        if (document.activeElement !== node && boardFocusOwnership.current === ownership) {
+          boardFocusOwnership.current = undefined;
+        }
+      });
+    },
+    [],
+  );
 
   const registerColumnNode = useCallback(
     (groupId: string, node: HTMLUListElement | null) => {
@@ -850,8 +1184,10 @@ export function Board({
         ownership === undefined ||
         ownership.node !== previous ||
         ownership.target.fallbackGroupId !== groupId ||
-        (document.activeElement !== previous && document.activeElement !== document.body) ||
-        !boardFocusRequestIsCurrent(
+        !boardFocusRemountMayQueue(
+          document.activeElement,
+          document.body,
+          previous,
           ownership.request,
           latestFocusRequest.current,
           ownership.expectedSession,
@@ -864,18 +1200,39 @@ export function Board({
       scheduleBoardFocus(
         { ...ownership.target, requireIssueInFallback: true },
         ownership.expectedSession,
+        ownership.focusAllowed,
       );
     },
     [scheduleBoardFocus],
   );
 
   const registerCardNode = useCallback(
-    (issueId: string, node: HTMLLIElement | null) => {
+    (issueId: string, node: HTMLLIElement | null, previousNode: HTMLLIElement | null) => {
       if (node !== null) {
         cardNodes.current.set(issueId, node);
+        const ownership = boardFocusOwnership.current;
+        if (
+          ownership !== undefined &&
+          ownership.target.issueId === issueId &&
+          boardFocusArrivalMayQueue(
+            document.activeElement,
+            document.body,
+            node,
+            ownership.target.fallbackGroupId === undefined
+              ? undefined
+              : columnNodes.current.get(ownership.target.fallbackGroupId),
+            ownership,
+            latestFocusRequest.current,
+            latestSession.current,
+            activeSession.current !== undefined,
+          )
+        ) {
+          scheduleBoardFocus(ownership.target, ownership.expectedSession, ownership.focusAllowed);
+        }
         return;
       }
-      const previous = cardNodes.current.get(issueId);
+      if (previousNode === null || cardNodes.current.get(issueId) !== previousNode) return;
+      const previous = previousNode;
       cardNodes.current.delete(issueId);
       const ownership = boardFocusOwnership.current;
       if (
@@ -884,8 +1241,10 @@ export function Board({
         ownership.node !== previous ||
         ownership.target.issueId !== issueId ||
         ownership.target.fallbackGroupId === undefined ||
-        (document.activeElement !== previous && document.activeElement !== document.body) ||
-        !boardFocusRequestIsCurrent(
+        !boardFocusRemountMayQueue(
+          document.activeElement,
+          document.body,
+          previous,
           ownership.request,
           latestFocusRequest.current,
           ownership.expectedSession,
@@ -902,6 +1261,7 @@ export function Board({
           requireIssueInFallback: true,
         },
         ownership.expectedSession,
+        ownership.focusAllowed,
       );
     },
     [scheduleBoardFocus],
@@ -919,6 +1279,7 @@ export function Board({
   const cancelActiveDrag = useCallback(
     (status: string, focusTarget?: BoardFocusTarget) => {
       const session = activeSession.current;
+      session?.endVisibilityActivity();
       activeSession.current = undefined;
       dragged.current = undefined;
       suppressedOverDelta.current = undefined;
@@ -928,9 +1289,12 @@ export function Board({
       setActiveId(null);
       const keyboardTarget =
         session?.keyboard === true
-          ? { issueId: session.issueId, fallbackGroupId: session.source.groupId }
+          ? (focusTarget ?? {
+              issueId: session.issueId,
+              fallbackGroupId: session.source.groupId,
+            })
           : undefined;
-      resetDndSensor(status, focusTarget ?? keyboardTarget);
+      resetDndSensor(status, keyboardTarget);
     },
     [resetDndSensor],
   );
@@ -1054,6 +1418,8 @@ export function Board({
       issueId: session.issueId,
       source: sourceState.source,
       keyboard: session.keyboard,
+      departedSource: session.departedSource,
+      endVisibilityActivity: session.endVisibilityActivity,
       ...(targetState?.kind === 'found' ? { target: targetState.target } : {}),
     };
   }, [
@@ -1085,6 +1451,8 @@ export function Board({
             issueId: issue.id,
             source,
             keyboard: event.activatorEvent.type === 'keydown',
+            departedSource: false,
+            endVisibilityActivity: onVisibilityActivityStart?.() ?? (() => undefined),
           };
     dragged.current = issue;
     setActiveId(id);
@@ -1114,6 +1482,8 @@ export function Board({
         issueId: session.issueId,
         source: session.source,
         keyboard: session.keyboard,
+        departedSource: true,
+        endVisibilityActivity: session.endVisibilityActivity,
       };
       setDragStatus(`Moving ${title} outside of the board.`);
       return;
@@ -1125,7 +1495,10 @@ export function Board({
         issueId: session.issueId,
         source: session.source,
         keyboard: session.keyboard,
+        departedSource: session.departedSource,
+        endVisibilityActivity: session.endVisibilityActivity,
       };
+      setDragStatus((current) => dragSourceReturnStatus(session, title, current));
       return;
     }
     const heldIssue = currentIssues.find((issue) => issue.id === session.issueId);
@@ -1146,11 +1519,13 @@ export function Board({
         issueId: session.issueId,
         source: session.source,
         keyboard: session.keyboard,
+        departedSource: true,
+        endVisibilityActivity: session.endVisibilityActivity,
       };
       setDragStatus(`Cannot move ${title} here.`);
       return;
     }
-    activeSession.current = { ...session, target: targetState.target };
+    activeSession.current = { ...session, departedSource: true, target: targetState.target };
     setDragStatus(`Moved ${title} to ${boardPositionLabel(targetState.target.destination)}.`);
   };
 
@@ -1162,6 +1537,7 @@ export function Board({
     const title = heldIssue?.identifier ?? 'item';
 
     if (session === undefined || session.session !== latestSession.current) {
+      session?.endVisibilityActivity();
       activeSession.current = undefined;
       suppressedOverDelta.current = undefined;
       setActiveId(null);
@@ -1198,6 +1574,7 @@ export function Board({
         scheduleBoardFocus({ issueId: session.issueId, fallbackGroupId: session.source.groupId });
       }
       setDragStatus(`${title} is no longer visible. Drag cancelled.`);
+      session.endVisibilityActivity();
       return;
     }
     if (sourceState.kind === 'pending' || sourceState.kind === 'ambiguous') {
@@ -1206,17 +1583,21 @@ export function Board({
         scheduleBoardFocus({ issueId: session.issueId, fallbackGroupId: session.source.groupId });
       }
       setDragStatus(`${sourceState.issue.identifier}'s position changed. Drag cancelled.`);
+      session.endVisibilityActivity();
       return;
     }
     if (sourceState.kind === 'moved') {
       latestSession.current += 1;
-      scheduleBoardFocus({
-        issueId: sourceState.issue.id,
-        fallbackGroupId: sourceState.source.groupId,
-      });
+      if (session.keyboard) {
+        scheduleBoardFocus({
+          issueId: sourceState.issue.id,
+          fallbackGroupId: sourceState.source.groupId,
+        });
+      }
       setDragStatus(
         `${sourceState.issue.identifier} moved in the background to ${boardPositionLabel(sourceState.source)}. Drag cancelled.`,
       );
+      session.endVisibilityActivity();
       return;
     }
     const currentTitle = sourceState.issue.identifier;
@@ -1230,6 +1611,7 @@ export function Board({
       setDragStatus(
         `Could not drop ${currentTitle}. Returned to ${boardPositionLabel(session.source)}.`,
       );
+      session.endVisibilityActivity();
       return;
     }
     if (target.kind === 'source') {
@@ -1240,6 +1622,7 @@ export function Board({
         );
       }
       setDragStatus(`Dropped ${currentTitle} in ${boardPositionLabel(session.source)}.`);
+      session.endVisibilityActivity();
       return;
     }
     if (
@@ -1248,13 +1631,16 @@ export function Board({
       !sameBoardSource(session.target.destination, currentTarget.target.destination)
     ) {
       latestSession.current += 1;
-      scheduleBoardFocus({
-        issueId: sourceState.issue.id,
-        fallbackGroupId: sourceState.source.groupId,
-      });
+      if (session.keyboard) {
+        scheduleBoardFocus({
+          issueId: sourceState.issue.id,
+          fallbackGroupId: sourceState.source.groupId,
+        });
+      }
       setDragStatus(
         `${currentTitle}'s drop target changed in the background. Drag cancelled at ${boardPositionLabel(sourceState.source)}.`,
       );
+      session.endVisibilityActivity();
       return;
     }
     const placement = currentTarget.target.placement;
@@ -1266,32 +1652,30 @@ export function Board({
       source: session.source,
       destination,
     };
-    const publishResult = (
-      outcome: SettledDragStatusInput['outcome'],
-      settled: Issue | undefined,
-    ) => {
-      const cached = authoritativeCachedIssue(queryClient, dragId);
-      const status = settledDragStatus({
-        latestSession: latestSession.current,
-        activeSession: activeSession.current?.session ?? null,
-        completed,
-        outcome,
-      });
-      if (status === null) return;
-      if (moveResultWasSuperseded(cached, settled, outcome)) {
-        setDragStatus(
-          `${currentTitle} changed again while the move finished. Showing the latest version.`,
+    const lifecycleGeneration = lifecycle.current.generation;
+    pendingSettlements.current.set(completed.session, {
+      endVisibilityActivity: session.endVisibilityActivity,
+    });
+    const restoreCompletedKeyboardFocus = (preferredGroupId: string, alternateGroupId: string) => {
+      const preferredColumn = columnNodes.current.get(preferredGroupId);
+      const alternateColumn = columnNodes.current.get(alternateGroupId);
+      let fallbackGroupId: string | null = null;
+      if (preferredColumn !== undefined) fallbackGroupId = preferredGroupId;
+      else if (alternateColumn !== undefined) fallbackGroupId = alternateGroupId;
+      if (fallbackGroupId === null) return;
+      const focusIsOwned = () =>
+        focusRemainsBoardOwned(
+          document.activeElement,
+          document.body,
+          cardNodes.current.get(dragId),
+          preferredColumn,
+          alternateColumn,
         );
-        return;
-      }
-      setDragStatus(status);
-    };
-
-    const restoreCompletedKeyboardFocus = (fallbackGroupId: string) => {
       if (
         session.keyboard &&
         latestSession.current === completed.session &&
-        activeSession.current === undefined
+        activeSession.current === undefined &&
+        focusIsOwned()
       ) {
         scheduleBoardFocus(
           {
@@ -1300,28 +1684,84 @@ export function Board({
             requireIssueInFallback: true,
           },
           completed.session,
+          focusIsOwned,
         );
       }
     };
+    const publishResult = (
+      outcome: SettledDragStatusInput['outcome'],
+      settled: Issue | undefined,
+      settlement?: IssueMoveSettlement,
+    ) => {
+      if (!lifecycle.current.mounted || lifecycle.current.generation !== lifecycleGeneration) {
+        releasePendingSettlement(completed.session, true);
+        return;
+      }
+      // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: settlement keeps every terminal outcome explicit
+      const frameId = window.requestAnimationFrame(() => {
+        if (!lifecycle.current.mounted || lifecycle.current.generation !== lifecycleGeneration) {
+          releasePendingSettlement(completed.session, false);
+          return;
+        }
+        const result = currentCompletedDragResult({
+          queryClient,
+          dragId,
+          deletionGeneration,
+          settlement,
+          outcome,
+          settled,
+          completed,
+          filtered: positionsIncomplete,
+          latestSession: latestSession.current,
+          activeSession: activeSession.current?.session ?? null,
+          cardNodes: cardNodes.current,
+          columnNodes: columnNodes.current,
+        });
+        if (result.status !== null) {
+          setDragStatus(result.status);
+        }
+        if (result.status !== null && result.focusGroupId !== null) {
+          const alternateGroupId =
+            outcome === 'success' ? session.source.groupId : destination.groupId;
+          restoreCompletedKeyboardFocus(result.focusGroupId, alternateGroupId);
+        }
+        releasePendingSettlement(completed.session, false);
+      });
+      const pending = pendingSettlements.current.get(completed.session);
+      if (pending === undefined) {
+        window.cancelAnimationFrame(frameId);
+        return;
+      }
+      pendingSettlements.current.set(completed.session, { ...pending, frameId });
+    };
+    const deletionGeneration = issueDeletionGeneration(queryClient, dragId);
     setIssuePending(dragId, true);
     setDragStatus(
       `Dropping ${currentTitle} from ${boardPositionLabel(session.source)} to ${boardPositionLabel(destination)}.`,
     );
-    move
-      .mutateAsync(placement)
+    const pendingMove = move.mutateAsync(placement);
+    restoreCompletedKeyboardFocus(destination.groupId, session.source.groupId);
+    pendingMove
       .then(
-        (moved) => {
+        (settlement) => {
+          if (!lifecycle.current.mounted || lifecycle.current.generation !== lifecycleGeneration) {
+            releasePendingSettlement(completed.session, true);
+            return;
+          }
           publishResult(
             'success',
-            moved.find((issue) => issue.id === dragId),
+            settlement.issues.find((issue) => issue.id === dragId),
+            settlement,
           );
           setIssuePending(dragId, false);
-          restoreCompletedKeyboardFocus(destination.groupId);
         },
         () => {
+          if (!lifecycle.current.mounted || lifecycle.current.generation !== lifecycleGeneration) {
+            releasePendingSettlement(completed.session, true);
+            return;
+          }
           publishResult('error', placement.issue);
           setIssuePending(dragId, false);
-          restoreCompletedKeyboardFocus(session.source.groupId);
         },
       )
       .catch(() => undefined);
@@ -1346,6 +1786,7 @@ export function Board({
         `Cancelled dragging ${issue.identifier}. Returned to ${boardPositionLabel(session.source)}.`,
       );
     }
+    session?.endVisibilityActivity();
   };
 
   const handleBoardKeyDown = (e: React.KeyboardEvent) => {
@@ -1353,8 +1794,9 @@ export function Board({
     if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
 
     const currentFocus = document.activeElement;
-    if (currentFocus === null) return;
-    const dom = getDOMIndices(currentFocus);
+    const board = boardNode.current;
+    if (currentFocus === null || board === null) return;
+    const dom = getDOMIndices(currentFocus, board);
     if (dom === null) return;
 
     e.preventDefault();
@@ -1383,8 +1825,12 @@ export function Board({
 
   const columns = (
     // biome-ignore lint/a11y/noStaticElementInteractions: event delegation for focus management
-    <div className="flex h-full min-h-0 gap-3 overflow-x-auto p-3" onKeyDown={handleBoardKeyDown}>
-      {groups.map((group) => (
+    <div
+      ref={boardNode}
+      className="flex h-full min-h-0 gap-3 overflow-x-auto p-3"
+      onKeyDown={handleBoardKeyDown}
+    >
+      {renderedGroups.map((group) => (
         <BoardColumn
           key={group.id}
           group={group}
@@ -1433,7 +1879,9 @@ export function Board({
 
       <DragOverlay dropAnimation={null}>
         {activeIssue === undefined ? null : (
-          <IssueCardView issue={activeIssue} lookups={lookups} properties={properties} dragging />
+          <div aria-hidden="true" inert className="pointer-events-none">
+            <IssueCardView issue={activeIssue} lookups={lookups} properties={properties} dragging />
+          </div>
         )}
       </DragOverlay>
 
@@ -1464,7 +1912,11 @@ interface BoardColumnProps {
   readonly columnsReady: boolean;
   readonly pendingIssueIds: ReadonlySet<string>;
   readonly onCreate: () => void;
-  readonly onCardNode: (id: string, node: HTMLLIElement | null) => void;
+  readonly onCardNode: (
+    id: string,
+    node: HTMLLIElement | null,
+    previousNode: HTMLLIElement | null,
+  ) => void;
   readonly onColumnNode: (id: string, node: HTMLUListElement | null) => void;
   readonly onOpen: (id: string) => void;
   readonly onRows: (groupId: string, issues: readonly Issue[]) => void;

--- a/apps/web/src/features/issues/issue-card.tsx
+++ b/apps/web/src/features/issues/issue-card.tsx
@@ -30,6 +30,16 @@ export interface IssueCardProps {
   readonly onOpen?: (issueId: string) => void;
 }
 
+function stopControlPointerDown(event: ReactPointerEvent<HTMLElement>) {
+  const target = event.target;
+  if (
+    target instanceof Element &&
+    target.closest('button, input, select, textarea, [role="button"], [role="menuitem"]') !== null
+  ) {
+    event.stopPropagation();
+  }
+}
+
 export function IssueCard({
   issue,
   labels,
@@ -55,6 +65,7 @@ export function IssueCard({
   return (
     <article
       onPointerEnter={warmUnlessDragging}
+      onPointerDown={stopControlPointerDown}
       onFocusCapture={warm}
       data-testid={`issue-card-${issue.identifier}`}
       className={cn(

--- a/apps/web/src/features/issues/issue-detail.tsx
+++ b/apps/web/src/features/issues/issue-detail.tsx
@@ -197,11 +197,23 @@ export function IssueDetailView({
   const workspace = useWorkspace();
   const detail = useIssueDetail(identifier, known);
   const issue = detail.data?.issue;
+  const redirectedIdentifier = useRef<string | null>(null);
   const comments = useComments(issue?.id ?? null);
   const update = useUpdateIssue();
   const deletion = useIssueDeletion();
 
   const [subscribed, setSubscribed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const canonicalIdentifier = issue?.identifier;
+    if (canonicalIdentifier === undefined || canonicalIdentifier === identifier) {
+      redirectedIdentifier.current = null;
+      return;
+    }
+    if (onDeleted !== undefined || redirectedIdentifier.current === canonicalIdentifier) return;
+    redirectedIdentifier.current = canonicalIdentifier;
+    router.replace(`/issue/${encodeURIComponent(canonicalIdentifier)}`);
+  }, [identifier, issue?.identifier, onDeleted, router]);
 
   const teams = workspace.teams;
   const leave = useCallback(() => {

--- a/apps/web/src/features/issues/my-issues-view.tsx
+++ b/apps/web/src/features/issues/my-issues-view.tsx
@@ -19,7 +19,7 @@ import type { Issue } from '@/lib/query/schemas.ts';
 import { sortIssues } from '@/lib/query/sync.ts';
 import { useAssignedIssues } from '@/lib/query/use-issues.ts';
 import type { StateResolver } from './board.tsx';
-import { Board, canRegroup } from './board.tsx';
+import { Board, boardVisibilityConfig, canDragBoard, useBoardVisibilityHold } from './board.tsx';
 import { GroupGlyph } from './group-glyph.tsx';
 import { IssuePeek } from './issue-peek.tsx';
 import { IssueRow } from './issue-row.tsx';
@@ -83,6 +83,10 @@ export function MyIssuesView() {
     scope,
   });
   const groups = model.groups;
+  const boardVisibility = useBoardVisibilityHold(
+    JSON.stringify([layout, boardVisibilityConfig(config), workspace.userId, workspace.role]),
+    model.shownCount === 0,
+  );
   const resolveState = useMemo(() => mergedStateResolver(workspace.states), [workspace.states]);
 
   if (!workspace.ready) {
@@ -114,6 +118,7 @@ export function MyIssuesView() {
       </div>
 
       <MyIssuesBody
+        boardVisibilityKey={boardVisibility.key}
         loading={loading}
         failed={assigned.isError}
         onRetry={() => {
@@ -135,6 +140,8 @@ export function MyIssuesView() {
         onPeek={setPeekId}
         hasNextPage={hasNextPage}
         sentinel={sentinel}
+        keepBoardMounted={boardVisibility.held}
+        onVisibilityActivityStart={boardVisibility.start}
       />
 
       <HiddenFooter
@@ -159,6 +166,7 @@ export function MyIssuesView() {
 }
 
 interface BodyProps {
+  readonly boardVisibilityKey: string;
   readonly loading: boolean;
   readonly failed: boolean;
   readonly onRetry: () => void;
@@ -176,9 +184,12 @@ interface BodyProps {
   readonly loadingMore: boolean;
   readonly onLoadMore: () => void;
   readonly sentinel: RefObject<HTMLDivElement | null>;
+  readonly keepBoardMounted: boolean;
+  readonly onVisibilityActivityStart: () => () => void;
 }
 
 function MyIssuesBody({
+  boardVisibilityKey,
   loading,
   failed,
   onRetry,
@@ -196,12 +207,14 @@ function MyIssuesBody({
   loadingMore,
   onLoadMore,
   sentinel,
+  keepBoardMounted,
+  onVisibilityActivityStart,
 }: BodyProps) {
   if (failed) {
     return <LoadFailed subject="your issues" onRetry={onRetry} testId="retry-my-issues" />;
   }
 
-  if (model.shownCount === 0) {
+  if (model.shownCount === 0 && !(layout === 'board' && keepBoardMounted)) {
     return (
       <EmptyState
         icon={<CircleDot strokeWidth={1.75} aria-hidden="true" />}
@@ -216,8 +229,9 @@ function MyIssuesBody({
     return (
       <div className="min-h-0 flex-1 overflow-hidden" data-testid="my-issues-board">
         <Board
+          key={boardVisibilityKey}
           groups={groups}
-          draggable={canRegroup(groupBy)}
+          draggable={canDragBoard(workspace.role, groupBy)}
           reorderable={orderBy === 'manual'}
           groupBy={groupBy}
           resolveState={resolveState}
@@ -225,6 +239,8 @@ function MyIssuesBody({
           hasMore={hasNextPage}
           loadingMore={loadingMore}
           onLoadMore={onLoadMore}
+          filtered={model.filtered}
+          onVisibilityActivityStart={onVisibilityActivityStart}
         />
       </div>
     );

--- a/apps/web/src/features/issues/team-view.tsx
+++ b/apps/web/src/features/issues/team-view.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { OrgRole } from '@orbit/shared/constants';
 import {
   conditionsOf,
   dropLastCondition,
@@ -26,7 +27,7 @@ import { columnParamFor } from '@/lib/query/issue-search.ts';
 import type { View, WorkflowState } from '@/lib/query/schemas.ts';
 import { useIssues } from '@/lib/query/use-issues.ts';
 import { useViews } from '@/lib/query/use-views.ts';
-import { Board, canRegroup } from './board.tsx';
+import { Board, boardVisibilityConfig, canDragBoard, useBoardVisibilityHold } from './board.tsx';
 import { IssueList } from './issue-list.tsx';
 import { ListSkeleton } from './list-skeleton.tsx';
 import { useIssueViewModel } from './use-issue-view-model.ts';
@@ -59,6 +60,10 @@ export function TeamView({ teamKey, layout }: TeamViewProps) {
 
   const rows = useMemo(() => issues.data ?? [], [issues.data]);
   const model = useIssueViewModel({ teamId, config, issues: rows });
+  const boardVisibility = useBoardVisibilityHold(
+    JSON.stringify([teamId, layout, boardVisibilityConfig(config), workspace.role]),
+    model.shownCount === 0,
+  );
 
   const other = layout === 'board' ? 'issues' : 'board';
   useHotkey(
@@ -121,11 +126,14 @@ export function TeamView({ teamKey, layout }: TeamViewProps) {
       />
 
       <TeamContent
+        boardVisibilityKey={boardVisibility.key}
         teamId={teamId}
+        role={workspace.role}
         states={model.states}
         groups={model.groups}
         config={config}
         layout={layout}
+        filtered={model.filtered}
         empty={model.shownCount === 0}
         loading={issues.isPending}
         failed={issues.isError}
@@ -138,6 +146,8 @@ export function TeamView({ teamKey, layout }: TeamViewProps) {
           issues.fetchNextPage().catch(() => undefined);
         }}
         onClearLastFilter={() => setConfig({ ...config, filter: dropLastCondition(config.filter) })}
+        keepBoardMounted={boardVisibility.held}
+        onVisibilityActivityStart={boardVisibility.start}
       />
 
       <HiddenFooter
@@ -166,11 +176,14 @@ function isDirty(config: ViewConfig, layout: ViewLayoutMode, view: View): boolea
 }
 
 interface TeamContentProps {
+  readonly boardVisibilityKey: string;
   readonly teamId: string;
+  readonly role: OrgRole;
   readonly states: readonly WorkflowState[];
   readonly groups: readonly IssueGroup[];
   readonly config: ViewConfig;
   readonly layout: ViewLayoutMode;
+  readonly filtered: boolean;
   readonly empty: boolean;
   readonly loading: boolean;
   readonly failed: boolean;
@@ -179,14 +192,19 @@ interface TeamContentProps {
   readonly loadingMore: boolean;
   readonly onLoadMore: () => void;
   readonly onClearLastFilter: () => void;
+  readonly keepBoardMounted: boolean;
+  readonly onVisibilityActivityStart: () => () => void;
 }
 
 function TeamContent({
+  boardVisibilityKey,
   teamId,
+  role,
   states,
   groups,
   config,
   layout,
+  filtered,
   empty,
   loading,
   failed,
@@ -195,13 +213,17 @@ function TeamContent({
   loadingMore,
   onLoadMore,
   onClearLastFilter,
+  keepBoardMounted,
+  onVisibilityActivityStart,
 }: TeamContentProps) {
   if (loading) return <ListSkeleton layout={layout} />;
 
   if (failed)
     return <LoadFailed subject="these issues" onRetry={onRetry} testId="retry-team-issues" />;
 
-  if (empty && conditionsOf(config.filter).length > 0) {
+  const showEmptyState = empty && !(layout === 'board' && keepBoardMounted);
+
+  if (showEmptyState && conditionsOf(config.filter).length > 0) {
     return (
       <EmptyState
         icon={<SearchX strokeWidth={1.75} aria-hidden="true" />}
@@ -217,7 +239,7 @@ function TeamContent({
     );
   }
 
-  if (empty) {
+  if (showEmptyState) {
     return (
       <EmptyState
         icon={<Columns3 strokeWidth={1.75} aria-hidden="true" />}
@@ -231,14 +253,17 @@ function TeamContent({
   if (layout === 'board') {
     return (
       <Board
+        key={boardVisibilityKey}
         groups={groups}
-        draggable={canRegroup(config.groupBy)}
+        draggable={canDragBoard(role, config.groupBy)}
         reorderable={config.orderBy === 'manual'}
         groupBy={config.groupBy}
         properties={config.display.properties}
         hasMore={hasMore}
         loadingMore={loadingMore}
         onLoadMore={onLoadMore}
+        filtered={filtered}
+        onVisibilityActivityStart={onVisibilityActivityStart}
         columnSource={
           columnParamFor(config.groupBy) === null
             ? undefined

--- a/apps/web/src/features/issues/use-issue-view-model.ts
+++ b/apps/web/src/features/issues/use-issue-view-model.ts
@@ -2,7 +2,7 @@
 
 import { isEmptyFilter } from '@orbit/shared/filters';
 import { useMemo } from 'react';
-import { applyDisplayFilters } from '@/features/filters/display-filter.ts';
+import { applyDisplayFilters, displayFiltersHideRows } from '@/features/filters/display-filter.ts';
 import type { IssueGroup } from '@/features/filters/grouping.ts';
 import { groupIssues, mergeStatesByName, remapTotals } from '@/features/filters/grouping.ts';
 import type { ViewConfig } from '@/features/filters/view-config.ts';
@@ -38,7 +38,7 @@ export function useIssueViewModel({
   scope,
 }: IssueViewModelInput): IssueViewModel {
   const workspace = useWorkspace();
-  const filtered = !isEmptyFilter(config.filter);
+  const queryFiltered = !isEmptyFilter(config.filter);
 
   const enabled = !scopeToTeam || teamId !== null;
   const search = summarySearch(
@@ -126,11 +126,11 @@ export function useIssueViewModel({
     shownCount: shown.issues.length,
     total,
     hiddenByFilters:
-      filtered && summary.data !== undefined && facets.data !== undefined
+      queryFiltered && summary.data !== undefined && facets.data !== undefined
         ? Math.max(0, facets.data.scopeTotal - summary.data.total)
         : 0,
     hiddenByDisplay: shown.hidden,
-    filtered,
+    filtered: queryFiltered || displayFiltersHideRows(config.display),
     facets: facets.data?.facets,
   };
 }

--- a/apps/web/src/features/projects/project-issues.tsx
+++ b/apps/web/src/features/projects/project-issues.tsx
@@ -12,7 +12,12 @@ import { useViewConfig } from '@/features/filters/use-view-config.ts';
 import type { ViewLayoutMode } from '@/features/filters/view-config.ts';
 import { useProvideViewControls } from '@/features/filters/view-controls.tsx';
 import type { BoardColumnSource, StateResolver } from '@/features/issues/board.tsx';
-import { Board, canDragBoard } from '@/features/issues/board.tsx';
+import {
+  Board,
+  boardVisibilityConfig,
+  canDragBoard,
+  useBoardVisibilityHold,
+} from '@/features/issues/board.tsx';
 import { IssueList } from '@/features/issues/issue-list.tsx';
 import { ListSkeleton } from '@/features/issues/list-skeleton.tsx';
 import { LoadFailed } from '@/features/issues/load-failed.tsx';
@@ -62,6 +67,10 @@ export function ProjectIssues({ projectId, projectName }: ProjectIssuesProps) {
     scopeToTeam: false,
     scope,
   });
+  const boardVisibility = useBoardVisibilityHold(
+    JSON.stringify([projectId, layout, boardVisibilityConfig(config), workspace.role]),
+    model.shownCount === 0,
+  );
 
   return (
     <section className="flex min-h-0 flex-col gap-3" data-testid="project-issues">
@@ -110,6 +119,7 @@ export function ProjectIssues({ projectId, projectName }: ProjectIssuesProps) {
       />
 
       <ProjectIssueBody
+        boardVisibilityKey={boardVisibility.key}
         model={model}
         layout={layout}
         groupBy={config.groupBy}
@@ -130,12 +140,15 @@ export function ProjectIssues({ projectId, projectName }: ProjectIssuesProps) {
         onClearLastFilter={() => setConfig({ ...config, filter: dropLastCondition(config.filter) })}
         filtered={conditionsOf(config.filter).length > 0}
         properties={config.display.properties}
+        keepBoardMounted={boardVisibility.held}
+        onVisibilityActivityStart={boardVisibility.start}
       />
     </section>
   );
 }
 
 interface BodyProps {
+  readonly boardVisibilityKey: string;
   readonly model: IssueViewModel;
   readonly columnSource: BoardColumnSource | undefined;
   readonly canDrag: boolean;
@@ -152,9 +165,12 @@ interface BodyProps {
   readonly onClearLastFilter: () => void;
   readonly filtered: boolean;
   readonly properties: readonly DisplayProperty[];
+  readonly keepBoardMounted: boolean;
+  readonly onVisibilityActivityStart: () => () => void;
 }
 
 function ProjectIssueBody({
+  boardVisibilityKey,
   model,
   columnSource,
   canDrag,
@@ -171,13 +187,15 @@ function ProjectIssueBody({
   onClearLastFilter,
   filtered,
   properties,
+  keepBoardMounted,
+  onVisibilityActivityStart,
 }: BodyProps) {
   if (loading) return <ListSkeleton layout={layout} />;
 
   if (failed)
     return <LoadFailed subject="these issues" onRetry={onRetry} testId="retry-project-issues" />;
 
-  if (model.shownCount === 0) {
+  if (model.shownCount === 0 && !(layout === 'board' && keepBoardMounted)) {
     return (
       <EmptyState
         icon={
@@ -208,6 +226,7 @@ function ProjectIssueBody({
   if (layout === 'board') {
     return (
       <Board
+        key={boardVisibilityKey}
         groups={model.groups}
         draggable={canDrag}
         reorderable={orderBy === 'manual'}
@@ -218,6 +237,8 @@ function ProjectIssueBody({
         loadingMore={loadingMore}
         onLoadMore={onLoadMore}
         columnSource={columnSource}
+        filtered={model.filtered}
+        onVisibilityActivityStart={onVisibilityActivityStart}
       />
     );
   }

--- a/apps/web/src/features/sprints/sprint-issues.tsx
+++ b/apps/web/src/features/sprints/sprint-issues.tsx
@@ -12,7 +12,12 @@ import { useViewConfig } from '@/features/filters/use-view-config.ts';
 import type { ViewLayoutMode } from '@/features/filters/view-config.ts';
 import { useProvideViewControls } from '@/features/filters/view-controls.tsx';
 import type { BoardColumnSource, StateResolver } from '@/features/issues/board.tsx';
-import { Board, canDragBoard } from '@/features/issues/board.tsx';
+import {
+  Board,
+  boardVisibilityConfig,
+  canDragBoard,
+  useBoardVisibilityHold,
+} from '@/features/issues/board.tsx';
 import { IssueList } from '@/features/issues/issue-list.tsx';
 import { ListSkeleton } from '@/features/issues/list-skeleton.tsx';
 import { LoadFailed } from '@/features/issues/load-failed.tsx';
@@ -58,6 +63,10 @@ export function SprintIssues({ cycleId, sprintName, layout }: SprintIssuesProps)
     scopeToTeam: false,
     scope,
   });
+  const boardVisibility = useBoardVisibilityHold(
+    JSON.stringify([cycleId, layout, boardVisibilityConfig(config), workspace.role]),
+    model.shownCount === 0,
+  );
 
   return (
     <section className="flex min-h-0 flex-col gap-3" data-testid="sprint-issues">
@@ -74,6 +83,7 @@ export function SprintIssues({ cycleId, sprintName, layout }: SprintIssuesProps)
       />
 
       <SprintIssueBody
+        boardVisibilityKey={boardVisibility.key}
         model={model}
         layout={layout}
         groupBy={config.groupBy}
@@ -94,12 +104,15 @@ export function SprintIssues({ cycleId, sprintName, layout }: SprintIssuesProps)
         onClearLastFilter={() => setConfig({ ...config, filter: dropLastCondition(config.filter) })}
         filtered={conditionsOf(config.filter).length > 0}
         properties={config.display.properties}
+        keepBoardMounted={boardVisibility.held}
+        onVisibilityActivityStart={boardVisibility.start}
       />
     </section>
   );
 }
 
 interface BodyProps {
+  readonly boardVisibilityKey: string;
   readonly model: IssueViewModel;
   readonly columnSource: BoardColumnSource | undefined;
   readonly canDrag: boolean;
@@ -116,9 +129,12 @@ interface BodyProps {
   readonly onClearLastFilter: () => void;
   readonly filtered: boolean;
   readonly properties: readonly DisplayProperty[];
+  readonly keepBoardMounted: boolean;
+  readonly onVisibilityActivityStart: () => () => void;
 }
 
 function SprintIssueBody({
+  boardVisibilityKey,
   model,
   columnSource,
   canDrag,
@@ -135,6 +151,8 @@ function SprintIssueBody({
   onClearLastFilter,
   filtered,
   properties,
+  keepBoardMounted,
+  onVisibilityActivityStart,
 }: BodyProps) {
   if (loading) return <ListSkeleton layout={layout} />;
 
@@ -142,7 +160,7 @@ function SprintIssueBody({
     return <LoadFailed subject="this sprint" onRetry={onRetry} testId="retry-sprint-issues" />;
   }
 
-  if (model.shownCount === 0) {
+  if (model.shownCount === 0 && !(layout === 'board' && keepBoardMounted)) {
     return (
       <EmptyState
         icon={
@@ -173,6 +191,7 @@ function SprintIssueBody({
   if (layout === 'board') {
     return (
       <Board
+        key={boardVisibilityKey}
         groups={model.groups}
         draggable={canDrag}
         reorderable={orderBy === 'manual'}
@@ -183,6 +202,8 @@ function SprintIssueBody({
         loadingMore={loadingMore}
         onLoadMore={onLoadMore}
         columnSource={columnSource}
+        filtered={model.filtered}
+        onVisibilityActivityStart={onVisibilityActivityStart}
       />
     );
   }

--- a/apps/web/src/features/standup/standup-board.tsx
+++ b/apps/web/src/features/standup/standup-board.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import type { DisplayProperty } from '@orbit/shared/filters';
+import type { OrgRole } from '@orbit/shared/constants';
+import type { DisplayProperty, GroupByField, IssueOrdering } from '@orbit/shared/filters';
 import { SearchX } from 'lucide-react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useCallback, useMemo, useState } from 'react';
@@ -11,7 +12,13 @@ import { type IssueGroup, mergedStateResolver } from '@/features/filters/groupin
 import { HiddenFooter } from '@/features/filters/hidden-footer.tsx';
 import { useViewConfig } from '@/features/filters/use-view-config.ts';
 import { useProvideViewControls } from '@/features/filters/view-controls.tsx';
-import { Board, type StateResolver } from '@/features/issues/board.tsx';
+import {
+  Board,
+  boardVisibilityConfig,
+  canDragBoard,
+  type StateResolver,
+  useBoardVisibilityHold,
+} from '@/features/issues/board.tsx';
 import { LoadFailed } from '@/features/issues/load-failed.tsx';
 import { useIssueViewModel } from '@/features/issues/use-issue-view-model.ts';
 import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
@@ -26,6 +33,14 @@ const WHOLE_WORKSPACE: Readonly<Record<string, string>> = {};
 export const PERSON_PARAM = 'person';
 
 const CARRIED_PARAMS: readonly string[] = [PERSON_PARAM];
+
+export function standupBoardOptions(role: OrgRole, groupBy: GroupByField, orderBy: IssueOrdering) {
+  return {
+    draggable: canDragBoard(role, groupBy),
+    groupBy,
+    reorderable: orderBy === 'manual',
+  };
+}
 
 export function StandupBoard() {
   const workspace = useWorkspace();
@@ -85,6 +100,10 @@ export function StandupBoard() {
     scopeToTeam: false,
     scope,
   });
+  const boardVisibility = useBoardVisibilityHold(
+    JSON.stringify([selectedId, boardVisibilityConfig(config), workspace.role]),
+    model.shownCount === 0,
+  );
 
   const resolveState = useMemo(() => mergedStateResolver(workspace.states), [workspace.states]);
 
@@ -104,6 +123,7 @@ export function StandupBoard() {
   }
 
   const empty = model.groups.every((group) => group.issues.length === 0);
+  const boardOptions = standupBoardOptions(workspace.role, config.groupBy, config.orderBy);
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="standup-board">
@@ -134,6 +154,7 @@ export function StandupBoard() {
       />
 
       <StandupBody
+        key={boardVisibility.key}
         loading={active.isPending}
         failed={active.isError}
         onRetry={() => {
@@ -141,6 +162,8 @@ export function StandupBoard() {
         }}
         empty={empty}
         groups={model.groups}
+        filtered={model.filtered}
+        {...boardOptions}
         properties={config.display.properties}
         hasMore={hasNextPage}
         loadingMore={isFetchingNextPage}
@@ -148,6 +171,8 @@ export function StandupBoard() {
         onLoadMore={() => {
           fetchNextPage().catch(() => undefined);
         }}
+        keepBoardMounted={boardVisibility.held}
+        onVisibilityActivityStart={boardVisibility.start}
       />
 
       <HiddenFooter
@@ -171,11 +196,17 @@ interface StandupBodyProps {
   readonly onRetry: () => void;
   readonly empty: boolean;
   readonly groups: readonly IssueGroup[];
+  readonly filtered: boolean;
+  readonly draggable: boolean;
+  readonly groupBy: GroupByField;
+  readonly reorderable: boolean;
   readonly properties: readonly DisplayProperty[];
   readonly hasMore: boolean;
   readonly loadingMore: boolean;
   readonly resolveState: StateResolver;
   readonly onLoadMore: () => void;
+  readonly keepBoardMounted: boolean;
+  readonly onVisibilityActivityStart: () => () => void;
 }
 
 function StandupBody({
@@ -184,11 +215,17 @@ function StandupBody({
   onRetry,
   empty,
   groups,
+  filtered,
+  draggable,
+  groupBy,
+  reorderable,
   properties,
   hasMore,
   loadingMore,
   resolveState,
   onLoadMore,
+  keepBoardMounted,
+  onVisibilityActivityStart,
 }: StandupBodyProps) {
   if (loading) {
     return (
@@ -204,7 +241,7 @@ function StandupBody({
     return <LoadFailed subject="the standup board" onRetry={onRetry} testId="retry-standup" />;
   }
 
-  if (empty) {
+  if (empty && !keepBoardMounted) {
     return (
       <EmptyState
         icon={<SearchX strokeWidth={1.75} aria-hidden="true" />}
@@ -219,11 +256,16 @@ function StandupBody({
     <div className="min-h-0 flex-1" data-testid="standup-kanban">
       <Board
         groups={groups}
+        filtered={filtered}
+        draggable={draggable}
+        groupBy={groupBy}
+        reorderable={reorderable}
         properties={properties}
         hasMore={hasMore}
         loadingMore={loadingMore}
         resolveState={resolveState}
         onLoadMore={onLoadMore}
+        onVisibilityActivityStart={onVisibilityActivityStart}
       />
     </div>
   );

--- a/apps/web/src/features/views/saved-view-page.tsx
+++ b/apps/web/src/features/views/saved-view-page.tsx
@@ -18,7 +18,12 @@ import {
 } from '@/features/filters/view-config.ts';
 import { useProvideViewControls } from '@/features/filters/view-controls.tsx';
 import type { BoardColumnSource, StateResolver } from '@/features/issues/board.tsx';
-import { Board, canDragBoard } from '@/features/issues/board.tsx';
+import {
+  Board,
+  boardVisibilityConfig,
+  canDragBoard,
+  useBoardVisibilityHold,
+} from '@/features/issues/board.tsx';
 import { IssueList } from '@/features/issues/issue-list.tsx';
 import { ListSkeleton } from '@/features/issues/list-skeleton.tsx';
 import { LoadFailed } from '@/features/issues/load-failed.tsx';
@@ -97,6 +102,10 @@ function SavedViewBody({ view }: { view: View }) {
     scopeToTeam: false,
     scope: scope.query,
   });
+  const boardVisibility = useBoardVisibilityHold(
+    JSON.stringify([view.id, layout, boardVisibilityConfig(config), scope.query, workspace.role]),
+    model.shownCount === 0,
+  );
 
   const resolveState = useMemo(() => mergedStateResolver(workspace.states), [workspace.states]);
   const canDrag = canDragBoard(workspace.role, config.groupBy);
@@ -150,6 +159,7 @@ function SavedViewBody({ view }: { view: View }) {
       />
 
       <SavedViewContent
+        boardVisibilityKey={boardVisibility.key}
         resolveState={resolveState}
         columnSource={columnSource}
         canDrag={canDrag}
@@ -158,6 +168,9 @@ function SavedViewBody({ view }: { view: View }) {
         config={config}
         layout={layout}
         empty={model.shownCount === 0}
+        filtered={model.filtered}
+        keepBoardMounted={boardVisibility.held}
+        onVisibilityActivityStart={boardVisibility.start}
         loading={issues.isPending}
         failed={issues.isError}
         onRetry={() => {
@@ -186,6 +199,7 @@ function SavedViewBody({ view }: { view: View }) {
 }
 
 interface SavedViewContentProps {
+  readonly boardVisibilityKey: string;
   readonly resolveState: StateResolver;
   readonly columnSource: BoardColumnSource | undefined;
   readonly canDrag: boolean;
@@ -194,6 +208,9 @@ interface SavedViewContentProps {
   readonly config: ViewConfig;
   readonly layout: ViewLayoutMode;
   readonly empty: boolean;
+  readonly filtered: boolean;
+  readonly keepBoardMounted: boolean;
+  readonly onVisibilityActivityStart: () => () => void;
   readonly loading: boolean;
   readonly failed: boolean;
   readonly onRetry: () => void;
@@ -203,6 +220,7 @@ interface SavedViewContentProps {
 }
 
 function SavedViewContent({
+  boardVisibilityKey,
   resolveState,
   columnSource,
   canDrag,
@@ -211,6 +229,9 @@ function SavedViewContent({
   config,
   layout,
   empty,
+  filtered,
+  keepBoardMounted,
+  onVisibilityActivityStart,
   loading,
   failed,
   onRetry,
@@ -222,12 +243,12 @@ function SavedViewContent({
 
   if (failed) return <LoadFailed subject="this view" onRetry={onRetry} testId="retry-saved-view" />;
 
-  if (empty) {
-    const filtered = conditionsOf(config.filter).length > 0;
+  if (empty && !(layout === 'board' && keepBoardMounted)) {
+    const queryFiltered = conditionsOf(config.filter).length > 0;
     return (
       <EmptyState
         icon={
-          filtered ? (
+          queryFiltered ? (
             <SearchX strokeWidth={1.75} aria-hidden="true" />
           ) : (
             <Columns3 strokeWidth={1.75} aria-hidden="true" />
@@ -235,7 +256,7 @@ function SavedViewContent({
         }
         title="No issues match this view"
         description={
-          filtered
+          queryFiltered
             ? 'Loosen a filter to widen the search, then save the change.'
             : 'Press C to create the first one.'
         }
@@ -248,6 +269,7 @@ function SavedViewContent({
     return (
       <div className="min-h-0 flex-1 overflow-hidden" data-testid="saved-view-board">
         <Board
+          key={boardVisibilityKey}
           groups={groups}
           draggable={canDrag}
           reorderable={config.orderBy === 'manual'}
@@ -258,6 +280,8 @@ function SavedViewContent({
           loadingMore={loadingMore}
           onLoadMore={onLoadMore}
           columnSource={columnSource}
+          filtered={filtered}
+          onVisibilityActivityStart={onVisibilityActivityStart}
         />
       </div>
     );

--- a/apps/web/src/lib/query/issue-cache-generation.ts
+++ b/apps/web/src/lib/query/issue-cache-generation.ts
@@ -1,0 +1,68 @@
+import type { QueryClient, QueryKey } from '@tanstack/react-query';
+
+const deletionGenerations = new WeakMap<QueryClient, Map<string, number>>();
+const revisionGenerations = new WeakMap<QueryClient, Map<string, number>>();
+const listRevisionGenerations = new WeakMap<QueryClient, Map<string, number>>();
+const cacheRevisionGenerations = new WeakMap<QueryClient, number>();
+
+function incrementGenerations(
+  generationsByClient: WeakMap<QueryClient, Map<string, number>>,
+  client: QueryClient,
+  issueIds: readonly string[],
+): void {
+  let generations = generationsByClient.get(client);
+  if (generations === undefined) {
+    generations = new Map();
+    generationsByClient.set(client, generations);
+  }
+  for (const issueId of issueIds) {
+    generations.set(issueId, (generations.get(issueId) ?? 0) + 1);
+  }
+}
+
+export function issueDeletionGeneration(client: QueryClient, issueId: string): number {
+  return deletionGenerations.get(client)?.get(issueId) ?? 0;
+}
+
+export function issueRevisionGeneration(client: QueryClient, issueId: string): number {
+  return revisionGenerations.get(client)?.get(issueId) ?? 0;
+}
+
+export function issueCacheRevisionGeneration(client: QueryClient): number {
+  return cacheRevisionGenerations.get(client) ?? 0;
+}
+
+function issueListRevisionKey(queryKey: QueryKey): string {
+  return JSON.stringify(queryKey);
+}
+
+export function issueListRevisionGeneration(client: QueryClient, queryKey: QueryKey): number {
+  return listRevisionGenerations.get(client)?.get(issueListRevisionKey(queryKey)) ?? 0;
+}
+
+export function recordIssueListRevisions(
+  client: QueryClient,
+  queryKeys: readonly QueryKey[],
+): void {
+  if (queryKeys.length === 0) return;
+  let generations = listRevisionGenerations.get(client);
+  if (generations === undefined) {
+    generations = new Map();
+    listRevisionGenerations.set(client, generations);
+  }
+  for (const queryKey of queryKeys) {
+    const key = issueListRevisionKey(queryKey);
+    generations.set(key, (generations.get(key) ?? 0) + 1);
+  }
+}
+
+export function recordIssueRevisions(client: QueryClient, issueIds: readonly string[]): void {
+  if (issueIds.length === 0) return;
+  incrementGenerations(revisionGenerations, client, issueIds);
+  cacheRevisionGenerations.set(client, issueCacheRevisionGeneration(client) + 1);
+}
+
+export function recordIssueDeletions(client: QueryClient, issueIds: readonly string[]): void {
+  incrementGenerations(deletionGenerations, client, issueIds);
+  recordIssueRevisions(client, issueIds);
+}

--- a/apps/web/src/lib/query/issue-cache-generation.ts
+++ b/apps/web/src/lib/query/issue-cache-generation.ts
@@ -4,6 +4,9 @@ const deletionGenerations = new WeakMap<QueryClient, Map<string, number>>();
 const revisionGenerations = new WeakMap<QueryClient, Map<string, number>>();
 const listRevisionGenerations = new WeakMap<QueryClient, Map<string, number>>();
 const cacheRevisionGenerations = new WeakMap<QueryClient, number>();
+const cacheResetGenerations = new WeakMap<QueryClient, number>();
+const syncWatermarks = new WeakMap<QueryClient, Map<string, number>>();
+const survivalSyncWatermarks = new WeakMap<QueryClient, Map<string, number>>();
 
 function incrementGenerations(
   generationsByClient: WeakMap<QueryClient, Map<string, number>>,
@@ -30,6 +33,18 @@ export function issueRevisionGeneration(client: QueryClient, issueId: string): n
 
 export function issueCacheRevisionGeneration(client: QueryClient): number {
   return cacheRevisionGenerations.get(client) ?? 0;
+}
+
+export function issueCacheResetGeneration(client: QueryClient): number {
+  return cacheResetGenerations.get(client) ?? 0;
+}
+
+export function issueSyncWatermark(client: QueryClient, issueId: string): number {
+  return syncWatermarks.get(client)?.get(issueId) ?? Number.NEGATIVE_INFINITY;
+}
+
+export function issueSurvivalSyncWatermark(client: QueryClient, issueId: string): number {
+  return survivalSyncWatermarks.get(client)?.get(issueId) ?? Number.NEGATIVE_INFINITY;
 }
 
 function issueListRevisionKey(queryKey: QueryKey): string {
@@ -65,4 +80,35 @@ export function recordIssueRevisions(client: QueryClient, issueIds: readonly str
 export function recordIssueDeletions(client: QueryClient, issueIds: readonly string[]): void {
   incrementGenerations(deletionGenerations, client, issueIds);
   recordIssueRevisions(client, issueIds);
+}
+
+export function recordIssueSyncWatermark(
+  client: QueryClient,
+  issueId: string,
+  syncId: number,
+): void {
+  let watermarks = syncWatermarks.get(client);
+  if (watermarks === undefined) {
+    watermarks = new Map();
+    syncWatermarks.set(client, watermarks);
+  }
+  watermarks.set(issueId, Math.max(watermarks.get(issueId) ?? Number.NEGATIVE_INFINITY, syncId));
+}
+
+export function recordIssueSurvivalSyncWatermark(
+  client: QueryClient,
+  issueId: string,
+  syncId: number,
+): void {
+  let watermarks = survivalSyncWatermarks.get(client);
+  if (watermarks === undefined) {
+    watermarks = new Map();
+    survivalSyncWatermarks.set(client, watermarks);
+  }
+  watermarks.set(issueId, Math.max(watermarks.get(issueId) ?? Number.NEGATIVE_INFINITY, syncId));
+}
+
+export function recordIssueCacheReset(client: QueryClient): void {
+  cacheRevisionGenerations.set(client, issueCacheRevisionGeneration(client) + 1);
+  cacheResetGenerations.set(client, issueCacheResetGeneration(client) + 1);
 }

--- a/apps/web/src/lib/query/use-issues.ts
+++ b/apps/web/src/lib/query/use-issues.ts
@@ -370,6 +370,8 @@ function reconcile(
   admitNew = false,
 ): readonly Issue[] {
   const index = issues.findIndex((issue) => issue.id === next.id);
+  const current = issues[index];
+  if (current !== undefined && current.syncId > next.syncId) return issues;
   if (!belongsInList(search, next)) {
     return index === -1 ? issues : issues.filter((issue) => issue.id !== next.id);
   }
@@ -380,6 +382,55 @@ function reconcile(
   }
   if (!(admitNew || admitsNewRows(search))) return issues;
   return sortForSearch(search, [...issues, next]);
+}
+
+export type AuthoritativeCachedIssue =
+  | { readonly kind: 'missing' }
+  | { readonly kind: 'ambiguous' }
+  | { readonly kind: 'found'; readonly issue: Issue };
+
+export function authoritativeCachedIssue(
+  client: QueryClient,
+  issueId: string,
+): AuthoritativeCachedIssue {
+  const occurrences = client
+    .getQueriesData<IssuePages>({ queryKey: [ISSUES_ROOT] })
+    .flatMap(([, pages]) =>
+      pages === undefined ? [] : flattenIssuePages(pages).filter((issue) => issue.id === issueId),
+    );
+  const newestSyncId = occurrences.reduce(
+    (newest, issue) => Math.max(newest, issue.syncId),
+    Number.NEGATIVE_INFINITY,
+  );
+  const newest = occurrences.filter((issue) => issue.syncId === newestSyncId);
+  const issue = newest[0];
+  if (issue === undefined) return { kind: 'missing' };
+  const heads = new Set(newest.map((candidate) => JSON.stringify(candidate)));
+  return heads.size === 1 ? { kind: 'found', issue } : { kind: 'ambiguous' };
+}
+
+function issueFromPages(pages: IssuePages | undefined, issueId: string): Issue | undefined {
+  return pages === undefined
+    ? undefined
+    : flattenIssuePages(pages).find((issue) => issue.id === issueId);
+}
+
+function issueFingerprint(issue: Issue): string {
+  return JSON.stringify(issue) ?? '';
+}
+
+function restoreIssueInPages(
+  pages: IssuePages,
+  search: string,
+  issueId: string,
+  before: Issue | undefined,
+): IssuePages {
+  return mapIssuePages(pages, (issues) => {
+    const current = issues.find((issue) => issue.id === issueId);
+    if (before === undefined && current === undefined) return issues;
+    const without = current === undefined ? issues : issues.filter((issue) => issue.id !== issueId);
+    return before === undefined ? without : reconcile(search, without, before, true);
+  });
 }
 
 function filteredListsHolding(
@@ -444,7 +495,10 @@ function placeIssues(client: QueryClient, moved: readonly Issue[]): void {
   const before = filteredListsHolding(client, moved);
   eachIssueList(client, { queryKey: [ISSUES_ROOT] }, (issues, search) => {
     let next = issues;
-    for (const issue of moved) next = reconcile(search, next, issue);
+    for (const issue of moved) {
+      if (!next.some((current) => current.id === issue.id)) continue;
+      next = reconcile(search, next, issue);
+    }
     return sortForSearch(search, next);
   });
   settleFilteredLists(client, moved, before);
@@ -568,16 +622,68 @@ export function useMoveIssue() {
     },
     onMutate: async (input) => {
       await client.cancelQueries({ queryKey: [ISSUES_ROOT] });
+      const before = client.getQueriesData<IssuePages>({ queryKey: [ISSUES_ROOT] });
       const optimistic: Issue = {
         ...input.issue,
         ...regroupingOf(input),
         sortOrder: sortOrderBetween(input.beforeOrder, input.afterOrder),
       };
       placeMovedIssue(client, optimistic);
-      return {};
+      return {
+        lists: before.map(([key, pages]) => ({
+          key,
+          before: issueFromPages(pages, input.issue.id),
+          optimistic: issueFromPages(client.getQueryData<IssuePages>(key), input.issue.id),
+        })),
+      };
     },
-    onError: (error, input) => {
-      placeIssue(client, input.issue);
+    onError: async (error, input, context) => {
+      const lists = context?.lists ?? [];
+      const refreshes: Promise<void>[] = [];
+      const expected = new Set(
+        lists.flatMap((snapshot) =>
+          snapshot.optimistic === undefined ? [] : [issueFingerprint(snapshot.optimistic)],
+        ),
+      );
+      const current = client
+        .getQueriesData<IssuePages>({ queryKey: [ISSUES_ROOT] })
+        .flatMap(([, pages]) => {
+          const found = issueFromPages(pages, input.issue.id);
+          return found === undefined ? [] : [found];
+        });
+      const hasOptimistic = current.some((issue) => expected.has(issueFingerprint(issue)));
+      const intervening = current.some((issue) => !expected.has(issueFingerprint(issue)));
+
+      for (const snapshot of lists) {
+        const pages = client.getQueryData<IssuePages>(snapshot.key);
+        const found = issueFromPages(pages, input.issue.id);
+        const stillOptimistic =
+          found === undefined
+            ? snapshot.optimistic === undefined
+            : snapshot.optimistic !== undefined &&
+              issueFingerprint(found) === issueFingerprint(snapshot.optimistic);
+        if (hasOptimistic && !intervening && stillOptimistic) {
+          client.setQueryData<IssuePages>(snapshot.key, (pages) => {
+            if (pages === undefined) return pages;
+            const found = issueFromPages(pages, input.issue.id);
+            if (found !== undefined && !expected.has(issueFingerprint(found))) return pages;
+            return restoreIssueInPages(
+              pages,
+              searchOf(snapshot.key),
+              input.issue.id,
+              snapshot.before,
+            );
+          });
+          continue;
+        }
+        if (intervening && !stillOptimistic) continue;
+        refreshes.push(
+          client
+            .invalidateQueries({ queryKey: snapshot.key, exact: true, refetchType: 'all' })
+            .catch(() => undefined),
+        );
+      }
+      await Promise.all(refreshes);
       toast({ title: 'Could not move that issue', description: messageOf(error), tone: 'danger' });
     },
     onSuccess: (moved) => {

--- a/apps/web/src/lib/query/use-issues.ts
+++ b/apps/web/src/lib/query/use-issues.ts
@@ -13,6 +13,7 @@ import { useCallback, useMemo } from 'react';
 import { useToast } from '@/components/ui/toast.tsx';
 import { apiFetch, messageOf } from './fetcher.ts';
 import {
+  issueCacheResetGeneration,
   issueCacheRevisionGeneration,
   issueDeletionGeneration,
   issueListRevisionGeneration,
@@ -631,6 +632,13 @@ function refreshCounts(client: QueryClient): void {
   staleBoardPages(client);
 }
 
+async function invalidateIssueCaches(client: QueryClient): Promise<void> {
+  await Promise.allSettled([
+    client.invalidateQueries({ queryKey: [ISSUES_ROOT] }),
+    client.invalidateQueries({ queryKey: [ISSUE_ROOT] }),
+  ]);
+}
+
 function resortTeamIssueLists(client: QueryClient, teamId: string): void {
   eachIssueList(client, { queryKey: queryKeys.issueTeam(teamId) }, (issues, search) =>
     sortForSearch(search, issues),
@@ -650,10 +658,12 @@ export function useUpdateIssue() {
       return result.issue;
     },
     onMutate: async (input) => {
-      await client.cancelQueries({ queryKey: [ISSUES_ROOT] });
-      const previousDetail = client.getQueryData<IssueDetail>(
-        queryKeys.issue(input.issue.identifier),
-      );
+      const detailKey = queryKeys.issue(input.issue.identifier);
+      await Promise.allSettled([
+        client.cancelQueries({ queryKey: [ISSUES_ROOT] }),
+        client.cancelQueries({ queryKey: detailKey, exact: true }),
+      ]);
+      const previousDetail = client.getQueryData<IssueDetail>(detailKey);
 
       const { reviewerIds, ...patch } = input.patch;
       const optimistic: Issue = {
@@ -664,8 +674,9 @@ export function useUpdateIssue() {
           input.patch.labelIds === undefined ? input.issue.labelIds : [...input.patch.labelIds],
       };
       placeIssue(client, optimistic, false);
+      let optimisticDetail: IssueDetail | undefined;
       if (previousDetail !== undefined) {
-        client.setQueryData(queryKeys.issue(input.issue.identifier), {
+        optimisticDetail = client.setQueryData<IssueDetail>(detailKey, {
           ...previousDetail,
           issue: {
             ...optimistic,
@@ -673,12 +684,31 @@ export function useUpdateIssue() {
           },
         });
       }
-      return { previousDetail, identifier: input.issue.identifier };
+      return {
+        previousDetail,
+        optimisticDetail,
+        identifier: input.issue.identifier,
+        resetGeneration: issueCacheResetGeneration(client),
+        issueRevision: issueRevisionGeneration(client, input.issue.id),
+      };
     },
     onError: (error, input, context) => {
-      placeIssue(client, input.issue);
-      if (context?.previousDetail !== undefined && context.identifier !== undefined) {
-        client.setQueryData(queryKeys.issue(context.identifier), context.previousDetail);
+      const currentDetail =
+        context === undefined
+          ? undefined
+          : client.getQueryData<IssueDetail>(queryKeys.issue(context.identifier));
+      const canRestore =
+        context !== undefined &&
+        issueCacheResetGeneration(client) === context.resetGeneration &&
+        issueRevisionGeneration(client, input.issue.id) === context.issueRevision &&
+        currentDetail === context.optimisticDetail;
+      if (canRestore) {
+        placeIssue(client, input.issue);
+        if (context.previousDetail !== undefined) {
+          client.setQueryData(queryKeys.issue(context.identifier), context.previousDetail);
+        }
+      } else {
+        invalidateIssueCaches(client).catch(() => undefined);
       }
       toast({ title: 'Could not save', description: messageOf(error), tone: 'danger' });
     },
@@ -686,7 +716,9 @@ export function useUpdateIssue() {
       placeIssue(client, issue);
       refreshCounts(client);
       client.setQueryData<IssueDetail>(queryKeys.issue(issue.identifier), (current) =>
-        current === undefined ? current : { ...current, issue },
+        current === undefined || current.issue.syncId > issue.syncId
+          ? current
+          : { ...current, issue },
       );
     },
     onSettled: (_issue, _error, input) => {
@@ -725,6 +757,7 @@ interface MoveMutationContext {
   readonly lists: readonly MoveListSnapshot[];
   readonly deletionGeneration: number;
   readonly issueRevision: number;
+  readonly resetGeneration: number;
 }
 
 export interface IssueMoveSettlement {
@@ -765,6 +798,65 @@ function restoreFailedMoveAfterUnavailableRefresh(
   }
 }
 
+function failedMoveRollbackFenced(
+  client: QueryClient,
+  input: MoveInput,
+  context: MoveMutationContext | undefined,
+): boolean {
+  return (
+    context !== undefined &&
+    (issueCacheResetGeneration(client) !== context.resetGeneration ||
+      issueRevisionGeneration(client, input.issue.id) !== context.issueRevision)
+  );
+}
+
+async function rollbackFailedMove(
+  client: QueryClient,
+  input: MoveInput,
+  context: MoveMutationContext | undefined,
+): Promise<void> {
+  const lists = context?.lists ?? [];
+  const refreshKeys: QueryKey[] = [];
+  const expected = new Set(
+    lists.flatMap((snapshot) =>
+      snapshot.optimistic === undefined ? [] : [issueFingerprint(snapshot.optimistic)],
+    ),
+  );
+  const current = client
+    .getQueriesData<IssuePages>({ queryKey: [ISSUES_ROOT] })
+    .flatMap(([, pages]) => {
+      const found = issueFromPages(pages, input.issue.id);
+      return found === undefined ? [] : [found];
+    });
+  const hasOptimistic = current.some((issue) => expected.has(issueFingerprint(issue)));
+  const intervening = current.some((issue) => !expected.has(issueFingerprint(issue)));
+
+  for (const snapshot of lists) {
+    const pages = client.getQueryData<IssuePages>(snapshot.key);
+    const found = issueFromPages(pages, input.issue.id);
+    const stillOptimistic =
+      found === undefined
+        ? snapshot.optimistic === undefined
+        : snapshot.optimistic !== undefined &&
+          issueFingerprint(found) === issueFingerprint(snapshot.optimistic);
+    if (hasOptimistic && !intervening && stillOptimistic) {
+      client.setQueryData<IssuePages>(snapshot.key, (pages) => {
+        if (pages === undefined) return pages;
+        const found = issueFromPages(pages, input.issue.id);
+        if (found !== undefined && !expected.has(issueFingerprint(found))) return pages;
+        return restoreIssueInPages(pages, searchOf(snapshot.key), input.issue.id, snapshot.before);
+      });
+      continue;
+    }
+    if (intervening && !stillOptimistic) continue;
+    refreshKeys.push(snapshot.key);
+  }
+  await refreshIssueListsUntilStable(client, refreshKeys, [input.issue.id], true, false);
+  if (context !== undefined) {
+    restoreFailedMoveAfterUnavailableRefresh(client, input, context, refreshKeys);
+  }
+}
+
 export function useMoveIssue() {
   const client = useQueryClient();
   const { toast } = useToast();
@@ -786,7 +878,7 @@ export function useMoveIssue() {
     },
     onMutate: async (input) => {
       moveDeletionGenerations.set(input, issueDeletionGeneration(client, input.issue.id));
-      await client.cancelQueries({ queryKey: [ISSUES_ROOT] });
+      await Promise.allSettled([client.cancelQueries({ queryKey: [ISSUES_ROOT] })]);
       const before = client.getQueriesData<IssuePages>({ queryKey: [ISSUES_ROOT] });
       const optimistic: Issue = {
         ...input.issue,
@@ -804,55 +896,13 @@ export function useMoveIssue() {
         deletionGeneration:
           moveDeletionGenerations.get(input) ?? issueDeletionGeneration(client, input.issue.id),
         issueRevision: issueRevisionGeneration(client, input.issue.id),
+        resetGeneration: issueCacheResetGeneration(client),
       };
     },
     onError: async (error, input, context) => {
-      const lists = context?.lists ?? [];
-      const refreshKeys: QueryKey[] = [];
-      const expected = new Set(
-        lists.flatMap((snapshot) =>
-          snapshot.optimistic === undefined ? [] : [issueFingerprint(snapshot.optimistic)],
-        ),
-      );
-      const current = client
-        .getQueriesData<IssuePages>({ queryKey: [ISSUES_ROOT] })
-        .flatMap(([, pages]) => {
-          const found = issueFromPages(pages, input.issue.id);
-          return found === undefined ? [] : [found];
-        });
-      const hasOptimistic = current.some((issue) => expected.has(issueFingerprint(issue)));
-      const intervening = current.some((issue) => !expected.has(issueFingerprint(issue)));
-
-      for (const snapshot of lists) {
-        const pages = client.getQueryData<IssuePages>(snapshot.key);
-        const found = issueFromPages(pages, input.issue.id);
-        const stillOptimistic =
-          found === undefined
-            ? snapshot.optimistic === undefined
-            : snapshot.optimistic !== undefined &&
-              issueFingerprint(found) === issueFingerprint(snapshot.optimistic);
-        if (hasOptimistic && !intervening && stillOptimistic) {
-          client.setQueryData<IssuePages>(snapshot.key, (pages) => {
-            if (pages === undefined) return pages;
-            const found = issueFromPages(pages, input.issue.id);
-            if (found !== undefined && !expected.has(issueFingerprint(found))) return pages;
-            return restoreIssueInPages(
-              pages,
-              searchOf(snapshot.key),
-              input.issue.id,
-              snapshot.before,
-            );
-          });
-          continue;
-        }
-        if (intervening && !stillOptimistic) continue;
-        refreshKeys.push(snapshot.key);
-      }
       toast({ title: 'Could not move that issue', description: messageOf(error), tone: 'danger' });
-      await refreshIssueListsUntilStable(client, refreshKeys, [input.issue.id], true, false);
-      if (context !== undefined) {
-        restoreFailedMoveAfterUnavailableRefresh(client, input, context, refreshKeys);
-      }
+      if (failedMoveRollbackFenced(client, input, context)) await invalidateIssueCaches(client);
+      else await rollbackFailedMove(client, input, context);
     },
     onSuccess: async (settlement, input) => {
       const confirmedDeletedIds = settlement.issues
@@ -928,6 +978,7 @@ interface DeleteListSnapshot {
 interface DeleteMutationContext {
   readonly lists: readonly DeleteListSnapshot[];
   readonly issueRevisions: ReadonlyMap<string, number>;
+  readonly resetGeneration: number;
 }
 
 function dropFromIssueLists(client: QueryClient, removed: ReadonlySet<string>): void {
@@ -953,13 +1004,13 @@ async function dropFromIssueDetails(
     .getQueryCache()
     .findAll({ queryKey: [ISSUE_ROOT] })
     .flatMap((query) => (query.state.fetchStatus === 'fetching' ? [query.queryKey] : []));
-  await Promise.all(
+  await Promise.allSettled(
     fetchingKeys.map((key) => client.cancelQueries({ queryKey: key, exact: true })),
   );
   for (const [key, detail] of client.getQueriesData<IssueDetail>({ queryKey: [ISSUE_ROOT] })) {
     if (detail === undefined) continue;
     if (removed.has(detail.issue.id)) {
-      client.resetQueries({ queryKey: key, exact: true });
+      client.resetQueries({ queryKey: key, exact: true }).catch(() => undefined);
       continue;
     }
     let next = orphanRemovedParent(detail, removed);
@@ -1098,7 +1149,7 @@ export function useDeleteIssues() {
   return useMutation({
     mutationFn: deleteEach,
     onMutate: async (issues) => {
-      await client.cancelQueries({ queryKey: [ISSUES_ROOT] });
+      await Promise.allSettled([client.cancelQueries({ queryKey: [ISSUES_ROOT] })]);
       const before = client.getQueriesData<IssuePages>({
         queryKey: [ISSUES_ROOT],
       });
@@ -1114,6 +1165,7 @@ export function useDeleteIssues() {
         issueRevisions: new Map(
           [...changedIds].map((issueId) => [issueId, issueRevisionGeneration(client, issueId)]),
         ),
+        resetGeneration: issueCacheResetGeneration(client),
       };
     },
     onError: async (error, _issues, context) => {
@@ -1121,9 +1173,12 @@ export function useDeleteIssues() {
       if (partiallyDeleted) {
         recordIssueDeletions(client, error.gone);
         recordIssueListRevisions(client, issueListKeys(client));
-        await client.cancelQueries({ queryKey: [ISSUES_ROOT] });
+        await Promise.allSettled([client.cancelQueries({ queryKey: [ISSUES_ROOT] })]);
       }
-      if (context !== undefined) restoreIssueLists(client, context);
+      const resetChanged =
+        context !== undefined && issueCacheResetGeneration(client) !== context.resetGeneration;
+      if (context !== undefined && !resetChanged) restoreIssueLists(client, context);
+      if (resetChanged) await invalidateIssueCaches(client);
       if (partiallyDeleted) {
         dropFromIssueLists(client, new Set(error.gone));
         await dropFromIssueDetails(client, new Set(error.gone));
@@ -1137,7 +1192,7 @@ export function useDeleteIssues() {
         issues.map((issue) => issue.id),
       );
       recordIssueListRevisions(client, issueListKeys(client));
-      await client.cancelQueries({ queryKey: [ISSUES_ROOT] });
+      await Promise.allSettled([client.cancelQueries({ queryKey: [ISSUES_ROOT] })]);
       dropFromIssueLists(client, removed);
       await dropFromIssueDetails(client, removed);
     },

--- a/apps/web/src/lib/query/use-issues.ts
+++ b/apps/web/src/lib/query/use-issues.ts
@@ -13,6 +13,15 @@ import { useCallback, useMemo } from 'react';
 import { useToast } from '@/components/ui/toast.tsx';
 import { apiFetch, messageOf } from './fetcher.ts';
 import {
+  issueCacheRevisionGeneration,
+  issueDeletionGeneration,
+  issueListRevisionGeneration,
+  issueRevisionGeneration,
+  recordIssueDeletions,
+  recordIssueListRevisions,
+  recordIssueRevisions,
+} from './issue-cache-generation.ts';
+import {
   ALL_ISSUES_QUERY,
   allIssuesSearch,
   assignedSearch,
@@ -211,13 +220,15 @@ export function seedBoardColumns(
   column: BoardColumnKey,
   page: BoardPage,
   fetchedAt: number,
+  revision = issueCacheRevisionGeneration(client),
 ): void {
+  if (issueCacheRevisionGeneration(client) !== revision) return;
   for (const group of page.groups) {
     const search = groupColumnSearch(column.query, column.groupBy, group.id, column.scope);
     if (search.length === 0) continue;
     const key = queryKeys.issues(columnScopeKey(column.scope), search);
     const held = client.getQueryState(key);
-    if (held !== undefined && held.data !== undefined && held.dataUpdatedAt > fetchedAt) continue;
+    if (held !== undefined && held.data !== undefined && held.dataUpdatedAt >= fetchedAt) continue;
     client.setQueryData<IssuePages>(key, {
       pages: [{ issues: [...group.issues], nextCursor: group.nextCursor }],
       pageParams: [null],
@@ -235,8 +246,9 @@ export function useBoardPage(column: BoardColumnKey, enabled: boolean) {
     staleTime: BOARD_SEED_STALE_MS,
     queryFn: async ({ signal }): Promise<BoardPage> => {
       const fetchedAt = Date.now();
+      const revision = issueCacheRevisionGeneration(client);
       const page = await apiFetch(`/api/issues/board?${search}`, boardPageSchema, { signal });
-      seedBoardColumns(client, column, page, fetchedAt);
+      seedBoardColumns(client, column, page, fetchedAt, revision);
       return page;
     },
   });
@@ -405,7 +417,7 @@ export function authoritativeCachedIssue(
   const newest = occurrences.filter((issue) => issue.syncId === newestSyncId);
   const issue = newest[0];
   if (issue === undefined) return { kind: 'missing' };
-  const heads = new Set(newest.map((candidate) => JSON.stringify(candidate)));
+  const heads = new Set(newest.map(issueFingerprint));
   return heads.size === 1 ? { kind: 'found', issue } : { kind: 'ambiguous' };
 }
 
@@ -416,7 +428,35 @@ function issueFromPages(pages: IssuePages | undefined, issueId: string): Issue |
 }
 
 function issueFingerprint(issue: Issue): string {
-  return JSON.stringify(issue) ?? '';
+  return (
+    JSON.stringify([
+      issue.id,
+      issue.teamId,
+      issue.number,
+      issue.identifier,
+      issue.title,
+      issue.stateId,
+      issue.priority,
+      issue.creatorId,
+      issue.assigneeId,
+      [...(issue.reviewerIds ?? [])].sort(),
+      issue.projectId,
+      issue.milestoneId,
+      issue.cycleId,
+      issue.parentId,
+      issue.estimate,
+      issue.dueDate,
+      issue.sortOrder,
+      issue.startedAt,
+      issue.completedAt,
+      issue.canceledAt,
+      issue.syncId,
+      issue.createdAt,
+      issue.updatedAt,
+      issue.archivedAt,
+      [...issue.labelIds].sort(),
+    ]) ?? ''
+  );
 }
 
 function restoreIssueInPages(
@@ -447,17 +487,84 @@ function filteredListsHolding(
     }));
 }
 
-function settleFilteredLists(
+function filteredIssueListKeys(client: QueryClient): QueryKey[] {
+  return client
+    .getQueryCache()
+    .findAll({ queryKey: [ISSUES_ROOT] })
+    .flatMap((query) => (admitsNewRows(searchOf(query.queryKey)) ? [] : [query.queryKey]));
+}
+
+function issueListKeys(client: QueryClient): QueryKey[] {
+  return client
+    .getQueryCache()
+    .findAll({ queryKey: [ISSUES_ROOT] })
+    .map((query) => query.queryKey);
+}
+
+const ISSUE_SETTLEMENT_ATTEMPTS = 3;
+
+async function refreshIssueListsUntilStable(
+  client: QueryClient,
+  initialKeys: readonly QueryKey[],
+  issueIds: readonly string[],
+  refetchAll: boolean,
+  expandFiltered: boolean,
+): Promise<void> {
+  let keys = [...initialKeys];
+  for (let attempt = 0; attempt < ISSUE_SETTLEMENT_ATTEMPTS && keys.length > 0; attempt += 1) {
+    const listRevisions = keys.map((key) => issueListRevisionGeneration(client, key));
+    const issueRevisions = issueIds.map((issueId) => issueRevisionGeneration(client, issueId));
+    await Promise.all(
+      keys.map((key) =>
+        client
+          .invalidateQueries(
+            refetchAll ? { queryKey: key, exact: true, refetchType: 'all' } : { queryKey: key },
+          )
+          .catch(() => undefined),
+      ),
+    );
+    const changedKeys = keys.filter(
+      (key, index) => issueListRevisionGeneration(client, key) !== listRevisions[index],
+    );
+    const issueChanged = issueIds.some(
+      (issueId, index) => issueRevisionGeneration(client, issueId) !== issueRevisions[index],
+    );
+    if (changedKeys.length === 0 && !issueChanged) return;
+    if (issueChanged) {
+      keys = expandFiltered ? filteredIssueListKeys(client) : keys;
+    } else keys = changedKeys;
+    if (attempt !== ISSUE_SETTLEMENT_ATTEMPTS - 1) continue;
+    for (const key of keys) {
+      client
+        .invalidateQueries(
+          refetchAll
+            ? { queryKey: key, exact: true, refetchType: 'all' }
+            : { queryKey: key, exact: true },
+        )
+        .catch(() => undefined);
+    }
+  }
+}
+
+async function settleFilteredLists(
   client: QueryClient,
   moved: readonly Issue[],
   before: readonly { key: QueryKey; held: boolean }[],
-): void {
+): Promise<void> {
+  const keys: QueryKey[] = [];
   for (const { key, held } of before) {
     const search = searchOf(key);
     const belongsNow = moved.some((issue) => belongsInList(search, issue));
     if (!(held || belongsNow)) continue;
-    client.invalidateQueries({ queryKey: key }).catch(() => undefined);
+    keys.push(key);
   }
+  await refreshIssueListsUntilStable(
+    client,
+    keys,
+    moved.map((issue) => issue.id),
+    false,
+    true,
+  );
 }
 
 export function staleBoardPages(client: QueryClient): void {
@@ -482,16 +589,18 @@ function placeIssue(client: QueryClient, next: Issue, settle = true): void {
   eachIssueList(client, { queryKey: [ISSUES_ROOT] }, (issues, search) =>
     reconcile(search, issues, next),
   );
-  if (settle) settleFilteredLists(client, [next], before);
+  recordIssueRevisions(client, [next.id]);
+  if (settle) settleFilteredLists(client, [next], before).catch(() => undefined);
 }
 
 function placeMovedIssue(client: QueryClient, next: Issue): void {
   eachIssueList(client, { queryKey: [ISSUES_ROOT] }, (issues, search) =>
     reconcile(search, issues, next, isGroupColumn(search, next)),
   );
+  recordIssueRevisions(client, [next.id]);
 }
 
-function placeIssues(client: QueryClient, moved: readonly Issue[]): void {
+async function placeIssues(client: QueryClient, moved: readonly Issue[]): Promise<void> {
   const before = filteredListsHolding(client, moved);
   eachIssueList(client, { queryKey: [ISSUES_ROOT] }, (issues, search) => {
     let next = issues;
@@ -501,7 +610,11 @@ function placeIssues(client: QueryClient, moved: readonly Issue[]): void {
     }
     return sortForSearch(search, next);
   });
-  settleFilteredLists(client, moved, before);
+  recordIssueRevisions(
+    client,
+    moved.map((issue) => issue.id),
+  );
+  await settleFilteredLists(client, moved, before);
 }
 
 function addToLists(client: QueryClient, next: Issue): void {
@@ -509,7 +622,8 @@ function addToLists(client: QueryClient, next: Issue): void {
   eachIssueList(client, { queryKey: [ISSUES_ROOT] }, (issues, search) =>
     reconcile(search, issues, next),
   );
-  settleFilteredLists(client, [next], before);
+  recordIssueRevisions(client, [next.id]);
+  settleFilteredLists(client, [next], before).catch(() => undefined);
 }
 
 function refreshCounts(client: QueryClient): void {
@@ -598,6 +712,26 @@ export type MoveInput = IssueRegrouping & {
   readonly afterOrder: number | null;
 };
 
+const moveDeletionGenerations = new WeakMap<MoveInput, number>();
+
+interface MoveListSnapshot {
+  readonly key: QueryKey;
+  readonly before: Issue | undefined;
+  readonly optimistic: Issue | undefined;
+  readonly listRevision: number;
+}
+
+interface MoveMutationContext {
+  readonly lists: readonly MoveListSnapshot[];
+  readonly deletionGeneration: number;
+  readonly issueRevision: number;
+}
+
+export interface IssueMoveSettlement {
+  readonly issues: readonly Issue[];
+  readonly issueWasDeletedDuringSettlement: boolean;
+}
+
 function regroupingOf(input: MoveInput): IssueRegrouping {
   return {
     ...(input.stateId === undefined ? {} : { stateId: input.stateId }),
@@ -608,19 +742,50 @@ function regroupingOf(input: MoveInput): IssueRegrouping {
   };
 }
 
+function restoreFailedMoveAfterUnavailableRefresh(
+  client: QueryClient,
+  input: MoveInput,
+  context: MoveMutationContext,
+  refreshKeys: readonly QueryKey[],
+): void {
+  if (issueDeletionGeneration(client, input.issue.id) !== context.deletionGeneration) return;
+  if (issueRevisionGeneration(client, input.issue.id) !== context.issueRevision) return;
+  if (authoritativeCachedIssue(client, input.issue.id).kind !== 'missing') return;
+  for (const snapshot of context.lists) {
+    if (snapshot.before === undefined || snapshot.optimistic !== undefined) continue;
+    if (!refreshKeys.includes(snapshot.key)) continue;
+    if (issueListRevisionGeneration(client, snapshot.key) !== snapshot.listRevision) continue;
+    const query = client.getQueryCache().find({ queryKey: snapshot.key, exact: true });
+    if (query === undefined || query.state.error === null) continue;
+    client.setQueryData<IssuePages>(snapshot.key, (pages) =>
+      pages === undefined
+        ? pages
+        : restoreIssueInPages(pages, searchOf(snapshot.key), input.issue.id, snapshot.before),
+    );
+  }
+}
+
 export function useMoveIssue() {
   const client = useQueryClient();
   const { toast } = useToast();
 
   return useMutation({
-    mutationFn: async (input: MoveInput): Promise<readonly Issue[]> => {
+    mutationFn: async (input: MoveInput): Promise<IssueMoveSettlement> => {
+      const deletionGeneration =
+        moveDeletionGenerations.get(input) ?? issueDeletionGeneration(client, input.issue.id);
       const result = await apiFetch(`/api/issues/${input.issue.id}/move`, issueMoveResultSchema, {
         method: 'POST',
         body: { ...regroupingOf(input), beforeId: input.beforeId, afterId: input.afterId },
       });
-      return [result.issue, ...result.rebalanced];
+      return {
+        issues: [result.issue, ...result.rebalanced],
+        get issueWasDeletedDuringSettlement() {
+          return issueDeletionGeneration(client, input.issue.id) !== deletionGeneration;
+        },
+      };
     },
     onMutate: async (input) => {
+      moveDeletionGenerations.set(input, issueDeletionGeneration(client, input.issue.id));
       await client.cancelQueries({ queryKey: [ISSUES_ROOT] });
       const before = client.getQueriesData<IssuePages>({ queryKey: [ISSUES_ROOT] });
       const optimistic: Issue = {
@@ -634,12 +799,16 @@ export function useMoveIssue() {
           key,
           before: issueFromPages(pages, input.issue.id),
           optimistic: issueFromPages(client.getQueryData<IssuePages>(key), input.issue.id),
+          listRevision: issueListRevisionGeneration(client, key),
         })),
+        deletionGeneration:
+          moveDeletionGenerations.get(input) ?? issueDeletionGeneration(client, input.issue.id),
+        issueRevision: issueRevisionGeneration(client, input.issue.id),
       };
     },
     onError: async (error, input, context) => {
       const lists = context?.lists ?? [];
-      const refreshes: Promise<void>[] = [];
+      const refreshKeys: QueryKey[] = [];
       const expected = new Set(
         lists.flatMap((snapshot) =>
           snapshot.optimistic === undefined ? [] : [issueFingerprint(snapshot.optimistic)],
@@ -677,17 +846,27 @@ export function useMoveIssue() {
           continue;
         }
         if (intervening && !stillOptimistic) continue;
-        refreshes.push(
-          client
-            .invalidateQueries({ queryKey: snapshot.key, exact: true, refetchType: 'all' })
-            .catch(() => undefined),
-        );
+        refreshKeys.push(snapshot.key);
       }
-      await Promise.all(refreshes);
       toast({ title: 'Could not move that issue', description: messageOf(error), tone: 'danger' });
+      await refreshIssueListsUntilStable(client, refreshKeys, [input.issue.id], true, false);
+      if (context !== undefined) {
+        restoreFailedMoveAfterUnavailableRefresh(client, input, context, refreshKeys);
+      }
     },
-    onSuccess: (moved) => {
-      placeIssues(client, moved);
+    onSuccess: async (settlement, input) => {
+      const confirmedDeletedIds = settlement.issues
+        .filter((issue) => issueDeletionGeneration(client, issue.id) > 0)
+        .map((issue) => issue.id);
+      const confirmedDeleted = new Set(confirmedDeletedIds);
+      await placeIssues(
+        client,
+        settlement.issues.filter((issue) => !confirmedDeleted.has(issue.id)),
+      );
+      if (confirmedDeleted.size > 0) dropFromIssueLists(client, confirmedDeleted);
+      if (settlement.issueWasDeletedDuringSettlement) {
+        dropFromIssueLists(client, new Set([input.issue.id]));
+      }
     },
     onSettled: (_moved, _error, input) => {
       resortTeamIssueLists(client, input.issue.teamId);
@@ -740,27 +919,152 @@ export function useCreateIssue(_teamId: string) {
   });
 }
 
-type ListSnapshot = readonly [QueryKey, IssuePages | undefined][];
+interface DeleteListSnapshot {
+  readonly key: QueryKey;
+  readonly before: IssuePages | undefined;
+  readonly optimistic: IssuePages | undefined;
+}
+
+interface DeleteMutationContext {
+  readonly lists: readonly DeleteListSnapshot[];
+  readonly issueRevisions: ReadonlyMap<string, number>;
+}
 
 function dropFromIssueLists(client: QueryClient, removed: ReadonlySet<string>): void {
   eachIssueList(client, { queryKey: [ISSUES_ROOT] }, (issues) => withoutIssues(issues, removed));
 }
 
-function dropFromIssueDetails(client: QueryClient, removed: ReadonlySet<string>): void {
+function orphanRemovedParent(detail: IssueDetail, removed: ReadonlySet<string>): IssueDetail {
+  const parentIdRemoved = detail.issue.parentId !== null && removed.has(detail.issue.parentId);
+  const parentRemoved = detail.parent !== null && removed.has(detail.parent.id);
+  if (!(parentIdRemoved || parentRemoved)) return detail;
+  return {
+    ...detail,
+    issue: parentIdRemoved ? { ...detail.issue, parentId: null } : detail.issue,
+    parent: null,
+  };
+}
+
+async function dropFromIssueDetails(
+  client: QueryClient,
+  removed: ReadonlySet<string>,
+): Promise<void> {
+  const fetchingKeys = client
+    .getQueryCache()
+    .findAll({ queryKey: [ISSUE_ROOT] })
+    .flatMap((query) => (query.state.fetchStatus === 'fetching' ? [query.queryKey] : []));
+  await Promise.all(
+    fetchingKeys.map((key) => client.cancelQueries({ queryKey: key, exact: true })),
+  );
   for (const [key, detail] of client.getQueriesData<IssueDetail>({ queryKey: [ISSUE_ROOT] })) {
     if (detail === undefined) continue;
     if (removed.has(detail.issue.id)) {
       client.resetQueries({ queryKey: key, exact: true });
       continue;
     }
-    let next = detail;
+    let next = orphanRemovedParent(detail, removed);
     for (const id of removed) next = withoutSubIssue(next, id) ?? next;
     if (next !== detail) client.setQueryData(key, next);
   }
+  for (const key of fetchingKeys) {
+    client.invalidateQueries({ queryKey: key, exact: true }).catch(() => undefined);
+  }
 }
 
-function restoreIssueLists(client: QueryClient, snapshot: ListSnapshot): void {
-  for (const [key, pages] of snapshot) client.setQueryData(key, pages);
+function deletionChangedIssueIds(snapshot: DeleteListSnapshot): string[] {
+  if (snapshot.before === undefined) return [];
+  return flattenIssuePages(snapshot.before).flatMap((issue) => {
+    const optimistic = issueFromPages(snapshot.optimistic, issue.id);
+    return optimistic === undefined || issueFingerprint(optimistic) !== issueFingerprint(issue)
+      ? [issue.id]
+      : [];
+  });
+}
+
+function restoreDeletedIssueInPages(
+  pages: IssuePages,
+  snapshot: IssuePages | undefined,
+  issueId: string,
+  before: Issue | undefined,
+): IssuePages {
+  return mapIssuePages(pages, (issues) => {
+    const currentIndex = issues.findIndex((issue) => issue.id === issueId);
+    if (before === undefined) {
+      return currentIndex === -1 ? issues : issues.filter((issue) => issue.id !== issueId);
+    }
+    if (currentIndex !== -1) {
+      const restored = [...issues];
+      restored[currentIndex] = before;
+      return restored;
+    }
+    const beforeRows = snapshot === undefined ? [] : flattenIssuePages(snapshot);
+    const snapshotIndex = beforeRows.findIndex((issue) => issue.id === issueId);
+    const previous = beforeRows
+      .slice(0, Math.max(0, snapshotIndex))
+      .reverse()
+      .find((issue) => issues.some((current) => current.id === issue.id));
+    if (previous !== undefined) {
+      const insertAt = issues.findIndex((issue) => issue.id === previous.id) + 1;
+      return [...issues.slice(0, insertAt), before, ...issues.slice(insertAt)];
+    }
+    const following = beforeRows
+      .slice(snapshotIndex + 1)
+      .find((issue) => issues.some((current) => current.id === issue.id));
+    if (following !== undefined) {
+      const insertAt = issues.findIndex((issue) => issue.id === following.id);
+      return [...issues.slice(0, insertAt), before, ...issues.slice(insertAt)];
+    }
+    return [...issues, before];
+  });
+}
+
+function restorableDeletedIssueIds(
+  client: QueryClient,
+  context: DeleteMutationContext,
+  changedIds: readonly string[],
+): string[] {
+  return changedIds.filter(
+    (issueId) => issueRevisionGeneration(client, issueId) === context.issueRevisions.get(issueId),
+  );
+}
+
+function cachedIssueMatches(present: Issue | undefined, expected: Issue | undefined): boolean {
+  if (present === undefined) return expected === undefined;
+  return expected !== undefined && issueFingerprint(present) === issueFingerprint(expected);
+}
+
+function restoreIssueList(
+  client: QueryClient,
+  context: DeleteMutationContext,
+  snapshot: DeleteListSnapshot,
+  current: IssuePages | undefined,
+): IssuePages | undefined {
+  const changedIds = deletionChangedIssueIds(snapshot);
+  if (changedIds.length === 0) return current;
+  const restorable = restorableDeletedIssueIds(client, context, changedIds);
+  if (current === undefined) {
+    return restorable.length === changedIds.length ? snapshot.before : current;
+  }
+  let restored = current;
+  for (const issueId of restorable) {
+    const optimistic = issueFromPages(snapshot.optimistic, issueId);
+    if (!cachedIssueMatches(issueFromPages(restored, issueId), optimistic)) continue;
+    restored = restoreDeletedIssueInPages(
+      restored,
+      snapshot.before,
+      issueId,
+      issueFromPages(snapshot.before, issueId),
+    );
+  }
+  return mapIssuePages(restored, (issues) => sortForSearch(searchOf(snapshot.key), issues));
+}
+
+function restoreIssueLists(client: QueryClient, context: DeleteMutationContext): void {
+  for (const snapshot of context.lists) {
+    client.setQueryData<IssuePages>(snapshot.key, (current) =>
+      restoreIssueList(client, context, snapshot, current),
+    );
+  }
 }
 
 export class PartialIssueDelete extends Error {
@@ -795,22 +1099,47 @@ export function useDeleteIssues() {
     mutationFn: deleteEach,
     onMutate: async (issues) => {
       await client.cancelQueries({ queryKey: [ISSUES_ROOT] });
-      const snapshot: ListSnapshot = client.getQueriesData<IssuePages>({
+      const before = client.getQueriesData<IssuePages>({
         queryKey: [ISSUES_ROOT],
       });
       dropFromIssueLists(client, new Set(issues.map((issue) => issue.id)));
-      return { snapshot };
+      const lists = before.map(([key, pages]) => ({
+        key,
+        before: pages,
+        optimistic: client.getQueryData<IssuePages>(key),
+      }));
+      const changedIds = new Set(lists.flatMap(deletionChangedIssueIds));
+      return {
+        lists,
+        issueRevisions: new Map(
+          [...changedIds].map((issueId) => [issueId, issueRevisionGeneration(client, issueId)]),
+        ),
+      };
     },
-    onError: (error, _issues, context) => {
-      if (context !== undefined) restoreIssueLists(client, context.snapshot);
-      if (error instanceof PartialIssueDelete && error.gone.length > 0) {
+    onError: async (error, _issues, context) => {
+      const partiallyDeleted = error instanceof PartialIssueDelete && error.gone.length > 0;
+      if (partiallyDeleted) {
+        recordIssueDeletions(client, error.gone);
+        recordIssueListRevisions(client, issueListKeys(client));
+        await client.cancelQueries({ queryKey: [ISSUES_ROOT] });
+      }
+      if (context !== undefined) restoreIssueLists(client, context);
+      if (partiallyDeleted) {
         dropFromIssueLists(client, new Set(error.gone));
-        dropFromIssueDetails(client, new Set(error.gone));
+        await dropFromIssueDetails(client, new Set(error.gone));
       }
       toast({ title: 'Could not delete', description: messageOf(error), tone: 'danger' });
     },
-    onSuccess: (issues) => {
-      dropFromIssueDetails(client, new Set(issues.map((issue) => issue.id)));
+    onSuccess: async (issues) => {
+      const removed = new Set(issues.map((issue) => issue.id));
+      recordIssueDeletions(
+        client,
+        issues.map((issue) => issue.id),
+      );
+      recordIssueListRevisions(client, issueListKeys(client));
+      await client.cancelQueries({ queryKey: [ISSUES_ROOT] });
+      dropFromIssueLists(client, removed);
+      await dropFromIssueDetails(client, removed);
     },
     onSettled: () => {
       refreshCounts(client);

--- a/apps/web/src/lib/realtime/delta-bridge.tsx
+++ b/apps/web/src/lib/realtime/delta-bridge.tsx
@@ -359,6 +359,7 @@ function migrateMovedIssueDetails(
         : movedIssueDetail(current, parsed.data);
     if (next === undefined) continue;
     client.setQueryData(previousKey, next);
+    client.invalidateQueries({ queryKey: previousKey, exact: true }).catch(noop);
     if (migrated === undefined || current !== undefined) migrated = next;
   }
   if (migrated === undefined) return;

--- a/apps/web/src/lib/realtime/delta-bridge.tsx
+++ b/apps/web/src/lib/realtime/delta-bridge.tsx
@@ -15,6 +15,11 @@ import { ANALYTICS_ROOT } from '@/features/analytics/analytics-keys.ts';
 import { clientId } from '@/lib/query/client-id.ts';
 import { apiFetch } from '@/lib/query/fetcher.ts';
 import {
+  recordIssueDeletions,
+  recordIssueListRevisions,
+  recordIssueRevisions,
+} from '@/lib/query/issue-cache-generation.ts';
+import {
   ALL_SCOPE,
   ASSIGNED_SCOPE,
   BOARD_ROOT,
@@ -115,24 +120,56 @@ function membershipOf(key: QueryKey): IssueBelongs | null {
   return (issue: Issue) => issue.teamId === scope && belongsInList(search, issue);
 }
 
+function issueActionMayAffectQuery(action: SyncAction, key: QueryKey): boolean {
+  const teamId = new URLSearchParams(searchOf(key)).get('teamId');
+  return teamId === null || action.scopes.includes(scopes.team(teamId));
+}
+
+function restartEmptyOverlappingQuery(
+  client: QueryClient,
+  key: QueryKey,
+  overlapsFetch: boolean,
+): QueryKey[] {
+  if (!overlapsFetch) return [];
+  client.invalidateQueries({ queryKey: key, exact: true }).catch(() => undefined);
+  return [key];
+}
+
 function patchIssueCaches(client: QueryClient, action: SyncAction): void {
+  const revisedKeys: QueryKey[] = [];
   for (const query of client.getQueryCache().findAll({ queryKey: [ISSUES_ROOT] })) {
     const belongs = membershipOf(query.queryKey);
     if (belongs === null) continue;
+    const overlapsFetch =
+      query.state.fetchStatus === 'fetching' && issueActionMayAffectQuery(action, query.queryKey);
+    if (overlapsFetch) {
+      client.cancelQueries({ queryKey: query.queryKey, exact: true }).catch(() => undefined);
+    }
     const current = query.state.data as IssuePages | undefined;
-    if (current === undefined) continue;
+    if (current === undefined) {
+      revisedKeys.push(...restartEmptyOverlappingQuery(client, query.queryKey, overlapsFetch));
+      continue;
+    }
     const search = searchOf(query.queryKey);
     const next = applyIssueDeltaToPages(current, action, belongs, search);
     if (next !== current) client.setQueryData(query.queryKey, next);
-    if (awaitsServerRefresh(flattenIssuePages(current), action, belongs, search)) {
-      client.invalidateQueries({ queryKey: query.queryKey }).catch(() => undefined);
+    const refreshFromServer = awaitsServerRefresh(
+      flattenIssuePages(current),
+      action,
+      belongs,
+      search,
+    );
+    if (next !== current || refreshFromServer || overlapsFetch) revisedKeys.push(query.queryKey);
+    if (refreshFromServer || overlapsFetch) {
+      client.invalidateQueries({ queryKey: query.queryKey, exact: true }).catch(() => undefined);
     }
   }
 
+  recordIssueListRevisions(client, revisedKeys);
   patchIssueDetailCaches(client, action);
 }
 
-function forgetDeletedIssue(client: QueryClient, issueId: string): void {
+function patchDeletedIssueDetails(client: QueryClient, issueId: string): void {
   for (const query of client.getQueryCache().findAll({ queryKey: [ISSUE_ROOT] })) {
     const current = query.state.data as IssueDetail | undefined;
     if (current === undefined) continue;
@@ -140,9 +177,57 @@ function forgetDeletedIssue(client: QueryClient, issueId: string): void {
       client.resetQueries({ queryKey: query.queryKey, exact: true });
       continue;
     }
-    const trimmed = withoutSubIssue(current, issueId);
+    const parentRemoved = current.issue.parentId === issueId || current.parent?.id === issueId;
+    const orphaned = parentRemoved
+      ? {
+          ...current,
+          issue:
+            current.issue.parentId === issueId
+              ? { ...current.issue, parentId: null }
+              : current.issue,
+          parent: null,
+        }
+      : current;
+    const trimmed = withoutSubIssue(orphaned, issueId);
     if (trimmed !== current) client.setQueryData(query.queryKey, trimmed);
   }
+}
+
+function forgetDeletedIssue(client: QueryClient, issueId: string): void {
+  const fetchingKeys = client
+    .getQueryCache()
+    .findAll({ queryKey: [ISSUE_ROOT] })
+    .flatMap((query) => (query.state.fetchStatus === 'fetching' ? [query.queryKey] : []));
+  const cancellations = fetchingKeys.map((key) =>
+    client.cancelQueries({ queryKey: key, exact: true }),
+  );
+  patchDeletedIssueDetails(client, issueId);
+  Promise.all(cancellations)
+    .then(() => {
+      patchDeletedIssueDetails(client, issueId);
+      for (const key of fetchingKeys) {
+        client.invalidateQueries({ queryKey: key, exact: true }).catch(() => undefined);
+      }
+    })
+    .catch(() => undefined);
+}
+
+function patchIssueDetailUpdates(client: QueryClient, action: SyncAction): void {
+  for (const query of client.getQueryCache().findAll({ queryKey: [ISSUE_ROOT] })) {
+    const current = query.state.data as IssueDetail | undefined;
+    if (current === undefined) continue;
+    const next = applyIssueDetailDelta(current, action);
+    if (next !== current) client.setQueryData(query.queryKey, next);
+  }
+}
+
+function cachedIssueIdentifier(client: QueryClient, issueId: string): string | undefined {
+  for (const [, pages] of client.getQueriesData<IssuePages>({ queryKey: [ISSUES_ROOT] })) {
+    const issue =
+      pages === undefined ? undefined : flattenIssuePages(pages).find((row) => row.id === issueId);
+    if (issue !== undefined) return issue.identifier;
+  }
+  return undefined;
 }
 
 function patchIssueDetailCaches(client: QueryClient, action: SyncAction): void {
@@ -150,12 +235,33 @@ function patchIssueDetailCaches(client: QueryClient, action: SyncAction): void {
     forgetDeletedIssue(client, action.modelId);
     return;
   }
-  for (const query of client.getQueryCache().findAll({ queryKey: [ISSUE_ROOT] })) {
-    const current = query.state.data as IssueDetail | undefined;
-    if (current === undefined) continue;
-    const next = applyIssueDetailDelta(current, action);
-    if (next !== current) client.setQueryData(query.queryKey, next);
-  }
+  const identifier = cachedIssueIdentifier(client, action.modelId);
+  const fetchingKeys = client
+    .getQueryCache()
+    .findAll({ queryKey: [ISSUE_ROOT] })
+    .flatMap((query) => {
+      const current = query.state.data as IssueDetail | undefined;
+      if (query.state.fetchStatus !== 'fetching') return [];
+      if (current?.issue.id === action.modelId) return [query.queryKey];
+      const queryIdentifier = query.queryKey[1];
+      return current === undefined &&
+        typeof queryIdentifier === 'string' &&
+        (identifier === undefined || queryIdentifier === identifier)
+        ? [query.queryKey]
+        : [];
+    });
+  const cancellations = fetchingKeys.map((key) =>
+    client.cancelQueries({ queryKey: key, exact: true }),
+  );
+  patchIssueDetailUpdates(client, action);
+  Promise.all(cancellations)
+    .then(() => {
+      patchIssueDetailUpdates(client, action);
+      for (const key of fetchingKeys) {
+        client.invalidateQueries({ queryKey: key, exact: true }).catch(() => undefined);
+      }
+    })
+    .catch(() => undefined);
 }
 
 function patchCommentCaches(
@@ -211,6 +317,8 @@ function routeAction(
 ): void {
   if (action.model === 'issue') {
     patchIssueCaches(client, action);
+    if (action.action === 'delete') recordIssueDeletions(client, [action.modelId]);
+    else recordIssueRevisions(client, [action.modelId]);
     roots.counts = true;
     roots.milestones = true;
     roots.boards = true;

--- a/apps/web/src/lib/realtime/delta-bridge.tsx
+++ b/apps/web/src/lib/realtime/delta-bridge.tsx
@@ -15,9 +15,15 @@ import { ANALYTICS_ROOT } from '@/features/analytics/analytics-keys.ts';
 import { clientId } from '@/lib/query/client-id.ts';
 import { apiFetch } from '@/lib/query/fetcher.ts';
 import {
+  issueRevisionGeneration,
+  issueSurvivalSyncWatermark,
+  issueSyncWatermark,
+  recordIssueCacheReset,
   recordIssueDeletions,
   recordIssueListRevisions,
   recordIssueRevisions,
+  recordIssueSurvivalSyncWatermark,
+  recordIssueSyncWatermark,
 } from '@/lib/query/issue-cache-generation.ts';
 import {
   ALL_SCOPE,
@@ -37,9 +43,17 @@ import {
   ISSUES_ROOT,
   MILESTONES_ROOT,
   PROJECT_SCOPE,
+  queryKeys,
   VIEWS_ROOT,
 } from '@/lib/query/keys.ts';
-import type { Comment, DocComment, Issue, IssueDetail } from '@/lib/query/schemas.ts';
+import {
+  type Comment,
+  type DocComment,
+  type Issue,
+  type IssueDetail,
+  issueDetailSchema,
+  issueSchema,
+} from '@/lib/query/schemas.ts';
 import type { IssueBelongs, IssuePages } from '@/lib/query/sync.ts';
 import {
   applyCommentDelta,
@@ -89,6 +103,7 @@ interface RootInvalidations {
   analytics: boolean;
   counts: boolean;
   boards: boolean;
+  issueCaches: boolean;
   bootstrap: boolean;
   views: boolean;
   docs: boolean;
@@ -122,7 +137,11 @@ function membershipOf(key: QueryKey): IssueBelongs | null {
 
 function issueActionMayAffectQuery(action: SyncAction, key: QueryKey): boolean {
   const teamId = new URLSearchParams(searchOf(key)).get('teamId');
-  return teamId === null || action.scopes.includes(scopes.team(teamId));
+  return (
+    teamId === null ||
+    action.data['teamChanged'] === true ||
+    action.scopes.includes(scopes.team(teamId))
+  );
 }
 
 function restartEmptyOverlappingQuery(
@@ -135,38 +154,104 @@ function restartEmptyOverlappingQuery(
   return [key];
 }
 
-function patchIssueCaches(client: QueryClient, action: SyncAction): void {
+function issueDetailIdentifierSets(
+  client: QueryClient,
+  action: SyncAction,
+  previousIdentifiers: ReadonlySet<string>,
+): { known: ReadonlySet<string>; moved: ReadonlySet<string>; stale: boolean } {
+  const known = new Set(previousIdentifiers);
+  const moved = new Set(previousIdentifiers);
+  const cached = [
+    ...client
+      .getQueriesData<IssuePages>({ queryKey: [ISSUES_ROOT] })
+      .flatMap(([, pages]) =>
+        pages === undefined
+          ? []
+          : flattenIssuePages(pages).filter((issue) => issue.id === action.modelId),
+      ),
+    ...client
+      .getQueriesData<IssueDetail>({ queryKey: [ISSUE_ROOT] })
+      .flatMap(([, detail]) => (detail?.issue.id === action.modelId ? [detail.issue] : [])),
+  ];
+  const current = action.data['identifier'];
+  const newestSyncId = cached.reduce(
+    (newest, issue) => Math.max(newest, issue.syncId),
+    issueSyncWatermark(client, action.modelId),
+  );
+  if (action.syncId < newestSyncId) return { known, moved, stale: true };
+  for (const issue of cached) {
+    if (issue.syncId !== newestSyncId) continue;
+    known.add(issue.identifier);
+    if (typeof current === 'string' && current !== issue.identifier) {
+      moved.add(issue.identifier);
+    }
+  }
+  return { known, moved, stale: false };
+}
+
+function patchIssueListCache(
+  client: QueryClient,
+  action: SyncAction,
+  key: QueryKey,
+  current: IssuePages | undefined,
+  fetching: boolean,
+): boolean {
+  const belongs = membershipOf(key);
+  if (belongs === null) return false;
+  const overlapsFetch = fetching && issueActionMayAffectQuery(action, key);
+  if (overlapsFetch) client.cancelQueries({ queryKey: key, exact: true }).catch(noop);
+  if (current === undefined)
+    return restartEmptyOverlappingQuery(client, key, overlapsFetch).length > 0;
+  const search = searchOf(key);
+  const cachedIssue = flattenIssuePages(current).find((issue) => issue.id === action.modelId);
+  const next =
+    cachedIssue !== undefined && action.syncId <= cachedIssue.syncId
+      ? current
+      : applyIssueDeltaToPages(current, action, belongs, search);
+  if (next !== current) client.setQueryData(key, next);
+  const refreshFromServer = awaitsServerRefresh(
+    flattenIssuePages(current),
+    action,
+    belongs,
+    search,
+  );
+  if (refreshFromServer || overlapsFetch) {
+    client.invalidateQueries({ queryKey: key, exact: true }).catch(noop);
+  }
+  return next !== current || refreshFromServer || overlapsFetch;
+}
+
+function patchIssueCaches(
+  client: QueryClient,
+  action: SyncAction,
+  preserveDeletedDetail: boolean,
+  previousIdentifiers: ReadonlySet<string>,
+): boolean {
+  const detailIdentifiers = issueDetailIdentifierSets(client, action, previousIdentifiers);
+  if (detailIdentifiers.stale) return false;
+  recordIssueSyncWatermark(client, action.modelId, action.syncId);
   const revisedKeys: QueryKey[] = [];
   for (const query of client.getQueryCache().findAll({ queryKey: [ISSUES_ROOT] })) {
-    const belongs = membershipOf(query.queryKey);
-    if (belongs === null) continue;
-    const overlapsFetch =
-      query.state.fetchStatus === 'fetching' && issueActionMayAffectQuery(action, query.queryKey);
-    if (overlapsFetch) {
-      client.cancelQueries({ queryKey: query.queryKey, exact: true }).catch(() => undefined);
-    }
     const current = query.state.data as IssuePages | undefined;
-    if (current === undefined) {
-      revisedKeys.push(...restartEmptyOverlappingQuery(client, query.queryKey, overlapsFetch));
-      continue;
-    }
-    const search = searchOf(query.queryKey);
-    const next = applyIssueDeltaToPages(current, action, belongs, search);
-    if (next !== current) client.setQueryData(query.queryKey, next);
-    const refreshFromServer = awaitsServerRefresh(
-      flattenIssuePages(current),
+    const revised = patchIssueListCache(
+      client,
       action,
-      belongs,
-      search,
+      query.queryKey,
+      current,
+      query.state.fetchStatus === 'fetching',
     );
-    if (next !== current || refreshFromServer || overlapsFetch) revisedKeys.push(query.queryKey);
-    if (refreshFromServer || overlapsFetch) {
-      client.invalidateQueries({ queryKey: query.queryKey, exact: true }).catch(() => undefined);
-    }
+    if (revised) revisedKeys.push(query.queryKey);
   }
 
   recordIssueListRevisions(client, revisedKeys);
-  patchIssueDetailCaches(client, action);
+  patchIssueDetailCaches(
+    client,
+    action,
+    preserveDeletedDetail,
+    detailIdentifiers.known,
+    detailIdentifiers.moved,
+  );
+  return true;
 }
 
 function patchDeletedIssueDetails(client: QueryClient, issueId: string): void {
@@ -174,7 +259,7 @@ function patchDeletedIssueDetails(client: QueryClient, issueId: string): void {
     const current = query.state.data as IssueDetail | undefined;
     if (current === undefined) continue;
     if (current.issue.id === issueId) {
-      client.resetQueries({ queryKey: query.queryKey, exact: true });
+      client.resetQueries({ queryKey: query.queryKey, exact: true }).catch(noop);
       continue;
     }
     const parentRemoved = current.issue.parentId === issueId || current.parent?.id === issueId;
@@ -202,7 +287,7 @@ function forgetDeletedIssue(client: QueryClient, issueId: string): void {
     client.cancelQueries({ queryKey: key, exact: true }),
   );
   patchDeletedIssueDetails(client, issueId);
-  Promise.all(cancellations)
+  Promise.allSettled(cancellations)
     .then(() => {
       patchDeletedIssueDetails(client, issueId);
       for (const key of fetchingKeys) {
@@ -221,21 +306,80 @@ function patchIssueDetailUpdates(client: QueryClient, action: SyncAction): void 
   }
 }
 
-function cachedIssueIdentifier(client: QueryClient, issueId: string): string | undefined {
-  for (const [, pages] of client.getQueriesData<IssuePages>({ queryKey: [ISSUES_ROOT] })) {
-    const issue =
-      pages === undefined ? undefined : flattenIssuePages(pages).find((row) => row.id === issueId);
-    if (issue !== undefined) return issue.identifier;
-  }
-  return undefined;
+function issueActionIdentifiers(
+  action: SyncAction,
+  previousIdentifiers: ReadonlySet<string>,
+): ReadonlySet<string> {
+  const identifiers = new Set(previousIdentifiers);
+  const current = action.data['identifier'];
+  if (typeof current === 'string') identifiers.add(current);
+  return identifiers;
 }
 
-function patchIssueDetailCaches(client: QueryClient, action: SyncAction): void {
+function realtimeIssueDetail(issue: Issue): IssueDetail {
+  return {
+    issue,
+    descriptionHtml: '',
+    activity: [],
+    activityCursor: null,
+    subIssues: [],
+    parent: null,
+    subscribed: false,
+    attachments: [],
+  };
+}
+
+function movedIssueDetail(current: IssueDetail, issue: Issue): IssueDetail | undefined {
+  if (current.issue.id !== issue.id || current.issue.syncId > issue.syncId) return undefined;
+  return {
+    ...current,
+    issue,
+    ...(current.issue.description === issue.description ? {} : { descriptionHtml: '' }),
+  };
+}
+
+function migrateMovedIssueDetails(
+  client: QueryClient,
+  action: SyncAction,
+  previousIdentifiers: ReadonlySet<string>,
+): void {
+  if (previousIdentifiers.size === 0) return;
+  const parsed = issueSchema.safeParse(action.data);
+  if (!parsed.success) return;
+  const nextKey = queryKeys.issue(parsed.data.identifier);
+  let migrated: IssueDetail | undefined;
+  for (const identifier of previousIdentifiers) {
+    if (identifier === parsed.data.identifier) continue;
+    const previousKey = queryKeys.issue(identifier);
+    if (client.getQueryState(previousKey) === undefined) continue;
+    const current = client.getQueryData<IssueDetail>(previousKey);
+    const next =
+      current === undefined
+        ? realtimeIssueDetail(parsed.data)
+        : movedIssueDetail(current, parsed.data);
+    if (next === undefined) continue;
+    client.setQueryData(previousKey, next);
+    if (migrated === undefined || current !== undefined) migrated = next;
+  }
+  if (migrated === undefined) return;
+  client.setQueryData<IssueDetail>(nextKey, (current) =>
+    current === undefined ? migrated : (movedIssueDetail(current, parsed.data) ?? current),
+  );
+  client.invalidateQueries({ queryKey: nextKey, exact: true }).catch(() => undefined);
+}
+
+function patchIssueDetailCaches(
+  client: QueryClient,
+  action: SyncAction,
+  preserveDeletedDetail: boolean,
+  knownIdentifiers: ReadonlySet<string>,
+  movedIdentifiers: ReadonlySet<string>,
+): void {
   if (action.action === 'delete') {
-    forgetDeletedIssue(client, action.modelId);
+    if (!preserveDeletedDetail) forgetDeletedIssue(client, action.modelId);
     return;
   }
-  const identifier = cachedIssueIdentifier(client, action.modelId);
+  const identifiers = issueActionIdentifiers(action, knownIdentifiers);
   const fetchingKeys = client
     .getQueryCache()
     .findAll({ queryKey: [ISSUE_ROOT] })
@@ -246,7 +390,7 @@ function patchIssueDetailCaches(client: QueryClient, action: SyncAction): void {
       const queryIdentifier = query.queryKey[1];
       return current === undefined &&
         typeof queryIdentifier === 'string' &&
-        (identifier === undefined || queryIdentifier === identifier)
+        (identifiers.size === 0 || identifiers.has(queryIdentifier))
         ? [query.queryKey]
         : [];
     });
@@ -254,10 +398,12 @@ function patchIssueDetailCaches(client: QueryClient, action: SyncAction): void {
     client.cancelQueries({ queryKey: key, exact: true }),
   );
   patchIssueDetailUpdates(client, action);
-  Promise.all(cancellations)
+  Promise.allSettled(cancellations)
     .then(() => {
       patchIssueDetailUpdates(client, action);
+      migrateMovedIssueDetails(client, action, movedIdentifiers);
       for (const key of fetchingKeys) {
+        if (movedIdentifiers.has(String(key[1] ?? ''))) continue;
         client.invalidateQueries({ queryKey: key, exact: true }).catch(() => undefined);
       }
     })
@@ -309,16 +455,147 @@ function isOwnEcho(action: SyncAction, tabClientId: string): boolean {
   return action.originClientId === tabClientId;
 }
 
+function cachedIssueSurvivesDeparture(client: QueryClient, action: SyncAction): boolean {
+  const departureIdentifier = action.data['identifier'];
+  const departureTeamId = action.data['teamId'];
+  if (typeof departureIdentifier !== 'string' || typeof departureTeamId !== 'string') return false;
+  const survives = (issue: Issue): boolean =>
+    issue.id === action.modelId &&
+    issue.syncId >= action.syncId &&
+    (issue.identifier !== departureIdentifier || issue.teamId !== departureTeamId);
+  return (
+    client
+      .getQueriesData<IssuePages>({ queryKey: [ISSUES_ROOT] })
+      .some(([, pages]) => pages !== undefined && flattenIssuePages(pages).some(survives)) ||
+    client
+      .getQueriesData<IssueDetail>({ queryKey: [ISSUE_ROOT] })
+      .some(([, detail]) => detail !== undefined && survives(detail.issue))
+  );
+}
+
+function pairedIssueDeparture(
+  client: QueryClient,
+  action: SyncAction,
+  survivingIssueIds: ReadonlySet<string>,
+): boolean {
+  return (
+    action.action === 'delete' &&
+    action.data['departure'] === true &&
+    (survivingIssueIds.has(action.modelId) ||
+      issueSurvivalSyncWatermark(client, action.modelId) >= action.syncId ||
+      cachedIssueSurvivesDeparture(client, action))
+  );
+}
+
+function issueActionSupersedes(current: SyncAction, candidate: SyncAction): boolean {
+  if (candidate.syncId !== current.syncId) return candidate.syncId > current.syncId;
+  const currentHardDelete = current.action === 'delete' && current.data['departure'] !== true;
+  const candidateHardDelete = candidate.action === 'delete' && candidate.data['departure'] !== true;
+  if (currentHardDelete !== candidateHardDelete) return candidateHardDelete;
+  const currentSurvives = current.action !== 'delete';
+  const candidateSurvives = candidate.action !== 'delete';
+  if (currentSurvives !== candidateSurvives) return candidateSurvives;
+  return true;
+}
+
+function preferredFinalIssueActions(
+  actions: readonly SyncAction[],
+  tabClientId?: string,
+): ReadonlyMap<string, SyncAction> {
+  const finalActions = new Map<string, SyncAction>();
+  for (const action of actions) {
+    if (action.model !== 'issue') continue;
+    if (tabClientId !== undefined && isOwnEcho(action, tabClientId)) continue;
+    const current = finalActions.get(action.modelId);
+    if (current === undefined || issueActionSupersedes(current, action)) {
+      finalActions.set(action.modelId, action);
+    }
+  }
+  return finalActions;
+}
+
+function finalSurvivingIssueIds(actions: readonly SyncAction[]): ReadonlySet<string> {
+  return new Set(
+    [...preferredFinalIssueActions(actions)].flatMap(([issueId, action]) =>
+      action.action === 'delete' ? [] : [issueId],
+    ),
+  );
+}
+
+function issueMoveKey(action: SyncAction): string {
+  return action.modelId;
+}
+
+function issueMovePreviousIdentifiers(
+  actions: readonly SyncAction[],
+  tabClientId: string,
+): ReadonlyMap<string, ReadonlySet<string>> {
+  const previous = new Map<string, Set<string>>();
+  for (const action of actions) {
+    if (isOwnEcho(action, tabClientId) || action.model !== 'issue') continue;
+    if (action.action !== 'delete' || action.data['departure'] !== true) continue;
+    const identifier = action.data['identifier'];
+    if (typeof identifier !== 'string') continue;
+    const key = issueMoveKey(action);
+    const identifiers = previous.get(key) ?? new Set<string>();
+    identifiers.add(identifier);
+    previous.set(key, identifiers);
+  }
+  return previous;
+}
+
+function finalSurvivingIssueActions(
+  actions: readonly SyncAction[],
+  tabClientId: string,
+): ReadonlyMap<string, SyncAction> {
+  return new Map(
+    [...preferredFinalIssueActions(actions, tabClientId)].filter(
+      ([, action]) => action.action !== 'delete',
+    ),
+  );
+}
+
+function recordIssueGeneration(
+  client: QueryClient,
+  action: SyncAction,
+  preserveDeletedDetail: boolean,
+): void {
+  if (action.action !== 'delete') {
+    recordIssueSurvivalSyncWatermark(client, action.modelId, action.syncId);
+    recordIssueRevisions(client, [action.modelId]);
+    return;
+  }
+  if (!preserveDeletedDetail) recordIssueDeletions(client, [action.modelId]);
+}
+
+function recordOwnIssueEcho(client: QueryClient, action: SyncAction): void {
+  if (action.model !== 'issue') return;
+  if (action.syncId < issueSyncWatermark(client, action.modelId)) return;
+  recordIssueSyncWatermark(client, action.modelId, action.syncId);
+  if (action.action === 'delete' && action.data['departure'] === true) {
+    recordIssueRevisions(client, [action.modelId]);
+    return;
+  }
+  recordIssueGeneration(client, action, action.data['departure'] === true);
+}
+
 function routeAction(
   client: QueryClient,
   action: SyncAction,
   currentUserId: string | null,
   roots: RootInvalidations,
+  survivingIssueIds: ReadonlySet<string>,
+  previousIssueIdentifiers: ReadonlyMap<string, ReadonlySet<string>>,
+  finalIssueActions: ReadonlyMap<string, SyncAction>,
 ): void {
   if (action.model === 'issue') {
-    patchIssueCaches(client, action);
-    if (action.action === 'delete') recordIssueDeletions(client, [action.modelId]);
-    else recordIssueRevisions(client, [action.modelId]);
+    const preserveDeletedDetail = pairedIssueDeparture(client, action, survivingIssueIds);
+    const previousIdentifiers =
+      finalIssueActions.get(action.modelId) === action
+        ? (previousIssueIdentifiers.get(issueMoveKey(action)) ?? new Set())
+        : new Set<string>();
+    const applied = patchIssueCaches(client, action, preserveDeletedDetail, previousIdentifiers);
+    if (applied) recordIssueGeneration(client, action, preserveDeletedDetail);
     roots.counts = true;
     roots.milestones = true;
     roots.boards = true;
@@ -369,6 +646,10 @@ function flushRoots(client: QueryClient, roots: RootInvalidations): void {
   if (roots.boards) {
     client.invalidateQueries({ queryKey: [BOARD_ROOT], refetchType: 'none' }).catch(noop);
   }
+  if (roots.issueCaches) {
+    client.invalidateQueries({ queryKey: [ISSUES_ROOT] }).catch(noop);
+    client.invalidateQueries({ queryKey: [ISSUE_ROOT] }).catch(noop);
+  }
   if (roots.bootstrap) client.invalidateQueries({ queryKey: [BOOTSTRAP_ROOT] }).catch(noop);
   if (roots.views) client.invalidateQueries({ queryKey: [VIEWS_ROOT] }).catch(noop);
   if (roots.relations) {
@@ -384,6 +665,123 @@ function flushRoots(client: QueryClient, roots: RootInvalidations): void {
   }
 }
 
+async function resetIssueCaches(client: QueryClient): Promise<void> {
+  recordIssueCacheReset(client);
+  await Promise.allSettled([
+    client.resetQueries({ queryKey: [ISSUES_ROOT] }),
+    client.resetQueries({ queryKey: [ISSUE_ROOT] }),
+    client.resetQueries({ queryKey: [BOARD_ROOT] }),
+  ]);
+}
+
+interface IssueDetailRecovery {
+  readonly keys: readonly QueryKey[];
+  readonly issueId: string;
+  readonly revision: number;
+}
+
+function issueDetailRecoveries(client: QueryClient): IssueDetailRecovery[] {
+  const recoveries = new Map<string, { keys: QueryKey[]; issueId: string; revision: number }>();
+  for (const query of client.getQueryCache().findAll({ queryKey: [ISSUE_ROOT], type: 'active' })) {
+    const detail = query.state.data as IssueDetail | undefined;
+    if (detail === undefined) continue;
+    const current = recoveries.get(detail.issue.id);
+    if (current !== undefined) {
+      current.keys.push(query.queryKey);
+      continue;
+    }
+    recoveries.set(detail.issue.id, {
+      keys: [query.queryKey],
+      issueId: detail.issue.id,
+      revision: issueRevisionGeneration(client, detail.issue.id),
+    });
+  }
+  return [...recoveries.values()];
+}
+
+function seedRecoveredIssueDetail(client: QueryClient, key: QueryKey, detail: IssueDetail): void {
+  client.setQueryData<IssueDetail>(key, (current) =>
+    current !== undefined && current.issue.syncId > detail.issue.syncId ? current : detail,
+  );
+}
+
+async function recoverIssueDetails(
+  client: QueryClient,
+  recoveries: readonly IssueDetailRecovery[],
+  signal: AbortSignal,
+  current: () => boolean,
+): Promise<void> {
+  await Promise.all(
+    recoveries.map(async (recovery) => {
+      try {
+        const detail = await apiFetch(
+          `/api/issues/${encodeURIComponent(recovery.issueId)}`,
+          issueDetailSchema,
+          { signal },
+        );
+        if (!current() || detail.issue.id !== recovery.issueId) return;
+        if (issueRevisionGeneration(client, recovery.issueId) !== recovery.revision) return;
+        recordIssueSyncWatermark(client, recovery.issueId, detail.issue.syncId);
+        recordIssueSurvivalSyncWatermark(client, recovery.issueId, detail.issue.syncId);
+        for (const key of recovery.keys) seedRecoveredIssueDetail(client, key, detail);
+        seedRecoveredIssueDetail(client, queryKeys.issue(detail.issue.identifier), detail);
+      } catch {
+        return;
+      }
+    }),
+  );
+}
+
+async function invalidateNonIssueCaches(client: QueryClient): Promise<void> {
+  await client.invalidateQueries({
+    predicate: (query) => {
+      const root = query.queryKey[0];
+      return root !== ISSUES_ROOT && root !== ISSUE_ROOT && root !== BOARD_ROOT;
+    },
+  });
+}
+
+interface ResumeReconciliation {
+  readonly client: QueryClient;
+  readonly since: number;
+  readonly detailRecoveries: readonly IssueDetailRecovery[];
+  readonly signal: AbortSignal;
+  readonly current: () => boolean;
+  readonly applyActions: (actions: readonly SyncAction[]) => boolean;
+  readonly observeSyncId: (syncId: number) => void;
+}
+
+async function reconcileCatchup(
+  reconciliation: ResumeReconciliation,
+  recovery: Promise<void>,
+): Promise<void> {
+  const { client, since, signal, current, applyActions, observeSyncId } = reconciliation;
+  const [catchup] = await Promise.all([
+    apiFetch(`/api/sync?since=${since}`, syncCatchupSchema, { signal }),
+    recovery,
+  ]);
+  if (!current()) return;
+  const appliedBootstrap = applyActions(catchup.actions);
+  observeSyncId(catchup.syncId);
+  if (catchup.truncated) {
+    await client.invalidateQueries();
+  } else if (!appliedBootstrap) {
+    await client.invalidateQueries({ queryKey: [BOOTSTRAP_ROOT] });
+  }
+}
+
+async function reconcileResume(reconciliation: ResumeReconciliation): Promise<void> {
+  const { client, since, detailRecoveries, signal, current } = reconciliation;
+  await resetIssueCaches(client);
+  if (!current()) return;
+  const recovery = recoverIssueDetails(client, detailRecoveries, signal, current);
+  if (since === 0) {
+    await Promise.all([recovery, invalidateNonIssueCaches(client)]);
+    return;
+  }
+  await reconcileCatchup(reconciliation, recovery);
+}
+
 export interface DeltaBridgeProps {
   readonly organizationId: string;
   readonly teamIds: readonly string[];
@@ -395,6 +793,25 @@ export function DeltaBridge({ organizationId, teamIds }: DeltaBridgeProps) {
   const observeSyncId = useObserveSyncId();
   const realtimeStatus = useRealtimeStatus();
   const reconciledOrganization = useRef<string | null>(null);
+  const resumeEpoch = useRef(0);
+  const resumeAbort = useRef<AbortController | null>(null);
+  const resumeOrganization = useRef(organizationId);
+
+  useEffect(() => {
+    if (resumeOrganization.current === organizationId) return;
+    resumeOrganization.current = organizationId;
+    resumeEpoch.current += 1;
+    resumeAbort.current?.abort();
+    resumeAbort.current = null;
+  }, [organizationId]);
+
+  useEffect(() => {
+    return () => {
+      resumeEpoch.current += 1;
+      resumeAbort.current?.abort();
+      resumeAbort.current = null;
+    };
+  }, []);
 
   useEffect(() => {
     if (realtimeStatus !== 'open' || reconciledOrganization.current === organizationId) return;
@@ -415,10 +832,14 @@ export function DeltaBridge({ organizationId, teamIds }: DeltaBridgeProps) {
   const applyActions = useCallback(
     (actions: readonly SyncAction[]) => {
       const tabClientId = clientId();
+      const survivingIssueIds = finalSurvivingIssueIds(actions);
+      const previousIssueIdentifiers = issueMovePreviousIdentifiers(actions, tabClientId);
+      const finalIssueActions = finalSurvivingIssueActions(actions, tabClientId);
       const roots: RootInvalidations = {
         analytics: false,
         counts: false,
         boards: false,
+        issueCaches: false,
         bootstrap: false,
         views: false,
         docs: false,
@@ -429,8 +850,25 @@ export function DeltaBridge({ organizationId, teamIds }: DeltaBridgeProps) {
 
       for (const action of actions) {
         if (ANALYTICS_MODELS.has(action.model)) roots.analytics = true;
-        if (isOwnEcho(action, tabClientId)) continue;
-        routeAction(client, action, currentUserId, roots);
+        if (action.model === 'issue') {
+          roots.counts = true;
+          roots.milestones = true;
+          roots.boards = true;
+        }
+        if (isOwnEcho(action, tabClientId)) {
+          recordOwnIssueEcho(client, action);
+          if (action.model === 'issue') roots.issueCaches = true;
+          continue;
+        }
+        routeAction(
+          client,
+          action,
+          currentUserId,
+          roots,
+          survivingIssueIds,
+          previousIssueIdentifiers,
+          finalIssueActions,
+        );
       }
 
       flushRoots(client, roots);
@@ -444,21 +882,33 @@ export function DeltaBridge({ organizationId, teamIds }: DeltaBridgeProps) {
   useResumeHandler(
     useCallback(
       (since: number) => {
-        if (since === 0) {
-          client.invalidateQueries().catch(noop);
-          return;
-        }
-        apiFetch(`/api/sync?since=${since}`, syncCatchupSchema)
-          .then((catchup) => {
-            const appliedBootstrap = applyActions(catchup.actions);
-            observeSyncId(catchup.syncId);
-            if (catchup.truncated) {
-              client.invalidateQueries().catch(noop);
-            } else if (!appliedBootstrap) {
-              client.invalidateQueries({ queryKey: [BOOTSTRAP_ROOT] }).catch(noop);
-            }
-          })
-          .catch(noop);
+        const detailRecoveries = issueDetailRecoveries(client);
+        const epoch = resumeEpoch.current + 1;
+        resumeEpoch.current = epoch;
+        resumeAbort.current?.abort();
+        const controller = new AbortController();
+        resumeAbort.current = controller;
+        const current = () => resumeEpoch.current === epoch && !controller.signal.aborted;
+
+        const reconcile = async (): Promise<void> => {
+          try {
+            await reconcileResume({
+              client,
+              since,
+              detailRecoveries,
+              signal: controller.signal,
+              current,
+              applyActions,
+              observeSyncId,
+            });
+          } catch {
+            if (current()) await invalidateNonIssueCaches(client).catch(noop);
+          } finally {
+            if (current()) resumeAbort.current = null;
+          }
+        };
+
+        reconcile().catch(noop);
       },
       [applyActions, client, observeSyncId],
     ),

--- a/apps/web/tests/components/keyboard-hints.test.tsx
+++ b/apps/web/tests/components/keyboard-hints.test.tsx
@@ -20,6 +20,9 @@ import type { Issue } from '@/lib/query/schemas.ts';
 import * as docsQuery from '@/lib/query/use-docs.ts';
 import * as issuesQuery from '@/lib/query/use-issues.ts';
 import { render } from '@/test/render.tsx';
+import { restoreModulesAfterThisFile } from '../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/lib/query/use-issues.ts']);
 
 mock.module('next/navigation', () => ({
   useRouter: () => ({ push: mock(), replace: mock(), refresh: mock() }),

--- a/apps/web/tests/features/docs/docs-sidebar.test.tsx
+++ b/apps/web/tests/features/docs/docs-sidebar.test.tsx
@@ -9,6 +9,9 @@ import * as docsQuery from '@/lib/query/use-docs.ts';
 import * as issuesQuery from '@/lib/query/use-issues.ts';
 import { render } from '@/test/render.tsx';
 import { DocsShell } from '../../../src/features/docs/docs-shell.tsx';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/lib/query/use-issues.ts']);
 
 const push = mock();
 

--- a/apps/web/tests/features/issues/board-drag-reach.test.ts
+++ b/apps/web/tests/features/issues/board-drag-reach.test.ts
@@ -4,8 +4,12 @@ import type { IssueGroup } from '@/features/filters/grouping.ts';
 import {
   canDragBoard,
   columnsReadyFor,
+  dragSourceSnapshotFor,
+  dragTargetSnapshotFor,
   dropPositionFor,
+  moveResultWasSuperseded,
   planDrop,
+  sameBoardSource,
   settledDragStatus,
 } from '@/features/issues/board.tsx';
 import { scrollStep } from '@/features/issues/use-board-autoscroll.ts';
@@ -44,7 +48,7 @@ function issue(id: string, overrides: Partial<Issue> = {}): Issue {
   } as Issue;
 }
 
-function group(id: string, issues: readonly Issue[]): IssueGroup {
+function group(id: string, issues: readonly Issue[], total = issues.length): IssueGroup {
   return {
     id,
     title: id,
@@ -52,7 +56,7 @@ function group(id: string, issues: readonly Issue[]): IssueGroup {
     category: null,
     issues,
     subGroups: [],
-    total: issues.length,
+    total,
   };
 }
 
@@ -116,6 +120,13 @@ describe('reordering a card within its current column', () => {
     expect(move?.beforeId).toBe('first');
     expect(move?.afterId).toBe('second');
   });
+
+  it('does not present a loaded subset count as the column total', () => {
+    expect(dropPositionFor([group('todo', rows, 40)], 'second', 'third')).toEqual({
+      column: 'todo',
+      position: 3,
+    });
+  });
 });
 
 describe('settling keyboard drag feedback', () => {
@@ -159,7 +170,7 @@ describe('settling keyboard drag feedback', () => {
     ).toBeNull();
   });
 
-  it('announces both endpoints and ordinals when the current move succeeds', () => {
+  it('does not repeat planned ordinals after the current move succeeds', () => {
     expect(
       settledDragStatus({
         latestSession: 1,
@@ -167,10 +178,10 @@ describe('settling keyboard drag feedback', () => {
         completed,
         outcome: 'success',
       }),
-    ).toBe('Moved ENG-1 from column Todo, position 1 of 2, to column Todo, position 2 of 2.');
+    ).toBe('Moved ENG-1 from column Todo to column Todo.');
   });
 
-  it('announces the source ordinal when the current move fails', () => {
+  it('does not claim a planned source ordinal after the current move fails', () => {
     expect(
       settledDragStatus({
         latestSession: 1,
@@ -178,7 +189,176 @@ describe('settling keyboard drag feedback', () => {
         completed,
         outcome: 'error',
       }),
-    ).toBe('Failed to move ENG-1. Returned to column Todo, position 1 of 2.');
+    ).toBe('Failed to move ENG-1. Returned to column Todo.');
+  });
+
+  it('suppresses a planned endpoint when a newer cache head already won', () => {
+    const response = issue('held', { stateId: 'done', syncId: 2 });
+    const current = issue('held', { stateId: 'todo', syncId: 3 });
+
+    expect(moveResultWasSuperseded({ kind: 'found', issue: current }, response, 'success')).toBe(
+      true,
+    );
+    expect(moveResultWasSuperseded({ kind: 'ambiguous' }, response, 'success')).toBe(true);
+    expect(moveResultWasSuperseded({ kind: 'found', issue: response }, response, 'success')).toBe(
+      false,
+    );
+  });
+
+  it('accepts a successful move that intentionally exits every filtered list', () => {
+    const response = issue('held', { stateId: 'done', syncId: 2 });
+
+    expect(moveResultWasSuperseded({ kind: 'missing' }, response, 'success')).toBe(false);
+    expect(moveResultWasSuperseded({ kind: 'missing' }, response, 'error')).toBe(true);
+  });
+});
+
+describe('identifying the authoritative drag source', () => {
+  it('distinguishes same-named groups by stable identity', () => {
+    expect(
+      sameBoardSource(
+        { groupId: 'member_1', column: 'Alex', position: 1, total: 2 },
+        { groupId: 'member_2', column: 'Alex', position: 1, total: 2 },
+      ),
+    ).toBe(false);
+  });
+
+  it('ignores a total-only change in the same group and position', () => {
+    expect(
+      sameBoardSource(
+        { groupId: 'member_1', column: 'Alex', position: 1, total: 2 },
+        { groupId: 'member_1', column: 'Alex', position: 1, total: 3 },
+      ),
+    ).toBe(true);
+  });
+
+  it('fails closed when equal-head mirrors disagree about the source', () => {
+    const todo = issue('held', { syncId: 2, stateId: 'todo' });
+    const done = issue('held', { syncId: 2, stateId: 'done' });
+
+    expect(
+      dragSourceSnapshotFor(
+        [group('todo', [todo]), group('done', [done])],
+        'held',
+        'state',
+        undefined,
+      ).kind,
+    ).toBe('ambiguous');
+  });
+
+  it('uses the first identical source mirror when row windows differ', () => {
+    const held = issue('held', { syncId: 2 });
+    const sibling = issue('sibling', { syncId: 2, sortOrder: 2048 });
+
+    expect(
+      dragSourceSnapshotFor(
+        [group('todo', [sibling, held]), group('todo', [held, sibling])],
+        'held',
+        'state',
+        undefined,
+      ),
+    ).toEqual({
+      kind: 'found',
+      issue: held,
+      source: { groupId: 'todo', column: 'todo', position: 2, total: 2 },
+    });
+  });
+
+  it('ignores transport-only differences in equal-head source mirrors', () => {
+    const detailed = issue('held', {
+      organizationId: 'org',
+      description: 'loaded by the issue list',
+      stateEnteredAt: '2026-01-02T00:00:00.000Z',
+      syncId: 2,
+    });
+    const summarized = issue('held', {
+      organizationId: '',
+      description: '',
+      stateEnteredAt: '',
+      syncId: 2,
+    });
+
+    expect(
+      dragSourceSnapshotFor(
+        [group('todo', [detailed]), group('todo', [summarized])],
+        'held',
+        'state',
+        undefined,
+      ).kind,
+    ).toBe('found');
+  });
+
+  it('waits when the newest mirror has not reached its matching group', () => {
+    const regrouping = issue('held', { syncId: 2, stateId: 'done' });
+
+    expect(
+      dragSourceSnapshotFor([group('todo', [regrouping])], 'held', 'state', undefined).kind,
+    ).toBe('pending');
+  });
+});
+
+describe('identifying the authoritative drop target', () => {
+  it('uses the first identical target mirror when row windows differ', () => {
+    const held = issue('held');
+    const first = issue('first', { stateId: 'done', syncId: 2, sortOrder: 1024 });
+    const target = issue('target', { stateId: 'done', syncId: 2, sortOrder: 2048 });
+
+    expect(
+      dragTargetSnapshotFor(
+        [group('done', [first, target]), group('done', [target, first])],
+        held,
+        'target',
+        'state',
+        undefined,
+        true,
+      ),
+    ).toEqual({
+      kind: 'found',
+      target: {
+        overId: 'target',
+        destination: { groupId: 'done', column: 'done', position: 2, total: 3 },
+        placement: expect.objectContaining({
+          issue: held,
+          stateId: 'done',
+          beforeId: 'first',
+          afterId: 'target',
+        }),
+      },
+    });
+  });
+
+  it('fails closed when equal-head target contents disagree', () => {
+    const held = issue('held');
+    const left = issue('target', { stateId: 'done', syncId: 2, sortOrder: 1024 });
+    const right = issue('target', { stateId: 'done', syncId: 2, sortOrder: 2048 });
+
+    expect(
+      dragTargetSnapshotFor(
+        [group('done', [left]), group('done', [right])],
+        held,
+        'target',
+        'state',
+        undefined,
+        true,
+      ).kind,
+    ).toBe('ambiguous');
+  });
+
+  it('does not claim an ordinal when the board ordering cannot place the drop there', () => {
+    const held = issue('held');
+    const target = issue('target', { stateId: 'done', syncId: 2 });
+    const snapshot = dragTargetSnapshotFor(
+      [group('done', [target])],
+      held,
+      'target',
+      'state',
+      undefined,
+      false,
+    );
+
+    expect(snapshot.kind).toBe('found');
+    if (snapshot.kind !== 'found') throw new Error('missing drop target');
+    expect(snapshot.target.destination).toEqual({ groupId: 'done', column: 'done' });
   });
 });
 

--- a/apps/web/tests/features/issues/board-drag-reach.test.ts
+++ b/apps/web/tests/features/issues/board-drag-reach.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'bun:test';
 import { showsEmptyGroups } from '@orbit/shared/filters';
 import type { IssueGroup } from '@/features/filters/grouping.ts';
-import { canDragBoard, columnsReadyFor, planDrop } from '@/features/issues/board.tsx';
+import {
+  canDragBoard,
+  columnsReadyFor,
+  dropPositionFor,
+  planDrop,
+  settledDragStatus,
+} from '@/features/issues/board.tsx';
 import { scrollStep } from '@/features/issues/use-board-autoscroll.ts';
 import type { Issue } from '@/lib/query/schemas.ts';
 
@@ -78,6 +84,101 @@ describe('dropping a card when the board is not sorted by hand', () => {
     expect(move?.stateId).toBe('done');
     expect(move?.beforeId).toBe('first');
     expect(move?.afterId).toBe('second');
+  });
+});
+
+describe('reordering a card within its current column', () => {
+  const first = issue('first', { sortOrder: 1024 });
+  const second = issue('second', { sortOrder: 2048 });
+  const third = issue('third', { sortOrder: 3072 });
+  const fourth = issue('fourth', { sortOrder: 4096 });
+  const rows = [first, second, third, fourth];
+  const groups = [group('todo', rows)];
+
+  it('inserts after the card crossed while moving down', () => {
+    const move = planDrop(groups, rows, 'second', 'third', 'state');
+
+    expect(move?.beforeId).toBe('third');
+    expect(move?.afterId).toBe('fourth');
+  });
+
+  it('reports the resulting ordinal after moving down', () => {
+    expect(dropPositionFor(groups, 'second', 'third')).toEqual({
+      column: 'todo',
+      position: 3,
+      total: 4,
+    });
+  });
+
+  it('inserts before the card crossed while moving up', () => {
+    const move = planDrop(groups, rows, 'third', 'second', 'state');
+
+    expect(move?.beforeId).toBe('first');
+    expect(move?.afterId).toBe('second');
+  });
+});
+
+describe('settling keyboard drag feedback', () => {
+  const completed = {
+    session: 1,
+    identifier: 'ENG-1',
+    source: { column: 'Todo', position: 1, total: 2 },
+    destination: { column: 'Todo', position: 2, total: 2 },
+  };
+
+  it('does not publish an older result over a newer active drag', () => {
+    expect(
+      settledDragStatus({
+        latestSession: 2,
+        activeSession: 2,
+        completed,
+        outcome: 'success',
+      }),
+    ).toBeNull();
+  });
+
+  it('does not publish an older result after the newer drag ends', () => {
+    expect(
+      settledDragStatus({
+        latestSession: 2,
+        activeSession: null,
+        completed,
+        outcome: 'success',
+      }),
+    ).toBeNull();
+  });
+
+  it('does not publish a result while its drag is active', () => {
+    expect(
+      settledDragStatus({
+        latestSession: 1,
+        activeSession: 1,
+        completed,
+        outcome: 'success',
+      }),
+    ).toBeNull();
+  });
+
+  it('announces both endpoints and ordinals when the current move succeeds', () => {
+    expect(
+      settledDragStatus({
+        latestSession: 1,
+        activeSession: null,
+        completed,
+        outcome: 'success',
+      }),
+    ).toBe('Moved ENG-1 from column Todo, position 1 of 2, to column Todo, position 2 of 2.');
+  });
+
+  it('announces the source ordinal when the current move fails', () => {
+    expect(
+      settledDragStatus({
+        latestSession: 1,
+        activeSession: null,
+        completed,
+        outcome: 'error',
+      }),
+    ).toBe('Failed to move ENG-1. Returned to column Todo, position 1 of 2.');
   });
 });
 

--- a/apps/web/tests/features/issues/board-drag-reach.test.ts
+++ b/apps/web/tests/features/issues/board-drag-reach.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, it } from 'bun:test';
-import { showsEmptyGroups } from '@orbit/shared/filters';
+import { defaultDisplayOptions, showsEmptyGroups } from '@orbit/shared/filters';
 import type { IssueGroup } from '@/features/filters/grouping.ts';
 import {
+  boardFocusRemountMayQueue,
+  boardFocusRequestMayRun,
+  boardPositionsAreIncomplete,
   canDragBoard,
   columnsReadyFor,
+  completedDragResult,
   dragSourceSnapshotFor,
   dragTargetSnapshotFor,
   dropPositionFor,
+  focusRemainsBoardOwned,
   moveResultWasSuperseded,
   planDrop,
+  registeredBoardPosition,
   sameBoardSource,
   settledDragStatus,
 } from '@/features/issues/board.tsx';
@@ -133,8 +139,8 @@ describe('settling keyboard drag feedback', () => {
   const completed = {
     session: 1,
     identifier: 'ENG-1',
-    source: { column: 'Todo', position: 1, total: 2 },
-    destination: { column: 'Todo', position: 2, total: 2 },
+    source: { groupId: 'todo', column: 'Todo', position: 1, total: 2 },
+    destination: { groupId: 'todo', column: 'Todo', position: 2, total: 2 },
   };
 
   it('does not publish an older result over a newer active drag', () => {
@@ -144,6 +150,7 @@ describe('settling keyboard drag feedback', () => {
         activeSession: 2,
         completed,
         outcome: 'success',
+        settledPosition: { column: 'Todo', position: 2, total: 2 },
       }),
     ).toBeNull();
   });
@@ -155,6 +162,7 @@ describe('settling keyboard drag feedback', () => {
         activeSession: null,
         completed,
         outcome: 'success',
+        settledPosition: { column: 'Todo', position: 2, total: 2 },
       }),
     ).toBeNull();
   });
@@ -166,30 +174,45 @@ describe('settling keyboard drag feedback', () => {
         activeSession: 1,
         completed,
         outcome: 'success',
+        settledPosition: { column: 'Todo', position: 2, total: 2 },
       }),
     ).toBeNull();
   });
 
-  it('does not repeat planned ordinals after the current move succeeds', () => {
+  it('announces the authoritative position after the current move succeeds', () => {
     expect(
       settledDragStatus({
         latestSession: 1,
         activeSession: null,
         completed,
         outcome: 'success',
+        settledPosition: { column: 'Todo', position: 2, total: 2 },
       }),
-    ).toBe('Moved ENG-1 from column Todo to column Todo.');
+    ).toBe('Moved ENG-1 from column Todo, position 1 of 2 to column Todo, position 2 of 2.');
   });
 
-  it('does not claim a planned source ordinal after the current move fails', () => {
+  it('announces the authoritative restored position after the current move fails', () => {
     expect(
       settledDragStatus({
         latestSession: 1,
         activeSession: null,
         completed,
         outcome: 'error',
+        settledPosition: { column: 'Todo', position: 1, total: 2 },
       }),
-    ).toBe('Failed to move ENG-1. Returned to column Todo.');
+    ).toBe('Failed to move ENG-1. Returned to column Todo, position 1 of 2.');
+  });
+
+  it('uses safe column-only feedback when the settled card is filtered out', () => {
+    expect(
+      settledDragStatus({
+        latestSession: 1,
+        activeSession: null,
+        completed,
+        outcome: 'success',
+        settledPosition: null,
+      }),
+    ).toBe('Moved ENG-1 from column Todo, position 1 of 2 to column Todo.');
   });
 
   it('suppresses a planned endpoint when a newer cache head already won', () => {
@@ -203,13 +226,121 @@ describe('settling keyboard drag feedback', () => {
     expect(moveResultWasSuperseded({ kind: 'found', issue: response }, response, 'success')).toBe(
       false,
     );
+    expect(
+      completedDragResult({
+        latestSession: 1,
+        activeSession: null,
+        completed,
+        outcome: 'success',
+        settledPosition: { column: 'Todo', position: 2, total: 2 },
+        superseded: true,
+      }),
+    ).toEqual({
+      status: 'ENG-1 changed again while the move finished. Showing the latest version.',
+      focusGroupId: null,
+    });
   });
 
   it('accepts a successful move that intentionally exits every filtered list', () => {
     const response = issue('held', { stateId: 'done', syncId: 2 });
 
-    expect(moveResultWasSuperseded({ kind: 'missing' }, response, 'success')).toBe(false);
+    expect(moveResultWasSuperseded({ kind: 'missing' }, response, 'success', false)).toBe(false);
+    expect(moveResultWasSuperseded({ kind: 'missing' }, response, 'success', true)).toBe(true);
     expect(moveResultWasSuperseded({ kind: 'missing' }, response, 'error')).toBe(true);
+  });
+
+  it('announces deletion and returns the outcome focus fallback', () => {
+    for (const outcome of ['success', 'error'] as const) {
+      expect(
+        completedDragResult({
+          latestSession: 1,
+          activeSession: null,
+          completed,
+          outcome,
+          settledPosition: null,
+          superseded: true,
+          deleted: true,
+        }),
+      ).toEqual({
+        status: 'ENG-1 was deleted while the move finished.',
+        focusGroupId: 'todo',
+      });
+    }
+  });
+
+  it('never derives a complete total from a windowed destination', () => {
+    const column = document.createElement('ul');
+    const cards = Array.from({ length: 15 }, () => {
+      const card = document.createElement('li');
+      card.tabIndex = 0;
+      column.append(card);
+      return card;
+    });
+    const sentinel = document.createElement('li');
+    sentinel.setAttribute('aria-hidden', 'true');
+    column.append(sentinel);
+    const held = cards[13];
+    if (held === undefined) throw new Error('missing held card');
+
+    expect(
+      registeredBoardPosition(
+        'held',
+        { groupId: 'done', column: 'Done', position: 14, total: 15 },
+        new Map([['held', held]]),
+        new Map([['done', column]]),
+      ),
+    ).toEqual({ column: 'Done', position: 14 });
+  });
+
+  it('does not reclaim focus from another control after settlement', () => {
+    const card = document.createElement('li');
+    const column = document.createElement('ul');
+    const alternateColumn = document.createElement('ul');
+    const otherControl = document.createElement('button');
+
+    expect(
+      focusRemainsBoardOwned(document.body, document.body, card, column, alternateColumn),
+    ).toBe(true);
+    expect(focusRemainsBoardOwned(card, document.body, card, column, alternateColumn)).toBe(true);
+    expect(focusRemainsBoardOwned(column, document.body, card, column, alternateColumn)).toBe(true);
+    expect(
+      focusRemainsBoardOwned(alternateColumn, document.body, card, column, alternateColumn),
+    ).toBe(true);
+    expect(focusRemainsBoardOwned(otherControl, document.body, card, column, alternateColumn)).toBe(
+      false,
+    );
+  });
+
+  it('rechecks focus ownership when queued restoration executes', () => {
+    expect(boardFocusRequestMayRun(1, 1, 1, 1, false, true)).toBe(true);
+    expect(boardFocusRequestMayRun(1, 1, 1, 1, false, false)).toBe(false);
+  });
+
+  it('queues a focused node remount before rechecking dynamic ownership', () => {
+    const previous = document.createElement('li');
+    const replacement = document.createElement('li');
+    const column = document.createElement('ul');
+    const otherControl = document.createElement('button');
+    previous.tabIndex = 0;
+    document.body.append(previous, column, otherControl);
+    previous.focus();
+    const cards = new Map<string, HTMLLIElement>([['held', previous]]);
+    const focusAllowed = () =>
+      focusRemainsBoardOwned(document.activeElement, document.body, cards.get('held'), column);
+    cards.delete('held');
+
+    expect(focusAllowed()).toBe(false);
+    expect(boardFocusRemountMayQueue(previous, document.body, previous, 1, 1, 1, 1, false)).toBe(
+      true,
+    );
+
+    previous.remove();
+    cards.set('held', replacement);
+    expect(focusAllowed()).toBe(true);
+    otherControl.focus();
+    expect(focusAllowed()).toBe(false);
+    column.remove();
+    otherControl.remove();
   });
 });
 
@@ -411,5 +542,23 @@ describe('who may drag a card', () => {
 
   it('never offers drag for a grouping that cannot be regrouped', () => {
     expect(canDragBoard('admin', 'label')).toBe(false);
+  });
+});
+
+describe('when board positions are incomplete', () => {
+  it('treats display-hidden rows like query-filtered rows', () => {
+    expect(
+      boardPositionsAreIncomplete(false, {
+        ...defaultDisplayOptions('board'),
+        showSubIssues: false,
+      }),
+    ).toBe(true);
+    expect(
+      boardPositionsAreIncomplete(false, {
+        ...defaultDisplayOptions('board'),
+        showCompleted: 'week',
+      }),
+    ).toBe(true);
+    expect(boardPositionsAreIncomplete(false, defaultDisplayOptions('board'))).toBe(false);
   });
 });

--- a/apps/web/tests/features/issues/board-sensors.test.ts
+++ b/apps/web/tests/features/issues/board-sensors.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { afterEach, describe, expect, it, jest, mock } from 'bun:test';
 import type { KeyboardSensorProps, PointerSensorProps, SensorProps } from '@dnd-kit/core';
 import { createBoardSensorController } from '@/features/issues/board-sensors.ts';
 
@@ -37,10 +37,13 @@ function sensorProps<Options extends object>(
   } as unknown as SensorProps<Options>;
 }
 
+const cards: HTMLElement[] = [];
+
 function card(): HTMLElement {
   const node = document.createElement('div');
   node.tabIndex = 0;
   document.body.append(node);
+  cards.push(node);
   return node;
 }
 
@@ -49,7 +52,8 @@ async function settleTimers(): Promise<void> {
 }
 
 afterEach(() => {
-  document.body.replaceChildren();
+  jest.useRealTimers();
+  for (const node of cards.splice(0)) node.remove();
 });
 
 describe('board sensor cancellation', () => {
@@ -132,6 +136,7 @@ describe('board sensor cancellation', () => {
   });
 
   it('cancels a pointer sensor synchronously without resizing the window', () => {
+    jest.useFakeTimers();
     const controller = createBoardSensorController();
     const node = card();
     const onCancel = mock();
@@ -147,5 +152,7 @@ describe('board sensor cancellation', () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(onResize).not.toHaveBeenCalled();
     window.removeEventListener('resize', onResize);
+    jest.advanceTimersByTime(50);
+    controller.unmount();
   });
 });

--- a/apps/web/tests/features/issues/board-sensors.test.ts
+++ b/apps/web/tests/features/issues/board-sensors.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import type { KeyboardSensorProps, PointerSensorProps, SensorProps } from '@dnd-kit/core';
+import { createBoardSensorController } from '@/features/issues/board-sensors.ts';
+
+function activationEvent(type: 'keyboard' | 'pointer', node: HTMLElement): Event {
+  const event =
+    type === 'keyboard'
+      ? new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', bubbles: true })
+      : new PointerEvent('pointerdown', { button: 0, isPrimary: true, bubbles: true });
+  node.dispatchEvent(event);
+  return event;
+}
+
+function sensorProps<Options extends object>(
+  event: Event,
+  node: HTMLElement,
+  options: Options,
+  onCancel: () => void,
+): SensorProps<Options> {
+  return {
+    active: 'issue_1',
+    activeNode: {
+      id: 'issue_1',
+      key: 'issue_1',
+      node: { current: node },
+      data: { current: {} },
+    },
+    event,
+    context: { current: {} },
+    options,
+    onAbort: mock(),
+    onPending: mock(),
+    onStart: mock(),
+    onCancel,
+    onMove: mock(),
+    onEnd: mock(),
+  } as unknown as SensorProps<Options>;
+}
+
+function card(): HTMLElement {
+  const node = document.createElement('div');
+  node.tabIndex = 0;
+  document.body.append(node);
+  return node;
+}
+
+async function settleTimers(): Promise<void> {
+  await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('board sensor cancellation', () => {
+  it('cancels a keyboard sensor once after its deferred listener attaches', async () => {
+    const controller = createBoardSensorController();
+    const node = card();
+    const onCancel = mock();
+    controller.mount();
+    new controller.Keyboard(
+      sensorProps(activationEvent('keyboard', node), node, {}, onCancel) as KeyboardSensorProps,
+    );
+
+    controller.cancel();
+    await settleTimers();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', cancelable: true }),
+    );
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let an old keyboard cancellation reach a replacement controller', async () => {
+    const first = createBoardSensorController();
+    const second = createBoardSensorController();
+    const firstCancel = mock();
+    const secondCancel = mock();
+    const firstNode = card();
+    const secondNode = card();
+    first.mount();
+    new first.Keyboard(
+      sensorProps(
+        activationEvent('keyboard', firstNode),
+        firstNode,
+        {},
+        firstCancel,
+      ) as KeyboardSensorProps,
+    );
+
+    first.cancel();
+    first.unmount();
+    second.mount();
+    new second.Keyboard(
+      sensorProps(
+        activationEvent('keyboard', secondNode),
+        secondNode,
+        {},
+        secondCancel,
+      ) as KeyboardSensorProps,
+    );
+    await settleTimers();
+
+    expect(firstCancel).not.toHaveBeenCalled();
+    expect(secondCancel).not.toHaveBeenCalled();
+    second.cancel();
+    await settleTimers();
+    expect(secondCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit Escape while cancelling a keyboard sensor', async () => {
+    const controller = createBoardSensorController();
+    const node = card();
+    const onCancel = mock();
+    const onEscape = mock();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' || event.code === 'Escape') onEscape();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    controller.mount();
+    new controller.Keyboard(
+      sensorProps(activationEvent('keyboard', node), node, {}, onCancel) as KeyboardSensorProps,
+    );
+
+    controller.cancel();
+    await settleTimers();
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onEscape).not.toHaveBeenCalled();
+    document.removeEventListener('keydown', onKeyDown);
+  });
+
+  it('cancels a pointer sensor synchronously without resizing the window', () => {
+    const controller = createBoardSensorController();
+    const node = card();
+    const onCancel = mock();
+    const onResize = mock();
+    window.addEventListener('resize', onResize, { once: true });
+    controller.mount();
+    new controller.Pointer(
+      sensorProps(activationEvent('pointer', node), node, {}, onCancel) as PointerSensorProps,
+    );
+
+    controller.cancel();
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onResize).not.toHaveBeenCalled();
+    window.removeEventListener('resize', onResize);
+  });
+});

--- a/apps/web/tests/features/issues/board-sensors.test.ts
+++ b/apps/web/tests/features/issues/board-sensors.test.ts
@@ -16,6 +16,7 @@ function sensorProps<Options extends object>(
   node: HTMLElement,
   options: Options,
   onCancel: () => void,
+  onAbort: () => void = mock(),
 ): SensorProps<Options> {
   return {
     active: 'issue_1',
@@ -28,7 +29,7 @@ function sensorProps<Options extends object>(
     event,
     context: { current: {} },
     options,
-    onAbort: mock(),
+    onAbort,
     onPending: mock(),
     onStart: mock(),
     onCancel,
@@ -111,6 +112,29 @@ describe('board sensor cancellation', () => {
     second.cancel();
     await settleTimers();
     expect(secondCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('tears down a keyboard sensor without publishing cancellation callbacks', async () => {
+    const controller = createBoardSensorController();
+    const node = card();
+    const onCancel = mock();
+    const onAbort = mock();
+    controller.mount();
+    new controller.Keyboard(
+      sensorProps(
+        activationEvent('keyboard', node),
+        node,
+        {},
+        onCancel,
+        onAbort,
+      ) as KeyboardSensorProps,
+    );
+
+    controller.unmount();
+    await settleTimers();
+
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(onAbort).not.toHaveBeenCalled();
   });
 
   it('does not emit Escape while cancelling a keyboard sensor', async () => {

--- a/apps/web/tests/features/issues/board.test.tsx
+++ b/apps/web/tests/features/issues/board.test.tsx
@@ -1,15 +1,35 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { defaultDisplayOptions, emptyFilterGroup } from '@orbit/shared/filters';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { ToastProvider } from '@/components/ui/toast.tsx';
 import { TooltipProvider } from '@/components/ui/tooltip.tsx';
 import { groupIssues } from '@/features/filters/grouping.ts';
 import { HotkeyProvider } from '@/lib/keyboard/index.ts';
-import type { Issue, WorkflowState } from '@/lib/query/schemas.ts';
+import { boardSearch } from '@/lib/query/issue-search.ts';
+import { queryKeys } from '@/lib/query/keys.ts';
+import type { BoardPage, Issue, WorkflowState } from '@/lib/query/schemas.ts';
+import { seedBoardColumns } from '@/lib/query/use-issues.ts';
+import type { BoardColumnSource } from '../../../src/features/issues/board.tsx';
 import type { WorkspaceData } from '../../../src/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '../../../src/features/issues/workspace-provider.tsx';
 
 const push = mock();
+const nativeFetch = globalThis.fetch;
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'fetch', {
+    configurable: true,
+    writable: true,
+    value: mock(async () => new Response('{}', { status: 200 })),
+  });
+});
+afterEach(() => {
+  Object.defineProperty(globalThis, 'fetch', {
+    configurable: true,
+    writable: true,
+    value: nativeFetch,
+  });
+});
 mock.module('next/navigation', () => ({
   useRouter: () => ({ push, replace: mock(), refresh: mock() }),
   usePathname: () => '/team/eng/board',
@@ -94,32 +114,170 @@ const second = issue({
   title: 'Second task',
 });
 
-function renderBoard() {
-  const groups = groupIssues(
-    [issue(), second],
-    'state',
-    { states: [todo], members: [], projects: [], cycles: [], labels: [] },
-    { showEmptyGroups: false, ordering: 'manual' },
-  );
+const ownedColumnSource: BoardColumnSource = {
+  query: { filter: emptyFilterGroup(), orderBy: 'manual' },
+  groupBy: 'state',
+  scope: { teamId: 'team_1' },
+  display: defaultDisplayOptions('board'),
+};
+
+function boardPage(rows: readonly Issue[]): BoardPage {
+  return {
+    groups: [{ id: todo.id, total: rows.length, issues: [...rows], nextCursor: null }],
+    truncated: false,
+  };
+}
+
+function renderBoard(
+  draggable = false,
+  rows: readonly Issue[] = [issue(), second],
+  columnSource?: BoardColumnSource,
+) {
+  const makeGroups = (nextRows: readonly Issue[]) =>
+    groupIssues(
+      nextRows,
+      'state',
+      { states: [todo], members: [], projects: [], cycles: [], labels: [] },
+      { showEmptyGroups: false, ordering: 'manual' },
+    );
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
   });
-  render(
+  if (columnSource !== undefined) {
+    const page = boardPage(rows);
+    client.setQueryData(
+      queryKeys.boardPage(
+        boardSearch(columnSource.query, columnSource.groupBy, columnSource.scope),
+      ),
+      page,
+    );
+    seedBoardColumns(client, columnSource, page, Date.now());
+  }
+  const board = (nextRows: readonly Issue[]) => (
     <QueryClientProvider client={client}>
       <TooltipProvider>
         <ToastProvider>
           <HotkeyProvider>
-            <Board groups={groups} draggable={false} />
+            <Board
+              groups={makeGroups(nextRows)}
+              draggable={draggable}
+              {...(columnSource === undefined ? {} : { columnSource })}
+            />
           </HotkeyProvider>
         </ToastProvider>
       </TooltipProvider>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
+  const rendered = render(board(rows));
+  return {
+    client,
+    rerenderBoard(nextRows: readonly Issue[]) {
+      rendered.rerender(board(nextRows));
+    },
+  };
 }
+
+describe('Board card keyboard boundaries', () => {
+  it('keeps the draggable wrapper a list item around nested controls', () => {
+    renderBoard(true);
+    const card = screen.getByTestId('issue-card-ENG-1');
+    const item = card.closest('li');
+
+    expect(item?.getAttribute('role')).toBe('listitem');
+    expect(within(card).getByRole('link', { name: 'Domain auto join' })).toBeInTheDocument();
+  });
+
+  it('leaves arrow keys on nested issue links untouched', () => {
+    renderBoard(true);
+    const link = cardLink('ENG-1', 'Domain auto join');
+    link.focus();
+
+    const allowed = fireEvent.keyDown(link, { key: 'ArrowRight', code: 'ArrowRight' });
+
+    expect(allowed).toBe(true);
+    expect(document.activeElement).toBe(link);
+  });
+
+  it('does not start a drag when Enter belongs to a nested issue link', () => {
+    renderBoard(true);
+    const link = cardLink('ENG-1', 'Domain auto join');
+    link.focus();
+
+    const allowed = fireEvent.keyDown(link, { key: 'Enter', code: 'Enter' });
+
+    expect(allowed).toBe(true);
+    expect(screen.getAllByTestId('issue-card-ENG-1')).toHaveLength(1);
+  });
+
+  it('reconciles a background update without replacing the active drag announcement', () => {
+    const rendered = renderBoard(true);
+    const card = screen.getByTestId('issue-card-ENG-1').closest('li');
+    if (card === null) throw new Error('missing draggable card');
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+
+    const dndStatus = document.querySelector<HTMLElement>(
+      '[id^="DndLiveRegion-"][aria-live="assertive"]',
+    );
+    if (dndStatus === null) throw new Error('missing drag status');
+    expect(dndStatus).toHaveTextContent('Picked up ENG-1');
+
+    const updated = issue({
+      syncId: 2,
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      title: 'Updated domain auto join',
+    });
+    rendered.rerenderBoard([updated, second]);
+
+    expect(dndStatus).not.toHaveTextContent('updated in the background');
+    expect(screen.getByTestId('board-drag-status')).toHaveTextContent(
+      'ENG-1 was updated in the background. Still holding it in column Todo, position 1 of 2.',
+    );
+  });
+
+  it('reconciles a background update from an owned column query', async () => {
+    const rendered = renderBoard(true, [issue(), second], ownedColumnSource);
+    const card = screen.getByTestId('issue-card-ENG-1').closest('li');
+    if (card === null) throw new Error('missing draggable card');
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    expect(dndStatus()).toHaveTextContent('Picked up ENG-1');
+
+    const updated = issue({
+      syncId: 2,
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      title: 'Updated domain auto join',
+    });
+    await act(async () => {
+      seedBoardColumns(
+        rendered.client,
+        ownedColumnSource,
+        boardPage([updated, second]),
+        Date.now() + 10_000,
+      );
+      await Promise.resolve();
+    });
+
+    expect(dndStatus()).not.toHaveTextContent('updated in the background');
+    await waitFor(() => {
+      expect(screen.getByTestId('board-drag-status')).toHaveTextContent(
+        'ENG-1 was updated in the background. Still holding it in column Todo, position 1 of 2.',
+      );
+    });
+  });
+});
 
 function cardLink(identifier: string, title: string): HTMLElement {
   const card = screen.getByTestId(`issue-card-${identifier}`);
   return within(card).getByRole('link', { name: title });
+}
+
+function dndStatus(): HTMLElement {
+  const status = document.querySelector<HTMLElement>(
+    '[id^="DndLiveRegion-"][aria-live="assertive"]',
+  );
+  if (status === null) throw new Error('missing drag status');
+  return status;
 }
 
 describe('Board peek', () => {

--- a/apps/web/tests/features/issues/board.test.tsx
+++ b/apps/web/tests/features/issues/board.test.tsx
@@ -24,7 +24,10 @@ import { seedBoardColumns } from '@/lib/query/use-issues.ts';
 
 const push = mock();
 const nativeFetch = globalThis.fetch;
-const nativeGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+const nativeGetBoundingClientRect = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  'getBoundingClientRect',
+);
 const nativeRequestAnimationFrame = window.requestAnimationFrame;
 const nativeCancelAnimationFrame = window.cancelAnimationFrame;
 beforeEach(() => {
@@ -40,7 +43,15 @@ afterEach(() => {
     writable: true,
     value: nativeFetch,
   });
-  HTMLElement.prototype.getBoundingClientRect = nativeGetBoundingClientRect;
+  if (nativeGetBoundingClientRect === undefined) {
+    Reflect.deleteProperty(HTMLElement.prototype, 'getBoundingClientRect');
+  } else {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'getBoundingClientRect',
+      nativeGetBoundingClientRect,
+    );
+  }
   window.requestAnimationFrame = nativeRequestAnimationFrame;
   window.cancelAnimationFrame = nativeCancelAnimationFrame;
 });

--- a/apps/web/tests/features/issues/board.test.tsx
+++ b/apps/web/tests/features/issues/board.test.tsx
@@ -1,21 +1,32 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import { defaultDisplayOptions, emptyFilterGroup } from '@orbit/shared/filters';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { ToastProvider } from '@/components/ui/toast.tsx';
 import { TooltipProvider } from '@/components/ui/tooltip.tsx';
 import { groupIssues } from '@/features/filters/grouping.ts';
+import type { BoardColumnSource } from '@/features/issues/board.tsx';
+import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
+import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import { HotkeyProvider } from '@/lib/keyboard/index.ts';
 import { boardSearch } from '@/lib/query/issue-search.ts';
 import { queryKeys } from '@/lib/query/keys.ts';
 import type { BoardPage, Issue, WorkflowState } from '@/lib/query/schemas.ts';
 import { seedBoardColumns } from '@/lib/query/use-issues.ts';
-import type { BoardColumnSource } from '../../../src/features/issues/board.tsx';
-import type { WorkspaceData } from '../../../src/features/issues/workspace-provider.tsx';
-import * as workspaceProvider from '../../../src/features/issues/workspace-provider.tsx';
 
 const push = mock();
 const nativeFetch = globalThis.fetch;
+const nativeGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+const nativeRequestAnimationFrame = window.requestAnimationFrame;
+const nativeCancelAnimationFrame = window.cancelAnimationFrame;
 beforeEach(() => {
   Object.defineProperty(globalThis, 'fetch', {
     configurable: true,
@@ -29,6 +40,9 @@ afterEach(() => {
     writable: true,
     value: nativeFetch,
   });
+  HTMLElement.prototype.getBoundingClientRect = nativeGetBoundingClientRect;
+  window.requestAnimationFrame = nativeRequestAnimationFrame;
+  window.cancelAnimationFrame = nativeCancelAnimationFrame;
 });
 mock.module('next/navigation', () => ({
   useRouter: () => ({ push, replace: mock(), refresh: mock() }),
@@ -91,6 +105,38 @@ function issue(overrides: Partial<Issue> = {}): Issue {
   };
 }
 
+function deferredResponse(): {
+  readonly promise: Promise<Response>;
+  readonly resolve: (response: Response) => void;
+} {
+  let resolvePromise: ((response: Response) => void) | undefined;
+  const promise = new Promise<Response>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (resolvePromise === undefined) throw new Error('deferred response did not initialize');
+  return { promise, resolve: resolvePromise };
+}
+
+function deferredSignal(): {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+} {
+  let resolvePromise: (() => void) | undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (resolvePromise === undefined) throw new Error('deferred signal did not initialize');
+  return { promise, resolve: resolvePromise };
+}
+
+function installBoardTestRects(): void {
+  HTMLElement.prototype.getBoundingClientRect = function getBoardTestRect() {
+    const inDoing = this.closest('[data-testid="board-column-In Progress"]') !== null;
+    const card = this.matches('li');
+    return new DOMRect(inDoing ? 320 : 0, card ? 80 : 0, card ? 260 : 280, card ? 72 : 500);
+  };
+}
+
 const workspace: WorkspaceData = {
   ready: true,
   userId: 'user_1',
@@ -111,12 +157,77 @@ const workspace: WorkspaceData = {
   openQuickCreate: () => undefined,
 };
 
-mock.module('../../../src/features/issues/workspace-provider.tsx', () => ({
+mock.module('@/features/issues/workspace-provider.tsx', () => ({
   ...workspaceProvider,
   useWorkspace: () => workspace,
 }));
 
-const { Board } = await import('../../../src/features/issues/board.tsx');
+const { Board, boardVisibilityConfig, useBoardVisibilityHold } = await import(
+  '@/features/issues/board.tsx'
+);
+
+describe('Board visibility during drag settlement', () => {
+  it('does not remount a board for cosmetic card property changes', () => {
+    const config = {
+      filter: emptyFilterGroup(),
+      groupBy: 'state' as const,
+      subGroupBy: 'none' as const,
+      orderBy: 'manual' as const,
+      display: defaultDisplayOptions('board'),
+    };
+    const before = JSON.stringify(boardVisibilityConfig(config));
+    const cosmetic = JSON.stringify(
+      boardVisibilityConfig({
+        ...config,
+        display: { ...config.display, properties: ['priority'] },
+      }),
+    );
+    const membership = JSON.stringify(
+      boardVisibilityConfig({
+        ...config,
+        display: { ...config.display, showSubIssues: !config.display.showSubIssues },
+      }),
+    );
+
+    expect(cosmetic).toBe(before);
+    expect(membership).not.toBe(before);
+  });
+
+  it('keeps an emptied board mounted without retaining unrelated empty states', () => {
+    const view = renderHook(({ contextKey, empty }) => useBoardVisibilityHold(contextKey, empty), {
+      initialProps: { contextKey: 'first', empty: false },
+    });
+    const startActivity = () => {
+      let end: (() => void) | undefined;
+      act(() => {
+        end = view.result.current.start();
+      });
+      if (end === undefined) throw new Error('visibility activity did not start');
+      return end;
+    };
+
+    const firstEnd = startActivity();
+    act(() => view.rerender({ contextKey: 'first', empty: true }));
+    expect(view.result.current.held).toBe(true);
+
+    const secondEnd = startActivity();
+    act(() => firstEnd());
+    expect(view.result.current.held).toBe(true);
+    act(() => secondEnd());
+    expect(view.result.current.held).toBe(true);
+
+    act(() => view.rerender({ contextKey: 'first', empty: false }));
+    expect(view.result.current.held).toBe(false);
+    act(() => view.rerender({ contextKey: 'first', empty: true }));
+    expect(view.result.current.held).toBe(false);
+
+    const staleEnd = startActivity();
+    act(() => view.rerender({ contextKey: 'second', empty: true }));
+    expect(view.result.current.held).toBe(false);
+    act(() => staleEnd());
+    expect(view.result.current.held).toBe(false);
+  });
+});
 
 const second = issue({
   id: 'issue_2',
@@ -158,13 +269,15 @@ function renderBoard(
   draggable = false,
   rows: readonly Issue[] = [issue(), second],
   columnSource?: BoardColumnSource,
+  showEmptyGroups = false,
+  onVisibilityActivityStart?: () => () => void,
 ) {
   const makeGroups = (nextRows: readonly Issue[]) =>
     groupIssues(
       nextRows,
       'state',
       { states: [todo, doing], members: [], projects: [], cycles: [], labels: [] },
-      { showEmptyGroups: false, ordering: 'manual' },
+      { showEmptyGroups, ordering: 'manual' },
     );
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
@@ -188,6 +301,7 @@ function renderBoard(
               groups={makeGroups(nextRows)}
               draggable={nextDraggable}
               {...(columnSource === undefined ? {} : { columnSource })}
+              {...(onVisibilityActivityStart === undefined ? {} : { onVisibilityActivityStart })}
             />
           </HotkeyProvider>
         </ToastProvider>
@@ -197,6 +311,8 @@ function renderBoard(
   const rendered = render(board(rows, draggable));
   return {
     client,
+    container: rendered.container,
+    unmount: rendered.unmount,
     rerenderBoard(nextRows: readonly Issue[], nextDraggable = draggable) {
       rendered.rerender(board(nextRows, nextDraggable));
     },
@@ -237,6 +353,241 @@ describe('Board card keyboard boundaries', () => {
     expect(screen.getAllByTestId('issue-card-ENG-1')).toHaveLength(1);
   });
 
+  it('keeps the drag overlay clone out of accessibility and tab navigation', async () => {
+    renderBoard(true);
+    const card = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => {
+      expect(screen.getAllByTestId('issue-card-ENG-1')).toHaveLength(2);
+    });
+
+    expect(screen.getAllByRole('link', { name: 'Domain auto join' })).toHaveLength(1);
+    fireEvent.keyDown(card, { key: 'Escape', code: 'Escape' });
+  });
+
+  it('ends an active visibility activity when the board unmounts', async () => {
+    const end = mock();
+    const start = mock(() => end);
+    const rendered = renderBoard(true, [issue()], undefined, false, start);
+    const card = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(1));
+
+    rendered.unmount();
+
+    expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  it('ends an accepted pending visibility activity when the board unmounts', async () => {
+    installBoardTestRects();
+    const pending = deferredResponse();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) =>
+      init?.method === 'POST'
+        ? pending.promise
+        : Promise.resolve(Response.json({ issues: [], nextCursor: null })),
+    ) as unknown as typeof fetch;
+    const end = mock();
+    const start = mock(() => end);
+    const rendered = renderBoard(true, [issue()], undefined, true, start);
+    const card = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => expect(screen.getAllByTestId('issue-card-ENG-1')).toHaveLength(2));
+    await act(async () => {
+      await settleKeyboardSensor();
+      fireEvent.keyDown(card, { key: 'ArrowRight', code: 'ArrowRight' });
+      await settleKeyboardSensor();
+    });
+    await waitFor(() => expect(dndStatus()).toHaveTextContent('column In Progress'));
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => expect(dndStatus()).toHaveTextContent('Dropping ENG-1'));
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(end).not.toHaveBeenCalled();
+
+    rendered.unmount();
+    expect(end).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pending.resolve(
+        Response.json({
+          issue: issue({ stateId: doing.id, syncId: 2 }),
+          rebalanced: [],
+        }),
+      );
+      await pending.promise;
+      await Promise.resolve();
+    });
+    expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  it('promotes a keyboard drop fallback to the optimistic card after a delayed handoff', async () => {
+    installBoardTestRects();
+    const cancellation = deferredSignal();
+    const pending = deferredResponse();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) =>
+      init?.method === 'POST'
+        ? pending.promise
+        : Promise.resolve(Response.json({ issues: [], nextCursor: null })),
+    ) as unknown as typeof fetch;
+    const rendered = renderBoard(true, [issue()], ownedColumnSource, true);
+    const cancelQueries = rendered.client.cancelQueries.bind(rendered.client);
+    rendered.client.cancelQueries = mock(
+      async (...args: Parameters<typeof rendered.client.cancelQueries>) => {
+        await cancellation.promise;
+        await cancelQueries(...args);
+      },
+    );
+    const card = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    await act(async () => {
+      await settleKeyboardSensor();
+      fireEvent.keyDown(card, { key: 'ArrowRight', code: 'ArrowRight' });
+      await settleKeyboardSensor();
+    });
+    await waitFor(() => expect(dndStatus()).toHaveTextContent('column In Progress'));
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    const destination = screen.getByRole('list', { name: 'In Progress issues' });
+    await waitFor(() => expect(document.activeElement === destination).toBe(true));
+
+    await act(async () => {
+      cancellation.resolve();
+      await cancellation.promise;
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(
+        within(destination).getByRole('listitem', { name: 'ENG-1: Domain auto join' }),
+      ).toBeInTheDocument();
+    });
+    const optimistic = within(destination).getByRole('listitem', {
+      name: 'ENG-1: Domain auto join',
+    });
+    expect(optimistic).toHaveAttribute('aria-disabled', 'true');
+    await waitFor(() => expect(document.activeElement === optimistic).toBe(true));
+
+    await act(async () => {
+      pending.resolve(
+        Response.json({
+          issue: issue({ stateId: doing.id, syncId: 2 }),
+          rebalanced: [],
+        }),
+      );
+      await pending.promise;
+      await Promise.resolve();
+    });
+  });
+
+  it('does not promote a keyboard drop fallback after focus leaves the board position', async () => {
+    installBoardTestRects();
+    const cancellation = deferredSignal();
+    const pending = deferredResponse();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) =>
+      init?.method === 'POST'
+        ? pending.promise
+        : Promise.resolve(Response.json({ issues: [], nextCursor: null })),
+    ) as unknown as typeof fetch;
+    const rendered = renderBoard(true, [issue()], ownedColumnSource, true);
+    const cancelQueries = rendered.client.cancelQueries.bind(rendered.client);
+    rendered.client.cancelQueries = mock(
+      async (...args: Parameters<typeof rendered.client.cancelQueries>) => {
+        await cancellation.promise;
+        await cancelQueries(...args);
+      },
+    );
+    const card = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    await act(async () => {
+      await settleKeyboardSensor();
+      fireEvent.keyDown(card, { key: 'ArrowRight', code: 'ArrowRight' });
+      await settleKeyboardSensor();
+    });
+    await waitFor(() => expect(dndStatus()).toHaveTextContent('column In Progress'));
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    const destination = screen.getByRole('list', { name: 'In Progress issues' });
+    await waitFor(() => expect(document.activeElement === destination).toBe(true));
+    const alternate = screen.getByRole('button', { name: 'Create an issue in Todo' });
+    alternate.focus();
+
+    await act(async () => {
+      cancellation.resolve();
+      await cancellation.promise;
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(
+        within(destination).getByRole('listitem', { name: 'ENG-1: Domain auto join' }),
+      ).toBeInTheDocument(),
+    );
+    expect(document.activeElement).toBe(alternate);
+
+    await act(async () => {
+      pending.resolve(
+        Response.json({
+          issue: issue({ stateId: doing.id, syncId: 2 }),
+          rebalanced: [],
+        }),
+      );
+      await pending.promise;
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(document.activeElement === alternate).toBe(true));
+  });
+
+  it('cancels a queued settlement frame when the board unmounts', async () => {
+    installBoardTestRects();
+    const pending = deferredResponse();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) =>
+      init?.method === 'POST'
+        ? pending.promise
+        : Promise.resolve(Response.json({ issues: [], nextCursor: null })),
+    ) as unknown as typeof fetch;
+    const end = mock();
+    const rendered = renderBoard(true, [issue()], undefined, true, () => end);
+    const card = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => expect(screen.getAllByTestId('issue-card-ENG-1')).toHaveLength(2));
+    await act(async () => {
+      await settleKeyboardSensor();
+      fireEvent.keyDown(card, { key: 'ArrowRight', code: 'ArrowRight' });
+      await settleKeyboardSensor();
+    });
+    await waitFor(() => expect(dndStatus()).toHaveTextContent('column In Progress'));
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => expect(dndStatus()).toHaveTextContent('Dropping ENG-1'));
+
+    let frame: FrameRequestCallback | undefined;
+    const requestFrame = mock((callback: FrameRequestCallback) => {
+      frame = callback;
+      return 700;
+    });
+    const cancelFrame = mock();
+    window.requestAnimationFrame = requestFrame;
+    window.cancelAnimationFrame = cancelFrame;
+    await act(async () => {
+      pending.resolve(
+        Response.json({
+          issue: issue({ stateId: doing.id, syncId: 2 }),
+          rebalanced: [],
+        }),
+      );
+      await pending.promise;
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(requestFrame).toHaveBeenCalledTimes(1));
+    expect(end).not.toHaveBeenCalled();
+
+    rendered.unmount();
+    expect(cancelFrame).toHaveBeenCalledWith(700);
+    expect(end).toHaveBeenCalledTimes(1);
+    act(() => frame?.(0));
+    expect(end).toHaveBeenCalledTimes(1);
+  });
+
   it('moves card focus with all four arrow keys before a drag starts', () => {
     renderBoard(true, [issue(), second, third]);
     const firstItem = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
@@ -252,6 +603,53 @@ describe('Board card keyboard boundaries', () => {
     expect(document.activeElement).toBe(thirdItem);
     fireEvent.keyDown(thirdItem, { key: 'ArrowLeft', code: 'ArrowLeft' });
     expect(document.activeElement).toBe(firstItem);
+  });
+
+  it('moves from a focused column fallback to a card on the same board', () => {
+    renderBoard(true, [issue(), second, third]);
+    const todoColumn = screen.getByTestId('board-column-Todo').querySelector('ul');
+    const doingColumn = screen.getByTestId('board-column-In Progress').querySelector('ul');
+    if (todoColumn === null || doingColumn === null) throw new Error('missing board column list');
+    const firstItem = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    const thirdItem = screen.getByRole('listitem', { name: 'ENG-3: Third task' });
+
+    todoColumn.focus();
+    fireEvent.keyDown(todoColumn, { key: 'ArrowDown', code: 'ArrowDown' });
+    expect(document.activeElement === firstItem).toBe(true);
+
+    doingColumn.focus();
+    fireEvent.keyDown(doingColumn, { key: 'ArrowLeft', code: 'ArrowLeft' });
+    expect(document.activeElement === firstItem).toBe(true);
+    expect(document.activeElement === thirdItem).toBe(false);
+  });
+
+  it('moves from a card into an empty adjacent column fallback', () => {
+    renderBoard(true, [issue()], undefined, true);
+    const firstItem = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    const doingColumn = screen.getByTestId('board-column-In Progress').querySelector('ul');
+    if (doingColumn === null) throw new Error('missing empty board column list');
+
+    firstItem.focus();
+    fireEvent.keyDown(firstItem, { key: 'ArrowRight', code: 'ArrowRight' });
+    expect(document.activeElement).toBe(doingColumn);
+
+    fireEvent.keyDown(doingColumn, { key: 'ArrowLeft', code: 'ArrowLeft' });
+    expect(document.activeElement).toBe(firstItem);
+  });
+
+  it('does not move focus into another board', () => {
+    const firstBoard = renderBoard(true, [issue(), second, third]);
+    renderBoard(true, [
+      issue({ id: 'issue_4', number: 4, identifier: 'ENG-4', title: 'Another board task' }),
+    ]);
+    const firstDoingCard = within(firstBoard.container).getByRole('listitem', {
+      name: 'ENG-3: Third task',
+    });
+
+    firstDoingCard.focus();
+    fireEvent.keyDown(firstDoingCard, { key: 'ArrowRight', code: 'ArrowRight' });
+
+    expect(document.activeElement === firstDoingCard).toBe(true);
   });
 
   it('clears an active keyboard session when dragging becomes unavailable', async () => {
@@ -525,7 +923,7 @@ describe('Board card keyboard boundaries', () => {
     });
 
     await waitFor(() => {
-      expect(dndStatus()).toHaveTextContent(
+      expect(dndStatus().textContent).toBe(
         'ENG-1 moved in the background to column In Progress, position 1. Drag cancelled.',
       );
     });
@@ -562,10 +960,35 @@ describe('Board card keyboard boundaries', () => {
     });
 
     await waitFor(() => {
-      expect(dndStatus()).toHaveTextContent(
+      expect(dndStatus().textContent).toBe(
         'ENG-1 moved in the background to column In Progress, position 1. Drag cancelled.',
       );
     });
+    const movedCard = within(screen.getByTestId('board-column-In Progress')).getByRole('listitem', {
+      name: 'ENG-1: Regrouped domain auto join',
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(movedCard);
+    });
+
+    await act(async () => {
+      seedBoardColumns(
+        rendered.client,
+        ownedColumnSource,
+        {
+          groups: [{ id: todo.id, total: 1, issues: [second], nextCursor: null }],
+          truncated: false,
+        },
+        Date.now() + 20_000,
+      );
+      await Promise.resolve();
+    });
+    await new Promise<void>((resolve) => {
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => resolve());
+      });
+    });
+    expect(document.activeElement).toBe(movedCard);
   });
 
   it('uses a fresh parent regroup to cancel while the owned column mirror catches up', async () => {

--- a/apps/web/tests/features/issues/board.test.tsx
+++ b/apps/web/tests/features/issues/board.test.tsx
@@ -49,6 +49,15 @@ const todo: WorkflowState = {
   position: 1,
 };
 
+const doing: WorkflowState = {
+  id: 'state_doing',
+  teamId: 'team_1',
+  name: 'In Progress',
+  category: 'started',
+  color: '#5a63c8',
+  position: 2,
+};
+
 function issue(overrides: Partial<Issue> = {}): Issue {
   return {
     id: 'issue_1',
@@ -87,13 +96,16 @@ const workspace: WorkspaceData = {
   userId: 'user_1',
   role: 'admin',
   teams: [{ id: 'team_1', name: 'Engineering', key: 'ENG', icon: 'circle', color: '#5a63c8' }],
-  states: [todo],
+  states: [todo, doing],
   labels: [],
   members: [],
   projects: [],
   cycles: [],
   seedIssues: [],
-  stateById: new Map([[todo.id, todo]]),
+  stateById: new Map([
+    [todo.id, todo],
+    [doing.id, doing],
+  ]),
   labelById: new Map(),
   memberById: new Map(),
   openQuickCreate: () => undefined,
@@ -114,6 +126,14 @@ const second = issue({
   title: 'Second task',
 });
 
+const third = issue({
+  id: 'issue_3',
+  number: 3,
+  identifier: 'ENG-3',
+  title: 'Third task',
+  stateId: doing.id,
+});
+
 const ownedColumnSource: BoardColumnSource = {
   query: { filter: emptyFilterGroup(), orderBy: 'manual' },
   groupBy: 'state',
@@ -122,8 +142,14 @@ const ownedColumnSource: BoardColumnSource = {
 };
 
 function boardPage(rows: readonly Issue[]): BoardPage {
+  const groups = [todo, doing].flatMap((state) => {
+    const issues = rows.filter((row) => row.stateId === state.id);
+    return issues.length === 0
+      ? []
+      : [{ id: state.id, total: issues.length, issues, nextCursor: null }];
+  });
   return {
-    groups: [{ id: todo.id, total: rows.length, issues: [...rows], nextCursor: null }],
+    groups,
     truncated: false,
   };
 }
@@ -137,7 +163,7 @@ function renderBoard(
     groupIssues(
       nextRows,
       'state',
-      { states: [todo], members: [], projects: [], cycles: [], labels: [] },
+      { states: [todo, doing], members: [], projects: [], cycles: [], labels: [] },
       { showEmptyGroups: false, ordering: 'manual' },
     );
   const client = new QueryClient({
@@ -153,14 +179,14 @@ function renderBoard(
     );
     seedBoardColumns(client, columnSource, page, Date.now());
   }
-  const board = (nextRows: readonly Issue[]) => (
+  const board = (nextRows: readonly Issue[], nextDraggable: boolean) => (
     <QueryClientProvider client={client}>
       <TooltipProvider>
         <ToastProvider>
           <HotkeyProvider>
             <Board
               groups={makeGroups(nextRows)}
-              draggable={draggable}
+              draggable={nextDraggable}
               {...(columnSource === undefined ? {} : { columnSource })}
             />
           </HotkeyProvider>
@@ -168,11 +194,11 @@ function renderBoard(
       </TooltipProvider>
     </QueryClientProvider>
   );
-  const rendered = render(board(rows));
+  const rendered = render(board(rows, draggable));
   return {
     client,
-    rerenderBoard(nextRows: readonly Issue[]) {
-      rendered.rerender(board(nextRows));
+    rerenderBoard(nextRows: readonly Issue[], nextDraggable = draggable) {
+      rendered.rerender(board(nextRows, nextDraggable));
     },
   };
 }
@@ -182,8 +208,10 @@ describe('Board card keyboard boundaries', () => {
     renderBoard(true);
     const card = screen.getByTestId('issue-card-ENG-1');
     const item = card.closest('li');
+    if (item === null) throw new Error('missing draggable list item');
 
-    expect(item?.getAttribute('role')).toBe('listitem');
+    expect(item.getAttribute('role')).toBe('listitem');
+    expect(screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' })).toBe(item);
     expect(within(card).getByRole('link', { name: 'Domain auto join' })).toBeInTheDocument();
   });
 
@@ -209,30 +237,163 @@ describe('Board card keyboard boundaries', () => {
     expect(screen.getAllByTestId('issue-card-ENG-1')).toHaveLength(1);
   });
 
-  it('reconciles a background update without replacing the active drag announcement', () => {
+  it('moves card focus with all four arrow keys before a drag starts', () => {
+    renderBoard(true, [issue(), second, third]);
+    const firstItem = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    const secondItem = screen.getByRole('listitem', { name: 'ENG-2: Second task' });
+    const thirdItem = screen.getByRole('listitem', { name: 'ENG-3: Third task' });
+    firstItem.focus();
+
+    fireEvent.keyDown(firstItem, { key: 'ArrowDown', code: 'ArrowDown' });
+    expect(document.activeElement).toBe(secondItem);
+    fireEvent.keyDown(secondItem, { key: 'ArrowUp', code: 'ArrowUp' });
+    expect(document.activeElement).toBe(firstItem);
+    fireEvent.keyDown(firstItem, { key: 'ArrowRight', code: 'ArrowRight' });
+    expect(document.activeElement).toBe(thirdItem);
+    fireEvent.keyDown(thirdItem, { key: 'ArrowLeft', code: 'ArrowLeft' });
+    expect(document.activeElement).toBe(firstItem);
+  });
+
+  it('clears an active keyboard session when dragging becomes unavailable', async () => {
+    const rows = [issue(), second];
+    const rendered = renderBoard(true, rows);
+    const card = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    expect(screen.getAllByTestId('issue-card-ENG-1')).toHaveLength(2);
+
+    await act(async () => {
+      rendered.rerenderBoard(rows, false);
+      await settleKeyboardSensor();
+    });
+    rendered.rerenderBoard(rows, true);
+
+    expect(screen.getAllByTestId('issue-card-ENG-1')).toHaveLength(1);
+    expect(dndStatus()).toBeEmptyDOMElement();
+    const restarted = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    restarted.focus();
+    fireEvent.keyDown(restarted, { key: 'Enter', code: 'Enter' });
+    expect(dndStatus()).toHaveTextContent('Picked up ENG-1');
+    expect(screen.getAllByTestId('issue-card-ENG-1')).toHaveLength(2);
+    await act(async () => {
+      await settleKeyboardSensor();
+      fireEvent.keyDown(restarted, { key: 'Escape', code: 'Escape' });
+    });
+  });
+
+  it('reconciles a background update without replacing the active drag announcement', async () => {
     const rendered = renderBoard(true);
     const card = screen.getByTestId('issue-card-ENG-1').closest('li');
     if (card === null) throw new Error('missing draggable card');
     card.focus();
     fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
 
-    const dndStatus = document.querySelector<HTMLElement>(
-      '[id^="DndLiveRegion-"][aria-live="assertive"]',
-    );
-    if (dndStatus === null) throw new Error('missing drag status');
+    const dndStatus = screen.getByTestId('board-drag-status');
     expect(dndStatus).toHaveTextContent('Picked up ENG-1');
+    const spokenStatuses = Array.from(
+      document.querySelectorAll<HTMLElement>('[aria-live="assertive"]'),
+    ).filter((node) => node.textContent?.trim().length !== 0);
+    expect(spokenStatuses).toEqual([dndStatus]);
 
     const updated = issue({
       syncId: 2,
       updatedAt: '2026-01-02T00:00:00.000Z',
       title: 'Updated domain auto join',
     });
-    rendered.rerenderBoard([updated, second]);
+    await act(async () => {
+      rendered.rerenderBoard([updated, second]);
+      await Promise.resolve();
+    });
 
-    expect(dndStatus).not.toHaveTextContent('updated in the background');
     expect(screen.getByTestId('board-drag-status')).toHaveTextContent(
-      'ENG-1 was updated in the background. Still holding it in column Todo, position 1 of 2.',
+      'Picked up ENG-1: Domain auto join in column Todo, position 1 of 2.',
     );
+    await act(async () => {
+      await settleKeyboardSensor();
+      fireEvent.keyDown(card, { key: 'Escape', code: 'Escape' });
+    });
+  });
+
+  it('cancels a drag when the held issue is reordered in the background', async () => {
+    const rendered = renderBoard(true);
+    const card = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+
+    await act(async () => {
+      rendered.rerenderBoard([
+        issue({ syncId: 2, sortOrder: 3072, updatedAt: '2026-01-02T00:00:00.000Z' }),
+        second,
+      ]);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(dndStatus()).toHaveTextContent(
+        'ENG-1 moved in the background to column Todo, position 2 of 2. Drag cancelled.',
+      );
+    });
+    expect(document.activeElement).toBe(
+      screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' }),
+    );
+  });
+
+  it('cancels cleanly when the held issue leaves the visible board', async () => {
+    const rendered = renderBoard(true);
+    const card = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    expect(dndStatus()).toHaveTextContent('Picked up ENG-1');
+
+    rendered.rerenderBoard([second]);
+
+    await waitFor(() => {
+      expect(dndStatus()).toHaveTextContent('ENG-1 is no longer visible. Drag cancelled.');
+    });
+    expect(screen.queryAllByTestId('issue-card-ENG-1')).toHaveLength(0);
+  });
+
+  it('cancels a drag when the held issue is moved in the background', async () => {
+    const rendered = renderBoard(true, [issue(), second, third]);
+    const card = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+
+    const updated = issue({
+      stateId: doing.id,
+      syncId: 2,
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    });
+    rendered.rerenderBoard([updated, second, third]);
+    await waitFor(() => {
+      expect(dndStatus()).toHaveTextContent(
+        'ENG-1 moved in the background to column In Progress, position 1 of 2. Drag cancelled.',
+      );
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' }),
+      );
+    });
+    expect(screen.getAllByTestId('issue-card-ENG-1')).toHaveLength(1);
+
+    const relocated = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    await act(async () => {
+      fireEvent.keyDown(relocated, { key: 'Enter', code: 'Enter' });
+      await settleKeyboardSensor();
+    });
+    expect(dndStatus()).toHaveTextContent(
+      'Picked up ENG-1: Domain auto join in column In Progress, position 1 of 2.',
+    );
+    expect(screen.getAllByTestId('issue-card-ENG-1')).toHaveLength(2);
+    await act(async () => {
+      fireEvent.keyDown(relocated, { key: 'Escape', code: 'Escape' });
+      await Promise.resolve();
+    });
+    expect(dndStatus()).toHaveTextContent('Returned to column In Progress, position 1 of 2.');
+    await waitFor(() => {
+      expect(screen.getAllByTestId('issue-card-ENG-1')).toHaveLength(1);
+    });
   });
 
   it('reconciles a background update from an owned column query', async () => {
@@ -258,10 +419,170 @@ describe('Board card keyboard boundaries', () => {
       await Promise.resolve();
     });
 
-    expect(dndStatus()).not.toHaveTextContent('updated in the background');
     await waitFor(() => {
-      expect(screen.getByTestId('board-drag-status')).toHaveTextContent(
-        'ENG-1 was updated in the background. Still holding it in column Todo, position 1 of 2.',
+      expect(
+        screen.getByRole('listitem', { name: 'ENG-1: Updated domain auto join' }),
+      ).toBeInTheDocument();
+    });
+    expect(dndStatus()).toHaveTextContent(
+      'Picked up ENG-1: Domain auto join in column Todo, position 1 of 2.',
+    );
+    await act(async () => {
+      await settleKeyboardSensor();
+      fireEvent.keyDown(screen.getByRole('listitem', { name: 'ENG-1: Updated domain auto join' }), {
+        key: 'Escape',
+        code: 'Escape',
+      });
+    });
+  });
+
+  it('cancels when owned rows reorder around the same held issue object', async () => {
+    const held = second;
+    const first = issue();
+    const rendered = renderBoard(true, [first, held], ownedColumnSource);
+    const card = screen.getByRole('listitem', { name: 'ENG-2: Second task' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+    expect(dndStatus()).toHaveTextContent('Picked up ENG-2');
+    await act(async () => {
+      await settleKeyboardSensor();
+    });
+
+    await act(async () => {
+      seedBoardColumns(
+        rendered.client,
+        ownedColumnSource,
+        boardPage([held, first]),
+        Date.now() + 10_000,
+      );
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(dndStatus()).toHaveTextContent(
+        'ENG-2 moved in the background to column Todo, position 1 of 2. Drag cancelled.',
+      );
+    });
+    expect(document.activeElement).toBe(
+      screen.getByRole('listitem', { name: 'ENG-2: Second task' }),
+    );
+  });
+
+  it('waits for an owned column handoff before cancelling a background regroup', async () => {
+    const rendered = renderBoard(true, [issue(), second, third], ownedColumnSource);
+    const card = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+
+    const updated = issue({
+      stateId: doing.id,
+      syncId: 2,
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      title: 'Regrouped domain auto join',
+    });
+    await act(async () => {
+      seedBoardColumns(
+        rendered.client,
+        ownedColumnSource,
+        {
+          groups: [{ id: todo.id, total: 2, issues: [updated, second], nextCursor: null }],
+          truncated: false,
+        },
+        Date.now() + 10_000,
+      );
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByRole('listitem', { name: 'ENG-1: Regrouped domain auto join' }),
+      ).toBeInTheDocument();
+    });
+    expect(dndStatus()).not.toHaveTextContent('updated in the background');
+
+    await act(async () => {
+      seedBoardColumns(
+        rendered.client,
+        ownedColumnSource,
+        {
+          groups: [{ id: todo.id, total: 1, issues: [second], nextCursor: null }],
+          truncated: false,
+        },
+        Date.now() + 20_000,
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      seedBoardColumns(
+        rendered.client,
+        ownedColumnSource,
+        {
+          groups: [{ id: doing.id, total: 2, issues: [updated, third], nextCursor: null }],
+          truncated: false,
+        },
+        Date.now() + 30_000,
+      );
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(dndStatus()).toHaveTextContent(
+        'ENG-1 moved in the background to column In Progress, position 1. Drag cancelled.',
+      );
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByRole('listitem', { name: 'ENG-1: Regrouped domain auto join' }),
+      );
+    });
+  });
+
+  it('uses the newest copy when a regroup briefly appears in both owned columns', async () => {
+    const rendered = renderBoard(true, [issue(), second, third], ownedColumnSource);
+    const card = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+
+    const updated = issue({
+      stateId: doing.id,
+      syncId: 2,
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      title: 'Regrouped domain auto join',
+    });
+    await act(async () => {
+      seedBoardColumns(
+        rendered.client,
+        ownedColumnSource,
+        {
+          groups: [{ id: doing.id, total: 2, issues: [updated, third], nextCursor: null }],
+          truncated: false,
+        },
+        Date.now() + 10_000,
+      );
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(dndStatus()).toHaveTextContent(
+        'ENG-1 moved in the background to column In Progress, position 1. Drag cancelled.',
+      );
+    });
+  });
+
+  it('uses a fresh parent regroup to cancel while the owned column mirror catches up', async () => {
+    const rendered = renderBoard(true, [issue(), second, third], ownedColumnSource);
+    const card = screen.getByRole('listitem', { name: 'ENG-1: Domain auto join' });
+    card.focus();
+    fireEvent.keyDown(card, { key: 'Enter', code: 'Enter' });
+
+    rendered.rerenderBoard([
+      issue({ stateId: doing.id, syncId: 2, updatedAt: '2026-01-02T00:00:00.000Z' }),
+      second,
+      third,
+    ]);
+
+    await waitFor(() => {
+      expect(dndStatus()).toHaveTextContent(
+        'ENG-1 moved in the background to column In Progress, position 1 of 2. Drag cancelled.',
       );
     });
   });
@@ -273,11 +594,11 @@ function cardLink(identifier: string, title: string): HTMLElement {
 }
 
 function dndStatus(): HTMLElement {
-  const status = document.querySelector<HTMLElement>(
-    '[id^="DndLiveRegion-"][aria-live="assertive"]',
-  );
-  if (status === null) throw new Error('missing drag status');
-  return status;
+  return screen.getByTestId('board-drag-status');
+}
+
+async function settleKeyboardSensor(): Promise<void> {
+  await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
 }
 
 describe('Board peek', () => {

--- a/apps/web/tests/features/issues/card-controls.test.tsx
+++ b/apps/web/tests/features/issues/card-controls.test.tsx
@@ -4,6 +4,9 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ToastProvider } from '@/components/ui/toast.tsx';
 import type { Issue, Member } from '@/lib/query/schemas.ts';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/lib/query/use-issues.ts']);
 
 const member: Member = {
   id: 'user_2',

--- a/apps/web/tests/features/issues/issue-card.test.tsx
+++ b/apps/web/tests/features/issues/issue-card.test.tsx
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, mock } from 'bun:test';
 import type { DisplayProperty } from '@orbit/shared/filters';
 import { DEFAULT_DISPLAY_PROPERTIES, DISPLAY_PROPERTIES } from '@orbit/shared/filters';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render as renderRaw, screen } from '@testing-library/react';
+import { fireEvent, render as renderRaw, screen } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { ToastProvider } from '@/components/ui/toast.tsx';
 import { groupIssues } from '@/features/filters/grouping.ts';
@@ -111,6 +111,26 @@ describe('IssueCard', () => {
     expect(screen.getByTitle(`Reviewers: ${reviewer.name}`)).toBeInTheDocument();
     expect(screen.getByRole('img', { name: reviewer.name })).toBeInTheDocument();
     expect(screen.getByRole('img', { name: member.name })).toBeInTheDocument();
+  });
+
+  it('keeps pointer presses on property controls out of a parent drag listener', () => {
+    const parentPointerDown = mock();
+    render(
+      <div onPointerDown={parentPointerDown}>
+        <IssueCard issue={issue()} labels={[]} assignee={member} state={state} />
+      </div>,
+    );
+
+    const priority = screen.getByRole('button', { name: 'Priority: Urgent' });
+    const status = screen.getByRole('button', { name: 'Status: In progress' });
+    const assignee = screen.getByRole('button', { name: 'Change assignee' });
+    fireEvent.pointerDown(priority, { button: 1 });
+    fireEvent.pointerDown(status, { button: 1 });
+    fireEvent.pointerDown(assignee, { button: 1 });
+
+    expect(parentPointerDown).not.toHaveBeenCalled();
+    fireEvent.pointerDown(screen.getByRole('link', { name: issue().title }), { button: 1 });
+    expect(parentPointerDown).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/tests/features/issues/issue-detail-delete.test.tsx
+++ b/apps/web/tests/features/issues/issue-detail-delete.test.tsx
@@ -12,11 +12,12 @@ import { queryKeys } from '@/lib/query/keys.ts';
 import type { Issue, IssueDetail, WorkflowState } from '@/lib/query/schemas.ts';
 
 const pushed: string[] = [];
+const replaced: string[] = [];
 
 mock.module('next/navigation', () => ({
   useRouter: () => ({
     push: (path: string) => pushed.push(path),
-    replace: () => undefined,
+    replace: (path: string) => replaced.push(path),
     refresh: () => undefined,
     prefetch: () => undefined,
   }),
@@ -161,11 +162,15 @@ function OpenLayer() {
   );
 }
 
-function mountDetail(onDeleted?: () => void, withOpenLayer = false): QueryClient {
+function mountDetail(
+  onDeleted?: () => void,
+  withOpenLayer = false,
+  loaded: IssueDetail = detail,
+): QueryClient {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
   });
-  client.setQueryData(queryKeys.issue('ENG-1'), detail);
+  client.setQueryData(queryKeys.issue('ENG-1'), loaded);
   render(
     <QueryClientProvider client={client}>
       <TooltipProvider>
@@ -197,6 +202,7 @@ const user = userEvent.setup({ pointerEventsCheck: 0 });
 
 beforeEach(() => {
   pushed.length = 0;
+  replaced.length = 0;
   deleted.length = 0;
   serverRefuses = false;
   stubFetch();
@@ -207,6 +213,15 @@ afterEach(() => {
 });
 
 describe('deleting from the issue detail surface', () => {
+  it('replaces a stale full-page identifier with the moved issue identifier', async () => {
+    mountDetail(undefined, false, {
+      ...detail,
+      issue: { ...detail.issue, teamId: 'team_2', identifier: 'DSGN-1' },
+    });
+
+    await waitFor(() => expect(replaced).toEqual(['/issue/DSGN-1']));
+  });
+
   it('offers delete in the header menu and confirms before it fires', async () => {
     mountDetail();
 

--- a/apps/web/tests/features/issues/issue-detail-delete.test.tsx
+++ b/apps/web/tests/features/issues/issue-detail-delete.test.tsx
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import * as realtimeReact from '@orbit/realtime-client/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -23,6 +24,11 @@ mock.module('next/navigation', () => ({
 }));
 
 const STUBBED = {
+  '@orbit/realtime-client/react': {
+    ...realtimeReact,
+    useDeltaHandler: () => undefined,
+    useScopeSubscription: () => undefined,
+  },
   '@/features/comments/viewer-presence.tsx': { ViewerPresence: () => null },
   '@/features/comments/comment-thread.tsx': { CommentThread: () => null },
   '@/features/pulls/issue-pull-requests.tsx': { IssuePullRequests: () => null },

--- a/apps/web/tests/features/issues/issue-list.test.tsx
+++ b/apps/web/tests/features/issues/issue-list.test.tsx
@@ -11,6 +11,9 @@ import * as issuesQuery from '@/lib/query/use-issues.ts';
 import { IssueList, SELECTION_PREFETCH_MS } from '../../../src/features/issues/issue-list.tsx';
 import type { WorkspaceData } from '../../../src/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '../../../src/features/issues/workspace-provider.tsx';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/lib/query/use-issues.ts']);
 
 mock.module('next/navigation', () => ({
   useRouter: () => ({ push: mock(), replace: mock(), refresh: mock() }),

--- a/apps/web/tests/features/issues/issue-properties.test.tsx
+++ b/apps/web/tests/features/issues/issue-properties.test.tsx
@@ -12,6 +12,9 @@ import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import { HotkeyProvider, useHotkeyList } from '@/lib/keyboard/index.ts';
 import { createQueryClient } from '@/lib/query/provider.tsx';
 import type { Issue, Member, Milestone } from '@/lib/query/schemas.ts';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/lib/query/use-issues.ts']);
 
 const patches: Record<string, unknown>[] = [];
 

--- a/apps/web/tests/features/issues/my-issues-view.test.tsx
+++ b/apps/web/tests/features/issues/my-issues-view.test.tsx
@@ -353,7 +353,7 @@ describe('dragging a card on the My Issues board', () => {
     expect(sortable.length).toBeGreaterThan(0);
   });
 
-  it('carries the issue id on each sortable card, so a drop knows what moved', () => {
+  it('keeps each sortable card a list item around its nested controls', () => {
     workspace = buildWorkspace();
     renderView('me', 'board');
 
@@ -361,6 +361,6 @@ describe('dragging a card on the My Issues board', () => {
     const first = board.querySelector('[aria-roledescription="sortable"]');
 
     expect(first).not.toBeNull();
-    expect(first?.getAttribute('role')).toBe('button');
+    expect(first?.getAttribute('role')).toBe('listitem');
   });
 });

--- a/apps/web/tests/features/issues/my-issues-view.test.tsx
+++ b/apps/web/tests/features/issues/my-issues-view.test.tsx
@@ -295,6 +295,34 @@ describe('MyIssuesView', () => {
     expect(screen.getByTestId('layout-board')).toHaveAttribute('aria-pressed', 'false');
   });
 
+  it('preserves list scroll when display configuration changes', async () => {
+    const realFetch = globalThis.fetch;
+    let stored = { page: 'my_issues', scope: '', layout: 'list', display: {} };
+    globalThis.fetch = mock((_input: unknown, init?: RequestInit) => {
+      if (init?.method === 'PUT' && typeof init.body === 'string') {
+        stored = { ...stored, ...(JSON.parse(init.body) as { display: object }) };
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ preferences: [stored] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as unknown as typeof fetch;
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    workspace = buildWorkspace();
+    renderView('me', 'list');
+    const list = screen.getByTestId('my-issues-list');
+    list.scrollTop = 137;
+
+    await user.click(screen.getByTestId('display-menu-trigger'));
+    await user.click(screen.getByTestId('toggle-sub-issues'));
+
+    expect(screen.getByTestId('my-issues-list')).toBe(list);
+    expect(list.scrollTop).toBe(137);
+    globalThis.fetch = realFetch;
+  });
+
   it('switches what is rendered when the control is used', async () => {
     const realFetch = globalThis.fetch;
     let stored = { page: 'my_issues', scope: '', layout: 'list', display: {} };
@@ -362,5 +390,13 @@ describe('dragging a card on the My Issues board', () => {
 
     expect(first).not.toBeNull();
     expect(first?.getAttribute('role')).toBe('listitem');
+  });
+
+  it('does not expose drag affordances to a guest who cannot update issues', () => {
+    workspace = { ...buildWorkspace(), role: 'guest' };
+    renderView('me', 'board');
+
+    const board = screen.getByTestId('my-issues-board');
+    expect(board.querySelectorAll('[aria-roledescription="sortable"]')).toHaveLength(0);
   });
 });

--- a/apps/web/tests/features/issues/quick-create.test.tsx
+++ b/apps/web/tests/features/issues/quick-create.test.tsx
@@ -5,6 +5,9 @@ import { useState } from 'react';
 import { ToastProvider } from '@/components/ui/toast.tsx';
 import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/lib/query/use-issues.ts']);
 
 const created = mock((_input: Record<string, unknown>) => undefined);
 const patched = mock((_input: Record<string, unknown>) => undefined);

--- a/apps/web/tests/features/standup/standup-board.test.tsx
+++ b/apps/web/tests/features/standup/standup-board.test.tsx
@@ -27,7 +27,9 @@ mock.module('../../../src/features/issues/workspace-provider.tsx', () => ({
   useWorkspace: () => workspace,
 }));
 
-const { StandupBoard } = await import('../../../src/features/standup/standup-board.tsx');
+const { StandupBoard, standupBoardOptions } = await import(
+  '../../../src/features/standup/standup-board.tsx'
+);
 
 const todo: WorkflowState = {
   id: 'state_todo',
@@ -435,5 +437,23 @@ describe('StandupBoard', () => {
     expect(screen.getByTestId('filter-bar')).toBeTruthy();
     expect(screen.getByTestId('add-filter')).toBeTruthy();
     expect(screen.queryByTestId('save-view')).toBeNull();
+  });
+
+  it('regroups by the chosen field without assigning manual positions in a sorted view', () => {
+    expect(standupBoardOptions('member', 'assignee', 'updated')).toEqual({
+      draggable: true,
+      groupBy: 'assignee',
+      reorderable: false,
+    });
+    expect(standupBoardOptions('member', 'project', 'manual')).toEqual({
+      draggable: true,
+      groupBy: 'project',
+      reorderable: true,
+    });
+  });
+
+  it('removes drag affordances from guests and non-regroupable boards', () => {
+    expect(standupBoardOptions('guest', 'state', 'manual').draggable).toBe(false);
+    expect(standupBoardOptions('member', 'label', 'manual').draggable).toBe(false);
   });
 });

--- a/apps/web/tests/lib/auth/mock-isolation.test.ts
+++ b/apps/web/tests/lib/auth/mock-isolation.test.ts
@@ -9,7 +9,7 @@ const PACKAGE_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
 
 const GUARDED = [SESSION_MODULE, PRINCIPAL_MODULE] as const;
 
-const MUST_BE_RESTORED = ['@/lib/query/use-issue-search.ts'] as const;
+const MUST_BE_RESTORED = ['@/lib/query/use-issue-search.ts', '@/lib/query/use-issues.ts'] as const;
 
 interface Candidate {
   readonly label: string;
@@ -67,8 +67,7 @@ function specifiersHandedToTheHelper(source: string): Set<string> {
 }
 
 function putsItBack(source: string, specifier: string): boolean {
-  if (specifiersHandedToTheHelper(source).has(specifier)) return true;
-  return timesStubbed(source, specifier) >= 2 && /afterAll\s*\(/.test(source);
+  return specifiersHandedToTheHelper(source).has(specifier);
 }
 
 async function directMocksIn(candidate: Candidate): Promise<string[]> {

--- a/apps/web/tests/lib/query/seed-board-columns.test.ts
+++ b/apps/web/tests/lib/query/seed-board-columns.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 import { emptyFilterGroup } from '@orbit/shared/filters';
 import { QueryClient } from '@tanstack/react-query';
+import {
+  issueCacheRevisionGeneration,
+  recordIssueRevisions,
+} from '@/lib/query/issue-cache-generation.ts';
 import { groupColumnSearch, type IssueQuery } from '@/lib/query/issue-search.ts';
 import { queryKeys } from '@/lib/query/keys.ts';
 import type { BoardPage, Issue } from '@/lib/query/schemas.ts';
@@ -62,5 +66,32 @@ describe('seedBoardColumns', () => {
     seedBoardColumns(client, column, boardPage(['ENG-1']), fetchedAt);
 
     expect(identifiersIn(client)).toEqual(['ENG-7']);
+  });
+
+  it('keeps data written in the same millisecond the board fetch started', () => {
+    const client = new QueryClient();
+    const fetchedAt = Date.now();
+    client.setQueryData<IssuePages>(
+      columnKey(),
+      {
+        pages: [{ issues: [issue('ENG-7')], nextCursor: null }],
+        pageParams: [null],
+      },
+      { updatedAt: fetchedAt },
+    );
+
+    seedBoardColumns(client, column, boardPage(['ENG-1']), fetchedAt);
+
+    expect(identifiersIn(client)).toEqual(['ENG-7']);
+  });
+
+  it('does not seed a stale board page after an issue changed in flight', () => {
+    const client = new QueryClient();
+    const revision = issueCacheRevisionGeneration(client);
+    recordIssueRevisions(client, ['issue-1']);
+
+    seedBoardColumns(client, column, boardPage(['ENG-1']), Date.now(), revision);
+
+    expect(identifiersIn(client)).toEqual([]);
   });
 });

--- a/apps/web/tests/lib/query/use-issues.test.tsx
+++ b/apps/web/tests/lib/query/use-issues.test.tsx
@@ -1,14 +1,22 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import type { Issue } from '../../../src/lib/query/schemas.ts';
+import type { IssuePages } from '../../../src/lib/query/sync.ts';
+import { flattenIssuePages, mapIssuePages } from '../../../src/lib/query/sync.ts';
 
 mock.module('@/components/ui/toast.tsx', () => ({ useToast: () => ({ toast: () => undefined }) }));
 
-const { useAssignedIssues, useDeleteIssues, useIssues, useMoveIssue } = await import(
-  '../../../src/lib/query/use-issues.ts'
-);
+const {
+  authoritativeCachedIssue,
+  DEFAULT_ISSUE_QUERY,
+  useAssignedIssues,
+  useColumnIssues,
+  useDeleteIssues,
+  useIssues,
+  useMoveIssue,
+} = await import('../../../src/lib/query/use-issues.ts');
 const { queryKeys } = await import('../../../src/lib/query/keys.ts');
 
 const TEAM = 'team_eng';
@@ -59,6 +67,20 @@ interface FetchLog {
   readonly methods: string[];
 }
 
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (resolvePromise === undefined) throw new Error('deferred promise did not initialize');
+  return { promise, resolve: resolvePromise };
+}
+
 function stubFetch(handler: (url: string, init: RequestInit | undefined) => unknown): FetchLog {
   const log: FetchLog = { urls: [], methods: [] };
   globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
@@ -83,6 +105,26 @@ function wrapper(client: QueryClient) {
 
 function newClient(): QueryClient {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function cachedIssue(client: QueryClient): Issue | undefined {
+  for (const [, pages] of client.getQueriesData<IssuePages>({
+    queryKey: queryKeys.issueTeam(TEAM),
+  })) {
+    const found = pages === undefined ? undefined : flattenIssuePages(pages)[0];
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+function issuePages(issues: readonly Issue[]): IssuePages {
+  return { pages: [{ issues: [...issues], nextCursor: null }], pageParams: [null] };
+}
+
+function issueFromPagesForTest(pages: IssuePages | undefined, issueId: string): Issue | undefined {
+  return pages === undefined
+    ? undefined
+    : flattenIssuePages(pages).find((row) => row.id === issueId);
 }
 
 afterEach(() => {
@@ -151,6 +193,450 @@ describe('issue mutations patch the cache without a refetch drain', () => {
 
     expect(log.methods.filter((method) => method === 'POST')).toHaveLength(1);
     expect(log.methods.filter((method) => method === 'GET')).toHaveLength(1);
+  });
+
+  it('does not let a failed move roll back a newer cached issue', async () => {
+    const pending = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') return pending.promise;
+      return Promise.resolve(Response.json(page(['issue_1'], null)));
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const list = renderHook(() => useIssues(TEAM, undefined), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<'success' | 'error'> | undefined;
+    await act(async () => {
+      result = move.result.current
+        .mutateAsync({
+          issue: issue(),
+          stateId: 'state_doing',
+          beforeId: null,
+          afterId: null,
+          beforeOrder: null,
+          afterOrder: null,
+        })
+        .then(
+          () => 'success' as const,
+          () => 'error' as const,
+        );
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+    await waitFor(() => expect(list.result.current.data?.[0]?.stateId).toBe('state_doing'));
+    act(() => {
+      client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) }, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) =>
+              issues.map((row) =>
+                row.id === 'issue_1' ? issue({ stateId: 'state_done', syncId: 3 }) : row,
+              ),
+            ),
+      );
+    });
+    await waitFor(() => expect(list.result.current.data?.[0]?.stateId).toBe('state_done'));
+
+    await act(async () => {
+      pending.resolve(
+        Response.json(
+          { error: { code: 'move_failed', message: 'The move failed.' } },
+          { status: 500 },
+        ),
+      );
+      expect(await result).toBe('error');
+    });
+    await waitFor(() => expect(move.result.current.isError).toBe(true));
+    expect(cachedIssue(client)).toMatchObject({ stateId: 'state_done', syncId: 3 });
+  });
+
+  it('does not roll back an equal-head intervening cache write', async () => {
+    const pending = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') return pending.promise;
+      return Promise.resolve(Response.json(page(['issue_1'], null)));
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const list = renderHook(() => useIssues(TEAM, undefined), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<'success' | 'error'> | undefined;
+    await act(async () => {
+      result = move.result.current
+        .mutateAsync({
+          issue: issue(),
+          stateId: 'state_doing',
+          beforeId: null,
+          afterId: null,
+          beforeOrder: null,
+          afterOrder: null,
+        })
+        .then(
+          () => 'success' as const,
+          () => 'error' as const,
+        );
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+    await waitFor(() => expect(list.result.current.data?.[0]?.stateId).toBe('state_doing'));
+    act(() => {
+      client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) }, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) =>
+              issues.map((row) => (row.id === 'issue_1' ? issue({ stateId: 'state_done' }) : row)),
+            ),
+      );
+    });
+    await act(async () => {
+      pending.resolve(
+        Response.json(
+          { error: { code: 'move_failed', message: 'The move failed.' } },
+          { status: 500 },
+        ),
+      );
+      expect(await result).toBe('error');
+    });
+    await waitFor(() => expect(move.result.current.isError).toBe(true));
+    expect(cachedIssue(client)).toMatchObject({ stateId: 'state_done', syncId: 1 });
+  });
+
+  it('rolls back a failed move without overwriting a newer sibling', async () => {
+    const pending = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') return pending.promise;
+      return Promise.resolve(Response.json(page(['issue_1', 'issue_2'], null)));
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const list = renderHook(() => useIssues(TEAM, undefined), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toHaveLength(2));
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<'success' | 'error'> | undefined;
+    await act(async () => {
+      result = move.result.current
+        .mutateAsync({
+          issue: issue(),
+          stateId: 'state_doing',
+          beforeId: null,
+          afterId: null,
+          beforeOrder: null,
+          afterOrder: null,
+        })
+        .then(
+          () => 'success' as const,
+          () => 'error' as const,
+        );
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+    await waitFor(() => expect(list.result.current.data?.[0]?.stateId).toBe('state_doing'));
+
+    act(() => {
+      client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) }, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) =>
+              issues.map((row) =>
+                row.id === 'issue_2' ? { ...row, title: 'Updated sibling', syncId: 3 } : row,
+              ),
+            ),
+      );
+    });
+    await waitFor(() =>
+      expect(list.result.current.data?.find((row) => row.id === 'issue_2')).toMatchObject({
+        title: 'Updated sibling',
+        syncId: 3,
+      }),
+    );
+
+    await act(async () => {
+      pending.resolve(
+        Response.json(
+          { error: { code: 'move_failed', message: 'The move failed.' } },
+          { status: 500 },
+        ),
+      );
+      expect(await result).toBe('error');
+    });
+    await waitFor(() =>
+      expect(list.result.current.data?.find((row) => row.id === 'issue_1')).toMatchObject({
+        stateId: 'state_todo',
+      }),
+    );
+    expect(list.result.current.data?.find((row) => row.id === 'issue_2')).toMatchObject({
+      title: 'Updated sibling',
+      syncId: 3,
+    });
+  });
+
+  for (const scenario of [
+    {
+      name: 'waits for canonical restoration when a failed move leaves no optimistic cache occurrence',
+      refreshed: page(['issue_1'], null),
+      expectedIds: ['issue_1'],
+    },
+    {
+      name: 'does not resurrect an intervening delete when a failed move leaves no optimistic cache occurrence',
+      refreshed: page([], null),
+      expectedIds: [],
+    },
+  ] as const) {
+    it(scenario.name, async () => {
+      const pendingMove = deferred<Response>();
+      const pendingRefresh = deferred<Response>();
+      let listRequests = 0;
+      globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+        if (init?.method === 'POST') return pendingMove.promise;
+        listRequests += 1;
+        if (listRequests === 1) {
+          return Promise.resolve(Response.json(page(['issue_1'], null)));
+        }
+        return pendingRefresh.promise;
+      }) as unknown as typeof fetch;
+      const client = newClient();
+      const column = {
+        query: DEFAULT_ISSUE_QUERY,
+        groupBy: 'state',
+        scope: { teamId: TEAM },
+      };
+      const source = renderHook(() => useColumnIssues(column, 'state_todo', true), {
+        wrapper: wrapper(client),
+      });
+      await waitFor(() =>
+        expect(source.result.current.data?.map((row) => row.id)).toEqual(['issue_1']),
+      );
+      const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+      const settlement = { status: 'pending' as 'pending' | 'success' | 'error' };
+
+      let result: Promise<'success' | 'error'> | undefined;
+      await act(async () => {
+        result = move.result.current
+          .mutateAsync({
+            issue: issue(),
+            stateId: 'state_doing',
+            beforeId: null,
+            afterId: null,
+            beforeOrder: null,
+            afterOrder: null,
+          })
+          .then(
+            () => {
+              settlement.status = 'success';
+              return 'success' as const;
+            },
+            () => {
+              settlement.status = 'error';
+              return 'error' as const;
+            },
+          );
+        await Promise.resolve();
+      });
+      if (result === undefined) throw new Error('missing move promise');
+      await waitFor(() => expect(source.result.current.data).toHaveLength(0));
+
+      await act(async () => {
+        pendingMove.resolve(
+          Response.json(
+            { error: { code: 'move_failed', message: 'The move failed.' } },
+            { status: 500 },
+          ),
+        );
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(listRequests).toBe(2));
+      expect(settlement.status).toBe('pending');
+      expect(source.result.current.data).toHaveLength(0);
+
+      await act(async () => {
+        pendingRefresh.resolve(Response.json(scenario.refreshed));
+        expect(await result).toBe('error');
+      });
+      await waitFor(() => expect(move.result.current.isError).toBe(true));
+      await waitFor(() =>
+        expect(source.result.current.data?.map((row) => row.id)).toEqual([...scenario.expectedIds]),
+      );
+    });
+  }
+
+  it('does not let a stale move response replace a newer cached issue', async () => {
+    const pending = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') return pending.promise;
+      return Promise.resolve(Response.json(page(['issue_1'], null)));
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const list = renderHook(() => useIssues(TEAM, undefined), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<readonly Issue[]> | undefined;
+    await act(async () => {
+      result = move.result.current.mutateAsync({
+        issue: issue(),
+        stateId: 'state_doing',
+        beforeId: null,
+        afterId: null,
+        beforeOrder: null,
+        afterOrder: null,
+      });
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+    await waitFor(() => expect(list.result.current.data?.[0]?.stateId).toBe('state_doing'));
+
+    act(() => {
+      client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) }, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) =>
+              issues.map((row) =>
+                row.id === 'issue_1' ? issue({ stateId: 'state_done', syncId: 3 }) : row,
+              ),
+            ),
+      );
+    });
+    await waitFor(() => expect(list.result.current.data?.[0]?.stateId).toBe('state_done'));
+
+    await act(async () => {
+      pending.resolve(
+        Response.json({ issue: issue({ stateId: 'state_doing', syncId: 2 }), rebalanced: [] }),
+      );
+      await result;
+    });
+    await waitFor(() => expect(move.result.current.isSuccess).toBe(true));
+    expect(cachedIssue(client)).toMatchObject({ stateId: 'state_done', syncId: 3 });
+    expect(authoritativeCachedIssue(client, 'issue_1')).toMatchObject({
+      kind: 'found',
+      issue: { stateId: 'state_done', syncId: 3 },
+    });
+  });
+
+  it('does not resurrect an issue deleted while a successful move response is in flight', async () => {
+    const pending = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') return pending.promise;
+      return Promise.resolve(Response.json(page(['issue_1'], null)));
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const list = renderHook(() => useIssues(TEAM, undefined), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<readonly Issue[]> | undefined;
+    await act(async () => {
+      result = move.result.current.mutateAsync({
+        issue: issue(),
+        stateId: 'state_doing',
+        beforeId: null,
+        afterId: null,
+        beforeOrder: null,
+        afterOrder: null,
+      });
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+    await waitFor(() => expect(list.result.current.data?.[0]?.stateId).toBe('state_doing'));
+
+    act(() => {
+      client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) }, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) => issues.filter((row) => row.id !== 'issue_1')),
+      );
+    });
+    await waitFor(() => expect(list.result.current.data).toHaveLength(0));
+
+    await act(async () => {
+      pending.resolve(
+        Response.json({ issue: issue({ stateId: 'state_doing', syncId: 2 }), rebalanced: [] }),
+      );
+      await result;
+    });
+    await waitFor(() => expect(move.result.current.isSuccess).toBe(true));
+    expect(authoritativeCachedIssue(client, 'issue_1')).toEqual({ kind: 'missing' });
+    await waitFor(() => expect(list.result.current.data).toHaveLength(0));
+  });
+
+  it('does not re-admit a stale move response into an old group column', async () => {
+    const pending = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') return pending.promise;
+      return Promise.resolve(Response.json(page(['issue_1'], null)));
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const doingKey = queryKeys.issues(TEAM, `teamId=${TEAM}&stateId=state_doing`);
+    client.setQueryData(doingKey, issuePages([]));
+    const list = renderHook(() => useIssues(TEAM, undefined), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<readonly Issue[]> | undefined;
+    await act(async () => {
+      result = move.result.current.mutateAsync({
+        issue: issue(),
+        stateId: 'state_doing',
+        beforeId: null,
+        afterId: null,
+        beforeOrder: null,
+        afterOrder: null,
+      });
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+    await waitFor(() =>
+      expect(
+        issueFromPagesForTest(client.getQueryData<IssuePages>(doingKey), 'issue_1'),
+      ).toMatchObject({ stateId: 'state_doing' }),
+    );
+
+    act(() => {
+      client.setQueryData<IssuePages>(doingKey, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) => issues.filter((row) => row.id !== 'issue_1')),
+      );
+      client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) }, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) =>
+              issues.map((row) =>
+                row.id === 'issue_1' ? issue({ stateId: 'state_done', syncId: 3 }) : row,
+              ),
+            ),
+      );
+    });
+
+    await act(async () => {
+      pending.resolve(
+        Response.json({ issue: issue({ stateId: 'state_doing', syncId: 2 }), rebalanced: [] }),
+      );
+      await result;
+    });
+    await waitFor(() => expect(move.result.current.isSuccess).toBe(true));
+    expect(
+      issueFromPagesForTest(client.getQueryData<IssuePages>(doingKey), 'issue_1'),
+    ).toBeUndefined();
+    expect(authoritativeCachedIssue(client, 'issue_1')).toMatchObject({
+      kind: 'found',
+      issue: { stateId: 'state_done', syncId: 3 },
+    });
+  });
+
+  it('treats equal-head cache disagreement as ambiguous', () => {
+    const client = newClient();
+    client.setQueryData(
+      queryKeys.issues(TEAM, 'first'),
+      issuePages([issue({ stateId: 'state_todo', syncId: 2 })]),
+    );
+    client.setQueryData(
+      queryKeys.issues(TEAM, 'second'),
+      issuePages([issue({ stateId: 'state_done', syncId: 2 })]),
+    );
+
+    expect(authoritativeCachedIssue(client, 'issue_1').kind).toBe('ambiguous');
   });
 });
 

--- a/apps/web/tests/lib/query/use-issues.test.tsx
+++ b/apps/web/tests/lib/query/use-issues.test.tsx
@@ -1,12 +1,23 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { inCondition } from '@orbit/shared/filters';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import type { Issue } from '../../../src/lib/query/schemas.ts';
-import type { IssuePages } from '../../../src/lib/query/sync.ts';
-import { flattenIssuePages, mapIssuePages } from '../../../src/lib/query/sync.ts';
+import {
+  recordIssueDeletions,
+  recordIssueListRevisions,
+  recordIssueRevisions,
+} from '@/lib/query/issue-cache-generation.ts';
+import type { Issue } from '@/lib/query/schemas.ts';
+import type { IssuePages } from '@/lib/query/sync.ts';
+import { flattenIssuePages, mapIssuePages } from '@/lib/query/sync.ts';
+import type { IssueMoveSettlement } from '@/lib/query/use-issues.ts';
 
-mock.module('@/components/ui/toast.tsx', () => ({ useToast: () => ({ toast: () => undefined }) }));
+const toasts: { readonly title: string }[] = [];
+
+mock.module('@/components/ui/toast.tsx', () => ({
+  useToast: () => ({ toast: (input: { readonly title: string }) => toasts.push(input) }),
+}));
 
 const {
   authoritativeCachedIssue,
@@ -16,8 +27,8 @@ const {
   useDeleteIssues,
   useIssues,
   useMoveIssue,
-} = await import('../../../src/lib/query/use-issues.ts');
-const { queryKeys } = await import('../../../src/lib/query/keys.ts');
+} = await import('@/lib/query/use-issues.ts');
+const { queryKeys } = await import('@/lib/query/keys.ts');
 
 const TEAM = 'team_eng';
 const originalFetch = globalThis.fetch;
@@ -107,11 +118,11 @@ function newClient(): QueryClient {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });
 }
 
-function cachedIssue(client: QueryClient): Issue | undefined {
+function cachedIssue(client: QueryClient, issueId = 'issue_1'): Issue | undefined {
   for (const [, pages] of client.getQueriesData<IssuePages>({
     queryKey: queryKeys.issueTeam(TEAM),
   })) {
-    const found = pages === undefined ? undefined : flattenIssuePages(pages)[0];
+    const found = issueFromPagesForTest(pages, issueId);
     if (found !== undefined) return found;
   }
   return undefined;
@@ -129,6 +140,7 @@ function issueFromPagesForTest(pages: IssuePages | undefined, issueId: string): 
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  toasts.length = 0;
 });
 
 describe('useIssues', () => {
@@ -193,6 +205,407 @@ describe('issue mutations patch the cache without a refetch drain', () => {
 
     expect(log.methods.filter((method) => method === 'POST')).toHaveLength(1);
     expect(log.methods.filter((method) => method === 'GET')).toHaveLength(1);
+  });
+
+  it('waits for filtered lists to converge before a successful move settles', async () => {
+    const pendingRefresh = deferred<Response>();
+    let listRequests = 0;
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return Promise.resolve(
+          Response.json({
+            issue: issue({ stateId: 'state_doing', syncId: 2 }),
+            rebalanced: [],
+          }),
+        );
+      }
+      listRequests += 1;
+      if (listRequests === 1) return Promise.resolve(Response.json(page(['issue_1'], null)));
+      return pendingRefresh.promise;
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const list = renderHook(
+      () =>
+        useIssues(TEAM, undefined, {
+          filter: {
+            kind: 'group',
+            combinator: 'and',
+            children: [inCondition('state', ['state_todo'])],
+          },
+          orderBy: 'manual',
+        }),
+      { wrapper: wrapper(client) },
+    );
+    await waitFor(() => expect(list.result.current.data).toHaveLength(1));
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+    const settlement = { status: 'pending' as 'pending' | 'success' | 'error' };
+    let issueWasDeleted: boolean | undefined;
+
+    await act(async () => {
+      move.result.current
+        .mutateAsync({
+          issue: issue(),
+          stateId: 'state_doing',
+          beforeId: null,
+          afterId: null,
+          beforeOrder: null,
+          afterOrder: null,
+        })
+        .then(
+          (result) => {
+            issueWasDeleted = result.issueWasDeletedDuringSettlement;
+            settlement.status = 'success';
+          },
+          () => {
+            settlement.status = 'error';
+          },
+        );
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(listRequests).toBe(2));
+    expect(settlement.status).toBe('pending');
+
+    act(() => {
+      pendingRefresh.resolve(Response.json(page([], null)));
+    });
+    await waitFor(() => expect(settlement.status).toBe('success'));
+    expect(issueWasDeleted).toBe(false);
+    await waitFor(() => expect(list.result.current.data).toHaveLength(0));
+  });
+
+  it('does not let a filtered settlement refetch resurrect a confirmed deletion', async () => {
+    const pendingRefresh = deferred<Response>();
+    let listRequests = 0;
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return Promise.resolve(
+          Response.json({
+            issue: issue({ syncId: 2 }),
+            rebalanced: [],
+          }),
+        );
+      }
+      listRequests += 1;
+      if (listRequests === 1) return Promise.resolve(Response.json(page(['issue_1'], null)));
+      return pendingRefresh.promise;
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const list = renderHook(
+      () =>
+        useIssues(TEAM, undefined, {
+          filter: {
+            kind: 'group',
+            combinator: 'and',
+            children: [inCondition('state', ['state_todo'])],
+          },
+          orderBy: 'manual',
+        }),
+      { wrapper: wrapper(client) },
+    );
+    await waitFor(() => expect(list.result.current.data).toHaveLength(1));
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<IssueMoveSettlement> | undefined;
+    await act(async () => {
+      result = move.result.current.mutateAsync({
+        issue: issue(),
+        stateId: 'state_todo',
+        beforeId: null,
+        afterId: null,
+        beforeOrder: null,
+        afterOrder: null,
+      });
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+    await waitFor(() => expect(listRequests).toBe(2));
+
+    act(() => {
+      recordIssueDeletions(client, ['issue_1']);
+      client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) }, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) => issues.filter((row) => row.id !== 'issue_1')),
+      );
+    });
+    await waitFor(() => expect(list.result.current.data).toHaveLength(0));
+
+    let settlement: IssueMoveSettlement | undefined;
+    await act(async () => {
+      pendingRefresh.resolve(Response.json({ issues: [issue({ syncId: 2 })], nextCursor: null }));
+      settlement = await result;
+    });
+
+    expect(settlement?.issueWasDeletedDuringSettlement).toBe(true);
+    await waitFor(() => expect(list.result.current.data).toHaveLength(0));
+    expect(authoritativeCachedIssue(client, 'issue_1')).toEqual({ kind: 'missing' });
+  });
+
+  it('retries a filtered settlement refetch that overwrites a newer revision', async () => {
+    const staleRefresh = deferred<Response>();
+    let listRequests = 0;
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return Promise.resolve(
+          Response.json({
+            issue: issue({ syncId: 2 }),
+            rebalanced: [],
+          }),
+        );
+      }
+      listRequests += 1;
+      if (listRequests === 1) return Promise.resolve(Response.json(page(['issue_1'], null)));
+      if (listRequests === 2) return staleRefresh.promise;
+      return Promise.resolve(
+        Response.json({
+          issues: [issue({ title: 'Updated elsewhere', syncId: 3 })],
+          nextCursor: null,
+        }),
+      );
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const list = renderHook(
+      () =>
+        useIssues(TEAM, undefined, {
+          filter: {
+            kind: 'group',
+            combinator: 'and',
+            children: [inCondition('state', ['state_todo'])],
+          },
+          orderBy: 'manual',
+        }),
+      { wrapper: wrapper(client) },
+    );
+    await waitFor(() => expect(list.result.current.data).toHaveLength(1));
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<IssueMoveSettlement> | undefined;
+    await act(async () => {
+      result = move.result.current.mutateAsync({
+        issue: issue(),
+        stateId: 'state_todo',
+        beforeId: null,
+        afterId: null,
+        beforeOrder: null,
+        afterOrder: null,
+      });
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+    await waitFor(() => expect(listRequests).toBe(2));
+
+    act(() => {
+      client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) }, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) =>
+              issues.map((row) =>
+                row.id === 'issue_1' ? issue({ title: 'Updated elsewhere', syncId: 3 }) : row,
+              ),
+            ),
+      );
+      recordIssueRevisions(client, ['issue_1']);
+    });
+    await waitFor(() => expect(list.result.current.data?.[0]?.syncId).toBe(3));
+
+    await act(async () => {
+      staleRefresh.resolve(Response.json({ issues: [issue({ syncId: 2 })], nextCursor: null }));
+      await result;
+    });
+
+    await waitFor(() => expect(move.result.current.isSuccess).toBe(true));
+    expect(listRequests).toBe(3);
+    expect(cachedIssue(client)).toMatchObject({ title: 'Updated elsewhere', syncId: 3 });
+  });
+
+  it('retries a filtered settlement refetch that overwrites an unrelated deletion', async () => {
+    const staleRefresh = deferred<Response>();
+    let listRequests = 0;
+    const deleted = issue({ id: 'issue_2', identifier: 'ENG-2' });
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return Promise.resolve(
+          Response.json({
+            issue: issue({ syncId: 2 }),
+            rebalanced: [],
+          }),
+        );
+      }
+      listRequests += 1;
+      if (listRequests === 1) {
+        return Promise.resolve(Response.json({ issues: [issue(), deleted], nextCursor: null }));
+      }
+      if (listRequests === 2) return staleRefresh.promise;
+      return Promise.resolve(Response.json({ issues: [issue({ syncId: 2 })], nextCursor: null }));
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const list = renderHook(
+      () =>
+        useIssues(TEAM, undefined, {
+          filter: {
+            kind: 'group',
+            combinator: 'and',
+            children: [inCondition('state', ['state_todo'])],
+          },
+          orderBy: 'manual',
+        }),
+      { wrapper: wrapper(client) },
+    );
+    await waitFor(() => expect(list.result.current.data).toHaveLength(2));
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<IssueMoveSettlement> | undefined;
+    await act(async () => {
+      result = move.result.current.mutateAsync({
+        issue: issue(),
+        stateId: 'state_todo',
+        beforeId: null,
+        afterId: null,
+        beforeOrder: null,
+        afterOrder: null,
+      });
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+    await waitFor(() => expect(listRequests).toBe(2));
+
+    act(() => {
+      client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) }, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) => issues.filter((row) => row.id !== deleted.id)),
+      );
+      recordIssueDeletions(client, [deleted.id]);
+      recordIssueListRevisions(
+        client,
+        client
+          .getQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) })
+          .map(([key]) => key),
+      );
+    });
+    await waitFor(() => expect(list.result.current.data).toHaveLength(1));
+
+    await act(async () => {
+      staleRefresh.resolve(
+        Response.json({ issues: [issue({ syncId: 2 }), deleted], nextCursor: null }),
+      );
+      await result;
+    });
+
+    await waitFor(() => expect(move.result.current.isSuccess).toBe(true));
+    expect(listRequests).toBe(3);
+    expect(cachedIssue(client, deleted.id)).toBeUndefined();
+  });
+
+  it('does not retry a filtered settlement for an unrelated list revision', async () => {
+    const staleRefresh = deferred<Response>();
+    let listRequests = 0;
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return Promise.resolve(
+          Response.json({
+            issue: issue({ syncId: 2 }),
+            rebalanced: [],
+          }),
+        );
+      }
+      listRequests += 1;
+      if (listRequests === 1) return Promise.resolve(Response.json(page(['issue_1'], null)));
+      if (listRequests === 2) return staleRefresh.promise;
+      return Promise.resolve(Response.json(page(['issue_1'], null)));
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const list = renderHook(
+      () =>
+        useIssues(TEAM, undefined, {
+          filter: {
+            kind: 'group',
+            combinator: 'and',
+            children: [inCondition('state', ['state_todo'])],
+          },
+          orderBy: 'manual',
+        }),
+      { wrapper: wrapper(client) },
+    );
+    await waitFor(() => expect(list.result.current.data).toHaveLength(1));
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<IssueMoveSettlement> | undefined;
+    await act(async () => {
+      result = move.result.current.mutateAsync({
+        issue: issue(),
+        stateId: 'state_todo',
+        beforeId: null,
+        afterId: null,
+        beforeOrder: null,
+        afterOrder: null,
+      });
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+    await waitFor(() => expect(listRequests).toBe(2));
+
+    act(() => recordIssueRevisions(client, ['issue_on_another_team']));
+    await act(async () => {
+      staleRefresh.resolve(Response.json({ issues: [issue({ syncId: 2 })], nextCursor: null }));
+      await result;
+    });
+
+    await waitFor(() => expect(move.result.current.isSuccess).toBe(true));
+    expect(listRequests).toBe(2);
+  });
+
+  it('bounds filtered settlement retries during continuous issue revisions', async () => {
+    let client: QueryClient | undefined;
+    let listRequests = 0;
+    let revisions = 0;
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return Promise.resolve(
+          Response.json({
+            issue: issue({ syncId: 2 }),
+            rebalanced: [],
+          }),
+        );
+      }
+      listRequests += 1;
+      if (listRequests > 1 && revisions < 5) {
+        if (client === undefined) throw new Error('missing query client');
+        recordIssueRevisions(client, ['issue_1']);
+        revisions += 1;
+      }
+      return Promise.resolve(Response.json({ issues: [issue({ syncId: 2 })], nextCursor: null }));
+    }) as unknown as typeof fetch;
+    client = newClient();
+    const list = renderHook(
+      () =>
+        useIssues(TEAM, undefined, {
+          filter: {
+            kind: 'group',
+            combinator: 'and',
+            children: [inCondition('state', ['state_todo'])],
+          },
+          orderBy: 'manual',
+        }),
+      { wrapper: wrapper(client) },
+    );
+    await waitFor(() => expect(list.result.current.data).toHaveLength(1));
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    await act(async () => {
+      await move.result.current.mutateAsync({
+        issue: issue(),
+        stateId: 'state_todo',
+        beforeId: null,
+        afterId: null,
+        beforeOrder: null,
+        afterOrder: null,
+      });
+    });
+
+    await waitFor(() => expect(move.result.current.isSuccess).toBe(true));
+    expect(listRequests).toBeLessThanOrEqual(5);
   });
 
   it('does not let a failed move roll back a newer cached issue', async () => {
@@ -449,6 +862,7 @@ describe('issue mutations patch the cache without a refetch drain', () => {
       await waitFor(() => expect(listRequests).toBe(2));
       expect(settlement.status).toBe('pending');
       expect(source.result.current.data).toHaveLength(0);
+      expect(toasts.map((entry) => entry.title)).toEqual(['Could not move that issue']);
 
       await act(async () => {
         pendingRefresh.resolve(Response.json(scenario.refreshed));
@@ -461,6 +875,221 @@ describe('issue mutations patch the cache without a refetch drain', () => {
     });
   }
 
+  it('restores the source snapshot when failed-move canonical refresh is unavailable', async () => {
+    let listRequests = 0;
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return Promise.resolve(
+          Response.json(
+            { error: { code: 'move_failed', message: 'The move failed.' } },
+            { status: 500 },
+          ),
+        );
+      }
+      listRequests += 1;
+      return listRequests === 1
+        ? Promise.resolve(Response.json(page(['issue_1'], null)))
+        : Promise.resolve(
+            Response.json(
+              { error: { code: 'offline', message: 'Canonical refresh unavailable.' } },
+              { status: 503 },
+            ),
+          );
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const column = {
+      query: DEFAULT_ISSUE_QUERY,
+      groupBy: 'state',
+      scope: { teamId: TEAM },
+    };
+    const source = renderHook(() => useColumnIssues(column, 'state_todo', true), {
+      wrapper: wrapper(client),
+    });
+    await waitFor(() =>
+      expect(source.result.current.data?.map((row) => row.id)).toEqual(['issue_1']),
+    );
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    await act(async () => {
+      await move.result.current
+        .mutateAsync({
+          issue: issue(),
+          stateId: 'state_doing',
+          beforeId: null,
+          afterId: null,
+          beforeOrder: null,
+          afterOrder: null,
+        })
+        .catch(() => undefined);
+    });
+
+    await waitFor(() => expect(move.result.current.isError).toBe(true));
+    expect(listRequests).toBe(2);
+    expect(source.result.current.data?.map((row) => row.id)).toEqual(['issue_1']);
+  });
+
+  for (const scenario of [
+    {
+      name: 'a deletion generation',
+      intervene: (client: QueryClient) => recordIssueDeletions(client, ['issue_1']),
+    },
+    {
+      name: 'a newer issue revision',
+      intervene: (client: QueryClient) => recordIssueRevisions(client, ['issue_1']),
+    },
+    {
+      name: 'a newer list revision',
+      intervene: (client: QueryClient) =>
+        recordIssueListRevisions(
+          client,
+          client
+            .getQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) })
+            .map(([key]) => key),
+        ),
+    },
+  ] as const) {
+    it(`does not restore a failed-move snapshot after ${scenario.name}`, async () => {
+      const pendingMove = deferred<Response>();
+      let listRequests = 0;
+      globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+        if (init?.method === 'POST') return pendingMove.promise;
+        listRequests += 1;
+        return listRequests === 1
+          ? Promise.resolve(Response.json(page(['issue_1'], null)))
+          : Promise.resolve(
+              Response.json(
+                { error: { code: 'offline', message: 'Canonical refresh unavailable.' } },
+                { status: 503 },
+              ),
+            );
+      }) as unknown as typeof fetch;
+      const client = newClient();
+      const column = {
+        query: DEFAULT_ISSUE_QUERY,
+        groupBy: 'state',
+        scope: { teamId: TEAM },
+      };
+      const source = renderHook(() => useColumnIssues(column, 'state_todo', true), {
+        wrapper: wrapper(client),
+      });
+      await waitFor(() =>
+        expect(source.result.current.data?.map((row) => row.id)).toEqual(['issue_1']),
+      );
+      const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+      let result: Promise<unknown> | undefined;
+      await act(async () => {
+        result = move.result.current
+          .mutateAsync({
+            issue: issue(),
+            stateId: 'state_doing',
+            beforeId: null,
+            afterId: null,
+            beforeOrder: null,
+            afterOrder: null,
+          })
+          .catch(() => undefined);
+        await Promise.resolve();
+      });
+      if (result === undefined) throw new Error('missing move promise');
+      await waitFor(() => expect(source.result.current.data).toHaveLength(0));
+      act(() => scenario.intervene(client));
+
+      await act(async () => {
+        pendingMove.resolve(
+          Response.json(
+            { error: { code: 'move_failed', message: 'The move failed.' } },
+            { status: 500 },
+          ),
+        );
+        await result;
+      });
+
+      await waitFor(() => expect(move.result.current.isError).toBe(true));
+      expect(listRequests).toBe(2);
+      expect(source.result.current.data).toHaveLength(0);
+    });
+  }
+
+  it('retries a failed-move refresh that overwrites a newer revision', async () => {
+    const pendingMove = deferred<Response>();
+    const staleRefresh = deferred<Response>();
+    let listRequests = 0;
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') return pendingMove.promise;
+      listRequests += 1;
+      if (listRequests === 1) return Promise.resolve(Response.json(page(['issue_1'], null)));
+      if (listRequests === 2) return staleRefresh.promise;
+      return Promise.resolve(
+        Response.json({
+          issues: [issue({ title: 'Updated elsewhere', syncId: 3 })],
+          nextCursor: null,
+        }),
+      );
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const column = {
+      query: DEFAULT_ISSUE_QUERY,
+      groupBy: 'state',
+      scope: { teamId: TEAM },
+    };
+    const source = renderHook(() => useColumnIssues(column, 'state_todo', true), {
+      wrapper: wrapper(client),
+    });
+    await waitFor(() => expect(source.result.current.data).toHaveLength(1));
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<'success' | 'error'> | undefined;
+    await act(async () => {
+      result = move.result.current
+        .mutateAsync({
+          issue: issue(),
+          stateId: 'state_doing',
+          beforeId: null,
+          afterId: null,
+          beforeOrder: null,
+          afterOrder: null,
+        })
+        .then(
+          () => 'success' as const,
+          () => 'error' as const,
+        );
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+    await waitFor(() => expect(source.result.current.data).toHaveLength(0));
+
+    await act(async () => {
+      pendingMove.resolve(
+        Response.json(
+          { error: { code: 'move_failed', message: 'The move failed.' } },
+          { status: 500 },
+        ),
+      );
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(listRequests).toBe(2));
+
+    act(() => {
+      client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) }, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, () => [issue({ title: 'Updated elsewhere', syncId: 3 })]),
+      );
+      recordIssueRevisions(client, ['issue_1']);
+    });
+    await waitFor(() => expect(source.result.current.data?.[0]?.syncId).toBe(3));
+
+    await act(async () => {
+      staleRefresh.resolve(Response.json({ issues: [issue({ syncId: 2 })], nextCursor: null }));
+      expect(await result).toBe('error');
+    });
+
+    await waitFor(() => expect(move.result.current.isError).toBe(true));
+    expect(listRequests).toBe(3);
+    expect(cachedIssue(client)).toMatchObject({ title: 'Updated elsewhere', syncId: 3 });
+  });
+
   it('does not let a stale move response replace a newer cached issue', async () => {
     const pending = deferred<Response>();
     globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
@@ -472,7 +1101,7 @@ describe('issue mutations patch the cache without a refetch drain', () => {
     await waitFor(() => expect(list.result.current.data).toBeDefined());
     const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
 
-    let result: Promise<readonly Issue[]> | undefined;
+    let result: Promise<IssueMoveSettlement> | undefined;
     await act(async () => {
       result = move.result.current.mutateAsync({
         issue: issue(),
@@ -525,7 +1154,7 @@ describe('issue mutations patch the cache without a refetch drain', () => {
     await waitFor(() => expect(list.result.current.data).toBeDefined());
     const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
 
-    let result: Promise<readonly Issue[]> | undefined;
+    let result: Promise<IssueMoveSettlement> | undefined;
     await act(async () => {
       result = move.result.current.mutateAsync({
         issue: issue(),
@@ -541,6 +1170,7 @@ describe('issue mutations patch the cache without a refetch drain', () => {
     await waitFor(() => expect(list.result.current.data?.[0]?.stateId).toBe('state_doing'));
 
     act(() => {
+      recordIssueDeletions(client, ['issue_1']);
       client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) }, (current) =>
         current === undefined
           ? current
@@ -549,15 +1179,145 @@ describe('issue mutations patch the cache without a refetch drain', () => {
     });
     await waitFor(() => expect(list.result.current.data).toHaveLength(0));
 
+    let settlement: Awaited<typeof result> | undefined;
     await act(async () => {
       pending.resolve(
         Response.json({ issue: issue({ stateId: 'state_doing', syncId: 2 }), rebalanced: [] }),
       );
-      await result;
+      settlement = await result;
     });
     await waitFor(() => expect(move.result.current.isSuccess).toBe(true));
+    expect(settlement?.issueWasDeletedDuringSettlement).toBe(true);
     expect(authoritativeCachedIssue(client, 'issue_1')).toEqual({ kind: 'missing' });
     await waitFor(() => expect(list.result.current.data).toHaveLength(0));
+  });
+
+  it('does not resurrect a deleted sibling from a move rebalance response', async () => {
+    const pending = deferred<Response>();
+    const sibling = issue({ id: 'issue_2', identifier: 'ENG-2', number: 2, sortOrder: 2048 });
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') return pending.promise;
+      return Promise.resolve(Response.json({ issues: [issue(), sibling], nextCursor: null }));
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const list = renderHook(() => useIssues(TEAM, undefined), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toHaveLength(2));
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<IssueMoveSettlement> | undefined;
+    await act(async () => {
+      result = move.result.current.mutateAsync({
+        issue: issue(),
+        stateId: 'state_doing',
+        beforeId: null,
+        afterId: null,
+        beforeOrder: null,
+        afterOrder: null,
+      });
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+
+    act(() => {
+      recordIssueDeletions(client, [sibling.id]);
+      client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) }, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) => issues.filter((row) => row.id !== sibling.id)),
+      );
+    });
+    await waitFor(() => expect(cachedIssue(client, sibling.id)).toBeUndefined());
+
+    await act(async () => {
+      pending.resolve(
+        Response.json({
+          issue: issue({ stateId: 'state_doing', syncId: 2 }),
+          rebalanced: [{ ...sibling, sortOrder: 3072, syncId: 2 }],
+        }),
+      );
+      await result;
+    });
+
+    await waitFor(() => expect(move.result.current.isSuccess).toBe(true));
+    expect(cachedIssue(client, sibling.id)).toBeUndefined();
+  });
+
+  it('keeps observing a confirmed deletion after a successful move settles', async () => {
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return Promise.resolve(
+          Response.json({
+            issue: issue({ stateId: 'state_doing', syncId: 2 }),
+            rebalanced: [],
+          }),
+        );
+      }
+      if (init?.method === 'DELETE') {
+        return Promise.resolve(Response.json({ deleted: { id: 'issue_1', identifier: 'ENG-1' } }));
+      }
+      return Promise.resolve(Response.json(page(['issue_1'], null)));
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const list = renderHook(() => useIssues(TEAM, undefined), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toBeDefined());
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+    const remove = renderHook(() => useDeleteIssues(), { wrapper: wrapper(client) });
+
+    let settlement: IssueMoveSettlement | undefined;
+    await act(async () => {
+      settlement = await move.result.current.mutateAsync({
+        issue: issue(),
+        stateId: 'state_doing',
+        beforeId: null,
+        afterId: null,
+        beforeOrder: null,
+        afterOrder: null,
+      });
+    });
+    expect(settlement).toMatchObject({ issueWasDeletedDuringSettlement: false });
+
+    await act(async () => {
+      await remove.result.current.mutateAsync([issue({ stateId: 'state_doing', syncId: 2 })]);
+    });
+
+    expect(settlement?.issueWasDeletedDuringSettlement).toBe(true);
+  });
+
+  it('captures deletion generation before optimistic query cancellation', async () => {
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return Promise.resolve(
+          Response.json({
+            issue: issue({ stateId: 'state_doing', syncId: 2 }),
+            rebalanced: [],
+          }),
+        );
+      }
+      return Promise.resolve(Response.json(page(['issue_1'], null)));
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    client.setQueryData(queryKeys.issues(TEAM), issuePages([issue()]));
+    const cancelQueries = client.cancelQueries.bind(client);
+    client.cancelQueries = (filters, options) => {
+      recordIssueDeletions(client, ['issue_1']);
+      return cancelQueries(filters, options);
+    };
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let settlement: IssueMoveSettlement | undefined;
+    await act(async () => {
+      settlement = await move.result.current.mutateAsync({
+        issue: issue(),
+        stateId: 'state_doing',
+        beforeId: null,
+        afterId: null,
+        beforeOrder: null,
+        afterOrder: null,
+      });
+    });
+
+    await waitFor(() => expect(move.result.current.isSuccess).toBe(true));
+    expect(settlement?.issueWasDeletedDuringSettlement).toBe(true);
   });
 
   it('does not re-admit a stale move response into an old group column', async () => {
@@ -573,7 +1333,7 @@ describe('issue mutations patch the cache without a refetch drain', () => {
     await waitFor(() => expect(list.result.current.data).toBeDefined());
     const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
 
-    let result: Promise<readonly Issue[]> | undefined;
+    let result: Promise<IssueMoveSettlement> | undefined;
     await act(async () => {
       result = move.result.current.mutateAsync({
         issue: issue(),
@@ -638,6 +1398,63 @@ describe('issue mutations patch the cache without a refetch drain', () => {
 
     expect(authoritativeCachedIssue(client, 'issue_1').kind).toBe('ambiguous');
   });
+
+  it('treats equal-head values with different property insertion order as one issue', () => {
+    const client = newClient();
+    const canonical = issue({ syncId: 2 });
+    const reordered = Object.fromEntries(Object.entries(canonical).reverse()) as Issue;
+    client.setQueryData(queryKeys.issues(TEAM, 'first'), issuePages([canonical]));
+    client.setQueryData(queryKeys.issues(TEAM, 'second'), issuePages([reordered]));
+
+    expect(authoritativeCachedIssue(client, 'issue_1')).toMatchObject({
+      kind: 'found',
+      issue: canonical,
+    });
+  });
+
+  it('treats full and list-shaped copies of one cache head as one issue', () => {
+    const client = newClient();
+    const canonical = issue({
+      organizationId: 'org_1',
+      description: 'Full detail',
+      stateEnteredAt: '2026-01-01T00:00:00.000Z',
+      syncId: 2,
+    });
+    const listShaped = {
+      ...canonical,
+      organizationId: '',
+      description: '',
+      stateEnteredAt: '',
+    };
+    client.setQueryData(queryKeys.issues(TEAM, 'full'), issuePages([canonical]));
+    client.setQueryData(queryKeys.issues(TEAM, 'list'), issuePages([listShaped]));
+
+    expect(authoritativeCachedIssue(client, 'issue_1')).toMatchObject({
+      kind: 'found',
+      issue: canonical,
+    });
+  });
+
+  it('treats reviewer and label ordering as set-equivalent in one cache head', () => {
+    const client = newClient();
+    const canonical = issue({
+      reviewerIds: ['user_1', 'user_2'],
+      labelIds: ['label_1', 'label_2'],
+      syncId: 2,
+    });
+    const permuted = issue({
+      reviewerIds: ['user_2', 'user_1'],
+      labelIds: ['label_2', 'label_1'],
+      syncId: 2,
+    });
+    client.setQueryData(queryKeys.issues(TEAM, 'first'), issuePages([canonical]));
+    client.setQueryData(queryKeys.issues(TEAM, 'second'), issuePages([permuted]));
+
+    expect(authoritativeCachedIssue(client, 'issue_1')).toMatchObject({
+      kind: 'found',
+      issue: canonical,
+    });
+  });
 });
 
 function stubDeletes(refuse: boolean): FetchLog {
@@ -652,7 +1469,12 @@ function stubDeletes(refuse: boolean): FetchLog {
         Response.json({
           issues: [
             issue({ id: 'issue_parent', identifier: 'ENG-1' }),
-            issue({ id: 'issue_child', identifier: 'ENG-2', parentId: 'issue_parent' }),
+            issue({
+              id: 'issue_child',
+              identifier: 'ENG-2',
+              parentId: 'issue_parent',
+              sortOrder: 2048,
+            }),
           ],
           nextCursor: null,
         }),
@@ -687,6 +1509,7 @@ function detailFor(row: Issue, subIssues: readonly Issue[]) {
     activity: [],
     activityCursor: null,
     subIssues,
+    parent: null,
     subscribed: false,
   };
 }
@@ -721,6 +1544,202 @@ describe('deleting an issue', () => {
     expect(mine.result.current.data?.map((row) => row.id)).toEqual(['issue_parent', 'issue_child']);
   });
 
+  it('restores a refused delete without overwriting a realtime sibling update', async () => {
+    const pendingDelete = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) =>
+      init?.method === 'DELETE'
+        ? pendingDelete.promise
+        : Promise.resolve(Response.json(page([], null))),
+    ) as unknown as typeof fetch;
+    const client = newClient();
+    const key = queryKeys.issues(TEAM);
+    const removed = issue({ id: 'issue_removed', identifier: 'ENG-1' });
+    const sibling = issue({ id: 'issue_sibling', identifier: 'ENG-2', number: 2 });
+    client.setQueryData(key, issuePages([removed, sibling]));
+    const remove = renderHook(() => useDeleteIssues(), { wrapper: wrapper(client) });
+
+    let result: Promise<readonly Issue[]> | undefined;
+    await act(async () => {
+      result = remove.result.current.mutateAsync([removed]);
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing delete promise');
+    await waitFor(() =>
+      expect(
+        issueFromPagesForTest(client.getQueryData<IssuePages>(key), removed.id),
+      ).toBeUndefined(),
+    );
+
+    act(() => {
+      client.setQueryData<IssuePages>(key, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) =>
+              issues.map((row) =>
+                row.id === sibling.id
+                  ? { ...row, title: 'Realtime sibling title', syncId: row.syncId + 1 }
+                  : row,
+              ),
+            ),
+      );
+      recordIssueRevisions(client, [sibling.id]);
+    });
+
+    await act(async () => {
+      pendingDelete.resolve(
+        Response.json(
+          { error: { code: 'forbidden', message: 'Your role cannot issue delete.' } },
+          { status: 403 },
+        ),
+      );
+      await result?.catch(() => undefined);
+    });
+
+    expect(issueFromPagesForTest(client.getQueryData<IssuePages>(key), removed.id)).toEqual(
+      removed,
+    );
+    expect(issueFromPagesForTest(client.getQueryData<IssuePages>(key), sibling.id)).toMatchObject({
+      title: 'Realtime sibling title',
+      syncId: 2,
+    });
+  });
+
+  it('resorts multiple pages after restoring around a realtime sibling move', async () => {
+    const pendingDelete = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) =>
+      init?.method === 'DELETE'
+        ? pendingDelete.promise
+        : Promise.resolve(Response.json(page([], null))),
+    ) as unknown as typeof fetch;
+    const client = newClient();
+    const key = queryKeys.issues(TEAM);
+    const removed = issue({ id: 'issue_removed', identifier: 'ENG-1', sortOrder: 1 });
+    const sibling = issue({ id: 'issue_sibling', identifier: 'ENG-2', number: 2, sortOrder: 2 });
+    client.setQueryData<IssuePages>(key, {
+      pages: [
+        { issues: [removed], nextCursor: 'next' },
+        { issues: [sibling], nextCursor: null },
+      ],
+      pageParams: [null, 'next'],
+    });
+    const remove = renderHook(() => useDeleteIssues(), { wrapper: wrapper(client) });
+
+    let result: Promise<readonly Issue[]> | undefined;
+    await act(async () => {
+      result = remove.result.current.mutateAsync([removed]);
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing delete promise');
+    await waitFor(() =>
+      expect(
+        issueFromPagesForTest(client.getQueryData<IssuePages>(key), removed.id),
+      ).toBeUndefined(),
+    );
+
+    act(() => {
+      client.setQueryData<IssuePages>(key, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) =>
+              issues.map((row) =>
+                row.id === sibling.id ? { ...row, sortOrder: 0, syncId: row.syncId + 1 } : row,
+              ),
+            ),
+      );
+      recordIssueRevisions(client, [sibling.id]);
+    });
+
+    await act(async () => {
+      pendingDelete.resolve(
+        Response.json(
+          { error: { code: 'forbidden', message: 'Your role cannot issue delete.' } },
+          { status: 403 },
+        ),
+      );
+      await result?.catch(() => undefined);
+    });
+
+    const restored = client.getQueryData<IssuePages>(key);
+    expect(restored === undefined ? [] : flattenIssuePages(restored).map((row) => row.id)).toEqual([
+      sibling.id,
+      removed.id,
+    ]);
+    expect(issueFromPagesForTest(restored, sibling.id)).toMatchObject({ sortOrder: 0, syncId: 2 });
+  });
+
+  it('drops a row again when a stale list result lands before deletion confirms', async () => {
+    const pendingDelete = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'DELETE') return pendingDelete.promise;
+      return Promise.resolve(Response.json(page(['issue_1'], null)));
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const list = renderHook(() => useIssues(TEAM, undefined), { wrapper: wrapper(client) });
+    await waitFor(() => expect(list.result.current.data).toHaveLength(1));
+    const remove = renderHook(() => useDeleteIssues(), { wrapper: wrapper(client) });
+
+    let result: Promise<readonly Issue[]> | undefined;
+    await act(async () => {
+      result = remove.result.current.mutateAsync([issue()]);
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing delete promise');
+    await waitFor(() => expect(list.result.current.data).toHaveLength(0));
+
+    act(() => {
+      client.setQueriesData<IssuePages>({ queryKey: queryKeys.issueTeam(TEAM) }, (current) =>
+        current === undefined
+          ? current
+          : mapIssuePages(current, (issues) => [...issues, issue({ syncId: 1 })]),
+      );
+    });
+    await waitFor(() => expect(list.result.current.data).toHaveLength(1));
+
+    await act(async () => {
+      pendingDelete.resolve(Response.json({ deleted: { id: 'issue_1', identifier: 'ENG-1' } }));
+      await result;
+    });
+
+    await waitFor(() => expect(list.result.current.data).toHaveLength(0));
+  });
+
+  it('cancels a stale list result that is still pending when deletion confirms', async () => {
+    const pendingDelete = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'DELETE') return pendingDelete.promise;
+      return Promise.resolve(Response.json(page(['issue_1'], null)));
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const key = queryKeys.issues(TEAM);
+    client.setQueryData(key, issuePages([issue()]));
+    const remove = renderHook(() => useDeleteIssues(), { wrapper: wrapper(client) });
+
+    let result: Promise<readonly Issue[]> | undefined;
+    await act(async () => {
+      result = remove.result.current.mutateAsync([issue()]);
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing delete promise');
+    expect(issueFromPagesForTest(client.getQueryData<IssuePages>(key), 'issue_1')).toBeUndefined();
+    const pendingRefresh = deferred<IssuePages>();
+    const refetch = client
+      .fetchQuery({ queryKey: key, queryFn: () => pendingRefresh.promise })
+      .catch(() => undefined);
+
+    await act(async () => {
+      pendingDelete.resolve(Response.json({ deleted: { id: 'issue_1', identifier: 'ENG-1' } }));
+      await result;
+    });
+    await waitFor(() => expect(remove.result.current.isSuccess).toBe(true));
+    expect(issueFromPagesForTest(client.getQueryData<IssuePages>(key), 'issue_1')).toBeUndefined();
+
+    await act(async () => {
+      pendingRefresh.resolve(issuePages([issue()]));
+      await refetch;
+    });
+    expect(issueFromPagesForTest(client.getQueryData<IssuePages>(key), 'issue_1')).toBeUndefined();
+  });
+
   it('frees a cached child rather than leaving it pointing at a row that is gone', async () => {
     stubDeletes(false);
     const client = newClient();
@@ -733,6 +1752,28 @@ describe('deleting an issue', () => {
       expect(team.result.current.data?.map((row) => row.id)).toEqual(['issue_child']),
     );
     expect(team.result.current.data?.[0]?.parentId).toBeNull();
+  });
+
+  it('orphans a cached child detail when its parent is deleted', async () => {
+    stubDeletes(false);
+    const client = newClient();
+    await mountLists(client);
+    const parent = issue({ id: 'issue_parent', identifier: 'ENG-1' });
+    const child = issue({ id: 'issue_child', identifier: 'ENG-2', parentId: parent.id });
+    client.setQueryData(queryKeys.issue(child.identifier), {
+      ...detailFor(child, []),
+      parent,
+    });
+    const remove = renderHook(() => useDeleteIssues(), { wrapper: wrapper(client) });
+
+    remove.result.current.mutate([parent]);
+
+    await waitFor(() => expect(remove.result.current.isSuccess).toBe(true));
+    const detail = client.getQueryData<ReturnType<typeof detailFor>>(
+      queryKeys.issue(child.identifier),
+    );
+    expect(detail?.issue.parentId).toBeNull();
+    expect(detail?.parent).toBeNull();
   });
 
   it('forgets the detail the deleted issue owned and trims it out of its parent', async () => {
@@ -753,6 +1794,30 @@ describe('deleting an issue', () => {
     expect(client.getQueryData(queryKeys.issue('ENG-2'))).toBeUndefined();
     const parent = client.getQueryData<{ subIssues: readonly Issue[] }>(queryKeys.issue('ENG-1'));
     expect(parent?.subIssues).toEqual([]);
+  });
+
+  it('cancels a pending parent detail before a deleted child can reappear', async () => {
+    stubDeletes(false);
+    const client = newClient();
+    await mountLists(client);
+    const parent = issue({ id: 'issue_parent', identifier: 'ENG-1' });
+    const child = issue({ id: 'issue_child', identifier: 'ENG-2', parentId: parent.id });
+    const key = queryKeys.issue(parent.identifier);
+    client.setQueryData(key, detailFor(parent, []));
+    const pendingDetail = deferred<ReturnType<typeof detailFor>>();
+    const refetch = client
+      .fetchQuery({ queryKey: key, queryFn: () => pendingDetail.promise })
+      .catch(() => undefined);
+    await waitFor(() => expect(client.getQueryState(key)?.fetchStatus).toBe('fetching'));
+    const remove = renderHook(() => useDeleteIssues(), { wrapper: wrapper(client) });
+
+    remove.result.current.mutate([child]);
+
+    await waitFor(() => expect(remove.result.current.isSuccess).toBe(true));
+    pendingDetail.resolve(detailFor(parent, [child]));
+    await refetch;
+    await Promise.resolve();
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(key)?.subIssues).toEqual([]);
   });
 
   it('keeps the issues that really went when a bulk delete is refused half way', async () => {

--- a/apps/web/tests/lib/query/use-issues.test.tsx
+++ b/apps/web/tests/lib/query/use-issues.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import {
+  recordIssueCacheReset,
   recordIssueDeletions,
   recordIssueListRevisions,
   recordIssueRevisions,
@@ -27,8 +28,9 @@ const {
   useDeleteIssues,
   useIssues,
   useMoveIssue,
+  useUpdateIssue,
 } = await import('@/lib/query/use-issues.ts');
-const { queryKeys } = await import('@/lib/query/keys.ts');
+const { ISSUE_ROOT, ISSUES_ROOT, queryKeys } = await import('@/lib/query/keys.ts');
 
 const TEAM = 'team_eng';
 const originalFetch = globalThis.fetch;
@@ -177,6 +179,204 @@ describe('useIssues', () => {
 });
 
 describe('issue mutations patch the cache without a refetch drain', () => {
+  it('does not roll back an update across an issue cache reset', async () => {
+    const pending = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) =>
+      init?.method === 'PATCH' ? pending.promise : Promise.resolve(Response.json(page([], null))),
+    ) as unknown as typeof fetch;
+    const client = newClient();
+    const listKey = queryKeys.issues(TEAM);
+    const detailKey = queryKeys.issue('ENG-1');
+    client.setQueryData(listKey, issuePages([issue()]));
+    client.setQueryData(detailKey, detailFor(issue(), []));
+    const update = renderHook(() => useUpdateIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<'success' | 'error'> | undefined;
+    await act(async () => {
+      result = update.result.current
+        .mutateAsync({ issue: issue(), patch: { title: 'Optimistic title' } })
+        .then(
+          () => 'success' as const,
+          () => 'error' as const,
+        );
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing update promise');
+    await waitFor(() => expect(cachedIssue(client)?.title).toBe('Optimistic title'));
+
+    const authoritative = issue({ title: 'After reconnect', syncId: 3 });
+    act(() => {
+      recordIssueCacheReset(client);
+      client.setQueryData(listKey, issuePages([authoritative]));
+      client.setQueryData(detailKey, detailFor(authoritative, []));
+    });
+
+    await act(async () => {
+      pending.resolve(
+        Response.json(
+          { error: { code: 'forbidden', message: 'The update failed.' } },
+          { status: 403 },
+        ),
+      );
+      expect(await result).toBe('error');
+    });
+
+    expect(cachedIssue(client)).toEqual(authoritative);
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(detailKey)?.issue).toEqual(
+      authoritative,
+    );
+    await waitFor(() => expect(update.result.current.isError).toBe(true));
+  });
+
+  it('does not roll back an update after its committed echo arrives', async () => {
+    const pending = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) =>
+      init?.method === 'PATCH' ? pending.promise : Promise.resolve(Response.json(page([], null))),
+    ) as unknown as typeof fetch;
+    const client = newClient();
+    const listKey = queryKeys.issues(TEAM);
+    const detailKey = queryKeys.issue('ENG-1');
+    client.setQueryData(listKey, issuePages([issue()]));
+    client.setQueryData(detailKey, detailFor(issue(), []));
+    const update = renderHook(() => useUpdateIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<'success' | 'error'> | undefined;
+    await act(async () => {
+      result = update.result.current
+        .mutateAsync({ issue: issue(), patch: { title: 'Committed title' } })
+        .then(
+          () => 'success' as const,
+          () => 'error' as const,
+        );
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing update promise');
+    await waitFor(() => expect(cachedIssue(client)?.title).toBe('Committed title'));
+    act(() => recordIssueRevisions(client, ['issue_1']));
+
+    await act(async () => {
+      pending.resolve(
+        Response.json(
+          { error: { code: 'network_error', message: 'The response was lost.' } },
+          { status: 500 },
+        ),
+      );
+      expect(await result).toBe('error');
+    });
+
+    expect(cachedIssue(client)?.title).toBe('Committed title');
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(detailKey)?.issue.title).toBe(
+      'Committed title',
+    );
+    await waitFor(() => expect(update.result.current.isError).toBe(true));
+  });
+
+  it('does not restore an old detail over a newer detail fetch', async () => {
+    const pendingUpdate = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) =>
+      init?.method === 'PATCH'
+        ? pendingUpdate.promise
+        : Promise.resolve(Response.json(page([], null))),
+    ) as unknown as typeof fetch;
+    const client = newClient();
+    const listKey = queryKeys.issues(TEAM);
+    const detailKey = queryKeys.issue('ENG-1');
+    client.setQueryData(listKey, issuePages([issue()]));
+    client.setQueryData(detailKey, detailFor(issue(), []));
+    const update = renderHook(() => useUpdateIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<'success' | 'error'> | undefined;
+    await act(async () => {
+      result = update.result.current
+        .mutateAsync({ issue: issue(), patch: { title: 'Optimistic title' } })
+        .then(
+          () => 'success' as const,
+          () => 'error' as const,
+        );
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing update promise');
+    await waitFor(() =>
+      expect(client.getQueryData<ReturnType<typeof detailFor>>(detailKey)?.issue.title).toBe(
+        'Optimistic title',
+      ),
+    );
+
+    const fetched = detailFor(issue({ title: 'Fetched title', syncId: 3 }), []);
+    await client.fetchQuery({ queryKey: detailKey, queryFn: () => Promise.resolve(fetched) });
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(detailKey)).toEqual(fetched);
+
+    await act(async () => {
+      pendingUpdate.resolve(
+        Response.json(
+          { error: { code: 'network_error', message: 'The response was lost.' } },
+          { status: 500 },
+        ),
+      );
+      expect(await result).toBe('error');
+    });
+
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(detailKey)).toEqual(fetched);
+    expect(cachedIssue(client)?.title).toBe('Optimistic title');
+    await waitFor(() => expect(update.result.current.isError).toBe(true));
+  });
+
+  it('does not let an older update response replace a newer detail', async () => {
+    const first = deferred<Response>();
+    const second = deferred<Response>();
+    let requests = 0;
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method !== 'PATCH') return Promise.resolve(Response.json(page([], null)));
+      requests += 1;
+      return requests === 1 ? first.promise : second.promise;
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const listKey = queryKeys.issues(TEAM);
+    const detailKey = queryKeys.issue('ENG-1');
+    client.setQueryData(listKey, issuePages([issue()]));
+    client.setQueryData(detailKey, detailFor(issue(), []));
+    const firstUpdate = renderHook(() => useUpdateIssue(), { wrapper: wrapper(client) });
+    const secondUpdate = renderHook(() => useUpdateIssue(), { wrapper: wrapper(client) });
+
+    let firstResult: Promise<Issue> | undefined;
+    await act(async () => {
+      firstResult = firstUpdate.result.current.mutateAsync({
+        issue: issue(),
+        patch: { title: 'First optimistic title' },
+      });
+      await Promise.resolve();
+    });
+    if (firstResult === undefined) throw new Error('missing first update promise');
+    await waitFor(() => expect(requests).toBe(1));
+
+    let secondResult: Promise<Issue> | undefined;
+    await act(async () => {
+      secondResult = secondUpdate.result.current.mutateAsync({
+        issue: issue({ title: 'First optimistic title' }),
+        patch: { title: 'Second optimistic title' },
+      });
+      await Promise.resolve();
+    });
+    if (secondResult === undefined) throw new Error('missing second update promise');
+    await waitFor(() => expect(requests).toBe(2));
+
+    const newer = issue({ title: 'Second confirmed title', syncId: 3 });
+    await act(async () => {
+      second.resolve(Response.json({ issue: newer }));
+      await secondResult;
+    });
+    const older = issue({ title: 'First confirmed title', syncId: 2 });
+    await act(async () => {
+      first.resolve(Response.json({ issue: older }));
+      await firstResult;
+    });
+    await waitFor(() => expect(firstUpdate.result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(secondUpdate.result.current.isSuccess).toBe(true));
+
+    expect(cachedIssue(client)).toEqual(newer);
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(detailKey)?.issue).toEqual(newer);
+  });
+
   it('sends one write and converges the cached row with zero list refetches', async () => {
     const log = stubFetch((_url, init) => {
       if (init?.method === 'POST') {
@@ -205,6 +405,49 @@ describe('issue mutations patch the cache without a refetch drain', () => {
 
     expect(log.methods.filter((method) => method === 'POST')).toHaveLength(1);
     expect(log.methods.filter((method) => method === 'GET')).toHaveLength(1);
+  });
+
+  it('continues a move when list cancellation rejects after canceling', async () => {
+    const log = stubFetch((_url, init) =>
+      init?.method === 'POST'
+        ? { issue: issue({ stateId: 'state_doing', syncId: 2 }), rebalanced: [] }
+        : page([], null),
+    );
+    const client = newClient();
+    client.setQueryData(queryKeys.issues(TEAM), issuePages([issue()]));
+    const originalCancel = client.cancelQueries.bind(client);
+    client.cancelQueries = (filters, options) => {
+      const cancellation = originalCancel(filters, options);
+      if (filters?.queryKey?.[0] !== ISSUES_ROOT) return cancellation;
+      return cancellation.then(() => Promise.reject(new Error('list cancellation failed')));
+    };
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    try {
+      const settlement = { status: 'pending' as 'pending' | 'success' | 'error' };
+      await act(async () => {
+        settlement.status = await move.result.current
+          .mutateAsync({
+            issue: issue(),
+            stateId: 'state_doing',
+            beforeId: null,
+            afterId: null,
+            beforeOrder: null,
+            afterOrder: null,
+          })
+          .then(
+            () => 'success' as const,
+            () => 'error' as const,
+          );
+      });
+
+      await waitFor(() => expect(move.result.current.isSuccess).toBe(true));
+      expect(settlement.status).toBe('success');
+      expect(cachedIssue(client)?.stateId).toBe('state_doing');
+      expect(log.methods.filter((method) => method === 'POST')).toHaveLength(1);
+    } finally {
+      client.cancelQueries = originalCancel;
+    }
   });
 
   it('waits for filtered lists to converge before a successful move settles', async () => {
@@ -606,6 +849,97 @@ describe('issue mutations patch the cache without a refetch drain', () => {
 
     await waitFor(() => expect(move.result.current.isSuccess).toBe(true));
     expect(listRequests).toBeLessThanOrEqual(5);
+  });
+
+  it('does not roll back a move after its committed echo arrives', async () => {
+    const pending = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) =>
+      init?.method === 'POST' ? pending.promise : Promise.resolve(Response.json(page([], null))),
+    ) as unknown as typeof fetch;
+    const client = newClient();
+    const key = queryKeys.issues(TEAM);
+    client.setQueryData(key, issuePages([issue()]));
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<'success' | 'error'> | undefined;
+    await act(async () => {
+      result = move.result.current
+        .mutateAsync({
+          issue: issue(),
+          stateId: 'state_doing',
+          beforeId: null,
+          afterId: null,
+          beforeOrder: null,
+          afterOrder: null,
+        })
+        .then(
+          () => 'success' as const,
+          () => 'error' as const,
+        );
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+    await waitFor(() => expect(cachedIssue(client)?.stateId).toBe('state_doing'));
+    act(() => recordIssueRevisions(client, ['issue_1']));
+
+    await act(async () => {
+      pending.resolve(
+        Response.json(
+          { error: { code: 'network_error', message: 'The response was lost.' } },
+          { status: 500 },
+        ),
+      );
+      expect(await result).toBe('error');
+    });
+
+    expect(cachedIssue(client)?.stateId).toBe('state_doing');
+    await waitFor(() => expect(move.result.current.isError).toBe(true));
+  });
+
+  it('does not roll back a move across an issue cache reset', async () => {
+    const pending = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) =>
+      init?.method === 'POST' ? pending.promise : Promise.reject(new Error('list unavailable')),
+    ) as unknown as typeof fetch;
+    const client = newClient();
+    const key = queryKeys.issues(TEAM);
+    client.setQueryData(key, issuePages([issue()]));
+    const move = renderHook(() => useMoveIssue(), { wrapper: wrapper(client) });
+
+    let result: Promise<'success' | 'error'> | undefined;
+    await act(async () => {
+      result = move.result.current
+        .mutateAsync({
+          issue: issue(),
+          stateId: 'state_doing',
+          beforeId: null,
+          afterId: null,
+          beforeOrder: null,
+          afterOrder: null,
+        })
+        .then(
+          () => 'success' as const,
+          () => 'error' as const,
+        );
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing move promise');
+    await waitFor(() => expect(cachedIssue(client)?.stateId).toBe('state_doing'));
+    act(() => recordIssueCacheReset(client));
+    await client.resetQueries({ queryKey: key, exact: true });
+
+    await act(async () => {
+      pending.resolve(
+        Response.json(
+          { error: { code: 'move_failed', message: 'The move failed.' } },
+          { status: 500 },
+        ),
+      );
+      expect(await result).toBe('error');
+    });
+
+    expect(cachedIssue(client)).toBeUndefined();
+    await waitFor(() => expect(move.result.current.isError).toBe(true));
   });
 
   it('does not let a failed move roll back a newer cached issue', async () => {
@@ -1530,6 +1864,109 @@ describe('deleting an issue', () => {
     await waitFor(() => expect(remove.result.current.isSuccess).toBe(true));
   });
 
+  it('commits a successful delete when list cancellation rejects after canceling', async () => {
+    const log = stubDeletes(false);
+    const client = newClient();
+    const removed = issue({ id: 'issue_child', identifier: 'ENG-2' });
+    client.setQueryData(queryKeys.issues(TEAM), issuePages([removed]));
+    client.setQueryData(queryKeys.issue(removed.identifier), detailFor(removed, []));
+    const originalCancel = client.cancelQueries.bind(client);
+    client.cancelQueries = (filters, options) => {
+      const cancellation = originalCancel(filters, options);
+      if (filters?.queryKey?.[0] !== ISSUES_ROOT) return cancellation;
+      return cancellation.then(() => Promise.reject(new Error('list cancellation failed')));
+    };
+    const remove = renderHook(() => useDeleteIssues(), { wrapper: wrapper(client) });
+
+    try {
+      const settlement = { status: 'pending' as 'pending' | 'success' | 'error' };
+      await act(async () => {
+        settlement.status = await remove.result.current.mutateAsync([removed]).then(
+          () => 'success' as const,
+          () => 'error' as const,
+        );
+      });
+
+      await waitFor(() => expect(remove.result.current.isSuccess).toBe(true));
+      expect(settlement.status).toBe('success');
+      expect(cachedIssue(client, removed.id)).toBeUndefined();
+      expect(client.getQueryData(queryKeys.issue(removed.identifier))).toBeUndefined();
+      expect(log.methods.filter((method) => method === 'DELETE')).toHaveLength(1);
+    } finally {
+      client.cancelQueries = originalCancel;
+    }
+  });
+
+  it('purges details when detail cancellation rejects after canceling', async () => {
+    stubDeletes(false);
+    const client = newClient();
+    const parent = issue({ id: 'issue_parent', identifier: 'ENG-1' });
+    const child = issue({ id: 'issue_child', identifier: 'ENG-2', parentId: parent.id });
+    const parentKey = queryKeys.issue(parent.identifier);
+    client.setQueryData(queryKeys.issues(TEAM), issuePages([parent, child]));
+    client.setQueryData(parentKey, detailFor(parent, [child]));
+    const pendingDetail = deferred<ReturnType<typeof detailFor>>();
+    const refetch = client
+      .fetchQuery({ queryKey: parentKey, queryFn: () => pendingDetail.promise })
+      .catch(() => undefined);
+    await waitFor(() => expect(client.getQueryState(parentKey)?.fetchStatus).toBe('fetching'));
+    const originalCancel = client.cancelQueries.bind(client);
+    client.cancelQueries = (filters, options) => {
+      const cancellation = originalCancel(filters, options);
+      if (filters?.queryKey?.[0] !== ISSUE_ROOT) return cancellation;
+      return cancellation.then(() => Promise.reject(new Error('detail cancellation failed')));
+    };
+    const remove = renderHook(() => useDeleteIssues(), { wrapper: wrapper(client) });
+
+    try {
+      const settlement = { status: 'pending' as 'pending' | 'success' | 'error' };
+      await act(async () => {
+        settlement.status = await remove.result.current.mutateAsync([child]).then(
+          () => 'success' as const,
+          () => 'error' as const,
+        );
+      });
+
+      await waitFor(() => expect(remove.result.current.isSuccess).toBe(true));
+      expect(settlement.status).toBe('success');
+      expect(client.getQueryData<ReturnType<typeof detailFor>>(parentKey)?.subIssues).toEqual([]);
+    } finally {
+      client.cancelQueries = originalCancel;
+      pendingDetail.resolve(detailFor(parent, []));
+      await refetch;
+    }
+  });
+
+  it('handles a rejected detail reset after a successful delete', async () => {
+    stubDeletes(false);
+    const client = newClient();
+    const removed = issue({ id: 'issue_child', identifier: 'ENG-2' });
+    const detailKey = queryKeys.issue(removed.identifier);
+    client.setQueryData(queryKeys.issues(TEAM), issuePages([removed]));
+    client.setQueryData(detailKey, detailFor(removed, []));
+    const originalReset = client.resetQueries.bind(client);
+    client.resetQueries = (filters, options) =>
+      originalReset(filters, options).then(() => Promise.reject(new Error('detail reset failed')));
+    const remove = renderHook(() => useDeleteIssues(), { wrapper: wrapper(client) });
+
+    try {
+      const settlement = { status: 'pending' as 'pending' | 'success' | 'error' };
+      await act(async () => {
+        settlement.status = await remove.result.current.mutateAsync([removed]).then(
+          () => 'success' as const,
+          () => 'error' as const,
+        );
+        await Promise.resolve();
+      });
+
+      await waitFor(() => expect(remove.result.current.isSuccess).toBe(true));
+      expect(settlement.status).toBe('success');
+      expect(client.getQueryData(detailKey)).toBeUndefined();
+    } finally {
+      client.resetQueries = originalReset;
+    }
+  });
+
   it('puts every list back exactly as it was when the server refuses', async () => {
     stubDeletes(true);
     const client = newClient();
@@ -1542,6 +1979,79 @@ describe('deleting an issue', () => {
     await waitFor(() => expect(remove.result.current.isError).toBe(true));
     expect(team.result.current.data?.map((row) => row.id)).toEqual(before ?? []);
     expect(mine.result.current.data?.map((row) => row.id)).toEqual(['issue_parent', 'issue_child']);
+  });
+
+  it('does not restore a delete after its committed echo arrives', async () => {
+    const pending = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) =>
+      init?.method === 'DELETE' ? pending.promise : Promise.resolve(Response.json(page([], null))),
+    ) as unknown as typeof fetch;
+    const client = newClient();
+    const key = queryKeys.issues(TEAM);
+    client.setQueryData(key, issuePages([issue()]));
+    const remove = renderHook(() => useDeleteIssues(), { wrapper: wrapper(client) });
+
+    let result: Promise<'success' | 'error'> | undefined;
+    await act(async () => {
+      result = remove.result.current.mutateAsync([issue()]).then(
+        () => 'success' as const,
+        () => 'error' as const,
+      );
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing delete promise');
+    await waitFor(() => expect(cachedIssue(client)).toBeUndefined());
+    act(() => recordIssueDeletions(client, ['issue_1']));
+
+    await act(async () => {
+      pending.resolve(
+        Response.json(
+          { error: { code: 'network_error', message: 'The response was lost.' } },
+          { status: 500 },
+        ),
+      );
+      expect(await result).toBe('error');
+    });
+
+    expect(cachedIssue(client)).toBeUndefined();
+    await waitFor(() => expect(remove.result.current.isError).toBe(true));
+  });
+
+  it('does not restore a delete across an issue cache reset', async () => {
+    const pending = deferred<Response>();
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) =>
+      init?.method === 'DELETE' ? pending.promise : Promise.resolve(Response.json(page([], null))),
+    ) as unknown as typeof fetch;
+    const client = newClient();
+    const key = queryKeys.issues(TEAM);
+    client.setQueryData(key, issuePages([issue()]));
+    const remove = renderHook(() => useDeleteIssues(), { wrapper: wrapper(client) });
+
+    let result: Promise<'success' | 'error'> | undefined;
+    await act(async () => {
+      result = remove.result.current.mutateAsync([issue()]).then(
+        () => 'success' as const,
+        () => 'error' as const,
+      );
+      await Promise.resolve();
+    });
+    if (result === undefined) throw new Error('missing delete promise');
+    await waitFor(() => expect(cachedIssue(client)).toBeUndefined());
+    act(() => recordIssueCacheReset(client));
+    await client.resetQueries({ queryKey: key, exact: true });
+
+    await act(async () => {
+      pending.resolve(
+        Response.json(
+          { error: { code: 'forbidden', message: 'The delete failed.' } },
+          { status: 403 },
+        ),
+      );
+      expect(await result).toBe('error');
+    });
+
+    expect(cachedIssue(client)).toBeUndefined();
+    await waitFor(() => expect(remove.result.current.isError).toBe(true));
   });
 
   it('restores a refused delete without overwriting a realtime sibling update', async () => {
@@ -1594,6 +2104,7 @@ describe('deleting an issue', () => {
       );
       await result?.catch(() => undefined);
     });
+    await waitFor(() => expect(remove.result.current.isError).toBe(true));
 
     expect(issueFromPagesForTest(client.getQueryData<IssuePages>(key), removed.id)).toEqual(
       removed,
@@ -1658,6 +2169,7 @@ describe('deleting an issue', () => {
       );
       await result?.catch(() => undefined);
     });
+    await waitFor(() => expect(remove.result.current.isError).toBe(true));
 
     const restored = client.getQueryData<IssuePages>(key);
     expect(restored === undefined ? [] : flattenIssuePages(restored).map((row) => row.id)).toEqual([
@@ -1862,6 +2374,62 @@ describe('deleting an issue', () => {
 
     await waitFor(() => expect(remove.result.current.isError).toBe(true));
     expect(team.result.current.data?.map((row) => row.id)).toEqual(['issue_child']);
+  });
+
+  it('finishes partial-delete recovery when list cancellation rejects after canceling', async () => {
+    let deletes = 0;
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method !== 'DELETE') return Promise.resolve(Response.json(page([], null)));
+      deletes += 1;
+      if (deletes === 1) {
+        return Promise.resolve(
+          Response.json({ deleted: { id: 'issue_parent', identifier: 'ENG-1' } }),
+        );
+      }
+      return Promise.resolve(
+        Response.json(
+          { error: { code: 'forbidden', message: 'Your role cannot issue delete.' } },
+          { status: 403 },
+        ),
+      );
+    }) as unknown as typeof fetch;
+    const client = newClient();
+    const parent = issue({ id: 'issue_parent', identifier: 'ENG-1' });
+    const child = issue({ id: 'issue_child', identifier: 'ENG-2', parentId: parent.id });
+    client.setQueryData(queryKeys.issues(TEAM), issuePages([parent, child]));
+    client.setQueryData(queryKeys.issue(parent.identifier), detailFor(parent, [child]));
+    client.setQueryData(queryKeys.issue(child.identifier), {
+      ...detailFor(child, []),
+      parent,
+    });
+    const originalCancel = client.cancelQueries.bind(client);
+    let listCancellations = 0;
+    client.cancelQueries = (filters, options) => {
+      const cancellation = originalCancel(filters, options);
+      if (filters?.queryKey?.[0] !== ISSUES_ROOT) return cancellation;
+      listCancellations += 1;
+      return listCancellations === 1
+        ? cancellation
+        : cancellation.then(() => Promise.reject(new Error('list cancellation failed')));
+    };
+    const remove = renderHook(() => useDeleteIssues(), { wrapper: wrapper(client) });
+
+    try {
+      await act(async () => {
+        await remove.result.current.mutateAsync([parent, child]).catch(() => undefined);
+      });
+
+      await waitFor(() => expect(remove.result.current.isError).toBe(true));
+      expect(cachedIssue(client, parent.id)).toBeUndefined();
+      expect(cachedIssue(client, child.id)).toMatchObject({ id: child.id, parentId: null });
+      expect(client.getQueryData(queryKeys.issue(parent.identifier))).toBeUndefined();
+      expect(
+        client.getQueryData<ReturnType<typeof detailFor>>(queryKeys.issue(child.identifier)),
+      ).toMatchObject({ issue: { parentId: null }, parent: null });
+      expect(toasts.map((toast) => toast.title)).toContain('Could not delete');
+    } finally {
+      client.cancelQueries = originalCancel;
+    }
   });
 
   it('sends one delete per selected issue when the bar deletes in bulk', async () => {

--- a/apps/web/tests/lib/realtime/delta-bridge.test.tsx
+++ b/apps/web/tests/lib/realtime/delta-bridge.test.tsx
@@ -5,6 +5,7 @@ import { act, render, waitFor } from '@testing-library/react';
 import { ANALYTICS_ROOT } from '@/features/analytics/analytics-keys.ts';
 import { clientId } from '@/lib/query/client-id.ts';
 import {
+  issueCacheRevisionGeneration,
   issueDeletionGeneration,
   issueListRevisionGeneration,
   issueRevisionGeneration,
@@ -16,7 +17,9 @@ import {
   DOCS_HOME_ROOT,
   DOCS_ROOT,
   ISSUE_FACETS_ROOT,
+  ISSUE_ROOT,
   ISSUE_SUMMARY_ROOT,
+  ISSUES_ROOT,
   MILESTONES_ROOT,
   queryKeys,
   VIEWS_ROOT,
@@ -271,6 +274,283 @@ describe('DeltaBridge origin suppression', () => {
     pending.resolve(pages);
     await request;
   });
+
+  it('cancels a stale source-team fetch when an issue moves to another team', async () => {
+    const client = mount();
+    const key = queryKeys.issues(TEAM, `teamId=${TEAM}`);
+    const pages: IssuePages = {
+      pages: [{ issues: [issue()], nextCursor: null }],
+      pageParams: [null],
+    };
+    client.setQueryData(key, pages);
+    const pending = deferred<IssuePages>();
+    const request = client
+      .fetchQuery({ queryKey: key, queryFn: () => pending.promise })
+      .catch(() => undefined);
+    await waitFor(() => expect(client.getQueryState(key)?.fetchStatus).toBe('fetching'));
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          scopes: ['team:team_design'],
+          data: {
+            ...issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 30 }),
+            teamChanged: true,
+          },
+          syncId: 30,
+        }),
+      ]),
+    );
+    expect(client.getQueryData<IssuePages>(key)?.pages[0]?.issues).toEqual([]);
+
+    pending.resolve(pages);
+    await request;
+    await Promise.resolve();
+
+    expect(client.getQueryData<IssuePages>(key)?.pages[0]?.issues).toEqual([]);
+  });
+
+  it('applies paired departure and arrival actions without clearing the surviving detail', () => {
+    const client = mount();
+    const sourceKey = queryKeys.issues(TEAM, `teamId=${TEAM}`);
+    const destinationKey = queryKeys.issues('team_design', 'teamId=team_design');
+    const detailKey = queryKeys.issue('ENG-3');
+    client.setQueryData(sourceKey, {
+      pages: [{ issues: [issue()], nextCursor: null }],
+      pageParams: [null],
+    });
+    client.setQueryData(destinationKey, {
+      pages: [{ issues: [], nextCursor: null }],
+      pageParams: [null],
+    });
+    client.setQueryData(detailKey, detailFor(issue(), []));
+    const deletionGeneration = issueDeletionGeneration(client, 'issue_1');
+    const revisionGeneration = issueRevisionGeneration(client, 'issue_1');
+    const arrived = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 30 });
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          data: {
+            id: 'issue_1',
+            teamId: TEAM,
+            identifier: 'ENG-3',
+            departure: true,
+            syncId: 30,
+          },
+          scopes: [`team:${TEAM}`],
+          syncId: 30,
+        }),
+        action({
+          data: { ...arrived, teamChanged: true },
+          scopes: ['team:team_design'],
+          syncId: 30,
+        }),
+      ]),
+    );
+
+    expect(client.getQueryData<IssuePages>(sourceKey)?.pages[0]?.issues).toEqual([]);
+    expect(client.getQueryData<IssuePages>(destinationKey)?.pages[0]?.issues).toEqual([arrived]);
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(detailKey)?.issue).toEqual(arrived);
+    expect(issueDeletionGeneration(client, 'issue_1')).toBe(deletionGeneration);
+    expect(issueRevisionGeneration(client, 'issue_1')).toBe(revisionGeneration + 1);
+  });
+
+  it('preserves a same-sync move when arrival precedes departure', async () => {
+    const client = mount();
+    const detailKey = queryKeys.issue('ENG-3');
+    const canonicalKey = queryKeys.issue('DSGN-4');
+    client.setQueryData(detailKey, detailFor(issue(), []));
+    const deletionGeneration = issueDeletionGeneration(client, 'issue_1');
+    const arrived = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 30 });
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          data: { ...arrived, teamChanged: true },
+          scopes: ['team:team_design'],
+          syncId: 30,
+        }),
+        action({
+          action: 'delete',
+          data: {
+            id: 'issue_1',
+            teamId: TEAM,
+            identifier: 'ENG-3',
+            departure: true,
+            syncId: 30,
+          },
+          syncId: 30,
+        }),
+      ]),
+    );
+
+    await waitFor(() =>
+      expect(client.getQueryData<ReturnType<typeof detailFor>>(detailKey)?.issue).toEqual(arrived),
+    );
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(canonicalKey)?.issue).toEqual(arrived);
+    expect(issueDeletionGeneration(client, 'issue_1')).toBe(deletionGeneration);
+  });
+
+  it('preserves a same-sync move whose departure arrives in a later frame', async () => {
+    const client = mount();
+    const detailKey = queryKeys.issue('ENG-3');
+    client.setQueryData(detailKey, detailFor(issue(), []));
+    const deletionGeneration = issueDeletionGeneration(client, 'issue_1');
+    const arrived = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 30 });
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          data: { ...arrived, teamChanged: true },
+          scopes: ['team:team_design'],
+          syncId: 30,
+        }),
+      ]),
+    );
+    await waitFor(() =>
+      expect(client.getQueryData<ReturnType<typeof detailFor>>(detailKey)?.issue).toEqual(arrived),
+    );
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          data: {
+            id: 'issue_1',
+            teamId: TEAM,
+            identifier: 'ENG-3',
+            departure: true,
+            syncId: 30,
+          },
+          syncId: 30,
+        }),
+      ]),
+    );
+
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(detailKey)?.issue).toEqual(arrived);
+    expect(issueDeletionGeneration(client, 'issue_1')).toBe(deletionGeneration);
+  });
+
+  it('applies an equal-sync departure only to a lagging list', () => {
+    const client = mount();
+    const sourceKey = queryKeys.issues(TEAM, `teamId=${TEAM}`);
+    const destinationKey = queryKeys.issues('team_design', 'teamId=team_design');
+    const arrived = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 30 });
+    client.setQueryData(sourceKey, {
+      pages: [{ issues: [issue()], nextCursor: null }],
+      pageParams: [null],
+    });
+    client.setQueryData(destinationKey, {
+      pages: [{ issues: [arrived], nextCursor: null }],
+      pageParams: [null],
+    });
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          data: {
+            id: 'issue_1',
+            teamId: TEAM,
+            identifier: 'ENG-3',
+            departure: true,
+            syncId: 30,
+          },
+          scopes: [`team:${TEAM}`],
+          syncId: 30,
+        }),
+      ]),
+    );
+
+    expect(client.getQueryData<IssuePages>(sourceKey)?.pages[0]?.issues).toEqual([]);
+    expect(client.getQueryData<IssuePages>(destinationKey)?.pages[0]?.issues).toEqual([arrived]);
+  });
+
+  it('clears an issue detail when only its source-team departure arrives', () => {
+    const client = mount();
+    const detailKey = queryKeys.issue('ENG-3');
+    client.setQueryData(detailKey, detailFor(issue(), []));
+    const deletionGeneration = issueDeletionGeneration(client, 'issue_1');
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          data: {
+            id: 'issue_1',
+            teamId: TEAM,
+            identifier: 'ENG-3',
+            departure: true,
+            syncId: 30,
+          },
+          scopes: [`team:${TEAM}`],
+          syncId: 30,
+        }),
+      ]),
+    );
+
+    expect(client.getQueryData(detailKey)).toBeUndefined();
+    expect(issueDeletionGeneration(client, 'issue_1')).toBe(deletionGeneration + 1);
+  });
+
+  it('clears a detail when a later departure is the final action in the batch', () => {
+    const client = mount();
+    const detailKey = queryKeys.issue('ENG-3');
+    client.setQueryData(detailKey, detailFor(issue(), []));
+    const arrived = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 30 });
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          data: { ...arrived, teamChanged: true },
+          scopes: ['team:team_design'],
+          syncId: 30,
+        }),
+        action({
+          action: 'delete',
+          data: {
+            id: 'issue_1',
+            teamId: 'team_design',
+            identifier: 'DSGN-4',
+            departure: true,
+            syncId: 31,
+          },
+          scopes: ['team:team_design'],
+          syncId: 31,
+        }),
+      ]),
+    );
+
+    expect(client.getQueryData(detailKey)).toBeUndefined();
+  });
+
+  it('keeps a detail when a later ordinary update is the final action in the batch', () => {
+    const client = mount();
+    const detailKey = queryKeys.issue('ENG-3');
+    client.setQueryData(detailKey, detailFor(issue(), []));
+    const newest = issue({ title: 'Newest after move', syncId: 31 });
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          data: {
+            id: 'issue_1',
+            teamId: TEAM,
+            identifier: 'ENG-3',
+            departure: true,
+            syncId: 30,
+          },
+          syncId: 30,
+        }),
+        action({ data: newest, syncId: 31 }),
+      ]),
+    );
+
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(detailKey)?.issue).toEqual(newest);
+  });
 });
 
 describe('DeltaBridge analytics freshness', () => {
@@ -291,10 +571,73 @@ describe('DeltaBridge analytics freshness', () => {
   it('invalidates aggregates for this tab before suppressing its row echo', () => {
     const client = mount();
     const seen = trackInvalidations(client);
+    const generation = issueRevisionGeneration(client, 'issue_1');
     act(() => capturedHandler?.([renameAction(clientId(), 'Own update')]));
 
     expect(seen).toContainEqual([ANALYTICS_ROOT]);
+    expect(seen).toContainEqual([ISSUE_SUMMARY_ROOT]);
+    expect(seen).toContainEqual([ISSUE_FACETS_ROOT]);
+    expect(seen).toContainEqual([BOARD_ROOT]);
+    expect(seen).toContainEqual([MILESTONES_ROOT]);
+    expect(seen).toContainEqual([ISSUES_ROOT]);
+    expect(seen).toContainEqual([ISSUE_ROOT]);
+    expect(issueRevisionGeneration(client, 'issue_1')).toBe(generation + 1);
     expect(titleIn(client)).toBe('Ship the board');
+  });
+
+  it('records an own delete echo without replaying the deleted row', () => {
+    const client = mount();
+    const seen = trackInvalidations(client);
+    const generation = issueDeletionGeneration(client, 'issue_1');
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          originClientId: clientId(),
+          data: { id: 'issue_1', teamId: TEAM, identifier: 'ENG-3', syncId: 11 },
+        }),
+      ]),
+    );
+
+    expect(idsIn(client)).toEqual(['issue_1']);
+    expect(issueDeletionGeneration(client, 'issue_1')).toBe(generation + 1);
+    expect(seen).toContainEqual([ISSUES_ROOT]);
+    expect(seen).toContainEqual([ISSUE_ROOT]);
+  });
+
+  it('records an own move arrival without treating its departure as deletion', () => {
+    const client = mount();
+    const deletionGeneration = issueDeletionGeneration(client, 'issue_1');
+    const revisionGeneration = issueRevisionGeneration(client, 'issue_1');
+    const arrived = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 30 });
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          originClientId: clientId(),
+          data: {
+            id: 'issue_1',
+            teamId: TEAM,
+            identifier: 'ENG-3',
+            departure: true,
+            syncId: 30,
+          },
+          syncId: 30,
+        }),
+        action({
+          originClientId: clientId(),
+          data: arrived,
+          scopes: ['team:team_design'],
+          syncId: 30,
+        }),
+      ]),
+    );
+
+    expect(idsIn(client)).toEqual(['issue_1']);
+    expect(issueDeletionGeneration(client, 'issue_1')).toBe(deletionGeneration);
+    expect(issueRevisionGeneration(client, 'issue_1')).toBe(revisionGeneration + 2);
   });
 
   it('does not invalidate analytics for unrelated comment activity', () => {
@@ -307,6 +650,31 @@ describe('DeltaBridge analytics freshness', () => {
 });
 
 describe('DeltaBridge ordering', () => {
+  it('applies an equal-sync action to lagging list and detail caches', () => {
+    const client = mount();
+    const currentKey = queryKeys.issues(TEAM, 'orderBy=updated');
+    const laggingKey = queryKeys.issues(TEAM, 'orderBy=manual');
+    const canonical = issue({ title: 'Canonical', syncId: 50 });
+    const lagging = issue({ title: 'Lagging', syncId: 40 });
+    client.setQueryData(currentKey, {
+      pages: [{ issues: [canonical], nextCursor: null }],
+      pageParams: [null],
+    });
+    client.setQueryData(laggingKey, {
+      pages: [{ issues: [lagging], nextCursor: null }],
+      pageParams: [null],
+    });
+    client.setQueryData(queryKeys.issue('ENG-3'), detailFor(lagging, []));
+
+    act(() => capturedHandler?.([action({ syncId: 50, data: canonical })]));
+
+    expect(client.getQueryData<IssuePages>(laggingKey)?.pages[0]?.issues[0]).toEqual(canonical);
+    expect(
+      client.getQueryData<ReturnType<typeof detailFor>>(queryKeys.issue('ENG-3'))?.issue,
+    ).toEqual(canonical);
+    expect(client.getQueryData<IssuePages>(currentKey)?.pages[0]?.issues[0]).toEqual(canonical);
+  });
+
   it('ignores a delta whose sync id is not newer than the cached row', () => {
     const client = mount();
     act(() =>
@@ -316,6 +684,29 @@ describe('DeltaBridge ordering', () => {
       ]),
     );
     expect(titleIn(client)).toBe('Newest');
+  });
+
+  it('does not resurrect a deleted issue from a delayed full update', () => {
+    const client = mount();
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          syncId: 50,
+          data: { id: 'issue_1', teamId: TEAM, identifier: 'ENG-3', syncId: 50 },
+        }),
+      ]),
+    );
+    expect(idsIn(client)).toEqual([]);
+
+    act(() =>
+      capturedHandler?.([
+        action({ syncId: 40, data: issue({ title: 'Delayed full row', syncId: 40 }) }),
+      ]),
+    );
+
+    expect(idsIn(client)).toEqual([]);
   });
 
   it('cancels a stale detail fetch before applying a newer realtime update', async () => {
@@ -384,6 +775,397 @@ describe('DeltaBridge ordering', () => {
       title: 'Newest detail',
       syncId: 40,
     });
+    unsubscribe();
+  });
+
+  it('cancels only the initial detail fetch named by an issue update', async () => {
+    const client = mount();
+    client.removeQueries({ queryKey: queryKeys.issues(TEAM), exact: true });
+    const matchingKey = queryKeys.issue('ENG-3');
+    const unrelatedKey = queryKeys.issue('ENG-99');
+    const matching = deferred<ReturnType<typeof detailFor>>();
+    const unrelated = deferred<ReturnType<typeof detailFor>>();
+    const matchingRequest = client
+      .fetchQuery({ queryKey: matchingKey, queryFn: () => matching.promise })
+      .catch(() => undefined);
+    const unrelatedRequest = client
+      .fetchQuery({ queryKey: unrelatedKey, queryFn: () => unrelated.promise })
+      .catch(() => undefined);
+    await waitFor(() => expect(client.getQueryState(matchingKey)?.fetchStatus).toBe('fetching'));
+    await waitFor(() => expect(client.getQueryState(unrelatedKey)?.fetchStatus).toBe('fetching'));
+
+    act(() =>
+      capturedHandler?.([
+        action({ data: issue({ title: 'Newest detail', syncId: 40 }), syncId: 40 }),
+      ]),
+    );
+
+    await waitFor(() => expect(client.getQueryState(matchingKey)?.fetchStatus).toBe('idle'));
+    expect(client.getQueryState(unrelatedKey)?.fetchStatus).toBe('fetching');
+
+    matching.resolve(detailFor(issue({ title: 'Stale response', syncId: 11 }), []));
+    unrelated.resolve(detailFor(issue({ identifier: 'ENG-99' }), []));
+    await Promise.all([matchingRequest, unrelatedRequest]);
+  });
+
+  it('moves a coalesced active detail fetch to the final identifier', async () => {
+    const client = mount();
+    client.removeQueries({ queryKey: queryKeys.issues(TEAM), exact: true });
+    const previousKey = queryKeys.issue('ENG-3');
+    const nextKey = queryKeys.issue('DSGN-4');
+    const stale = deferred<ReturnType<typeof detailFor>>();
+    const fresh = deferred<ReturnType<typeof detailFor>>();
+    const requests: string[] = [];
+    const previousObserver = new QueryObserver(client, {
+      queryKey: previousKey,
+      queryFn: () => {
+        requests.push('ENG-3');
+        return stale.promise;
+      },
+      retry: false,
+    });
+    const unsubscribePrevious = previousObserver.subscribe(() => undefined);
+    await waitFor(() => expect(requests).toEqual(['ENG-3']));
+    const arrived = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 40 });
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          data: {
+            id: 'issue_1',
+            teamId: TEAM,
+            identifier: 'ENG-3',
+            departure: true,
+            syncId: 30,
+          },
+          syncId: 30,
+        }),
+        action({
+          data: arrived,
+          scopes: ['team:team_design'],
+          syncId: 40,
+        }),
+      ]),
+    );
+
+    await waitFor(() =>
+      expect(client.getQueryData<ReturnType<typeof detailFor>>(previousKey)?.issue).toEqual(
+        arrived,
+      ),
+    );
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(nextKey)?.issue).toEqual(arrived);
+    expect(requests).toEqual(['ENG-3']);
+
+    const nextObserver = new QueryObserver(client, {
+      queryKey: nextKey,
+      queryFn: () => {
+        requests.push('DSGN-4');
+        return fresh.promise;
+      },
+      retry: false,
+    });
+    const unsubscribeNext = nextObserver.subscribe(() => undefined);
+    await waitFor(() => expect(requests).toEqual(['ENG-3', 'DSGN-4']));
+    fresh.resolve(detailFor(arrived, []));
+    await waitFor(() =>
+      expect(client.getQueryData<ReturnType<typeof detailFor>>(nextKey)?.issue.syncId).toBe(40),
+    );
+    stale.resolve(detailFor(issue({ title: 'Stale response', syncId: 11 }), []));
+    await stale.promise;
+    await Promise.resolve();
+
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(previousKey)?.issue).toMatchObject({
+      identifier: 'DSGN-4',
+      syncId: 40,
+    });
+    expect(requests).toEqual(['ENG-3', 'DSGN-4']);
+    unsubscribePrevious();
+    unsubscribeNext();
+  });
+
+  it('migrates a moved detail when canceling its old request rejects', async () => {
+    const client = mount();
+    client.removeQueries({ queryKey: queryKeys.issues(TEAM), exact: true });
+    const previousKey = queryKeys.issue('ENG-3');
+    const nextKey = queryKeys.issue('DSGN-4');
+    client.setQueryData(previousKey, detailFor(issue(), []));
+    const pending = deferred<ReturnType<typeof detailFor>>();
+    const request = client
+      .fetchQuery({ queryKey: previousKey, queryFn: () => pending.promise })
+      .catch(() => undefined);
+    await waitFor(() => expect(client.getQueryState(previousKey)?.fetchStatus).toBe('fetching'));
+    const originalCancel = client.cancelQueries.bind(client);
+    client.cancelQueries = (filters, options) =>
+      filters?.queryKey?.[0] === ISSUE_ROOT
+        ? Promise.reject(new Error('cancel failed'))
+        : originalCancel(filters, options);
+    const invalidated: unknown[][] = [];
+    const originalInvalidate = client.invalidateQueries.bind(client);
+    client.invalidateQueries = (filters, options) => {
+      if (filters?.queryKey !== undefined) invalidated.push([...filters.queryKey]);
+      return originalInvalidate(filters, options);
+    };
+    const arrived = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 30 });
+
+    try {
+      act(() =>
+        capturedHandler?.([
+          action({
+            action: 'delete',
+            data: {
+              id: 'issue_1',
+              teamId: TEAM,
+              identifier: 'ENG-3',
+              departure: true,
+              syncId: 30,
+            },
+            syncId: 30,
+          }),
+          action({ data: arrived, scopes: ['team:team_design'], syncId: 30 }),
+        ]),
+      );
+
+      await waitFor(() =>
+        expect(client.getQueryData<ReturnType<typeof detailFor>>(nextKey)?.issue).toEqual(arrived),
+      );
+      expect(invalidated).toContainEqual([...nextKey]);
+    } finally {
+      client.cancelQueries = originalCancel;
+      client.invalidateQueries = originalInvalidate;
+      pending.resolve(detailFor(issue(), []));
+      await request;
+    }
+  });
+
+  it('migrates an equal-sync detail without an issue list cache', async () => {
+    const client = mount();
+    client.removeQueries({ queryKey: queryKeys.issues(TEAM), exact: true });
+    const previousKey = queryKeys.issue('ENG-3');
+    const nextKey = queryKeys.issue('DSGN-4');
+    const previous = issue({ syncId: 30 });
+    const arrived = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 30 });
+    client.setQueryData(previousKey, detailFor(previous, []));
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          data: {
+            id: 'issue_1',
+            teamId: TEAM,
+            identifier: 'ENG-3',
+            departure: true,
+            syncId: 30,
+          },
+          syncId: 30,
+        }),
+        action({ data: arrived, scopes: ['team:team_design'], syncId: 30 }),
+      ]),
+    );
+
+    await waitFor(() =>
+      expect(client.getQueryData<ReturnType<typeof detailFor>>(previousKey)?.issue).toEqual(
+        arrived,
+      ),
+    );
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(nextKey)?.issue).toEqual(arrived);
+  });
+
+  it('migrates an empty old detail when same-sync arrival precedes departure', async () => {
+    const client = mount();
+    client.removeQueries({ queryKey: queryKeys.issues(TEAM), exact: true });
+    const previousKey = queryKeys.issue('ENG-3');
+    const nextKey = queryKeys.issue('DSGN-4');
+    const pending = deferred<ReturnType<typeof detailFor>>();
+    const request = client
+      .fetchQuery({ queryKey: previousKey, queryFn: () => pending.promise })
+      .catch(() => undefined);
+    await waitFor(() => expect(client.getQueryState(previousKey)?.fetchStatus).toBe('fetching'));
+    const arrived = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 30 });
+
+    act(() =>
+      capturedHandler?.([
+        action({ data: arrived, scopes: ['team:team_design'], syncId: 30 }),
+        action({
+          action: 'delete',
+          data: {
+            id: 'issue_1',
+            teamId: TEAM,
+            identifier: 'ENG-3',
+            departure: true,
+            syncId: 30,
+          },
+          syncId: 30,
+        }),
+      ]),
+    );
+
+    await waitFor(() =>
+      expect(client.getQueryData<ReturnType<typeof detailFor>>(previousKey)?.issue).toEqual(
+        arrived,
+      ),
+    );
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(nextKey)?.issue).toEqual(arrived);
+    pending.resolve(detailFor(issue(), []));
+    await request;
+  });
+
+  it('migrates empty old detail keys across two coalesced team moves', async () => {
+    const client = mount();
+    client.removeQueries({ queryKey: queryKeys.issues(TEAM), exact: true });
+    const firstKey = queryKeys.issue('ENG-3');
+    const middleKey = queryKeys.issue('DSGN-4');
+    const finalKey = queryKeys.issue('PROD-2');
+    const firstPending = deferred<ReturnType<typeof detailFor>>();
+    const middlePending = deferred<ReturnType<typeof detailFor>>();
+    const firstRequest = client
+      .fetchQuery({ queryKey: firstKey, queryFn: () => firstPending.promise })
+      .catch(() => undefined);
+    const middleRequest = client
+      .fetchQuery({ queryKey: middleKey, queryFn: () => middlePending.promise })
+      .catch(() => undefined);
+    await waitFor(() => expect(client.getQueryState(firstKey)?.fetchStatus).toBe('fetching'));
+    await waitFor(() => expect(client.getQueryState(middleKey)?.fetchStatus).toBe('fetching'));
+    const arrived = issue({ teamId: 'team_product', identifier: 'PROD-2', syncId: 31 });
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          data: {
+            id: 'issue_1',
+            teamId: TEAM,
+            identifier: 'ENG-3',
+            departure: true,
+            syncId: 30,
+          },
+          syncId: 30,
+        }),
+        action({
+          data: issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 30 }),
+          scopes: ['team:team_design'],
+          syncId: 30,
+        }),
+        action({
+          action: 'delete',
+          data: {
+            id: 'issue_1',
+            teamId: 'team_design',
+            identifier: 'DSGN-4',
+            departure: true,
+            syncId: 31,
+          },
+          scopes: ['team:team_design'],
+          syncId: 31,
+        }),
+        action({ data: arrived, scopes: ['team:team_product'], syncId: 31 }),
+      ]),
+    );
+
+    await waitFor(() =>
+      expect(client.getQueryData<ReturnType<typeof detailFor>>(firstKey)?.issue).toEqual(arrived),
+    );
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(middleKey)?.issue).toEqual(arrived);
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(finalKey)?.issue).toEqual(arrived);
+    firstPending.resolve(detailFor(issue(), []));
+    middlePending.resolve(detailFor(issue({ identifier: 'DSGN-4' }), []));
+    await Promise.all([firstRequest, middleRequest]);
+  });
+
+  it('keeps a newer no-list detail fetch ahead of a delayed move pair', async () => {
+    const client = mount();
+    client.removeQueries({ queryKey: queryKeys.issues(TEAM), exact: true });
+    const canonical = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 50 });
+    const canonicalKey = queryKeys.issue('DSGN-4');
+    client.setQueryData(canonicalKey, detailFor(canonical, []));
+    const pending = deferred<ReturnType<typeof detailFor>>();
+    const request = client
+      .fetchQuery({ queryKey: canonicalKey, queryFn: () => pending.promise })
+      .catch(() => undefined);
+    await waitFor(() => expect(client.getQueryState(canonicalKey)?.fetchStatus).toBe('fetching'));
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          data: {
+            id: 'issue_1',
+            teamId: 'team_design',
+            identifier: 'DSGN-4',
+            departure: true,
+            syncId: 40,
+          },
+          scopes: ['team:team_design'],
+          syncId: 40,
+        }),
+        action({
+          data: issue({ teamId: 'team_product', identifier: 'PROD-2', syncId: 40 }),
+          scopes: ['team:team_product'],
+          syncId: 40,
+        }),
+      ]),
+    );
+    await Promise.resolve();
+
+    expect(client.getQueryState(canonicalKey)?.fetchStatus).toBe('fetching');
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(canonicalKey)?.issue).toEqual(
+      canonical,
+    );
+    expect(client.getQueryData(queryKeys.issue('PROD-2'))).toBeUndefined();
+
+    pending.resolve(detailFor(canonical, []));
+    await request;
+  });
+
+  it('keeps a newer canonical detail fetch ahead of a delayed full move action', async () => {
+    const client = mount();
+    const canonical = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 50 });
+    client.setQueryData(queryKeys.issues(TEAM), {
+      pages: [{ issues: [canonical], nextCursor: null }],
+      pageParams: [null],
+    });
+    const canonicalKey = queryKeys.issue('DSGN-4');
+    const fresh = deferred<ReturnType<typeof detailFor>>();
+    let requests = 0;
+    const observer = new QueryObserver(client, {
+      queryKey: canonicalKey,
+      queryFn: () => {
+        requests += 1;
+        return fresh.promise;
+      },
+      retry: false,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+    await waitFor(() => expect(requests).toBe(1));
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          data: {
+            ...issue({ teamId: 'team_product', identifier: 'PROD-2', syncId: 40 }),
+            teamChanged: true,
+          },
+          scopes: ['team:team_product'],
+          syncId: 40,
+        }),
+      ]),
+    );
+    await Promise.resolve();
+
+    expect(client.getQueryState(canonicalKey)?.fetchStatus).toBe('fetching');
+    expect(client.getQueryData(queryKeys.issue('PROD-2'))).toBeUndefined();
+    expect(client.getQueryData<IssuePages>(queryKeys.issues(TEAM))?.pages[0]?.issues).toEqual([
+      canonical,
+    ]);
+    expect(requests).toBe(1);
+
+    fresh.resolve(detailFor(canonical, []));
+    await waitFor(() =>
+      expect(client.getQueryData<ReturnType<typeof detailFor>>(canonicalKey)?.issue).toEqual(
+        canonical,
+      ),
+    );
     unsubscribe();
   });
 
@@ -566,8 +1348,271 @@ describe('DeltaBridge doc comments', () => {
 });
 
 describe('DeltaBridge reconnect backfill', () => {
-  it('refetches caches instead of replaying current rows when no watermark exists', async () => {
+  it('advances the issue cache revision before resetting reconnect caches', async () => {
     const client = mount();
+    const revision = issueCacheRevisionGeneration(client);
+
+    act(() => capturedResume?.(0));
+
+    await waitFor(() => expect(issueCacheRevisionGeneration(client)).toBe(revision + 1));
+  });
+
+  it('clears cached board pages before reconnect catch up', async () => {
+    const client = mount();
+    const boardKey = [BOARD_ROOT, 'state'] as const;
+    client.setQueryData(boardKey, { groups: [{ id: 'todo' }] });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        Response.json({ syncId: 42, truncated: false, actions: [] }),
+      )) as unknown as typeof fetch;
+
+    try {
+      act(() => capturedResume?.(17));
+      await waitFor(() => expect(client.getQueryData(boardKey)).toBeUndefined());
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('fences a board request that started before reconnect reset', async () => {
+    const client = mount();
+    observed.length = 0;
+    const boardKey = [BOARD_ROOT, 'state'] as const;
+    const stale = deferred<{ version: string }>();
+    const fresh = deferred<{ version: string }>();
+    let boardRequests = 0;
+    client.setQueryData(boardKey, { version: 'cached' });
+    const observer = new QueryObserver(client, {
+      queryKey: boardKey,
+      queryFn: () => {
+        boardRequests += 1;
+        return boardRequests === 1 ? stale.promise : fresh.promise;
+      },
+      retry: false,
+      staleTime: Number.POSITIVE_INFINITY,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+    const firstRequest = observer.refetch().catch(() => undefined);
+    await waitFor(() => expect(boardRequests).toBe(1));
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((_input: RequestInfo | URL) =>
+      Promise.resolve(
+        Response.json({ syncId: 42, truncated: false, actions: [] }),
+      )) as typeof fetch;
+
+    try {
+      act(() => capturedResume?.(17));
+      await waitFor(() => expect(boardRequests).toBe(2));
+      stale.resolve({ version: 'stale' });
+      await stale.promise;
+      await Promise.resolve();
+      expect(client.getQueryData<{ version: string }>(boardKey)?.version).not.toBe('stale');
+
+      fresh.resolve({ version: 'fresh' });
+      await waitFor(() =>
+        expect(client.getQueryData<{ version: string }>(boardKey)?.version).toBe('fresh'),
+      );
+      await waitFor(() => expect(observed).toEqual([42]));
+      await firstRequest;
+    } finally {
+      globalThis.fetch = originalFetch;
+      unsubscribe();
+    }
+  });
+
+  it('recovers an old-identifier detail by stable id without a watermark', async () => {
+    const client = mount();
+    const previousKey = queryKeys.issue('ENG-3');
+    const canonicalKey = queryKeys.issue('DSGN-4');
+    const canonical = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 40 });
+    client.setQueryData(previousKey, detailFor(issue(), []));
+    const observer = new QueryObserver(client, {
+      queryKey: previousKey,
+      queryFn: () => Promise.reject(new Error('old identifier unavailable')),
+      retry: false,
+      staleTime: Number.POSITIVE_INFINITY,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+    const requested: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = String(input);
+      requested.push(url);
+      return Promise.resolve(Response.json(detailFor(canonical, [])));
+    }) as typeof fetch;
+
+    try {
+      act(() => capturedResume?.(0));
+      await waitFor(() =>
+        expect(client.getQueryData<ReturnType<typeof detailFor>>(previousKey)?.issue).toEqual(
+          canonical,
+        ),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      unsubscribe();
+    }
+
+    expect(requested).toContain('/api/issues/issue_1');
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(canonicalKey)?.issue).toEqual(
+      canonical,
+    );
+  });
+
+  it('recovers an old-identifier detail by stable id alongside catch up', async () => {
+    const client = mount();
+    const previousKey = queryKeys.issue('ENG-3');
+    const canonicalKey = queryKeys.issue('DSGN-4');
+    const canonical = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 40 });
+    client.setQueryData(previousKey, detailFor(issue(), []));
+    const observer = new QueryObserver(client, {
+      queryKey: previousKey,
+      queryFn: () => Promise.reject(new Error('old identifier unavailable')),
+      retry: false,
+      staleTime: Number.POSITIVE_INFINITY,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+    const requested: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = String(input);
+      requested.push(url);
+      return Promise.resolve(
+        url.startsWith('/api/sync')
+          ? Response.json({ syncId: 42, truncated: false, actions: [] })
+          : Response.json(detailFor(canonical, [])),
+      );
+    }) as typeof fetch;
+
+    try {
+      act(() => capturedResume?.(17));
+      await waitFor(() =>
+        expect(client.getQueryData<ReturnType<typeof detailFor>>(previousKey)?.issue).toEqual(
+          canonical,
+        ),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      unsubscribe();
+    }
+
+    expect(requested.sort()).toEqual(['/api/issues/issue_1', '/api/sync?since=17']);
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(canonicalKey)?.issue).toEqual(
+      canonical,
+    );
+  });
+
+  it('does not recover an inactive detail during reconnect', async () => {
+    const client = mount();
+    observed.length = 0;
+    client.setQueryData(queryKeys.issue('ENG-3'), detailFor(issue(), []));
+    const requested: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      requested.push(String(input));
+      return Promise.resolve(Response.json({ syncId: 42, truncated: false, actions: [] }));
+    }) as typeof fetch;
+
+    try {
+      act(() => capturedResume?.(17));
+      await waitFor(() => expect(observed).toContain(42));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(requested).toEqual(['/api/sync?since=17']);
+  });
+
+  it('aborts and ignores an older reconnect after a newer resume starts', async () => {
+    mount();
+    observed.length = 0;
+    const first = deferred<Response>();
+    const second = deferred<Response>();
+    const signals: (AbortSignal | null | undefined)[] = [];
+    let requests = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
+      signals.push(init?.signal);
+      requests += 1;
+      return requests === 1 ? first.promise : second.promise;
+    }) as typeof fetch;
+
+    try {
+      act(() => capturedResume?.(17));
+      await waitFor(() => expect(requests).toBe(1));
+      act(() => capturedResume?.(18));
+      await waitFor(() => expect(requests).toBe(2));
+      expect(signals[0]?.aborted).toBe(true);
+
+      second.resolve(Response.json({ syncId: 42, truncated: false, actions: [] }));
+      await waitFor(() => expect(observed).toEqual([42]));
+      first.resolve(Response.json({ syncId: 41, truncated: false, actions: [] }));
+      await first.promise;
+      await Promise.resolve();
+
+      expect(observed).toEqual([42]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('aborts an in-flight reconnect when the bridge unmounts', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const response = deferred<Response>();
+    const signals: (AbortSignal | null | undefined)[] = [];
+    observed.length = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
+      signals.push(init?.signal);
+      return response.promise;
+    }) as typeof fetch;
+    const mounted = render(
+      <QueryClientProvider client={client}>
+        <DeltaBridge organizationId="org_1" teamIds={[TEAM]} />
+      </QueryClientProvider>,
+    );
+
+    try {
+      act(() => capturedResume?.(17));
+      await waitFor(() => expect(signals).toHaveLength(1));
+      mounted.unmount();
+      expect(signals[0]?.aborted).toBe(true);
+      response.resolve(Response.json({ syncId: 42, truncated: false, actions: [] }));
+      await response.promise;
+      await Promise.resolve();
+      expect(observed).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('clears issue caches before refreshing all queries when no watermark exists', async () => {
+    const client = mount();
+    const listKey = queryKeys.issues(TEAM);
+    const detailKey = queryKeys.issue('ENG-3');
+    client.setQueryData(detailKey, detailFor(issue(), []));
+    const failedRefetches: string[] = [];
+    const listObserver = new QueryObserver(client, {
+      queryKey: listKey,
+      queryFn: () => {
+        failedRefetches.push('list');
+        return Promise.reject(new Error('list unavailable'));
+      },
+      retry: false,
+      staleTime: Number.POSITIVE_INFINITY,
+    });
+    const detailObserver = new QueryObserver(client, {
+      queryKey: detailKey,
+      queryFn: () => {
+        failedRefetches.push('detail');
+        return Promise.reject(new Error('detail unavailable'));
+      },
+      retry: false,
+      staleTime: Number.POSITIVE_INFINITY,
+    });
+    const unsubscribeList = listObserver.subscribe(() => undefined);
+    const unsubscribeDetail = detailObserver.subscribe(() => undefined);
     const invalidations: (unknown[] | null)[] = [];
     const originalInvalidate = client.invalidateQueries.bind(client);
     client.invalidateQueries = (filters?: Parameters<typeof originalInvalidate>[0]) => {
@@ -582,20 +1627,23 @@ describe('DeltaBridge reconnect backfill', () => {
     }) as typeof fetch;
 
     try {
-      await act(async () => {
-        capturedResume?.(0);
-        await Promise.resolve();
-      });
+      act(() => capturedResume?.(0));
+      await waitFor(() => expect(invalidations).toEqual([null]));
     } finally {
       globalThis.fetch = originalFetch;
     }
 
-    expect(requested).toEqual([]);
-    expect(invalidations).toEqual([null]);
+    expect(requested).toEqual(['/api/issues/issue_1']);
+    expect(client.getQueryData(listKey)).toBeUndefined();
+    expect(client.getQueryData(detailKey)).toBeUndefined();
+    expect(failedRefetches.sort()).toEqual(['detail', 'list']);
+    unsubscribeList();
+    unsubscribeDetail();
   });
 
-  it('replays the catch up endpoint instead of refetching the visible list', async () => {
+  it('clears issue caches before applying reconnect catch up', async () => {
     const client = mount();
+    client.setQueryData(queryKeys.issue('ENG-3'), detailFor(issue(), []));
     const seen = trackInvalidations(client);
     observed.length = 0;
     const requested: string[] = [];
@@ -626,7 +1674,8 @@ describe('DeltaBridge reconnect backfill', () => {
     }
 
     expect(requested).toEqual(['/api/sync?since=17']);
-    expect(titleIn(client)).toBe('Caught up');
+    expect(client.getQueryData(queryKeys.issues(TEAM))).toBeUndefined();
+    expect(client.getQueryData(queryKeys.issue('ENG-3'))).toBeUndefined();
     expect(observed).toContain(42);
     expect(seen).toEqual([
       [ANALYTICS_ROOT],
@@ -636,6 +1685,70 @@ describe('DeltaBridge reconnect backfill', () => {
       [MILESTONES_ROOT],
       [BOOTSTRAP_ROOT],
     ]);
+  });
+
+  it('clears issue caches even when reconnect catch up fails', async () => {
+    const client = mount();
+    const detailKey = queryKeys.issue('ENG-3');
+    client.setQueryData(detailKey, detailFor(issue(), []));
+    const requested: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      requested.push(String(input));
+      return Promise.reject(new Error('catch up unavailable'));
+    }) as typeof fetch;
+
+    try {
+      act(() => capturedResume?.(17));
+      await waitFor(() => expect(requested).toContain('/api/sync?since=17'));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(client.getQueryData(queryKeys.issues(TEAM))).toBeUndefined();
+    expect(client.getQueryData(detailKey)).toBeUndefined();
+    expect(requested).toEqual(['/api/sync?since=17']);
+  });
+
+  it('continues reconnect catch up when an active cache reset rejects', async () => {
+    const client = mount();
+    observed.length = 0;
+    const requested: string[] = [];
+    const originalReset = client.resetQueries.bind(client);
+    client.resetQueries = (filters, options) => {
+      const reset = originalReset(filters, options);
+      if (filters?.queryKey?.[0] !== ISSUES_ROOT) return reset;
+      return reset.then(() => Promise.reject(new Error('list reset failed')));
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      requested.push(String(input));
+      return Promise.resolve(Response.json({ syncId: 42, truncated: false, actions: [] }));
+    }) as typeof fetch;
+
+    try {
+      act(() => capturedResume?.(17));
+      await waitFor(() => expect(requested).toEqual(['/api/sync?since=17']));
+      await waitFor(() => expect(observed).toEqual([42]));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('invalidates nonissue caches when reconnect catch up fails', async () => {
+    const client = mount();
+    const viewKey = [VIEWS_ROOT, 'mine'] as const;
+    client.setQueryData(viewKey, { id: 'view_1' });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.reject(new Error('catch up unavailable'))) as unknown as typeof fetch;
+
+    try {
+      act(() => capturedResume?.(17));
+      await waitFor(() => expect(client.getQueryState(viewKey)?.isInvalidated).toBe(true));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it('refreshes bootstrap when catch up only contains this tab own echo', async () => {
@@ -722,6 +1835,24 @@ describe('DeltaBridge deletions', () => {
     act(() => capturedHandler?.([deleteAction('issue_1', 'ENG-3')]));
 
     expect(client.getQueryData(queryKeys.issue('ENG-3'))).toBeUndefined();
+  });
+
+  it('handles a rejected detail reset while forgetting a realtime deletion', async () => {
+    const client = mount();
+    const detailKey = queryKeys.issue('ENG-3');
+    client.setQueryData(detailKey, detailFor(issue(), []));
+    const originalReset = client.resetQueries.bind(client);
+    client.resetQueries = (filters, options) =>
+      originalReset(filters, options).then(() => Promise.reject(new Error('detail reset failed')));
+
+    try {
+      act(() => capturedHandler?.([deleteAction('issue_1', 'ENG-3')]));
+      await Promise.resolve();
+
+      expect(client.getQueryData(detailKey)).toBeUndefined();
+    } finally {
+      client.resetQueries = originalReset;
+    }
   });
 
   it('takes a deleted child out of the sub issue list its parent still shows', () => {

--- a/apps/web/tests/lib/realtime/delta-bridge.test.tsx
+++ b/apps/web/tests/lib/realtime/delta-bridge.test.tsx
@@ -816,17 +816,21 @@ describe('DeltaBridge ordering', () => {
     const stale = deferred<ReturnType<typeof detailFor>>();
     const fresh = deferred<ReturnType<typeof detailFor>>();
     const requests: string[] = [];
+    const arrived = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 40 });
+    let previousRequests = 0;
     const previousObserver = new QueryObserver(client, {
       queryKey: previousKey,
       queryFn: () => {
         requests.push('ENG-3');
-        return stale.promise;
+        previousRequests += 1;
+        return previousRequests === 1
+          ? stale.promise
+          : Promise.resolve({ ...detailFor(arrived, []), descriptionHtml: 'Canonical detail' });
       },
       retry: false,
     });
     const unsubscribePrevious = previousObserver.subscribe(() => undefined);
     await waitFor(() => expect(requests).toEqual(['ENG-3']));
-    const arrived = issue({ teamId: 'team_design', identifier: 'DSGN-4', syncId: 40 });
 
     act(() =>
       capturedHandler?.([
@@ -855,7 +859,10 @@ describe('DeltaBridge ordering', () => {
       ),
     );
     expect(client.getQueryData<ReturnType<typeof detailFor>>(nextKey)?.issue).toEqual(arrived);
-    expect(requests).toEqual(['ENG-3']);
+    await waitFor(() => expect(requests).toEqual(['ENG-3', 'ENG-3']));
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(previousKey)?.descriptionHtml).toBe(
+      'Canonical detail',
+    );
 
     const nextObserver = new QueryObserver(client, {
       queryKey: nextKey,
@@ -866,7 +873,7 @@ describe('DeltaBridge ordering', () => {
       retry: false,
     });
     const unsubscribeNext = nextObserver.subscribe(() => undefined);
-    await waitFor(() => expect(requests).toEqual(['ENG-3', 'DSGN-4']));
+    await waitFor(() => expect(requests).toEqual(['ENG-3', 'ENG-3', 'DSGN-4']));
     fresh.resolve(detailFor(arrived, []));
     await waitFor(() =>
       expect(client.getQueryData<ReturnType<typeof detailFor>>(nextKey)?.issue.syncId).toBe(40),
@@ -879,7 +886,7 @@ describe('DeltaBridge ordering', () => {
       identifier: 'DSGN-4',
       syncId: 40,
     });
-    expect(requests).toEqual(['ENG-3', 'DSGN-4']);
+    expect(requests).toEqual(['ENG-3', 'ENG-3', 'DSGN-4']);
     unsubscribePrevious();
     unsubscribeNext();
   });

--- a/apps/web/tests/lib/realtime/delta-bridge.test.tsx
+++ b/apps/web/tests/lib/realtime/delta-bridge.test.tsx
@@ -1,9 +1,14 @@
 import { describe, expect, it, mock } from 'bun:test';
 import type { SyncAction } from '@orbit/shared/events';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, render } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, QueryObserver } from '@tanstack/react-query';
+import { act, render, waitFor } from '@testing-library/react';
 import { ANALYTICS_ROOT } from '@/features/analytics/analytics-keys.ts';
 import { clientId } from '@/lib/query/client-id.ts';
+import {
+  issueDeletionGeneration,
+  issueListRevisionGeneration,
+  issueRevisionGeneration,
+} from '@/lib/query/issue-cache-generation.ts';
 import {
   BOARD_ROOT,
   BOOTSTRAP_ROOT,
@@ -39,6 +44,20 @@ mock.module('@orbit/realtime-client/react', () => ({
 const { DeltaBridge } = await import('../../../src/lib/realtime/delta-bridge.tsx');
 
 const TEAM = 'team_eng';
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (resolvePromise === undefined) throw new Error('deferred promise did not initialize');
+  return { promise, resolve: resolvePromise };
+}
 
 function issue(overrides: Partial<Issue> = {}): Issue {
   return {
@@ -152,9 +171,13 @@ function trackInvalidations(client: QueryClient): unknown[][] {
 describe('DeltaBridge origin suppression', () => {
   it('applies a delta that originated in another tab of the same user', () => {
     const client = mount();
+    const generation = issueRevisionGeneration(client, 'issue_1');
+    const listGeneration = issueListRevisionGeneration(client, queryKeys.issues(TEAM));
     expect(capturedHandler).not.toBeNull();
     act(() => capturedHandler?.([renameAction('other-tab-client-id', 'Renamed elsewhere')]));
     expect(titleIn(client)).toBe('Renamed elsewhere');
+    expect(issueRevisionGeneration(client, 'issue_1')).toBe(generation + 1);
+    expect(issueListRevisionGeneration(client, queryKeys.issues(TEAM))).toBe(listGeneration + 1);
   });
 
   it('skips a delta that this tab originated', () => {
@@ -168,6 +191,85 @@ describe('DeltaBridge origin suppression', () => {
     const { originClientId: _ignored, ...withoutOrigin } = renameAction('unused', 'From the MCP');
     act(() => capturedHandler?.([withoutOrigin]));
     expect(titleIn(client)).toBe('From the MCP');
+  });
+
+  it('marks an overlapping list fetch when a missing row is deleted', async () => {
+    const client = mount();
+    const key = queryKeys.issues(TEAM);
+    const pending = deferred<IssuePages>();
+    const request = client.fetchQuery({ queryKey: key, queryFn: () => pending.promise });
+    const generation = issueListRevisionGeneration(client, key);
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          modelId: 'issue_2',
+          data: { id: 'issue_2', teamId: TEAM },
+        }),
+      ]),
+    );
+
+    expect(issueListRevisionGeneration(client, key)).toBe(generation + 1);
+    const current = client.getQueryData<IssuePages>(key);
+    if (current === undefined) throw new Error('missing issue pages');
+    pending.resolve(current);
+    await request;
+  });
+
+  it('cancels a stale list fetch before applying a realtime deletion', async () => {
+    const client = mount();
+    const key = queryKeys.issues(TEAM);
+    const pending = deferred<IssuePages>();
+    const request = client
+      .fetchQuery({ queryKey: key, queryFn: () => pending.promise })
+      .catch(() => undefined);
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          action: 'delete',
+          modelId: 'issue_1',
+          data: { id: 'issue_1', teamId: TEAM },
+        }),
+      ]),
+    );
+    expect(client.getQueryData<IssuePages>(key)?.pages[0]?.issues).toEqual([]);
+
+    pending.resolve({
+      pages: [{ issues: [issue()], nextCursor: null }],
+      pageParams: [null],
+    });
+    await request;
+
+    expect(client.getQueryData<IssuePages>(key)?.pages[0]?.issues).toEqual([]);
+  });
+
+  it('does not mark an overlapping team list for another team action', async () => {
+    const client = mount();
+    const key = queryKeys.issues(TEAM, `teamId=${TEAM}`);
+    const pages: IssuePages = {
+      pages: [{ issues: [issue()], nextCursor: null }],
+      pageParams: [null],
+    };
+    client.setQueryData(key, pages);
+    const pending = deferred<IssuePages>();
+    const request = client.fetchQuery({ queryKey: key, queryFn: () => pending.promise });
+    const generation = issueListRevisionGeneration(client, key);
+
+    act(() =>
+      capturedHandler?.([
+        action({
+          scopes: ['team:team_other'],
+          modelId: 'issue_2',
+          data: { ...issue({ id: 'issue_2', teamId: 'team_other' }), syncId: 11 },
+        }),
+      ]),
+    );
+
+    expect(issueListRevisionGeneration(client, key)).toBe(generation);
+    pending.resolve(pages);
+    await request;
   });
 });
 
@@ -214,6 +316,75 @@ describe('DeltaBridge ordering', () => {
       ]),
     );
     expect(titleIn(client)).toBe('Newest');
+  });
+
+  it('cancels a stale detail fetch before applying a newer realtime update', async () => {
+    const client = mount();
+    const key = queryKeys.issue('ENG-3');
+    client.setQueryData(key, detailFor(issue(), []));
+    const pendingDetail = deferred<ReturnType<typeof detailFor>>();
+    const refetch = client
+      .fetchQuery({ queryKey: key, queryFn: () => pendingDetail.promise })
+      .catch(() => undefined);
+    await waitFor(() => expect(client.getQueryState(key)?.fetchStatus).toBe('fetching'));
+
+    act(() =>
+      capturedHandler?.([
+        action({ syncId: 40, data: { id: 'issue_1', title: 'Newest detail', syncId: 40 } }),
+      ]),
+    );
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(key)?.issue).toMatchObject({
+      title: 'Newest detail',
+      syncId: 40,
+    });
+
+    pendingDetail.resolve(detailFor(issue({ title: 'Stale response', syncId: 11 }), []));
+    await refetch;
+    await Promise.resolve();
+
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(key)?.issue).toMatchObject({
+      title: 'Newest detail',
+      syncId: 40,
+    });
+  });
+
+  it('restarts an initial detail fetch when its issue updates in realtime', async () => {
+    const client = mount();
+    const key = queryKeys.issue('ENG-3');
+    const staleDetail = deferred<ReturnType<typeof detailFor>>();
+    const freshDetail = deferred<ReturnType<typeof detailFor>>();
+    let requests = 0;
+    const observer = new QueryObserver(client, {
+      queryKey: key,
+      queryFn: () => {
+        requests += 1;
+        return requests === 1 ? staleDetail.promise : freshDetail.promise;
+      },
+      retry: false,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+    await waitFor(() => expect(requests).toBe(1));
+
+    act(() =>
+      capturedHandler?.([
+        action({ syncId: 40, data: { id: 'issue_1', title: 'Newest detail', syncId: 40 } }),
+      ]),
+    );
+    await waitFor(() => expect(requests).toBe(2));
+    freshDetail.resolve(detailFor(issue({ title: 'Newest detail', syncId: 40 }), []));
+    await waitFor(() =>
+      expect(client.getQueryData<ReturnType<typeof detailFor>>(key)?.issue.syncId).toBe(40),
+    );
+
+    staleDetail.resolve(detailFor(issue({ title: 'Stale response', syncId: 11 }), []));
+    await staleDetail.promise;
+    await Promise.resolve();
+
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(key)?.issue).toMatchObject({
+      title: 'Newest detail',
+      syncId: 40,
+    });
+    unsubscribe();
   });
 
   it('keeps a delta for another team out of this team list', () => {
@@ -522,6 +693,7 @@ function detailFor(row: Issue, subIssues: readonly Issue[]) {
     activity: [],
     activityCursor: null,
     subIssues,
+    parent: null,
     subscribed: false,
   };
 }
@@ -535,10 +707,12 @@ describe('DeltaBridge deletions', () => {
   it('drops the row from a list somebody else is looking at', () => {
     const client = mount();
     expect(idsIn(client)).toEqual(['issue_1']);
+    const generation = issueDeletionGeneration(client, 'issue_1');
 
     act(() => capturedHandler?.([deleteAction('issue_1', 'ENG-3')]));
 
     expect(idsIn(client)).toEqual([]);
+    expect(issueDeletionGeneration(client, 'issue_1')).toBe(generation + 1);
   });
 
   it('forgets the open detail for the issue that was deleted', () => {
@@ -562,6 +736,47 @@ describe('DeltaBridge deletions', () => {
     );
     expect(parent?.subIssues).toEqual([]);
     expect(parent?.issue.id).toBe('issue_1');
+  });
+
+  it('orphans a cached child detail when its parent is deleted', () => {
+    const client = mount();
+    const parent = issue();
+    const child = issue({ id: 'issue_child', identifier: 'ENG-4', parentId: parent.id });
+    client.setQueryData(queryKeys.issue(child.identifier), {
+      ...detailFor(child, []),
+      parent,
+    });
+
+    act(() => capturedHandler?.([deleteAction(parent.id, parent.identifier)]));
+
+    const detail = client.getQueryData<ReturnType<typeof detailFor>>(
+      queryKeys.issue(child.identifier),
+    );
+    expect(detail?.issue.parentId).toBeNull();
+    expect(detail?.parent).toBeNull();
+  });
+
+  it('cancels a pending parent detail before a deleted child can reappear', async () => {
+    const client = mount();
+    const parent = issue();
+    const child = issue({ id: 'issue_child', identifier: 'ENG-4', parentId: parent.id });
+    const key = queryKeys.issue(parent.identifier);
+    client.setQueryData(key, detailFor(parent, []));
+    const pendingDetail = deferred<ReturnType<typeof detailFor>>();
+    const refetch = client
+      .fetchQuery({ queryKey: key, queryFn: () => pendingDetail.promise })
+      .catch(() => undefined);
+    await waitFor(() => expect(client.getQueryState(key)?.fetchStatus).toBe('fetching'));
+
+    act(() => capturedHandler?.([deleteAction(child.id, child.identifier)]));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    pendingDetail.resolve(detailFor(parent, [child]));
+    await refetch;
+    await Promise.resolve();
+
+    expect(client.getQueryData<ReturnType<typeof detailFor>>(key)?.subIssues).toEqual([]);
   });
 
   it('frees a cached child when the parent delete is followed by its own update', () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,10 +131,12 @@ because the announcement is the thing that fails when a process dies.
 
 ### Reconnecting
 
-The client tracks the last `syncId` it saw. On reconnect it asks for everything
-since, and gets a replay rather than a refetch. The reconnect banner only
-appears once retries have actually been failing, so a blip does not flash a
-warning at anyone.
+The client tracks the last `syncId` it saw. On reconnect it asks for current
+rows changed since that watermark. Issue list and detail caches are reset and
+refetched because a current-row replay cannot reconstruct a hard delete or the
+team an issue moved from. Durable event recovery for those cases is tracked by
+RT-001. The reconnect banner only appears once retries have actually been
+failing, so a blip does not flash a warning at anyone.
 
 ### Why node, and not Bun
 

--- a/packages/core/src/content/attachment-service.ts
+++ b/packages/core/src/content/attachment-service.ts
@@ -19,7 +19,7 @@ import { type Executor, newId, requireRow } from '../internal.ts';
 import { lockOrganization } from '../org/organization-lock.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
-import { getProject } from '../work/project-service.ts';
+import { getProject, projectReachScopes, projectTeamIds } from '../work/project-service.ts';
 import { loadReadableDoc } from './doc-service.ts';
 
 export type AttachmentRecord = typeof schema.attachment.$inferSelect;
@@ -38,21 +38,121 @@ export async function resolveAttachmentScopes(
   row: Pick<AttachmentRecord, 'parentType' | 'parentId' | 'uploadedById'>,
   organizationId: string,
 ): Promise<string[]> {
-  if (row.parentType !== 'comment') return attachmentScopes(row);
-  const [comment] = await executor
-    .select({ issueId: schema.comment.issueId })
-    .from(schema.comment)
-    .where(
-      and(eq(schema.comment.id, row.parentId), eq(schema.comment.organizationId, organizationId)),
-    )
-    .limit(1);
-  if (comment === undefined) return [scopes.user(row.uploadedById)];
-  return [scopes.issue(comment.issueId)];
+  if (row.parentType === 'issue') {
+    const [issue] = await executor
+      .select({ id: schema.issue.id, teamId: schema.issue.teamId })
+      .from(schema.issue)
+      .where(
+        and(eq(schema.issue.id, row.parentId), eq(schema.issue.organizationId, organizationId)),
+      )
+      .limit(1);
+    if (issue === undefined) return [scopes.user(row.uploadedById)];
+    return [scopes.team(issue.teamId), scopes.issue(issue.id)];
+  }
+  if (row.parentType === 'comment') {
+    const [comment] = await executor
+      .select({ issueId: schema.comment.issueId, teamId: schema.issue.teamId })
+      .from(schema.comment)
+      .innerJoin(schema.issue, eq(schema.issue.id, schema.comment.issueId))
+      .where(
+        and(eq(schema.comment.id, row.parentId), eq(schema.comment.organizationId, organizationId)),
+      )
+      .limit(1);
+    if (comment === undefined) return [scopes.user(row.uploadedById)];
+    return [scopes.team(comment.teamId), scopes.issue(comment.issueId)];
+  }
+  if (row.parentType === 'project') {
+    const [project] = await executor
+      .select({ id: schema.project.id, organizationId: schema.project.organizationId })
+      .from(schema.project)
+      .where(
+        and(eq(schema.project.id, row.parentId), eq(schema.project.organizationId, organizationId)),
+      )
+      .limit(1);
+    if (project === undefined) return [scopes.user(row.uploadedById)];
+    return projectReachScopes(
+      project.organizationId,
+      project.id,
+      await projectTeamIds(executor, project.id),
+    );
+  }
+  return attachmentScopes(row);
 }
 
 export interface CompletedAttachment {
   readonly attachment: AttachmentRecord;
   readonly actions: SyncAction[];
+}
+
+type UploadParentType = Parameters<typeof assertUploadParent>[2];
+
+function isUploadParentType(value: string): value is UploadParentType {
+  return value === 'issue' || value === 'comment' || value === 'doc' || value === 'project';
+}
+
+async function lockAttachmentParent(
+  tx: Transaction,
+  row: Pick<AttachmentRecord, 'parentType' | 'parentId'>,
+  organizationId: string,
+): Promise<void> {
+  if (row.parentType === 'issue') {
+    await tx
+      .select({ id: schema.issue.id })
+      .from(schema.issue)
+      .where(
+        and(eq(schema.issue.id, row.parentId), eq(schema.issue.organizationId, organizationId)),
+      )
+      .for('update')
+      .limit(1);
+    return;
+  }
+  if (row.parentType === 'comment') {
+    const [comment] = await tx
+      .select({ issueId: schema.comment.issueId })
+      .from(schema.comment)
+      .where(
+        and(eq(schema.comment.id, row.parentId), eq(schema.comment.organizationId, organizationId)),
+      )
+      .limit(1);
+    if (comment === undefined) return;
+    await tx
+      .select({ id: schema.issue.id })
+      .from(schema.issue)
+      .where(
+        and(eq(schema.issue.id, comment.issueId), eq(schema.issue.organizationId, organizationId)),
+      )
+      .for('update')
+      .limit(1);
+    const [lockedComment] = await tx
+      .select({ deletedAt: schema.comment.deletedAt })
+      .from(schema.comment)
+      .where(
+        and(eq(schema.comment.id, row.parentId), eq(schema.comment.organizationId, organizationId)),
+      )
+      .for('update')
+      .limit(1);
+    if (lockedComment?.deletedAt !== null) throw notFound('That comment does not exist.');
+    return;
+  }
+  if (row.parentType === 'doc') {
+    await tx
+      .select({ id: schema.doc.id })
+      .from(schema.doc)
+      .where(and(eq(schema.doc.id, row.parentId), eq(schema.doc.organizationId, organizationId)))
+      .for('update')
+      .limit(1);
+    return;
+  }
+  if (row.parentType === 'project') {
+    await tx
+      .select({ id: schema.project.id })
+      .from(schema.project)
+      .where(
+        and(eq(schema.project.id, row.parentId), eq(schema.project.organizationId, organizationId)),
+      )
+      .for('update')
+      .limit(1);
+  }
 }
 
 export async function findAttachmentForOrganization(
@@ -79,11 +179,48 @@ export async function markAttachmentReady(
   storedSize: number,
 ): Promise<CompletedAttachment> {
   return await db.transaction(async (tx) => {
+    const [candidate] = await tx
+      .select()
+      .from(schema.attachment)
+      .where(
+        and(
+          eq(schema.attachment.id, record.id),
+          eq(schema.attachment.organizationId, principal.organizationId),
+          eq(schema.attachment.uploadedById, principal.userId),
+        ),
+      )
+      .limit(1);
+    if (candidate === undefined) throw notFound('That upload was not registered.');
+    if (isUploadParentType(candidate.parentType)) {
+      await lockAttachmentParent(tx, candidate, principal.organizationId);
+    }
+    const [current] = await tx
+      .select()
+      .from(schema.attachment)
+      .where(
+        and(
+          eq(schema.attachment.id, record.id),
+          eq(schema.attachment.organizationId, principal.organizationId),
+          eq(schema.attachment.uploadedById, principal.userId),
+        ),
+      )
+      .for('update')
+      .limit(1);
+    if (
+      current === undefined ||
+      current.parentType !== candidate.parentType ||
+      current.parentId !== candidate.parentId
+    ) {
+      throw notFound('That upload was not registered.');
+    }
+    if (isUploadParentType(current.parentType)) {
+      await assertUploadParent(tx, principal, current.parentType, current.parentId);
+    }
     const syncId = await nextSyncId(tx);
     const [updated] = await tx
       .update(schema.attachment)
       .set({ status: 'ready', size: storedSize, syncId })
-      .where(eq(schema.attachment.id, record.id))
+      .where(eq(schema.attachment.id, current.id))
       .returning();
     if (updated === undefined) throw notFound('That upload was not registered.');
 
@@ -184,6 +321,7 @@ export async function registerUpload(
   return await db.transaction(async (tx) => {
     const organization = await lockOrganization(tx, principal.organizationId);
     assertOrganizationAcceptsFiles(organization);
+    await lockAttachmentParent(tx, parsed, principal.organizationId);
     await assertUploadParent(tx, principal, parsed.parentType, parsed.parentId);
     const store = driver ?? storageDriver();
     const target = await store.createUploadTarget(key, upload.contentType, upload.size);
@@ -241,6 +379,7 @@ export async function attachFile(
     return await db.transaction(async (tx) => {
       const organization = await lockOrganization(tx, principal.organizationId);
       assertOrganizationAcceptsFiles(organization);
+      await lockAttachmentParent(tx, parsed, principal.organizationId);
       await assertUploadParent(tx, principal, parsed.parentType, parsed.parentId);
       store ??= storageDriver();
       await store.put(key, bytes, upload.contentType);

--- a/packages/core/src/content/doc-service.ts
+++ b/packages/core/src/content/doc-service.ts
@@ -1430,6 +1430,13 @@ export async function deleteDoc(principal: Principal, docId: string): Promise<De
   assertCan(principal, 'doc:write');
 
   return await db.transaction(async (tx) => {
+    const [locked] = await tx
+      .select({ id: schema.doc.id })
+      .from(schema.doc)
+      .where(and(eq(schema.doc.id, docId), eq(schema.doc.organizationId, principal.organizationId)))
+      .for('update')
+      .limit(1);
+    requireRow(locked, 'That doc does not exist.');
     const current = await loadReadableDoc(tx, principal, docId);
     if (principal.role !== 'admin' && current.authorId !== principal.userId) {
       throw forbidden('Only the author or an admin can delete a doc for good.');

--- a/packages/core/src/org/starter-content.ts
+++ b/packages/core/src/org/starter-content.ts
@@ -231,17 +231,11 @@ export async function seedStarterContent(
       .returning();
     if (issue === undefined) continue;
     await captureCreatedCycleMembership(executor, { issue, occurredAt: now });
-    const issueScopes = [
-      scopes.organization(params.organizationId),
-      scopes.team(params.team.id),
-      scopes.issue(issue.id),
-    ];
-    if (issue.projectId !== null) issueScopes.push(scopes.project(issue.projectId));
     actions.push(
       buildSyncAction({
         syncId: params.syncId,
         organizationId: params.organizationId,
-        scopes: issueScopes,
+        scopes: [scopes.team(params.team.id), scopes.issue(issue.id)],
         action: 'insert',
         model: 'issue',
         modelId: issue.id,

--- a/packages/core/src/realtime/backfill.ts
+++ b/packages/core/src/realtime/backfill.ts
@@ -38,6 +38,11 @@ type AttachmentParent = {
   readonly parentId: string;
 };
 
+interface AttachmentReach {
+  readonly issueId: string | null;
+  readonly teamIds: readonly string[];
+}
+
 function withoutBody<T extends { content: string }>(row: T): Omit<T, 'content'> {
   const { content: _body, ...rest } = row;
   return rest;
@@ -60,68 +65,128 @@ async function readableDocIds(
 async function issueTeamsById(
   executor: Executor,
   issueIds: readonly string[],
+  organizationId: string,
 ): Promise<Map<string, string>> {
   const ids = [...new Set(issueIds)];
   if (ids.length === 0) return new Map();
   const rows = await executor
     .select({ id: schema.issue.id, teamId: schema.issue.teamId })
     .from(schema.issue)
-    .where(inArray(schema.issue.id, ids));
+    .where(and(inArray(schema.issue.id, ids), eq(schema.issue.organizationId, organizationId)));
   return new Map(rows.map((row) => [row.id, row.teamId]));
 }
 
-async function commentTeamsById(
+async function commentIssueReachById(
   executor: Executor,
   commentIds: readonly string[],
-): Promise<Map<string, string>> {
+  organizationId: string,
+): Promise<Map<string, { readonly issueId: string; readonly teamId: string }>> {
   const ids = [...new Set(commentIds)];
   if (ids.length === 0) return new Map();
   const rows = await executor
-    .select({ id: schema.comment.id, teamId: schema.issue.teamId })
+    .select({ id: schema.comment.id, issueId: schema.issue.id, teamId: schema.issue.teamId })
     .from(schema.comment)
     .innerJoin(schema.issue, eq(schema.issue.id, schema.comment.issueId))
-    .where(inArray(schema.comment.id, ids));
-  return new Map(rows.map((row) => [row.id, row.teamId]));
+    .where(
+      and(
+        inArray(schema.comment.id, ids),
+        eq(schema.comment.organizationId, organizationId),
+        eq(schema.issue.organizationId, organizationId),
+      ),
+    );
+  return new Map(
+    rows.map((row) => [row.id, { issueId: row.issueId, teamId: row.teamId }] as const),
+  );
 }
 
-async function teamsByAttachmentParent(
+async function attachmentReachByParent(
   executor: Executor,
   rows: readonly AttachmentParent[],
-): Promise<Map<string, string[]>> {
+  organizationId: string,
+): Promise<Map<string, AttachmentReach>> {
   const of = (type: string) => rows.filter((row) => row.parentType === type);
   const issueParents = of('issue');
   const commentParents = of('comment');
   const projectParents = of('project');
 
-  const [issueTeams, commentTeams, projectTeams] = await Promise.all([
+  const [issueTeams, commentIssueReach, projectTeams] = await Promise.all([
     issueTeamsById(
       executor,
       issueParents.map((row) => row.parentId),
+      organizationId,
     ),
-    commentTeamsById(
+    commentIssueReachById(
       executor,
       commentParents.map((row) => row.parentId),
+      organizationId,
     ),
     teamsByProject(
       executor,
       projectParents.map((row) => row.parentId),
     ),
   ]);
+  const projectIds = [...new Set(projectParents.map((row) => row.parentId))];
+  const existingProjects =
+    projectIds.length === 0
+      ? new Set<string>()
+      : new Set(
+          (
+            await executor
+              .select({ id: schema.project.id })
+              .from(schema.project)
+              .where(
+                and(
+                  inArray(schema.project.id, projectIds),
+                  eq(schema.project.organizationId, organizationId),
+                ),
+              )
+          ).map((row) => row.id),
+        );
 
-  const byAttachment = new Map<string, string[]>();
+  const byAttachment = new Map<string, AttachmentReach>();
   for (const row of issueParents) {
     const teamId = issueTeams.get(row.parentId);
-    if (teamId !== undefined) byAttachment.set(row.id, [teamId]);
+    if (teamId !== undefined) {
+      byAttachment.set(row.id, { issueId: row.parentId, teamIds: [teamId] });
+    }
   }
   for (const row of commentParents) {
-    const teamId = commentTeams.get(row.parentId);
-    if (teamId !== undefined) byAttachment.set(row.id, [teamId]);
+    const reach = commentIssueReach.get(row.parentId);
+    if (reach !== undefined) {
+      byAttachment.set(row.id, { issueId: reach.issueId, teamIds: [reach.teamId] });
+    }
   }
   for (const row of projectParents) {
+    if (!existingProjects.has(row.parentId)) continue;
     const found = projectTeams.get(row.parentId) ?? [];
-    if (found.length > 0) byAttachment.set(row.id, found);
+    byAttachment.set(row.id, { issueId: null, teamIds: found });
   }
   return byAttachment;
+}
+
+function attachmentBackfillScopes(
+  row: typeof schema.attachment.$inferSelect,
+  reach: AttachmentReach | undefined,
+  principal: Principal,
+): string[] | null {
+  const organizationScope = scopes.organization(row.organizationId);
+  if (row.parentType === 'doc') return [organizationScope, scopes.doc(row.parentId)];
+  if (row.parentType === 'project') {
+    if (reach === undefined) return null;
+    return [
+      organizationScope,
+      scopes.project(row.parentId),
+      ...(reach?.teamIds ?? []).map(scopes.team),
+    ];
+  }
+  if (row.parentType === 'issue' || row.parentType === 'comment') {
+    if (reach?.issueId === null || reach?.issueId === undefined || reach.teamIds.length === 0) {
+      return null;
+    }
+    return [organizationScope, ...reach.teamIds.map(scopes.team), scopes.issue(reach.issueId)];
+  }
+  if (row.uploadedById !== principal.userId) return null;
+  return [organizationScope, scopes.user(row.uploadedById)];
 }
 
 async function teamsByProject(
@@ -386,15 +451,11 @@ const LOADERS: Record<SyncModel, Loader> = {
     return rows.map((row) => ({
       modelId: row.id,
       syncId: row.syncId,
-      scopes:
-        row.projectId === null
-          ? [scopes.organization(row.organizationId), scopes.team(row.teamId), scopes.issue(row.id)]
-          : [
-              scopes.organization(row.organizationId),
-              scopes.team(row.teamId),
-              scopes.issue(row.id),
-              scopes.project(row.projectId),
-            ],
+      scopes: [
+        scopes.organization(row.organizationId),
+        scopes.team(row.teamId),
+        scopes.issue(row.id),
+      ],
       data: {
         ...row,
         labelIds: labels.get(row.id) ?? [],
@@ -424,7 +485,6 @@ const LOADERS: Record<SyncModel, Loader> = {
         scopes.organization(row.organizationId),
         scopes.team(teamId),
         scopes.issue(row.issueId),
-        scopes.issue(row.relatedIssueId),
       ],
       data: row,
     })),
@@ -447,7 +507,7 @@ const LOADERS: Record<SyncModel, Loader> = {
     ).map(({ row }) => ({
       modelId: `${row.issueId}:${row.userId}`,
       syncId: row.syncId,
-      scopes: [scopes.issue(row.issueId), scopes.user(row.userId)],
+      scopes: [scopes.user(row.userId)],
       data: row,
     })),
 
@@ -539,7 +599,7 @@ const LOADERS: Record<SyncModel, Loader> = {
       )
       .orderBy(asc(schema.attachment.syncId))
       .limit(limit);
-    const teams = await teamsByAttachmentParent(executor, rows);
+    const reach = await attachmentReachByParent(executor, rows, principal.organizationId);
     const readableDocs = await readableDocIds(
       executor,
       principal,
@@ -547,19 +607,11 @@ const LOADERS: Record<SyncModel, Loader> = {
     );
     return rows
       .filter((row) => row.parentType !== 'doc' || readableDocs.has(row.parentId))
-      .map((row) => ({
-        modelId: row.id,
-        syncId: row.syncId,
-        scopes:
-          row.parentType === 'doc'
-            ? [scopes.organization(row.organizationId), scopes.doc(row.parentId)]
-            : [
-                scopes.organization(row.organizationId),
-                scopes.issue(row.parentId),
-                ...(teams.get(row.id) ?? []).map(scopes.team),
-              ],
-        data: row,
-      }));
+      .flatMap((row) => {
+        const rowScopes = attachmentBackfillScopes(row, reach.get(row.id), principal);
+        if (rowScopes === null) return [];
+        return [{ modelId: row.id, syncId: row.syncId, scopes: rowScopes, data: row }];
+      });
   },
 
   doc: async (executor, principal, since, limit) =>

--- a/packages/core/src/work/issue-fields.ts
+++ b/packages/core/src/work/issue-fields.ts
@@ -4,12 +4,8 @@ import { scopes } from '@orbit/shared/events';
 export type IssueRow = typeof schema.issue.$inferSelect;
 export type IssueValues = Partial<typeof schema.issue.$inferInsert>;
 
-export function issueScopes(
-  row: Pick<IssueRow, 'organizationId' | 'teamId' | 'id' | 'projectId'>,
-): string[] {
-  const list = [scopes.team(row.teamId), scopes.issue(row.id)];
-  if (row.projectId !== null) list.push(scopes.project(row.projectId));
-  return list;
+export function issueScopes(row: Pick<IssueRow, 'teamId' | 'id'>): string[] {
+  return [scopes.team(row.teamId), scopes.issue(row.id)];
 }
 
 export function stateTimestamps(category: string, now: Date): IssueValues {

--- a/packages/core/src/work/issue-service.ts
+++ b/packages/core/src/work/issue-service.ts
@@ -128,6 +128,7 @@ function issueAction(
   actor: Actor,
   action: 'insert' | 'update' | 'delete' | 'archive' | 'unarchive',
   decorations: { readonly labelIds: readonly string[]; readonly reviewerIds: readonly string[] },
+  teamChanged = false,
 ): SyncAction {
   return buildSyncAction({
     syncId,
@@ -140,6 +141,26 @@ function issueAction(
       ...row,
       labelIds: [...decorations.labelIds],
       reviewerIds: [...decorations.reviewerIds],
+      ...(teamChanged ? { teamChanged: true } : {}),
+    },
+    actor,
+  });
+}
+
+function issueDepartureAction(row: IssueRow, syncId: number, actor: Actor): SyncAction {
+  return buildSyncAction({
+    syncId,
+    organizationId: row.organizationId,
+    scopes: [scopes.team(row.teamId), scopes.issue(row.id)],
+    action: 'delete',
+    model: 'issue',
+    modelId: row.id,
+    data: {
+      id: row.id,
+      teamId: row.teamId,
+      identifier: row.identifier,
+      departure: true,
+      syncId,
     },
     actor,
   });
@@ -1446,6 +1467,16 @@ export async function moveIssue(
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
 
+    if (changingTeam) {
+      await tx.insert(schema.issueIdentifierAlias).values({
+        id: newId(),
+        organizationId: principal.organizationId,
+        identifier: current.identifier,
+        issueId: current.id,
+        syncId,
+      });
+    }
+
     const landing = await landingOrder(tx, parsed, teamId, state.id, syncId);
     const rebalanced = landing.rebalanced;
 
@@ -1502,11 +1533,19 @@ export async function moveIssue(
       issue,
       rebalanced,
       actions: [
+        ...(changingTeam ? [issueDepartureAction(current, syncId, actor)] : []),
         ...affected.map((row) =>
-          issueAction(row, syncId, actor, 'update', {
-            labelIds: decorations.labels.get(row.id) ?? [],
-            reviewerIds: decorations.reviewers.get(row.id) ?? [],
-          }),
+          issueAction(
+            row,
+            syncId,
+            actor,
+            'update',
+            {
+              labelIds: decorations.labels.get(row.id) ?? [],
+              reviewerIds: decorations.reviewers.get(row.id) ?? [],
+            },
+            changingTeam && row.id === issue.id,
+          ),
         ),
         ...notifications,
       ],
@@ -2190,15 +2229,35 @@ export async function getIssueFacets(
 export async function getIssue(principal: Principal, idOrIdentifier: string): Promise<IssueRow> {
   assertCan(principal, 'issue:read');
   const parsed = parseIssueIdentifier(idOrIdentifier);
-  const match =
-    parsed === null
-      ? eq(schema.issue.id, idOrIdentifier)
-      : eq(schema.issue.identifier, issueIdentifier(parsed.prefix, parsed.number));
-  const [row] = await db
+  const identifier = parsed === null ? null : issueIdentifier(parsed.prefix, parsed.number);
+  const [direct] = await db
     .select()
     .from(schema.issue)
-    .where(and(eq(schema.issue.organizationId, principal.organizationId), match))
+    .where(
+      and(
+        eq(schema.issue.organizationId, principal.organizationId),
+        identifier === null
+          ? eq(schema.issue.id, idOrIdentifier)
+          : eq(schema.issue.identifier, identifier),
+      ),
+    )
     .limit(1);
+  const [aliased] =
+    direct !== undefined || identifier === null
+      ? []
+      : await db
+          .select(getTableColumns(schema.issue))
+          .from(schema.issueIdentifierAlias)
+          .innerJoin(schema.issue, eq(schema.issue.id, schema.issueIdentifierAlias.issueId))
+          .where(
+            and(
+              eq(schema.issueIdentifierAlias.organizationId, principal.organizationId),
+              eq(schema.issueIdentifierAlias.identifier, identifier),
+              eq(schema.issue.organizationId, principal.organizationId),
+            ),
+          )
+          .limit(1);
+  const row = direct ?? aliased;
   const issue = requireRow(row, 'That issue does not exist.');
   if (!isInTeam(principal, teamScope(issue))) throw notFound('That issue does not exist.');
   return issue;
@@ -2214,6 +2273,15 @@ export async function listIssueLabels(
     .select({ labelId: schema.issueLabel.labelId })
     .from(schema.issueLabel)
     .where(eq(schema.issueLabel.issueId, issueId));
+}
+
+function relationScopes(
+  row: Pick<IssueRelationRow, 'issueId'>,
+  source: Pick<IssueRow, 'id' | 'teamId'>,
+  target: Pick<IssueRow, 'id' | 'teamId'>,
+): string[] {
+  const owner = row.issueId === source.id ? source : target;
+  return [scopes.team(owner.teamId), scopes.issue(owner.id)];
 }
 
 export async function setRelation(
@@ -2276,7 +2344,7 @@ export async function setRelation(
         buildSyncAction({
           syncId,
           organizationId: principal.organizationId,
-          scopes: [scopes.issue(row.issueId), scopes.issue(row.relatedIssueId)],
+          scopes: relationScopes(row, source, target),
           action: 'insert',
           model: 'issue_relation',
           modelId: row.id,
@@ -2297,8 +2365,8 @@ export async function removeRelation(
   const parsed = issueRelationSchema.parse(input);
 
   return await db.transaction(async (tx) => {
-    await loadIssue(tx, principal, issueId);
-    await loadIssue(tx, principal, parsed.relatedIssueId);
+    const source = await loadIssue(tx, principal, issueId);
+    const target = await loadIssue(tx, principal, parsed.relatedIssueId);
 
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
@@ -2330,7 +2398,7 @@ export async function removeRelation(
       buildSyncAction({
         syncId,
         organizationId: principal.organizationId,
-        scopes: [scopes.issue(row.issueId), scopes.issue(row.relatedIssueId)],
+        scopes: relationScopes(row, source, target),
         action: 'delete',
         model: 'issue_relation',
         modelId: row.id,
@@ -2434,7 +2502,7 @@ export async function subscribe(
         buildSyncAction({
           syncId,
           organizationId: principal.organizationId,
-          scopes: [scopes.issue(issueId), scopes.user(principal.userId)],
+          scopes: [scopes.user(principal.userId)],
           action: 'insert',
           model: 'issue_subscription',
           modelId: `${issueId}:${principal.userId}`,
@@ -2469,7 +2537,7 @@ export async function unsubscribe(
         buildSyncAction({
           syncId,
           organizationId: principal.organizationId,
-          scopes: [scopes.issue(issueId), scopes.user(principal.userId)],
+          scopes: [scopes.user(principal.userId)],
           action: 'delete',
           model: 'issue_subscription',
           modelId: `${issueId}:${principal.userId}`,

--- a/packages/core/src/work/project-service.ts
+++ b/packages/core/src/work/project-service.ts
@@ -148,6 +148,26 @@ export async function assertProjectVisible(
   }
 }
 
+async function lockProjectForMutation(
+  executor: Executor,
+  principal: Principal,
+  projectId: string,
+): Promise<void> {
+  const [row] = await executor
+    .select({ id: schema.project.id })
+    .from(schema.project)
+    .where(
+      and(
+        eq(schema.project.id, projectId),
+        eq(schema.project.organizationId, principal.organizationId),
+      ),
+    )
+    .for('update')
+    .limit(1);
+  requireRow(row, 'That project does not exist.');
+  await assertProjectVisible(executor, principal, projectId);
+}
+
 async function replaceProjectTeams(
   executor: Executor,
   projectId: string,
@@ -249,7 +269,7 @@ export async function updateProject(
   const parsed = projectUpdateSchema.parse(input);
 
   return await db.transaction(async (tx) => {
-    await assertProjectVisible(tx, principal, projectId);
+    await lockProjectForMutation(tx, principal, projectId);
     const previousReach =
       parsed.teamIds === undefined
         ? null
@@ -434,7 +454,7 @@ export async function addProjectTeam(
   assertCan(principal, 'project:manage');
 
   return await db.transaction(async (tx) => {
-    await assertProjectVisible(tx, principal, projectId);
+    await lockProjectForMutation(tx, principal, projectId);
     await assertTeamsInOrganization(tx, principal.organizationId, [teamId]);
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
@@ -465,7 +485,7 @@ export async function removeProjectTeam(
   assertCan(principal, 'project:manage');
 
   return await db.transaction(async (tx) => {
-    await assertProjectVisible(tx, principal, projectId);
+    await lockProjectForMutation(tx, principal, projectId);
     const syncId = await nextSyncId(tx);
     const actor = await principalActor(tx, principal);
     await tx

--- a/packages/core/tests/content/attachment-service.test.ts
+++ b/packages/core/tests/content/attachment-service.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import { db, eq, schema } from '@orbit/db';
+import { and, db, eq, schema } from '@orbit/db';
 import type { StorageDriver, StoredObject } from '@orbit/services/storage';
 import type { Principal } from '@orbit/shared/policy';
 import postgres from 'postgres';
@@ -13,7 +13,7 @@ import {
   registerUpload,
 } from '../../src/content/attachment-service.ts';
 import { createComment } from '../../src/content/comment-service.ts';
-import { createDoc } from '../../src/content/doc-service.ts';
+import { createDoc, deleteDoc } from '../../src/content/doc-service.ts';
 import { newId } from '../../src/internal.ts';
 import { createTeam } from '../../src/org/team-service.ts';
 import {
@@ -23,6 +23,7 @@ import {
   type Workspace,
 } from '../../src/test-support.ts';
 import { createIssue } from '../../src/work/issue-service.ts';
+import { createProject } from '../../src/work/project-service.ts';
 
 let nova: Workspace;
 let orion: Workspace;
@@ -83,8 +84,12 @@ function pause(ms: number): Promise<void> {
   });
 }
 
-async function waitForDatabaseLock(client: ReturnType<typeof postgres>): Promise<void> {
+async function waitForDatabaseLockCount(
+  client: ReturnType<typeof postgres>,
+  expected: number,
+): Promise<void> {
   const deadline = Date.now() + 5_000;
+  let waiting = 0;
   while (Date.now() < deadline) {
     const rows = await client<{ waiting: number }[]>`
       select count(*)::int as waiting
@@ -93,10 +98,35 @@ async function waitForDatabaseLock(client: ReturnType<typeof postgres>): Promise
         and pid <> pg_backend_pid()
         and wait_event_type = 'Lock'
     `;
-    if ((rows[0]?.waiting ?? 0) > 0) return;
+    waiting = rows[0]?.waiting ?? 0;
+    if (waiting >= expected) return;
     await pause(10);
   }
-  throw new Error('The upload did not wait for the organization row lock.');
+  throw new Error(`Expected ${expected} database lock waiters, found ${waiting}.`);
+}
+
+async function waitForDatabaseLock(client: ReturnType<typeof postgres>): Promise<void> {
+  await waitForDatabaseLockCount(client, 1);
+}
+
+async function pauseDocDeletionAfterAttachmentCleanup(): Promise<{
+  readonly client: ReturnType<typeof postgres>;
+  readonly deletion: ReturnType<typeof deleteDoc>;
+}> {
+  const favoriteId = newId();
+  await db.insert(schema.favorite).values({
+    id: favoriteId,
+    organizationId: nova.organizationId,
+    userId: nova.admin.userId,
+    entityType: 'doc',
+    entityId: docId,
+  });
+  const client = postgres(databaseUrl(), { max: 1, idle_timeout: 5, onnotice: () => undefined });
+  await client.unsafe('begin');
+  await client`select id from favorite where id = ${favoriteId} for update`;
+  const deletion = deleteDoc(nova.admin, docId);
+  await waitForDatabaseLock(client);
+  return { client, deletion };
 }
 
 beforeEach(async () => {
@@ -113,7 +143,7 @@ beforeEach(async () => {
 
 async function register(
   principal: Principal,
-  parentType: 'issue' | 'doc' | 'user',
+  parentType: 'issue' | 'doc' | 'project' | 'user',
   parentId: string,
 ): Promise<AttachmentRecord> {
   const [row] = await db
@@ -210,7 +240,7 @@ describe('markAttachmentReady', () => {
     expect(row).toEqual({ status: 'ready', size: 4_096 });
   });
 
-  it('publishes an issue upload on the issue scope only', async () => {
+  it('publishes an issue upload on its current team and issue scopes', async () => {
     const record = await register(nova.admin, 'issue', issueId);
 
     const completed = await markAttachmentReady(nova.admin, record, 10);
@@ -219,7 +249,7 @@ describe('markAttachmentReady', () => {
     expect(action?.model).toBe('attachment');
     expect(action?.action).toBe('update');
     expect(action?.organizationId).toBe(nova.organizationId);
-    expect(action?.scopes).toEqual([`issue:${issueId}`]);
+    expect(action?.scopes).toEqual([`team:${nova.teamId}`, `issue:${issueId}`]);
   });
 
   it('publishes a doc upload on the doc scope, so a reader without the doc never sees it', async () => {
@@ -245,6 +275,76 @@ describe('markAttachmentReady', () => {
 
     expect(completed.attachment.syncId).toBeGreaterThan(record.syncId);
     expect(completed.actions[0]?.syncId).toBe(completed.attachment.syncId);
+  });
+});
+
+describe('doc deletion attachment serialization', () => {
+  it('prevents a concurrent upload from leaving an attachment row or stored object', async () => {
+    const storage = fakeStorage();
+    const paused = await pauseDocDeletionAfterAttachmentCleanup();
+    const uploadClient = postgres(databaseUrl(), {
+      max: 1,
+      idle_timeout: 5,
+      onnotice: () => undefined,
+    });
+    const attachmentId = newId();
+    const storageKey = `uploads/${newId()}.pdf`;
+    const uploading = uploadClient.begin(async (sql) => {
+      const parents = await sql<{ id: string }[]>`
+        select id from doc where id = ${docId} for update nowait
+      `;
+      if (parents[0] === undefined) throw new Error('The doc was deleted before the upload began.');
+      await storage.driver.put(storageKey, new Uint8Array(6), 'application/pdf');
+      await sql`
+        insert into attachment (
+          id,
+          organization_id,
+          parent_type,
+          parent_id,
+          file_name,
+          content_type,
+          size,
+          storage_key,
+          status,
+          uploaded_by_id
+        ) values (
+          ${attachmentId},
+          ${nova.organizationId},
+          'doc',
+          ${docId},
+          'roadmap.pdf',
+          'application/pdf',
+          6,
+          ${storageKey},
+          'ready',
+          ${nova.admin.userId}
+        )
+      `;
+    });
+    const outcome = uploading.then(
+      () => ({ status: 'fulfilled' as const }),
+      (reason: unknown) => ({ status: 'rejected' as const, reason }),
+    );
+    let deletionReleased = false;
+
+    try {
+      expect((await outcome).status).toBe('rejected');
+      await paused.client.unsafe('commit');
+      deletionReleased = true;
+      await paused.deletion;
+    } finally {
+      if (!deletionReleased) await paused.client.unsafe('rollback').catch(() => undefined);
+      await paused.deletion.catch(() => undefined);
+      await outcome;
+      await Promise.all([paused.client.end(), uploadClient.end()]);
+    }
+
+    expect(storage.puts).toHaveLength(0);
+    const rows = await db
+      .select({ id: schema.attachment.id })
+      .from(schema.attachment)
+      .where(eq(schema.attachment.id, attachmentId));
+    expect(rows).toHaveLength(0);
   });
 });
 
@@ -293,7 +393,54 @@ describe('registerUpload', () => {
     expect(registered.attachment.status).toBe('pending');
     expect(registered.attachment.uploadExpiresAt?.toISOString()).toBe(registered.upload.expiresAt);
     expect(registered.upload.method).toBe('PUT');
-    expect(registered.actions[0]?.scopes).toEqual([`issue:${issueId}`]);
+    expect(registered.actions[0]?.scopes).toEqual([`team:${nova.teamId}`, `issue:${issueId}`]);
+  });
+
+  it('publishes a team-owned project upload to its project and owning team', async () => {
+    const { project } = await createProject(nova.admin, {
+      name: 'Team launch',
+      teamIds: [nova.teamId],
+    });
+    const storage = fakeStorage();
+
+    const registered = await registerUpload(
+      nova.admin,
+      {
+        fileName: 'roadmap.pdf',
+        contentType: 'application/pdf',
+        size: 64,
+        parentType: 'project',
+        parentId: project.id,
+      },
+      storage.driver,
+    );
+
+    expect(registered.actions[0]?.scopes).toEqual([`project:${project.id}`, `team:${nova.teamId}`]);
+  });
+
+  it('publishes a teamless project upload to its workspace and project', async () => {
+    const { project } = await createProject(nova.admin, {
+      name: 'Workspace launch',
+      teamIds: [],
+    });
+    const storage = fakeStorage();
+
+    const registered = await registerUpload(
+      nova.admin,
+      {
+        fileName: 'roadmap.pdf',
+        contentType: 'application/pdf',
+        size: 64,
+        parentType: 'project',
+        parentId: project.id,
+      },
+      storage.driver,
+    );
+
+    expect(registered.actions[0]?.scopes).toEqual([
+      `org:${nova.organizationId}`,
+      `project:${project.id}`,
+    ]);
   });
 
   it('refuses a comment on an issue in a team the caller cannot see', async () => {
@@ -360,6 +507,62 @@ describe('registerUpload', () => {
       await client.end();
     }
   });
+
+  it('rejects registration when a committed doc access change owns the parent lock first', async () => {
+    const { principal } = await addMember(nova, 'member');
+    let targetCreated = false;
+    const storage = fakeStorage({ onCreateTarget: () => (targetCreated = true) });
+    const client = postgres(databaseUrl(), { max: 1, idle_timeout: 5, onnotice: () => undefined });
+    await client.unsafe('begin');
+    await client`update doc set visibility = 'private' where id = ${docId}`;
+    const registering = registerUpload(
+      principal,
+      {
+        fileName: 'roadmap.pdf',
+        contentType: 'application/pdf',
+        size: 64,
+        parentType: 'doc',
+        parentId: docId,
+      },
+      storage.driver,
+    );
+    const outcome = registering.then(
+      () => ({ status: 'fulfilled' as const }),
+      (reason: unknown) => ({ status: 'rejected' as const, reason }),
+    );
+
+    try {
+      const first = await Promise.race([
+        outcome.then(() => 'settled' as const),
+        waitForDatabaseLock(client).then(() => 'locked' as const),
+      ]);
+      expect(first).toBe('locked');
+      await client.unsafe('commit');
+      const result = await outcome;
+      expect(result.status).toBe('rejected');
+      expect(result.status === 'rejected' ? result.reason : undefined).toMatchObject({
+        code: 'not_found',
+        status: 404,
+      });
+    } finally {
+      await client.unsafe('rollback').catch(() => undefined);
+      await outcome;
+      await client.end();
+    }
+
+    expect(targetCreated).toBe(false);
+    const rows = await db
+      .select({ id: schema.attachment.id })
+      .from(schema.attachment)
+      .where(
+        and(
+          eq(schema.attachment.parentType, 'doc'),
+          eq(schema.attachment.parentId, docId),
+          eq(schema.attachment.uploadedById, principal.userId),
+        ),
+      );
+    expect(rows).toHaveLength(0);
+  });
 });
 
 describe('finishUpload', () => {
@@ -403,6 +606,211 @@ describe('finishUpload', () => {
     expect(
       await errorOf(() => finishUpload(principal, registered.attachment.id, storage.driver)),
     ).toEqual({ code: 'not_found', status: 404 });
+  });
+
+  it('refuses completion after the issue moves beyond the uploader reach', async () => {
+    const { principal } = await addMember(nova, 'member');
+    const { team } = await createTeam(nova.admin, { name: 'Private', key: 'PRIV' });
+    const storage = fakeStorage();
+    const registered = await registerUpload(
+      principal,
+      {
+        fileName: 'trace.log',
+        contentType: 'text/plain',
+        size: 64,
+        parentType: 'issue',
+        parentId: issueId,
+      },
+      storage.driver,
+    );
+    await storage.driver.put(registered.attachment.storageKey, new Uint8Array(40), 'text/plain');
+    await db.update(schema.issue).set({ teamId: team.id }).where(eq(schema.issue.id, issueId));
+
+    expect(
+      await errorOf(() => finishUpload(principal, registered.attachment.id, storage.driver)),
+    ).toEqual({ code: 'not_found', status: 404 });
+    const [stored] = await db
+      .select({ status: schema.attachment.status })
+      .from(schema.attachment)
+      .where(eq(schema.attachment.id, registered.attachment.id));
+    expect(stored?.status).toBe('pending');
+  });
+
+  it('rejects completion when a committed doc access change owns the parent lock first', async () => {
+    const { principal } = await addMember(nova, 'member');
+    const storage = fakeStorage();
+    const registered = await registerUpload(
+      principal,
+      {
+        fileName: 'roadmap.pdf',
+        contentType: 'application/pdf',
+        size: 64,
+        parentType: 'doc',
+        parentId: docId,
+      },
+      storage.driver,
+    );
+    await storage.driver.put(
+      registered.attachment.storageKey,
+      new Uint8Array(40),
+      'application/pdf',
+    );
+    const client = postgres(databaseUrl(), { max: 1, idle_timeout: 5, onnotice: () => undefined });
+    await client.unsafe('begin');
+    await client`update doc set visibility = 'private' where id = ${docId}`;
+    const finishing = finishUpload(principal, registered.attachment.id, storage.driver);
+    const outcome = finishing.then(
+      () => ({ status: 'fulfilled' as const }),
+      (reason: unknown) => ({ status: 'rejected' as const, reason }),
+    );
+
+    try {
+      const first = await Promise.race([
+        outcome.then(() => 'settled' as const),
+        waitForDatabaseLock(client).then(() => 'locked' as const),
+      ]);
+      expect(first).toBe('locked');
+      await client.unsafe('commit');
+      const result = await outcome;
+      expect(result.status).toBe('rejected');
+      expect(result.status === 'rejected' ? result.reason : undefined).toMatchObject({
+        code: 'not_found',
+        status: 404,
+      });
+    } finally {
+      await client.unsafe('rollback').catch(() => undefined);
+      await outcome;
+      await client.end();
+    }
+
+    const [stored] = await db
+      .select({ status: schema.attachment.status })
+      .from(schema.attachment)
+      .where(eq(schema.attachment.id, registered.attachment.id));
+    expect(stored?.status).toBe('pending');
+  });
+
+  it('waits for the doc parent before locking the attachment row', async () => {
+    const storage = fakeStorage();
+    const registered = await registerUpload(
+      nova.admin,
+      {
+        fileName: 'roadmap.pdf',
+        contentType: 'application/pdf',
+        size: 64,
+        parentType: 'doc',
+        parentId: docId,
+      },
+      storage.driver,
+    );
+    await storage.driver.put(
+      registered.attachment.storageKey,
+      new Uint8Array(40),
+      'application/pdf',
+    );
+    const parentClient = postgres(databaseUrl(), {
+      max: 1,
+      idle_timeout: 5,
+      onnotice: () => undefined,
+    });
+    const attachmentClient = postgres(databaseUrl(), {
+      max: 1,
+      idle_timeout: 5,
+      onnotice: () => undefined,
+    });
+    await parentClient.unsafe('begin');
+    await parentClient`select id from doc where id = ${docId} for update`;
+    const finishing = finishUpload(nova.admin, registered.attachment.id, storage.driver);
+    await waitForDatabaseLockCount(parentClient, 1);
+    await attachmentClient.unsafe('begin');
+    let parentReleased = false;
+    let attachmentReleased = false;
+
+    try {
+      const lockResult = await attachmentClient`
+        select id from attachment
+        where id = ${registered.attachment.id}
+        for update nowait
+      `.then(
+        () => 'acquired' as const,
+        () => 'blocked' as const,
+      );
+      expect(lockResult).toBe('acquired');
+      await attachmentClient.unsafe('rollback');
+      attachmentReleased = true;
+      await parentClient.unsafe('commit');
+      parentReleased = true;
+      expect((await finishing).attachment.status).toBe('ready');
+    } finally {
+      if (!parentReleased) await parentClient.unsafe('commit').catch(() => undefined);
+      await finishing.catch(() => undefined);
+      if (!attachmentReleased) await attachmentClient.unsafe('rollback').catch(() => undefined);
+      await Promise.all([parentClient.end(), attachmentClient.end()]);
+    }
+  });
+
+  it('rejects completion when a committed project access change owns the parent lock first', async () => {
+    const { principal } = await addMember(nova, 'member');
+    const { team } = await createTeam(nova.admin, { name: 'Private', key: 'PRIV' });
+    const { project } = await createProject(nova.admin, {
+      name: 'Launch',
+      teamIds: [nova.teamId],
+    });
+    const storage = fakeStorage();
+    const registered = await registerUpload(
+      principal,
+      {
+        fileName: 'roadmap.pdf',
+        contentType: 'application/pdf',
+        size: 64,
+        parentType: 'project',
+        parentId: project.id,
+      },
+      storage.driver,
+    );
+    await storage.driver.put(
+      registered.attachment.storageKey,
+      new Uint8Array(40),
+      'application/pdf',
+    );
+    const client = postgres(databaseUrl(), { max: 1, idle_timeout: 5, onnotice: () => undefined });
+    await client.unsafe('begin');
+    await client`select id from project where id = ${project.id} for update`;
+    await client`
+      update project_team
+      set team_id = ${team.id}
+      where project_id = ${project.id}
+    `;
+    const finishing = finishUpload(principal, registered.attachment.id, storage.driver);
+    const outcome = finishing.then(
+      () => ({ status: 'fulfilled' as const }),
+      (reason: unknown) => ({ status: 'rejected' as const, reason }),
+    );
+
+    try {
+      const first = await Promise.race([
+        outcome.then(() => 'settled' as const),
+        waitForDatabaseLock(client).then(() => 'locked' as const),
+      ]);
+      expect(first).toBe('locked');
+      await client.unsafe('commit');
+      const result = await outcome;
+      expect(result.status).toBe('rejected');
+      expect(result.status === 'rejected' ? result.reason : undefined).toMatchObject({
+        code: 'not_found',
+        status: 404,
+      });
+    } finally {
+      await client.unsafe('rollback').catch(() => undefined);
+      await outcome;
+      await client.end();
+    }
+
+    const [stored] = await db
+      .select({ status: schema.attachment.status })
+      .from(schema.attachment)
+      .where(eq(schema.attachment.id, registered.attachment.id));
+    expect(stored?.status).toBe('pending');
   });
 });
 
@@ -451,7 +859,7 @@ describe('attachFile', () => {
     expect(stored.attachment.status).toBe('ready');
     expect(stored.attachment.uploadExpiresAt).toBeNull();
     expect(stored.url).toBe(`/api/files/${stored.attachment.storageKey}`);
-    expect(stored.actions[0]?.scopes).toEqual([`issue:${issueId}`]);
+    expect(stored.actions[0]?.scopes).toEqual([`team:${nova.teamId}`, `issue:${issueId}`]);
   });
 
   it('refuses a workspace the caller does not belong to', async () => {
@@ -545,5 +953,103 @@ describe('attachFile', () => {
 
     expect(storage.puts).toHaveLength(1);
     expect(storage.deletes).toEqual([storage.puts[0]?.key ?? 'no key was stored']);
+  });
+
+  it('rejects inline storage when a committed doc access change owns the parent lock first', async () => {
+    const { principal } = await addMember(nova, 'member');
+    const storage = fakeStorage();
+    const client = postgres(databaseUrl(), { max: 1, idle_timeout: 5, onnotice: () => undefined });
+    await client.unsafe('begin');
+    await client`update doc set visibility = 'private' where id = ${docId}`;
+    const attaching = attachFile(
+      principal,
+      {
+        parentType: 'doc',
+        parentId: docId,
+        fileName: 'roadmap.pdf',
+        contentType: 'application/pdf',
+        content: Buffer.from('launch').toString('base64'),
+      },
+      storage.driver,
+    );
+    const outcome = attaching.then(
+      () => ({ status: 'fulfilled' as const }),
+      (reason: unknown) => ({ status: 'rejected' as const, reason }),
+    );
+
+    try {
+      const first = await Promise.race([
+        outcome.then(() => 'settled' as const),
+        waitForDatabaseLock(client).then(() => 'locked' as const),
+      ]);
+      expect(first).toBe('locked');
+      await client.unsafe('commit');
+      const result = await outcome;
+      expect(result.status).toBe('rejected');
+      expect(result.status === 'rejected' ? result.reason : undefined).toMatchObject({
+        code: 'not_found',
+        status: 404,
+      });
+    } finally {
+      await client.unsafe('rollback').catch(() => undefined);
+      await outcome;
+      await client.end();
+    }
+
+    expect(storage.puts).toHaveLength(0);
+  });
+
+  it('rejects inline storage when a committed project access change owns the parent lock first', async () => {
+    const { principal } = await addMember(nova, 'member');
+    const { team } = await createTeam(nova.admin, { name: 'Private', key: 'PRIV' });
+    const { project } = await createProject(nova.admin, {
+      name: 'Launch',
+      teamIds: [nova.teamId],
+    });
+    const storage = fakeStorage();
+    const client = postgres(databaseUrl(), { max: 1, idle_timeout: 5, onnotice: () => undefined });
+    await client.unsafe('begin');
+    await client`select id from project where id = ${project.id} for update`;
+    await client`
+      update project_team
+      set team_id = ${team.id}
+      where project_id = ${project.id}
+    `;
+    const attaching = attachFile(
+      principal,
+      {
+        parentType: 'project',
+        parentId: project.id,
+        fileName: 'roadmap.pdf',
+        contentType: 'application/pdf',
+        content: Buffer.from('launch').toString('base64'),
+      },
+      storage.driver,
+    );
+    const outcome = attaching.then(
+      () => ({ status: 'fulfilled' as const }),
+      (reason: unknown) => ({ status: 'rejected' as const, reason }),
+    );
+
+    try {
+      const first = await Promise.race([
+        outcome.then(() => 'settled' as const),
+        waitForDatabaseLock(client).then(() => 'locked' as const),
+      ]);
+      expect(first).toBe('locked');
+      await client.unsafe('commit');
+      const result = await outcome;
+      expect(result.status).toBe('rejected');
+      expect(result.status === 'rejected' ? result.reason : undefined).toMatchObject({
+        code: 'not_found',
+        status: 404,
+      });
+    } finally {
+      await client.unsafe('rollback').catch(() => undefined);
+      await outcome;
+      await client.end();
+    }
+
+    expect(storage.puts).toHaveLength(0);
   });
 });

--- a/packages/core/tests/org/starter-content.test.ts
+++ b/packages/core/tests/org/starter-content.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { db, eq, schema } from '@orbit/db';
+import { scopes } from '@orbit/shared/events';
 import { createOrganization } from '../../src/org/organization-service.ts';
 import { createUser, resetDatabase } from '../../src/test-support.ts';
 
@@ -52,6 +53,11 @@ describe('workspace seeding on create', () => {
     expect(models.has('issue')).toBe(true);
     expect(models.has('doc')).toBe(true);
     expect(models.has('project')).toBe(true);
+    const issueActions = bootstrap.actions.filter((action) => action.model === 'issue');
+    expect(issueActions).toHaveLength(issues.length);
+    for (const action of issueActions) {
+      expect(action.scopes).toEqual([scopes.team(bootstrap.team.id), scopes.issue(action.modelId)]);
+    }
   });
 
   it('leaves the workspace empty when seeding is not requested', async () => {

--- a/packages/core/tests/realtime/backfill.test.ts
+++ b/packages/core/tests/realtime/backfill.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { db, schema } from '@orbit/db';
-import { SYNC_MODELS } from '@orbit/shared/events';
+import { SYNC_MODELS, scopes } from '@orbit/shared/events';
 import { createComment, toggleReaction } from '../../src/content/comment-service.ts';
 import { createDoc, createDocCollection, setDocAccess } from '../../src/content/doc-service.ts';
 import { newId } from '../../src/internal.ts';
@@ -14,7 +14,8 @@ import {
   resetDatabase,
   type Workspace,
 } from '../../src/test-support.ts';
-import { createIssue, subscribe, updateIssue } from '../../src/work/issue-service.ts';
+import { createIssue, setRelation, subscribe, updateIssue } from '../../src/work/issue-service.ts';
+import { createProject } from '../../src/work/project-service.ts';
 import { createView } from '../../src/work/view-service.ts';
 
 function teamKey(): string {
@@ -91,6 +92,26 @@ describe('catchUp', () => {
     expect(action?.data['reviewerIds']).toEqual([reviewer.user.id]);
   });
 
+  it('does not widen an issue replay through its project scope', async () => {
+    const { project } = await createProject(workspace.admin, {
+      name: 'Scoped project',
+      teamIds: [workspace.teamId],
+    });
+    const created = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      projectId: project.id,
+      title: 'Scoped issue',
+    });
+
+    const result = await catchUp(workspace.admin, 0);
+    const action = result.actions.find(
+      (entry) => entry.model === 'issue' && entry.modelId === created.issue.id,
+    );
+    expect(action?.scopes).toContain(scopes.team(workspace.teamId));
+    expect(action?.scopes).toContain(scopes.issue(created.issue.id));
+    expect(action?.scopes).not.toContain(scopes.project(project.id));
+  });
+
   it('never returns a row from another organization', async () => {
     const other = await createWorkspace('Rival');
     await createIssue(other.admin, { teamId: other.teamId, title: 'Rival roadmap' });
@@ -132,6 +153,135 @@ describe('catchUp', () => {
     expect(models.has('doc_collection')).toBe(true);
     expect(models.has('issue_subscription')).toBe(true);
     expect(modelIds(result.actions, 'doc_collection')).toEqual([collection.collection.id]);
+    const subscription = result.actions.find((action) => action.model === 'issue_subscription');
+    expect(subscription?.scopes).toEqual([scopes.user(workspace.admin.userId)]);
+  });
+
+  it('replays mirrored relations only to each owning issue team and scope', async () => {
+    const source = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Source',
+    });
+    const target = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Target',
+    });
+    await setRelation(workspace.admin, source.issue.id, {
+      relatedIssueId: target.issue.id,
+      type: 'blocks',
+    });
+
+    const result = await catchUp(workspace.admin, 0);
+    const relations = result.actions.filter((action) => action.model === 'issue_relation');
+    expect(relations.map((action) => action.scopes)).toEqual([
+      [
+        scopes.organization(workspace.organizationId),
+        scopes.team(workspace.teamId),
+        scopes.issue(source.issue.id),
+      ],
+      [
+        scopes.organization(workspace.organizationId),
+        scopes.team(workspace.teamId),
+        scopes.issue(target.issue.id),
+      ],
+    ]);
+  });
+
+  it('resolves every attachment parent to its authoritative replay scope', async () => {
+    const issue = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Attached issue',
+    });
+    const comment = await createComment(workspace.admin, issue.issue.id, {
+      body: 'Attached comment',
+    });
+    const { project } = await createProject(workspace.admin, {
+      name: 'Attached project',
+      teamIds: [workspace.teamId],
+    });
+    const ids = {
+      issue: newId(),
+      comment: newId(),
+      project: newId(),
+      missing: newId(),
+    };
+    await db.insert(schema.attachment).values([
+      {
+        id: ids.issue,
+        organizationId: workspace.organizationId,
+        parentType: 'issue',
+        parentId: issue.issue.id,
+        fileName: 'issue.txt',
+        contentType: 'text/plain',
+        size: 1,
+        storageKey: `uploads/${ids.issue}`,
+        status: 'ready',
+        uploadedById: workspace.admin.userId,
+        syncId: 800_001,
+      },
+      {
+        id: ids.comment,
+        organizationId: workspace.organizationId,
+        parentType: 'comment',
+        parentId: comment.comment.id,
+        fileName: 'comment.txt',
+        contentType: 'text/plain',
+        size: 1,
+        storageKey: `uploads/${ids.comment}`,
+        status: 'ready',
+        uploadedById: workspace.admin.userId,
+        syncId: 800_002,
+      },
+      {
+        id: ids.project,
+        organizationId: workspace.organizationId,
+        parentType: 'project',
+        parentId: project.id,
+        fileName: 'project.txt',
+        contentType: 'text/plain',
+        size: 1,
+        storageKey: `uploads/${ids.project}`,
+        status: 'ready',
+        uploadedById: workspace.admin.userId,
+        syncId: 800_003,
+      },
+      {
+        id: ids.missing,
+        organizationId: workspace.organizationId,
+        parentType: 'issue',
+        parentId: 'issue_missing',
+        fileName: 'missing.txt',
+        contentType: 'text/plain',
+        size: 1,
+        storageKey: `uploads/${ids.missing}`,
+        status: 'ready',
+        uploadedById: workspace.admin.userId,
+        syncId: 800_004,
+      },
+    ]);
+
+    const result = await catchUp(workspace.admin, 0);
+    const byId = new Map(
+      result.actions
+        .filter((action) => action.model === 'attachment')
+        .map((action) => [action.modelId, action]),
+    );
+    expect(byId.get(ids.issue)?.scopes).toEqual([
+      scopes.organization(workspace.organizationId),
+      scopes.team(workspace.teamId),
+      scopes.issue(issue.issue.id),
+    ]);
+    expect(byId.get(ids.comment)?.scopes).toEqual([
+      scopes.organization(workspace.organizationId),
+      scopes.team(workspace.teamId),
+      scopes.issue(issue.issue.id),
+    ]);
+    expect(byId.get(ids.project)?.scopes).toEqual([
+      scopes.organization(workspace.organizationId),
+      scopes.project(project.id),
+      scopes.team(workspace.teamId),
+    ]);
+    expect(byId.has(ids.missing)).toBe(false);
   });
 
   it('marks the page truncated when there is more than the caller asked for', async () => {

--- a/packages/core/tests/realtime/backfill.test.ts
+++ b/packages/core/tests/realtime/backfill.test.ts
@@ -173,17 +173,16 @@ describe('catchUp', () => {
 
     const result = await catchUp(workspace.admin, 0);
     const relations = result.actions.filter((action) => action.model === 'issue_relation');
-    expect(relations.map((action) => action.scopes)).toEqual([
-      [
-        scopes.organization(workspace.organizationId),
-        scopes.team(workspace.teamId),
-        scopes.issue(source.issue.id),
-      ],
-      [
-        scopes.organization(workspace.organizationId),
-        scopes.team(workspace.teamId),
-        scopes.issue(target.issue.id),
-      ],
+    expect(relations).toHaveLength(2);
+    expect(relations.map((action) => action.scopes)).toContainEqual([
+      scopes.organization(workspace.organizationId),
+      scopes.team(workspace.teamId),
+      scopes.issue(source.issue.id),
+    ]);
+    expect(relations.map((action) => action.scopes)).toContainEqual([
+      scopes.organization(workspace.organizationId),
+      scopes.team(workspace.teamId),
+      scopes.issue(target.issue.id),
     ]);
   });
 

--- a/packages/core/tests/work/issue-service.test.ts
+++ b/packages/core/tests/work/issue-service.test.ts
@@ -666,6 +666,7 @@ describe('moveIssue', () => {
 
   it('reallocates the identifier when moved to another team', async () => {
     const issue = await newIssue('Transferred');
+    const sourceOnly = await addMember(workspace, 'member', { name: 'Source reader' });
     const { team, states } = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
     const target = states.find((state) => state.category === 'unstarted');
     if (target === undefined) throw new Error('missing target state');
@@ -680,7 +681,76 @@ describe('moveIssue', () => {
     expect(moved.issue.teamId).toBe(team.id);
     expect(moved.issue.identifier).toBe('DSGN-1');
     expect(moved.issue.number).toBe(1);
-    expect(moved.actions[0]?.scopes).toContain(scopes.team(team.id));
+    expect(moved.actions[0]).toMatchObject({
+      action: 'delete',
+      modelId: issue.id,
+      scopes: [scopes.team(workspace.teamId), scopes.issue(issue.id)],
+      data: {
+        id: issue.id,
+        teamId: workspace.teamId,
+        identifier: issue.identifier,
+        departure: true,
+      },
+    });
+    expect(moved.actions[0]?.data).not.toHaveProperty('title');
+    expect(moved.actions[1]?.scopes).toContain(scopes.team(team.id));
+    expect(moved.actions[1]?.scopes).not.toContain(scopes.team(workspace.teamId));
+    expect(moved.actions[1]?.data).toMatchObject({ teamChanged: true });
+    expect(moved.actions[1]?.data).not.toHaveProperty('previousTeamId');
+    expect(moved.actions[1]?.data).not.toHaveProperty('previousIdentifier');
+    const [alias] = await db
+      .select()
+      .from(schema.issueIdentifierAlias)
+      .where(eq(schema.issueIdentifierAlias.identifier, issue.identifier));
+    expect(alias).toMatchObject({
+      organizationId: workspace.organizationId,
+      identifier: issue.identifier,
+      issueId: issue.id,
+      syncId: moved.issue.syncId,
+    });
+    expect(await getIssue(workspace.admin, issue.identifier)).toMatchObject({
+      id: issue.id,
+      identifier: moved.issue.identifier,
+    });
+    await expect(getIssue(sourceOnly.principal, issue.identifier)).rejects.toMatchObject({
+      code: 'not_found',
+    });
+  });
+
+  it('keeps every previous identifier resolving across repeated team moves', async () => {
+    const issue = await newIssue('Frequently transferred');
+    const design = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const product = await createTeam(workspace.admin, { name: 'Product', key: 'PROD' });
+    const designState = design.states.find((state) => state.category === 'unstarted');
+    const productState = product.states.find((state) => state.category === 'unstarted');
+    if (designState === undefined || productState === undefined) throw new Error('missing state');
+
+    const firstMove = await moveIssue(workspace.admin, issue.id, {
+      teamId: design.team.id,
+      stateId: designState.id,
+      beforeId: null,
+      afterId: null,
+    });
+    const secondMove = await moveIssue(workspace.admin, issue.id, {
+      teamId: product.team.id,
+      stateId: productState.id,
+      beforeId: null,
+      afterId: null,
+    });
+
+    const aliases = await db
+      .select({ identifier: schema.issueIdentifierAlias.identifier })
+      .from(schema.issueIdentifierAlias)
+      .where(eq(schema.issueIdentifierAlias.issueId, issue.id));
+    expect(aliases.map((row) => row.identifier).sort()).toEqual(
+      [issue.identifier, firstMove.issue.identifier].sort(),
+    );
+    expect((await getIssue(workspace.admin, issue.identifier)).identifier).toBe(
+      secondMove.issue.identifier,
+    );
+    expect((await getIssue(workspace.admin, firstMove.issue.identifier)).identifier).toBe(
+      secondMove.issue.identifier,
+    );
   });
 
   it('requires every reviewer to access the destination team', async () => {
@@ -710,7 +780,10 @@ describe('moveIssue', () => {
     const moved = await moveIssue(workspace.admin, issue.id, move);
 
     expect(moved.issue.teamId).toBe(team.id);
-    expect(moved.actions[0]?.data['reviewerIds']).toEqual(reviewerIds);
+    const issueUpdate = moved.actions.find(
+      (action) => action.modelId === issue.id && action.action === 'update',
+    );
+    expect(issueUpdate?.data['reviewerIds']).toEqual(reviewerIds);
   });
 
   it('moves an issue into a sprint without touching its status', async () => {
@@ -819,6 +892,10 @@ describe('moveIssue', () => {
       afterId: null,
     });
     expect(moved.issue.projectId).toBe(project.id);
+    const arrival = moved.actions.find(
+      (action) => action.modelId === issue.id && action.action === 'update',
+    );
+    expect(arrival?.scopes).not.toContain(scopes.project(project.id));
   });
 
   it('applies state timestamps when moving across columns', async () => {
@@ -1197,6 +1274,10 @@ describe('relations', () => {
     });
     expect(relations).toHaveLength(2);
     expect(actions.every((action) => action.model === 'issue_relation')).toBe(true);
+    expect(actions.map((action) => action.scopes)).toEqual([
+      [scopes.team(workspace.teamId), scopes.issue(blocker.id)],
+      [scopes.team(workspace.teamId), scopes.issue(blocked.id)],
+    ]);
 
     const inverse = await listRelations(workspace.admin, blocked.id);
     expect(inverse[0]?.type).toBe('blocked_by');
@@ -1310,12 +1391,13 @@ describe('subscriptions', () => {
     const { principal } = await addMember(workspace, 'member');
 
     const added = await subscribe(principal, issue.id);
-    expect(added.actions[0]?.scopes).toContain(scopes.user(principal.userId));
+    expect(added.actions[0]?.scopes).toEqual([scopes.user(principal.userId)]);
     expect((await listSubscribers(workspace.admin, issue.id)).map((row) => row.userId)).toContain(
       principal.userId,
     );
 
-    await unsubscribe(principal, issue.id);
+    const removed = await unsubscribe(principal, issue.id);
+    expect(removed.actions[0]?.scopes).toEqual([scopes.user(principal.userId)]);
     expect(
       (await listSubscribers(workspace.admin, issue.id)).map((row) => row.userId),
     ).not.toContain(principal.userId);

--- a/packages/core/tests/work/issue-service.test.ts
+++ b/packages/core/tests/work/issue-service.test.ts
@@ -1273,10 +1273,15 @@ describe('relations', () => {
       type: 'blocks',
     });
     expect(relations).toHaveLength(2);
+    expect(actions).toHaveLength(2);
     expect(actions.every((action) => action.model === 'issue_relation')).toBe(true);
-    expect(actions.map((action) => action.scopes)).toEqual([
-      [scopes.team(workspace.teamId), scopes.issue(blocker.id)],
-      [scopes.team(workspace.teamId), scopes.issue(blocked.id)],
+    expect(actions.map((action) => action.scopes)).toContainEqual([
+      scopes.team(workspace.teamId),
+      scopes.issue(blocker.id),
+    ]);
+    expect(actions.map((action) => action.scopes)).toContainEqual([
+      scopes.team(workspace.teamId),
+      scopes.issue(blocked.id),
     ]);
 
     const inverse = await listRelations(workspace.admin, blocked.id);

--- a/packages/core/tests/work/label-scope.test.ts
+++ b/packages/core/tests/work/label-scope.test.ts
@@ -353,7 +353,8 @@ describe('carrying an issue to another team drops the labels that team cannot us
     expect(moved.issue.teamId).toBe(nova.teamId);
     expect(await labelIdsOn(issue.issue.id)).toEqual([shared.label.id]);
     const action = moved.actions.find(
-      (entry) => entry.model === 'issue' && entry.modelId === issue.issue.id,
+      (entry) =>
+        entry.model === 'issue' && entry.modelId === issue.issue.id && entry.action === 'update',
     );
     expect(action?.data['labelIds']).toEqual([shared.label.id]);
     expect(action?.scopes).toContain(scopes.team(nova.teamId));

--- a/packages/core/tests/work/project-service.test.ts
+++ b/packages/core/tests/work/project-service.test.ts
@@ -6,6 +6,7 @@ import {
   replaceGithubRepositories,
 } from '@orbit/services/github';
 import { scopes } from '@orbit/shared/events';
+import postgres from 'postgres';
 import { createTeam } from '../../src/org/team-service.ts';
 import {
   addMember,
@@ -50,6 +51,34 @@ async function newIssue(
 }
 
 let workspace: Workspace;
+
+function databaseUrl(): string {
+  const url = process.env['DATABASE_URL'];
+  if (url === undefined || url.length === 0) throw new Error('DATABASE_URL is required.');
+  return url;
+}
+
+function pause(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function waitForDatabaseLock(client: ReturnType<typeof postgres>): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = await client<{ waiting: number }[]>`
+      select count(*)::int as waiting
+      from pg_stat_activity
+      where datname = current_database()
+        and pid <> pg_backend_pid()
+        and wait_event_type = 'Lock'
+    `;
+    if ((rows[0]?.waiting ?? 0) > 0) return;
+    await pause(10);
+  }
+  throw new Error('The project mutation did not wait for the project row lock.');
+}
 
 beforeEach(async () => {
   await resetDatabase();
@@ -99,6 +128,49 @@ describe('updateProject', () => {
     const teams = await listProjectTeams(workspace.admin, project.id);
     expect(teams).toHaveLength(1);
   });
+
+  it('computes retired reach after a queued team change commits', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const project = await newProject();
+    const client = postgres(databaseUrl(), { max: 1, idle_timeout: 5, onnotice: () => undefined });
+    await client.unsafe('begin');
+    await client`select id from project where id = ${project.id} for update`;
+    await client`
+      update project_team
+      set team_id = ${other.team.id}
+      where project_id = ${project.id}
+    `;
+    const updating = updateProject(workspace.admin, project.id, {
+      summary: 'Back with engineering',
+      teamIds: [workspace.teamId],
+    });
+    const outcome = updating.then(
+      (value) => ({ status: 'fulfilled' as const, value }),
+      (reason: unknown) => ({ status: 'rejected' as const, reason }),
+    );
+
+    try {
+      const first = await Promise.race([
+        outcome.then(() => 'settled' as const),
+        waitForDatabaseLock(client).then(() => 'locked' as const),
+      ]);
+      expect(first).toBe('locked');
+      await client.unsafe('commit');
+      const result = await outcome;
+      expect(result.status).toBe('fulfilled');
+      expect(
+        result.status === 'fulfilled'
+          ? result.value.actions.some((action) =>
+              action.scopes.includes(scopes.team(other.team.id)),
+            )
+          : false,
+      ).toBe(true);
+    } finally {
+      await client.unsafe('rollback').catch(() => undefined);
+      await outcome;
+      await client.end();
+    }
+  });
 });
 
 describe('project teams', () => {
@@ -110,6 +182,59 @@ describe('project teams', () => {
     const actions = await addProjectTeam(workspace.admin, project.id, workspace.teamId);
     expect(actions[0]?.scopes).toContain(scopes.team(workspace.teamId));
     expect(await listProjectTeams(workspace.admin, project.id)).toHaveLength(1);
+  });
+
+  it('takes the project row lock before adding a team', async () => {
+    const project = await newProject();
+    const other = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const client = postgres(databaseUrl(), { max: 1, idle_timeout: 5, onnotice: () => undefined });
+    await client.unsafe('begin');
+    await client`select id from project where id = ${project.id} for no key update`;
+    const adding = addProjectTeam(workspace.admin, project.id, other.team.id);
+    const outcome = adding.then(
+      () => ({ status: 'fulfilled' as const }),
+      (reason: unknown) => ({ status: 'rejected' as const, reason }),
+    );
+
+    try {
+      const first = await Promise.race([
+        outcome.then(() => 'settled' as const),
+        waitForDatabaseLock(client).then(() => 'locked' as const),
+      ]);
+      expect(first).toBe('locked');
+      await client.unsafe('commit');
+      expect((await outcome).status).toBe('fulfilled');
+    } finally {
+      await client.unsafe('rollback').catch(() => undefined);
+      await outcome;
+      await client.end();
+    }
+  });
+
+  it('takes the project row lock before removing a team', async () => {
+    const project = await newProject();
+    const client = postgres(databaseUrl(), { max: 1, idle_timeout: 5, onnotice: () => undefined });
+    await client.unsafe('begin');
+    await client`select id from project where id = ${project.id} for no key update`;
+    const removing = removeProjectTeam(workspace.admin, project.id, workspace.teamId);
+    const outcome = removing.then(
+      () => ({ status: 'fulfilled' as const }),
+      (reason: unknown) => ({ status: 'rejected' as const, reason }),
+    );
+
+    try {
+      const first = await Promise.race([
+        outcome.then(() => 'settled' as const),
+        waitForDatabaseLock(client).then(() => 'locked' as const),
+      ]);
+      expect(first).toBe('locked');
+      await client.unsafe('commit');
+      expect((await outcome).status).toBe('fulfilled');
+    } finally {
+      await client.unsafe('rollback').catch(() => undefined);
+      await outcome;
+      await client.end();
+    }
   });
 });
 

--- a/packages/realtime-server/src/auth.ts
+++ b/packages/realtime-server/src/auth.ts
@@ -193,15 +193,44 @@ export async function refreshedPrincipal(
   };
 }
 
-async function issueScopeAllowed(issueId: string, principal: ConnectionPrincipal) {
+export async function authorizedIssueTeamId(
+  issueId: string,
+  principal: ConnectionPrincipal,
+): Promise<string | null> {
+  const teamId = await issueTeamIdInOrganization(issueId, principal.organizationId);
+  if (teamId === null) return null;
+  if (principal.role !== 'admin' && !principal.teamIds.includes(teamId)) return null;
+  return teamId;
+}
+
+export async function issueTeamIdInOrganization(
+  issueId: string,
+  organizationId: string,
+): Promise<string | null> {
+  return (await issueReachInOrganization(issueId, organizationId))?.teamId ?? null;
+}
+
+export interface IssueReach {
+  readonly teamId: string;
+  readonly syncId: number;
+}
+
+export async function issueReachInOrganization(
+  issueId: string,
+  organizationId: string,
+): Promise<IssueReach | null> {
   const rows = await db
-    .select({ organizationId: schema.issue.organizationId, teamId: schema.issue.teamId })
+    .select({
+      organizationId: schema.issue.organizationId,
+      teamId: schema.issue.teamId,
+      syncId: schema.issue.syncId,
+    })
     .from(schema.issue)
     .where(eq(schema.issue.id, issueId))
     .limit(1);
   const issue = rows[0];
-  if (issue === undefined || issue.organizationId !== principal.organizationId) return false;
-  return principal.role === 'admin' || principal.teamIds.includes(issue.teamId);
+  if (issue === undefined || issue.organizationId !== organizationId) return null;
+  return { teamId: issue.teamId, syncId: issue.syncId };
 }
 
 async function projectScopeAllowed(projectId: string, principal: ConnectionPrincipal) {
@@ -281,7 +310,7 @@ export async function authorizeScope(
     case 'user':
       return id === principal.userId;
     case 'issue':
-      return await issueScopeAllowed(id, principal);
+      return (await authorizedIssueTeamId(id, principal)) !== null;
     case 'project':
       return await projectScopeAllowed(id, principal);
     case 'doc':

--- a/packages/realtime-server/src/connection.ts
+++ b/packages/realtime-server/src/connection.ts
@@ -22,6 +22,11 @@ export class Connection {
   lastSeenAt = Date.now();
   private readonly pending = new Map<string, SyncAction>();
   private flushTimer: ReturnType<typeof setTimeout> | undefined;
+  private deltaFlushSuspensionDepth = 0;
+  private authorizationFenceDepth = 0;
+  private authorizationGeneration = 0;
+  private authorizationReady: Promise<void> = Promise.resolve();
+  private releaseAuthorization: (() => void) | undefined;
   private tokens: number;
   private refilledAt = Date.now();
   private throttled = false;
@@ -117,17 +122,73 @@ export class Connection {
 
   queueDelta(action: SyncAction): void {
     if (action.syncId <= this.watermark) return;
-    const key = `${action.model}|${action.modelId}|${action.action}`;
+    const departure =
+      action.model === 'issue' && action.action === 'delete' && action.data['departure'] === true;
+    const key = `${action.model}|${action.modelId}|${action.action}${departure ? `|${action.syncId}` : ''}`;
     const existing = this.pending.get(key);
     if (existing === undefined || existing.syncId <= action.syncId) {
+      this.pending.delete(key);
       this.pending.set(key, action);
     }
-    if (this.flushTimer !== undefined) return;
+    this.scheduleDeltaFlush();
+  }
+
+  suspendDeltaFlush(): void {
+    this.deltaFlushSuspensionDepth += 1;
+    if (this.flushTimer === undefined) return;
+    clearTimeout(this.flushTimer);
+    this.flushTimer = undefined;
+  }
+
+  resumeDeltaFlush(retain: (action: SyncAction) => boolean): void {
+    for (const [key, action] of this.pending) {
+      if (!retain(action)) this.pending.delete(key);
+    }
+    if (this.deltaFlushSuspensionDepth > 0) this.deltaFlushSuspensionDepth -= 1;
+    this.scheduleDeltaFlush();
+  }
+
+  suspendAuthorization(): void {
+    this.authorizationGeneration += 1;
+    this.authorizationFenceDepth += 1;
+    if (this.authorizationFenceDepth > 1) return;
+    this.authorizationReady = new Promise((resolve) => {
+      this.releaseAuthorization = resolve;
+    });
+  }
+
+  resumeAuthorization(): void {
+    if (this.authorizationFenceDepth === 0) return;
+    this.authorizationFenceDepth -= 1;
+    if (this.authorizationFenceDepth > 0) return;
+    const release = this.releaseAuthorization;
+    this.releaseAuthorization = undefined;
+    this.authorizationReady = Promise.resolve();
+    release?.();
+  }
+
+  async waitForAuthorization(): Promise<number> {
+    await this.authorizationReady;
+    return this.authorizationGeneration;
+  }
+
+  authorizationIsCurrent(generation: number): boolean {
+    return this.authorizationFenceDepth === 0 && this.authorizationGeneration === generation;
+  }
+
+  private scheduleDeltaFlush(): void {
+    if (
+      this.deltaFlushSuspensionDepth > 0 ||
+      this.flushTimer !== undefined ||
+      this.pending.size === 0
+    )
+      return;
     this.flushTimer = setTimeout(() => this.flushDeltas(), this.limits.batchWindowMs);
     this.flushTimer.unref();
   }
 
   flushDeltas(): void {
+    if (this.deltaFlushSuspensionDepth > 0) return;
     if (this.flushTimer !== undefined) {
       clearTimeout(this.flushTimer);
       this.flushTimer = undefined;
@@ -144,6 +205,13 @@ export class Connection {
       this.flushTimer = undefined;
     }
     this.pending.clear();
+    this.deltaFlushSuspensionDepth = 0;
+    this.authorizationFenceDepth = 0;
+    this.authorizationGeneration += 1;
+    const release = this.releaseAuthorization;
+    this.releaseAuthorization = undefined;
+    this.authorizationReady = Promise.resolve();
+    release?.();
     if (this.socket.readyState === SOCKET_OPEN) {
       this.socket.close(code, reason);
       return;

--- a/packages/realtime-server/src/hub.ts
+++ b/packages/realtime-server/src/hub.ts
@@ -860,6 +860,13 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
         await revalidateMutableResourceScopes(action, resourceAffected);
         await revalidateAffected(action);
         revalidated = true;
+      } catch (error: unknown) {
+        logger.error('delta action processing failed', {
+          organizationId: action.organizationId,
+          model: action.model,
+          modelId: action.modelId,
+          ...errorFields(error),
+        });
       } finally {
         finishMutableResourceReach(action, resourceAffected);
         finishIssueMoveReach(action, issueMoveAffected);

--- a/packages/realtime-server/src/hub.ts
+++ b/packages/realtime-server/src/hub.ts
@@ -14,6 +14,7 @@ import {
   REDIS_PRESENCE_CHANNEL,
   SESSION_REVOKED_CLOSE_CODE,
   type SyncAction,
+  scopes,
   syncActionSchema,
   UNAUTHORIZED_CLOSE_CODE,
 } from '@orbit/shared/events';
@@ -21,8 +22,11 @@ import { Redis } from 'ioredis';
 import { z } from 'zod';
 import {
   authenticateTicket,
+  authorizedIssueTeamId,
   authorizeScope,
   type ConnectionRejection,
+  issueReachInOrganization,
+  issueTeamIdInOrganization,
   liveSessionIds,
   memberDeleteSchema,
   membershipStillValid,
@@ -31,6 +35,7 @@ import {
   sessionStillValid,
 } from './auth.ts';
 import { Connection, type SocketState } from './connection.ts';
+import { IssueTeamBoundaries, type IssueTeamBoundary } from './issue-team-boundaries.ts';
 import { errorFields, logger } from './logger.ts';
 import { PresenceStore } from './presence.ts';
 import { type RealtimeSocket, SOCKET_OPEN } from './socket.ts';
@@ -41,6 +46,8 @@ export const MESSAGE_BURST = 60;
 export const MESSAGES_PER_SECOND = 20;
 export const AUTH_TIMEOUT_MS = 10_000;
 export const SESSION_SWEEP_INTERVAL_MS = 60_000;
+export const ISSUE_TEAM_BOUNDARY_TTL_MS = 300_000;
+export const MAX_ISSUE_TEAM_BOUNDARIES = 10_000;
 
 export interface RealtimeHubOptions {
   redisUrl?: string;
@@ -51,6 +58,8 @@ export interface RealtimeHubOptions {
   heartbeatTimeoutMs?: number;
   sessionSweepIntervalMs?: number;
   presenceTtlMs?: number;
+  issueTeamBoundaryTtlMs?: number;
+  maxIssueTeamBoundaries?: number;
   maxSubscriptions?: number;
   maxBufferedBytes?: number;
   messageBurst?: number;
@@ -80,6 +89,136 @@ const deltaEnvelopeSchema = z.union([
   z.unknown().transform((action) => [action]),
 ]);
 
+const redisPresenceMessageSchema = presenceMessageSchema.extend({
+  audience: z
+    .object({
+      teamId: z.string().min(1).nullable(),
+    })
+    .optional(),
+});
+
+function issueScopeId(scope: string): string | null {
+  if (!scope.startsWith('issue:')) return null;
+  const issueId = scope.slice('issue:'.length);
+  return issueId.length > 0 ? issueId : null;
+}
+
+function presenceWithinReach(
+  connection: Connection,
+  organizationId: string,
+  scope: string,
+  userId: string,
+  issueAudienceTeamId: string | null,
+): boolean {
+  if (connection.principal.userId === userId) return false;
+  if (!connection.matches([scope], organizationId)) return false;
+  if (issueScopeId(scope) === null) return true;
+  if (issueAudienceTeamId === null) return false;
+  return (
+    connection.principal.role === 'admin' ||
+    connection.principal.teamIds.includes(issueAudienceTeamId)
+  );
+}
+
+function issueTeamId(action: SyncAction): string | null {
+  if (action.model !== 'issue') return null;
+  const teamId = action.data['teamId'];
+  return typeof teamId === 'string' && teamId.length > 0 ? teamId : null;
+}
+
+function issueTeamBoundaryKey(organizationId: string, issueId: string): string {
+  return `${organizationId}|${issueId}`;
+}
+
+type IssueBinding =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'invalid' }
+  | {
+      readonly kind: 'issue';
+      readonly issueId: string;
+      readonly claimedTeamIds: readonly string[];
+      readonly departure: boolean;
+    };
+
+type BoundIssue = Extract<IssueBinding, { readonly kind: 'issue' }>;
+
+type ActionAudience =
+  | { readonly allowed: false }
+  | { readonly allowed: true; readonly teamId: string | null };
+
+type IssueDeletePreparation =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'rejected' }
+  | { readonly kind: 'hard-delete'; readonly sourceTeamId: string }
+  | {
+      readonly kind: 'departure';
+      readonly sourceTeamId: string;
+      readonly destinationTeamId: string;
+    };
+
+function issueBinding(action: SyncAction): IssueBinding {
+  const issueIds = [
+    ...new Set(
+      action.scopes.map(issueScopeId).filter((issueId): issueId is string => issueId !== null),
+    ),
+  ];
+  if (issueIds.length === 0) return { kind: 'none' };
+  if (issueIds.length !== 1) return { kind: 'invalid' };
+  const issueId = issueIds[0];
+  if (issueId === undefined) return { kind: 'invalid' };
+  if (action.model === 'issue' && issueId !== action.modelId) return { kind: 'invalid' };
+  return {
+    kind: 'issue',
+    issueId,
+    claimedTeamIds: action.scopes
+      .filter((scope) => scope.startsWith('team:'))
+      .map((scope) => scope.slice('team:'.length)),
+    departure:
+      action.model === 'issue' && action.action === 'delete' && action.data['departure'] === true,
+  };
+}
+
+function pendingActionWithinReach(connection: Connection, action: SyncAction): boolean {
+  if (connection.principal.role === 'admin') return true;
+  if (action.model === 'issue') {
+    const teamId = issueTeamId(action);
+    return (
+      teamId !== null &&
+      action.scopes.includes(scopes.team(teamId)) &&
+      connection.principal.teamIds.includes(teamId)
+    );
+  }
+  if (!action.scopes.some((scope) => scope.startsWith('issue:'))) {
+    return true;
+  }
+  return action.scopes.some(
+    (scope) =>
+      scope.startsWith('team:') &&
+      connection.principal.teamIds.includes(scope.slice('team:'.length)),
+  );
+}
+
+function audienceWithinReach(connection: Connection, audience: ActionAudience): boolean {
+  if (!audience.allowed) return false;
+  if (connection.principal.role === 'admin') return true;
+  return audience.teamId === null || connection.principal.teamIds.includes(audience.teamId);
+}
+
+function declaredIssueAudience(action: SyncAction): ActionAudience {
+  if (action.model !== 'issue') return { allowed: true, teamId: null };
+  const teamId = issueTeamId(action);
+  if (teamId === null || !action.scopes.includes(scopes.team(teamId))) {
+    return { allowed: false };
+  }
+  return { allowed: true, teamId };
+}
+
+function issueDeclarationMatchesBinding(action: SyncAction, binding: IssueBinding): boolean {
+  if (binding.kind !== 'issue' || action.model !== 'issue') return true;
+  const teamId = issueTeamId(action);
+  return teamId !== null && binding.claimedTeamIds.includes(teamId);
+}
+
 const CLOSE_CODES: Record<ConnectionRejection, number> = {
   unauthorized: UNAUTHORIZED_CLOSE_CODE,
   organization_forbidden: ORGANIZATION_FORBIDDEN_CLOSE_CODE,
@@ -91,6 +230,24 @@ function parseJson(payload: string): unknown {
   } catch {
     return undefined;
   }
+}
+
+function parseDeltaActions(payload: string): SyncAction[] | null {
+  const envelope = deltaEnvelopeSchema.safeParse(parseJson(payload));
+  if (!envelope.success) {
+    logger.warn('discarded malformed delta', { channel: REDIS_DELTA_CHANNEL });
+    return null;
+  }
+  const actions: SyncAction[] = [];
+  for (const entry of envelope.data) {
+    const parsed = syncActionSchema.safeParse(entry);
+    if (!parsed.success) {
+      logger.warn('discarded malformed delta action', { channel: REDIS_DELTA_CHANNEL });
+      continue;
+    }
+    actions.push(parsed.data);
+  }
+  return actions;
 }
 
 export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promise<RealtimeHub> {
@@ -105,6 +262,8 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
   const heartbeatTimeoutMs = options.heartbeatTimeoutMs ?? HEARTBEAT_TIMEOUT_MS;
   const sessionSweepIntervalMs = options.sessionSweepIntervalMs ?? SESSION_SWEEP_INTERVAL_MS;
   const presenceTtlMs = options.presenceTtlMs ?? PRESENCE_TTL_MS;
+  const issueTeamBoundaryTtlMs = options.issueTeamBoundaryTtlMs ?? ISSUE_TEAM_BOUNDARY_TTL_MS;
+  const maxIssueTeamBoundaries = options.maxIssueTeamBoundaries ?? MAX_ISSUE_TEAM_BOUNDARIES;
   const authTimeoutMs = options.authTimeoutMs ?? AUTH_TIMEOUT_MS;
   const redisUrl = options.redisUrl ?? process.env['REDIS_URL'] ?? 'redis://localhost:6380';
   const ticketSecret = options.ticketSecret ?? process.env['BETTER_AUTH_SECRET'] ?? '';
@@ -114,6 +273,10 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
 
   const connections = new Map<string, Connection>();
   const presence = new PresenceStore(presenceTtlMs);
+  const issueTeamBoundaries = new IssueTeamBoundaries(
+    issueTeamBoundaryTtlMs,
+    maxIssueTeamBoundaries,
+  );
   const subscriber = new Redis(redisUrl, { maxRetriesPerRequest: null });
   const publisher = new Redis(redisUrl, { maxRetriesPerRequest: 3 });
 
@@ -213,30 +376,72 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
     closeOrganizationConnections(parsed.data.organizationId);
   }
 
-  function revalidateDocScopes(action: SyncAction): void {
-    if (action.model !== 'doc' && action.model !== 'doc_comment') return;
-    const scope = action.scopes.find((entry) => entry.startsWith('doc:'));
-    if (scope === undefined) return;
-    for (const connection of connections.values()) {
-      if (connection.organizationId !== action.organizationId) continue;
-      if (!connection.scopes.has(scope)) continue;
-      authorizeScope(scope, connection.principal)
-        .then((allowed) => {
-          if (allowed) return;
+  function mutableResourceScope(action: SyncAction): string | null {
+    const docScope = action.scopes.find((entry) => entry.startsWith('doc:'));
+    if (docScope !== undefined) return docScope;
+    const projectScope = action.scopes.find((entry) => entry.startsWith('project:'));
+    return projectScope ?? null;
+  }
+
+  function suspendMutableResourceReach(action: SyncAction): Connection[] {
+    const scope = mutableResourceScope(action);
+    if (scope === null) return [];
+    const affected = [...connections.values()].filter(
+      (connection) => connection.organizationId === action.organizationId,
+    );
+    for (const connection of affected) {
+      connection.suspendDeltaFlush();
+      connection.suspendAuthorization();
+    }
+    return affected;
+  }
+
+  async function revalidateMutableResourceScopes(
+    action: SyncAction,
+    affected: readonly Connection[],
+  ): Promise<void> {
+    const scope = mutableResourceScope(action);
+    if (scope === null) return;
+    await Promise.all(
+      affected.map(async (connection) => {
+        if (!connection.scopes.has(scope)) return;
+        try {
+          if (await authorizeScope(scope, connection.principal)) return;
           connection.removeScopes([scope]);
-          logger.info('dropped a doc scope the reader may no longer read', {
+          logger.info('dropped a mutable resource scope the reader may no longer read', {
             connectionId: connection.id,
             scope,
           });
-        })
-        .catch((error: unknown) => {
+        } catch (error: unknown) {
           connection.removeScopes([scope]);
-          logger.error('doc scope revalidation failed, dropping to fail closed', {
+          logger.error('mutable resource scope revalidation failed, dropping to fail closed', {
             connectionId: connection.id,
             scope,
             ...errorFields(error),
           });
-        });
+        }
+      }),
+    );
+  }
+
+  function isCurrentMutableResourceTombstone(action: SyncAction, pending: SyncAction): boolean {
+    return (
+      action === pending &&
+      action.action === 'delete' &&
+      (action.model === 'doc' || action.model === 'project')
+    );
+  }
+
+  function finishMutableResourceReach(action: SyncAction, affected: readonly Connection[]): void {
+    for (const connection of affected) {
+      if (connections.get(connection.id) === connection) {
+        connection.resumeDeltaFlush(
+          (pending) =>
+            isCurrentMutableResourceTombstone(action, pending) ||
+            connection.matches(pending.scopes, pending.organizationId),
+        );
+      }
+      connection.resumeAuthorization();
     }
   }
 
@@ -261,71 +466,430 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
     });
   }
 
-  function revalidateMembershipReach(action: SyncAction): void {
+  async function revalidateMembershipReach(action: SyncAction): Promise<void> {
     if (action.model !== 'team_member' && action.model !== 'member') return;
     if (action.model === 'member' && action.action === 'delete') return;
-    for (const connection of connections.values()) {
-      if (connection.organizationId !== action.organizationId) continue;
-      revalidateReach(connection).catch((error: unknown) => {
-        connections.delete(connection.id);
-        connection.close(ORGANIZATION_FORBIDDEN_CLOSE_CODE, 'membership_revoked');
-        logger.error('reach revalidation failed, closing to fail closed', {
-          connectionId: connection.id,
-          ...errorFields(error),
-        });
-      });
-    }
+    const affected = [...connections.values()].filter(
+      (connection) => connection.organizationId === action.organizationId,
+    );
+    await Promise.all(
+      affected.map(async (connection) => {
+        try {
+          await revalidateReach(connection);
+        } catch (error: unknown) {
+          connections.delete(connection.id);
+          connection.close(ORGANIZATION_FORBIDDEN_CLOSE_CODE, 'membership_revoked');
+          logger.error('reach revalidation failed, closing to fail closed', {
+            connectionId: connection.id,
+            ...errorFields(error),
+          });
+        }
+      }),
+    );
   }
 
-  function revalidateAffected(action: SyncAction): void {
-    revalidateDocScopes(action);
-    revalidateMembershipReach(action);
+  async function revalidateAffected(action: SyncAction): Promise<void> {
+    await revalidateMembershipReach(action);
     if (action.model !== 'member' || action.action !== 'delete') return;
     const removed = memberDeleteSchema.safeParse(action.data);
-    if (!removed.success) return;
-    for (const connection of connections.values()) {
-      if (connection.organizationId !== action.organizationId) continue;
-      if (connection.principal.userId !== removed.data.userId) continue;
-      revalidate(connection).catch((error: unknown) => {
-        logger.error('membership revalidation failed', {
-          connectionId: connection.id,
-          ...errorFields(error),
-        });
-      });
+    if (!removed.success) throw new Error('member removal payload cannot be revalidated');
+    const affected = [...connections.values()].filter(
+      (connection) =>
+        connection.organizationId === action.organizationId &&
+        connection.principal.userId === removed.data.userId,
+    );
+    await Promise.all(
+      affected.map(async (connection) => {
+        try {
+          await revalidate(connection);
+        } catch (error: unknown) {
+          connections.delete(connection.id);
+          connection.close(ORGANIZATION_FORBIDDEN_CLOSE_CODE, 'membership_revoked');
+          logger.error('membership revalidation failed', {
+            connectionId: connection.id,
+            ...errorFields(error),
+          });
+        }
+      }),
+    );
+  }
+
+  function affectsMembershipReach(action: SyncAction): boolean {
+    return action.model === 'team_member' || action.model === 'member';
+  }
+
+  function suspendMembershipDeltaFlush(action: SyncAction): Connection[] {
+    if (!affectsMembershipReach(action)) return [];
+    const affected = [...connections.values()].filter(
+      (connection) => connection.organizationId === action.organizationId,
+    );
+    for (const connection of affected) {
+      connection.suspendDeltaFlush();
+      connection.suspendAuthorization();
+    }
+    return affected;
+  }
+
+  function finishMembershipDeltaFlush(
+    action: SyncAction,
+    affected: readonly Connection[],
+    revalidated: boolean,
+  ): void {
+    if (affected.length === 0) return;
+    for (const connection of affected) {
+      if (connections.get(connection.id) !== connection) {
+        connection.resumeAuthorization();
+        continue;
+      }
+      if (!revalidated) {
+        connections.delete(connection.id);
+        connection.close(ORGANIZATION_FORBIDDEN_CLOSE_CODE, 'membership_revoked');
+        connection.resumeAuthorization();
+        continue;
+      }
+      connection.resumeDeltaFlush(
+        (pending) =>
+          pendingActionWithinReach(connection, pending) &&
+          connection.matches(pending.scopes, pending.organizationId),
+      );
+      connection.resumeAuthorization();
+    }
+    if (revalidated) return;
+    logger.error('membership delta processing failed, closing to fail closed', {
+      organizationId: action.organizationId,
+    });
+  }
+
+  function affectsIssueMoveReach(action: SyncAction): boolean {
+    if (action.model !== 'issue') return false;
+    return (
+      action.action === 'delete' ||
+      action.data['teamChanged'] === true ||
+      action.data['departure'] === true
+    );
+  }
+
+  function suspendIssueMoveReach(action: SyncAction): Connection[] {
+    if (!affectsIssueMoveReach(action)) return [];
+    const affected = [...connections.values()].filter(
+      (connection) => connection.organizationId === action.organizationId,
+    );
+    for (const connection of affected) {
+      connection.suspendDeltaFlush();
+      connection.suspendAuthorization();
+    }
+    return affected;
+  }
+
+  function pendingIssueActionWithinReach(connection: Connection, action: SyncAction): boolean {
+    const binding = issueBinding(action);
+    if (binding.kind === 'invalid') return false;
+    if (binding.kind === 'none') {
+      return (
+        pendingActionWithinReach(connection, action) &&
+        connection.matches(action.scopes, action.organizationId)
+      );
+    }
+    const boundary = issueTeamBoundaries.get(
+      issueTeamBoundaryKey(action.organizationId, binding.issueId),
+    );
+    if (boundary === undefined) {
+      return (
+        pendingActionWithinReach(connection, action) &&
+        connection.matches(action.scopes, action.organizationId)
+      );
+    }
+    if (boundary.moveSyncId !== null && action.syncId < boundary.moveSyncId) return false;
+    if (binding.departure) return pendingActionWithinReach(connection, action);
+    return (
+      audienceWithinReach(connection, issueAudienceAtBoundary(action, binding, boundary)) &&
+      connection.matches(action.scopes, action.organizationId)
+    );
+  }
+
+  function isCurrentIssueTombstone(action: SyncAction, pending: SyncAction): boolean {
+    return action === pending && action.model === 'issue' && action.action === 'delete';
+  }
+
+  function finishIssueMoveReach(action: SyncAction, affected: readonly Connection[]): void {
+    for (const connection of affected) {
+      if (connections.get(connection.id) === connection) {
+        connection.resumeDeltaFlush(
+          (pending) =>
+            isCurrentIssueTombstone(action, pending) ||
+            pendingIssueActionWithinReach(connection, pending),
+        );
+      }
+      connection.resumeAuthorization();
     }
   }
 
-  function deliverDelta(payload: string): void {
-    const envelope = deltaEnvelopeSchema.safeParse(parseJson(payload));
-    if (!envelope.success) {
-      logger.warn('discarded malformed delta', { channel: REDIS_DELTA_CHANNEL });
-      return;
-    }
-    for (const entry of envelope.data) {
-      const parsed = syncActionSchema.safeParse(entry);
-      if (!parsed.success) {
-        logger.warn('discarded malformed delta action', { channel: REDIS_DELTA_CHANNEL });
+  function dropIssueScopeOutsideTeam(action: SyncAction, destinationTeamId: string | null): void {
+    const issueScope = scopes.issue(action.modelId);
+    for (const connection of connections.values()) {
+      if (connection.organizationId !== action.organizationId) continue;
+      if (!connection.scopes.has(issueScope) || connection.principal.role === 'admin') continue;
+      if (destinationTeamId !== null && connection.principal.teamIds.includes(destinationTeamId)) {
         continue;
       }
-      const action = parsed.data;
-      for (const connection of connections.values()) {
-        if (connection.matches(action.scopes, action.organizationId)) connection.queueDelta(action);
+      connection.removeScopes([issueScope]);
+    }
+  }
+
+  async function prepareIssueMoveArrival(action: SyncAction): Promise<boolean> {
+    if (action.model !== 'issue' || action.action === 'delete') return true;
+    if (action.data['teamChanged'] !== true) return true;
+    const destinationTeamId = issueTeamId(action);
+    if (destinationTeamId === null) return false;
+    const boundaryKey = issueTeamBoundaryKey(action.organizationId, action.modelId);
+    const known = issueTeamBoundaries.get(boundaryKey);
+    if (known !== undefined && known.moveSyncId !== null && known.moveSyncId > action.syncId) {
+      return false;
+    }
+    const current = await loadAuthoritativeIssueReach(
+      action,
+      'issue move validation failed, preserving existing reach',
+    );
+    if (
+      current === null ||
+      current.teamId !== destinationTeamId ||
+      action.syncId !== current.syncId
+    ) {
+      return false;
+    }
+    issueTeamBoundaries.rememberMove(boundaryKey, action.syncId, destinationTeamId);
+    presence.move(scopes.issue(action.modelId), destinationTeamId);
+    dropIssueScopeOutsideTeam(action, destinationTeamId);
+    return true;
+  }
+
+  async function loadAuthoritativeIssueReach(
+    action: SyncAction,
+    failureMessage: string,
+  ): Promise<Awaited<ReturnType<typeof issueReachInOrganization>>> {
+    try {
+      return await issueReachInOrganization(action.modelId, action.organizationId);
+    } catch (error: unknown) {
+      logger.error(failureMessage, {
+        organizationId: action.organizationId,
+        issueId: action.modelId,
+        ...errorFields(error),
+      });
+      return null;
+    }
+  }
+
+  async function prepareMoveDeparture(
+    action: SyncAction,
+    sourceTeamId: string,
+  ): Promise<IssueDeletePreparation> {
+    const boundaryKey = issueTeamBoundaryKey(action.organizationId, action.modelId);
+    let current: Awaited<ReturnType<typeof issueReachInOrganization>>;
+    try {
+      current = await issueReachInOrganization(action.modelId, action.organizationId);
+    } catch (error: unknown) {
+      logger.error('issue departure validation failed, preserving existing reach', {
+        organizationId: action.organizationId,
+        issueId: action.modelId,
+        ...errorFields(error),
+      });
+      return { kind: 'rejected' };
+    }
+    if (current === null) return { kind: 'hard-delete', sourceTeamId };
+    if (current.syncId < action.syncId) {
+      return { kind: 'rejected' };
+    }
+    issueTeamBoundaries.rememberAuthoritative(boundaryKey, action.syncId, current.teamId);
+    if (current.teamId === sourceTeamId) return { kind: 'rejected' };
+    return { kind: 'departure', sourceTeamId, destinationTeamId: current.teamId };
+  }
+
+  async function prepareHardIssueDelete(
+    action: SyncAction,
+    sourceTeamId: string,
+  ): Promise<IssueDeletePreparation> {
+    try {
+      const current = await issueReachInOrganization(action.modelId, action.organizationId);
+      return current === null ? { kind: 'hard-delete', sourceTeamId } : { kind: 'rejected' };
+    } catch (error: unknown) {
+      logger.error('hard issue delete validation failed, preserving existing reach', {
+        organizationId: action.organizationId,
+        issueId: action.modelId,
+        ...errorFields(error),
+      });
+      return { kind: 'rejected' };
+    }
+  }
+
+  async function prepareIssueDelete(action: SyncAction): Promise<IssueDeletePreparation> {
+    if (action.model !== 'issue' || action.action !== 'delete') return { kind: 'none' };
+    const sourceTeamId = issueTeamId(action);
+    if (sourceTeamId === null || !action.scopes.includes(scopes.team(sourceTeamId))) {
+      return { kind: 'rejected' };
+    }
+    return action.data['departure'] === true
+      ? await prepareMoveDeparture(action, sourceTeamId)
+      : await prepareHardIssueDelete(action, sourceTeamId);
+  }
+
+  function clearDeletedIssueReach(action: SyncAction): void {
+    const issueScope = scopes.issue(action.modelId);
+    issueTeamBoundaries.delete(issueTeamBoundaryKey(action.organizationId, action.modelId));
+    presence.move(issueScope, null);
+    for (const connection of connections.values()) {
+      if (connection.organizationId === action.organizationId) {
+        connection.removeScopes([issueScope]);
       }
-      revalidateAffected(action);
+    }
+  }
+
+  function settleIssueDelete(action: SyncAction, preparation: IssueDeletePreparation): void {
+    if (preparation.kind === 'hard-delete') {
+      clearDeletedIssueReach(action);
+      return;
+    }
+    if (preparation.kind !== 'departure') return;
+    presence.move(scopes.issue(action.modelId), preparation.destinationTeamId);
+    dropIssueScopeOutsideTeam(action, preparation.destinationTeamId);
+  }
+
+  async function loadIssueTeamBoundary(
+    action: SyncAction,
+    binding: BoundIssue,
+  ): Promise<IssueTeamBoundary | null> {
+    const boundaryKey = issueTeamBoundaryKey(action.organizationId, binding.issueId);
+    const cached = issueTeamBoundaries.get(boundaryKey);
+    if (cached !== undefined) return cached;
+    try {
+      const teamId = await issueTeamIdInOrganization(binding.issueId, action.organizationId);
+      if (teamId === null) return null;
+      issueTeamBoundaries.rememberCurrent(boundaryKey, teamId);
+      return { teamId, moveSyncId: null };
+    } catch (error: unknown) {
+      logger.error('issue audience lookup failed, discarding action to fail closed', {
+        organizationId: action.organizationId,
+        issueId: binding.issueId,
+        ...errorFields(error),
+      });
+      return null;
+    }
+  }
+
+  function issueAudienceAtBoundary(
+    action: SyncAction,
+    binding: BoundIssue,
+    boundary: IssueTeamBoundary,
+  ): ActionAudience {
+    if (boundary.moveSyncId !== null && action.syncId < boundary.moveSyncId) {
+      return { allowed: false };
+    }
+    if (!binding.claimedTeamIds.includes(boundary.teamId)) return { allowed: false };
+    if (action.model === 'issue' && issueTeamId(action) !== boundary.teamId) {
+      return { allowed: false };
+    }
+    return { allowed: true, teamId: boundary.teamId };
+  }
+
+  function departureAudience(
+    action: SyncAction,
+    boundary: IssueTeamBoundary | undefined,
+  ): ActionAudience {
+    if (
+      boundary !== undefined &&
+      boundary.moveSyncId !== null &&
+      action.syncId < boundary.moveSyncId
+    ) {
+      return { allowed: false };
+    }
+    return declaredIssueAudience(action);
+  }
+
+  async function resolveActionAudience(action: SyncAction): Promise<ActionAudience> {
+    const binding = issueBinding(action);
+    if (binding.kind === 'invalid') return { allowed: false };
+    if (binding.kind === 'none') return declaredIssueAudience(action);
+    if (!issueDeclarationMatchesBinding(action, binding)) return { allowed: false };
+    const boundaryKey = issueTeamBoundaryKey(action.organizationId, binding.issueId);
+    if (binding.departure) {
+      return departureAudience(action, issueTeamBoundaries.get(boundaryKey));
+    }
+    const boundary = await loadIssueTeamBoundary(action, binding);
+    return boundary === null
+      ? { allowed: false }
+      : issueAudienceAtBoundary(action, binding, boundary);
+  }
+
+  function queueActionForAudience(action: SyncAction, audience: ActionAudience): void {
+    for (const connection of connections.values()) {
+      if (!audienceWithinReach(connection, audience)) continue;
+      if (connection.matches(action.scopes, action.organizationId)) {
+        connection.queueDelta(action);
+      }
+    }
+  }
+
+  async function resolvePreparedActionAudience(
+    action: SyncAction,
+    moveArrivalValid: boolean,
+    issueDelete: IssueDeletePreparation,
+  ): Promise<ActionAudience> {
+    if (!moveArrivalValid || issueDelete.kind === 'rejected') return { allowed: false };
+    if (issueDelete.kind === 'hard-delete') {
+      return { allowed: true, teamId: issueDelete.sourceTeamId };
+    }
+    if (issueDelete.kind === 'departure') {
+      return { allowed: true, teamId: issueDelete.sourceTeamId };
+    }
+    return await resolveActionAudience(action);
+  }
+
+  async function deliverDelta(payload: string): Promise<void> {
+    const actions = parseDeltaActions(payload);
+    if (actions === null) return;
+    for (const action of actions) {
+      const membershipAffected = suspendMembershipDeltaFlush(action);
+      const resourceAffected = suspendMutableResourceReach(action);
+      const issueMoveAffected = suspendIssueMoveReach(action);
+      let revalidated = false;
+      try {
+        const moveArrivalValid = await prepareIssueMoveArrival(action);
+        const issueDelete = await prepareIssueDelete(action);
+        const audience = await resolvePreparedActionAudience(action, moveArrivalValid, issueDelete);
+        queueActionForAudience(action, audience);
+        settleIssueDelete(action, issueDelete);
+        await revalidateMutableResourceScopes(action, resourceAffected);
+        await revalidateAffected(action);
+        revalidated = true;
+      } finally {
+        finishMutableResourceReach(action, resourceAffected);
+        finishIssueMoveReach(action, issueMoveAffected);
+        finishMembershipDeltaFlush(action, membershipAffected, revalidated);
+      }
     }
   }
 
   function deliverPresence(payload: string): void {
-    const parsed = presenceMessageSchema.safeParse(parseJson(payload));
+    const parsed = redisPresenceMessageSchema.safeParse(parseJson(payload));
     if (!parsed.success) {
       logger.warn('discarded malformed presence', { channel: REDIS_PRESENCE_CHANNEL });
       return;
     }
-    const message = parsed.data;
-    presence.record(message);
+    const { audience, ...message } = parsed.data;
+    if (!presence.record(message, audience ?? null)) return;
+    const issueId = issueScopeId(message.scope);
+    const issueAudienceTeamId = issueId === null ? null : (audience?.teamId ?? null);
     for (const connection of connections.values()) {
-      if (connection.principal.userId === message.userId) continue;
-      if (!connection.matches([message.scope], message.organizationId)) continue;
+      if (
+        !presenceWithinReach(
+          connection,
+          message.organizationId,
+          message.scope,
+          message.userId,
+          issueAudienceTeamId,
+        )
+      ) {
+        continue;
+      }
       connection.send({ type: 'presence', messages: [message] });
     }
   }
@@ -347,8 +911,11 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
     return { accepted, denied };
   }
 
-  async function handleSubscribe(connection: Connection, requested: string[]): Promise<void> {
-    const { accepted, denied } = await partitionScopes(connection, requested);
+  function sendSubscriptionResult(
+    connection: Connection,
+    accepted: readonly string[],
+    denied: readonly string[],
+  ): void {
     const overflow = connection.addScopes(accepted);
     connection.send({
       type: 'subscribed',
@@ -358,10 +925,67 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
     for (const scope of accepted) {
       if (!connection.scopes.has(scope)) continue;
       const messages = presence
-        .snapshot(scope)
+        .snapshot(scope, {
+          admin: connection.principal.role === 'admin',
+          teamIds: connection.principal.teamIds,
+        })
         .filter((message) => message.userId !== connection.principal.userId);
       if (messages.length > 0) connection.send({ type: 'presence', messages });
     }
+  }
+
+  async function handleSubscribe(connection: Connection, requested: string[]): Promise<void> {
+    while (connections.get(connection.id) === connection) {
+      const generation = await connection.waitForAuthorization();
+      if (connections.get(connection.id) !== connection) return;
+      const { accepted, denied } = await partitionScopes(connection, requested);
+      if (connections.get(connection.id) !== connection) return;
+      if (!connection.authorizationIsCurrent(generation)) continue;
+      sendSubscriptionResult(connection, accepted, denied);
+      return;
+    }
+  }
+
+  interface PresenceAuthorization {
+    readonly allowed: boolean;
+    readonly held: boolean;
+    readonly issueTeamId: string | null;
+  }
+
+  async function authorizePresence(
+    connection: Connection,
+    scope: string,
+  ): Promise<PresenceAuthorization> {
+    const held = connection.scopes.has(scope);
+    const issueId = issueScopeId(scope);
+    const issueAudienceTeamId =
+      issueId === null ? null : await authorizedIssueTeamId(issueId, connection.principal);
+    const allowed =
+      issueId === null
+        ? held || (await authorizeScope(scope, connection.principal))
+        : issueAudienceTeamId !== null;
+    return { allowed, held, issueTeamId: issueAudienceTeamId };
+  }
+
+  async function publishPresence(
+    connection: Connection,
+    scope: string,
+    kind: PresenceKind,
+    issueTeamId: string | null,
+  ): Promise<void> {
+    await publisher.publish(
+      REDIS_PRESENCE_CHANNEL,
+      JSON.stringify({
+        organizationId: connection.organizationId,
+        scope,
+        kind,
+        userId: connection.principal.userId,
+        name: connection.principal.name,
+        image: connection.principal.image,
+        at: new Date().toISOString(),
+        audience: { teamId: issueTeamId },
+      }),
+    );
   }
 
   async function handlePresence(
@@ -369,22 +993,20 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
     scope: string,
     kind: PresenceKind,
   ): Promise<void> {
-    const allowed =
-      connection.scopes.has(scope) || (await authorizeScope(scope, connection.principal));
-    if (!allowed) {
-      connection.send({ type: 'error', code: 'forbidden_scope', message: 'Scope not allowed.' });
+    while (connections.get(connection.id) === connection) {
+      const generation = await connection.waitForAuthorization();
+      if (connections.get(connection.id) !== connection) return;
+      const authorization = await authorizePresence(connection, scope);
+      if (connections.get(connection.id) !== connection) return;
+      if (!connection.authorizationIsCurrent(generation)) continue;
+      if (!authorization.allowed) {
+        if (authorization.held) connection.removeScopes([scope]);
+        connection.send({ type: 'error', code: 'forbidden_scope', message: 'Scope not allowed.' });
+        return;
+      }
+      await publishPresence(connection, scope, kind, authorization.issueTeamId);
       return;
     }
-    const message = {
-      organizationId: connection.organizationId,
-      scope,
-      kind,
-      userId: connection.principal.userId,
-      name: connection.principal.name,
-      image: connection.principal.image,
-      at: new Date().toISOString(),
-    };
-    await publisher.publish(REDIS_PRESENCE_CHANNEL, JSON.stringify(message));
   }
 
   async function handleMessage(connection: Connection, raw: string): Promise<void> {
@@ -509,14 +1131,25 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
     };
   }
 
+  let closing = false;
+  let orderedDelivery = Promise.resolve();
+
   subscriber.on('message', (channel: string, message: string) => {
-    if (channel === REDIS_DELTA_CHANNEL) deliverDelta(message);
-    else if (channel === REDIS_PRESENCE_CHANNEL) deliverPresence(message);
-    else if (channel === REDIS_CONTROL_CHANNEL) deliverControl(message);
+    if (channel === REDIS_DELTA_CHANNEL || channel === REDIS_PRESENCE_CHANNEL) {
+      orderedDelivery = orderedDelivery
+        .then(async () => {
+          if (channel === REDIS_DELTA_CHANNEL) await deliverDelta(message);
+          else deliverPresence(message);
+        })
+        .catch((error: unknown) => {
+          logger.error('ordered realtime delivery failed', errorFields(error));
+        });
+      return;
+    }
+    if (channel === REDIS_CONTROL_CHANNEL) deliverControl(message);
   });
   await subscriber.subscribe(REDIS_DELTA_CHANNEL, REDIS_PRESENCE_CHANNEL, REDIS_CONTROL_CHANNEL);
 
-  let closing = false;
   subscriber.on('error', (error: Error): void => {
     if (!closing) logger.error('redis subscriber error', errorFields(error));
   });
@@ -538,7 +1171,13 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
   }, heartbeatIntervalMs);
   heartbeat.unref();
 
-  const sweeper = setInterval(() => presence.sweep(), Math.max(1_000, presenceTtlMs / 3));
+  const sweeper = setInterval(
+    () => {
+      presence.sweep();
+      issueTeamBoundaries.sweep();
+    },
+    Math.max(1_000, Math.min(presenceTtlMs, issueTeamBoundaryTtlMs) / 3),
+  );
   sweeper.unref();
 
   const sessionSweeper = setInterval(() => {
@@ -557,7 +1196,7 @@ export async function createRealtimeHub(options: RealtimeHubOptions = {}): Promi
     connections.clear();
     subscriber.disconnect();
     publisher.disconnect();
-    await Promise.resolve();
+    await orderedDelivery;
   }
 
   return { accept, stats, close };

--- a/packages/realtime-server/src/issue-team-boundaries.ts
+++ b/packages/realtime-server/src/issue-team-boundaries.ts
@@ -1,0 +1,75 @@
+export interface IssueTeamBoundary {
+  readonly teamId: string;
+  readonly moveSyncId: number | null;
+}
+
+interface StoredIssueTeamBoundary extends IssueTeamBoundary {
+  readonly expiresAt: number;
+}
+
+export class IssueTeamBoundaries {
+  private readonly entries = new Map<string, StoredIssueTeamBoundary>();
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+
+  constructor(ttlMs: number, maxEntries: number) {
+    this.ttlMs = Math.max(1, Math.floor(ttlMs));
+    this.maxEntries = Math.max(1, Math.floor(maxEntries));
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  get(key: string, now = Date.now()): IssueTeamBoundary | undefined {
+    const entry = this.entries.get(key);
+    if (entry === undefined) return undefined;
+    if (entry.expiresAt <= now) {
+      this.entries.delete(key);
+      return undefined;
+    }
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return { teamId: entry.teamId, moveSyncId: entry.moveSyncId };
+  }
+
+  rememberCurrent(key: string, teamId: string, now = Date.now()): void {
+    const current = this.get(key, now);
+    if (current !== undefined && current.moveSyncId !== null) return;
+    this.set(key, { teamId, moveSyncId: null, expiresAt: now + this.ttlMs });
+  }
+
+  rememberMove(key: string, syncId: number, teamId: string, now = Date.now()): void {
+    const current = this.get(key, now);
+    if (current !== undefined && current.moveSyncId !== null && current.moveSyncId > syncId) {
+      return;
+    }
+    this.set(key, { teamId, moveSyncId: syncId, expiresAt: now + this.ttlMs });
+  }
+
+  rememberAuthoritative(key: string, syncId: number, teamId: string, now = Date.now()): void {
+    const current = this.get(key, now);
+    const moveSyncId = Math.max(syncId, current?.moveSyncId ?? syncId);
+    this.set(key, { teamId, moveSyncId, expiresAt: now + this.ttlMs });
+  }
+
+  delete(key: string): void {
+    this.entries.delete(key);
+  }
+
+  sweep(now = Date.now()): void {
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) this.entries.delete(key);
+    }
+  }
+
+  private set(key: string, entry: StoredIssueTeamBoundary): void {
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (typeof oldest !== 'string') return;
+      this.entries.delete(oldest);
+    }
+  }
+}

--- a/packages/realtime-server/src/presence.ts
+++ b/packages/realtime-server/src/presence.ts
@@ -2,26 +2,68 @@ import type { PresenceMessage } from '@orbit/shared/events';
 
 interface PresenceEntry {
   readonly message: PresenceMessage;
+  readonly teamId: string | null;
   readonly expiresAt: number;
+}
+
+interface PresenceBoundary {
+  readonly teamId: string | null;
+  readonly expiresAt: number;
+}
+
+export interface PresenceAudience {
+  readonly teamId: string | null;
+}
+
+export interface PresenceRecipient {
+  readonly admin: boolean;
+  readonly teamIds: readonly string[];
 }
 
 export class PresenceStore {
   private readonly byScope = new Map<string, Map<string, PresenceEntry>>();
+  private readonly boundaries = new Map<string, PresenceBoundary>();
 
   constructor(private readonly ttlMs: number) {}
 
-  record(message: PresenceMessage, now = Date.now()): void {
+  record(message: PresenceMessage, audience: PresenceAudience | null, now = Date.now()): boolean {
+    const expiresAt = Date.parse(message.at) + this.ttlMs;
+    if (!Number.isFinite(expiresAt) || expiresAt <= now) return false;
+    const issuePresence = message.scope.startsWith('issue:');
+    if (issuePresence && (audience === null || audience.teamId === null)) return false;
+    const boundary = this.boundaries.get(message.scope);
+    if (boundary !== undefined && boundary.expiresAt <= now) this.boundaries.delete(message.scope);
+    if (
+      boundary !== undefined &&
+      boundary.expiresAt > now &&
+      (audience === null || boundary.teamId === null || audience.teamId !== boundary.teamId)
+    ) {
+      return false;
+    }
     const scope = this.byScope.get(message.scope) ?? new Map<string, PresenceEntry>();
-    scope.set(message.userId, { message, expiresAt: now + this.ttlMs });
+    scope.set(message.userId, { message, teamId: audience?.teamId ?? null, expiresAt });
     this.byScope.set(message.scope, scope);
+    return true;
   }
 
-  snapshot(scope: string, now = Date.now()): PresenceMessage[] {
+  snapshot(scope: string, recipient: PresenceRecipient, now = Date.now()): PresenceMessage[] {
     const entries = this.byScope.get(scope);
     if (entries === undefined) return [];
+    const issuePresence = scope.startsWith('issue:');
     return [...entries.values()]
-      .filter((entry) => entry.expiresAt > now)
+      .filter(
+        (entry) =>
+          entry.expiresAt > now &&
+          (!issuePresence ||
+            (entry.teamId !== null &&
+              (recipient.admin || recipient.teamIds.includes(entry.teamId)))),
+      )
       .map((entry) => entry.message);
+  }
+
+  move(scope: string, teamId: string | null, now = Date.now()): void {
+    this.byScope.delete(scope);
+    this.boundaries.set(scope, { teamId, expiresAt: now + this.ttlMs });
   }
 
   sweep(now = Date.now()): void {
@@ -30,6 +72,9 @@ export class PresenceStore {
         if (entry.expiresAt <= now) entries.delete(userId);
       }
       if (entries.size === 0) this.byScope.delete(scope);
+    }
+    for (const [scope, boundary] of this.boundaries) {
+      if (boundary.expiresAt <= now) this.boundaries.delete(scope);
     }
   }
 }

--- a/packages/realtime-server/tests/connection.test.ts
+++ b/packages/realtime-server/tests/connection.test.ts
@@ -92,6 +92,93 @@ describe('Connection', () => {
     expect(message.actions.at(-1).data.title).toBe('newest');
   });
 
+  it('keeps the final move departure before the coalesced arrival', () => {
+    const { socket, connection } = build();
+    connection.queueDelta({
+      ...action('issue_a', 30, 'first arrival'),
+      data: { teamChanged: true, title: 'first arrival' },
+    });
+    connection.queueDelta({
+      ...action('issue_a', 31, 'departure'),
+      action: 'delete',
+      data: { departure: true },
+    });
+    connection.queueDelta({
+      ...action('issue_a', 31, 'final arrival'),
+      data: { teamChanged: true, title: 'final arrival' },
+    });
+    connection.flushDeltas();
+
+    const message = JSON.parse(socket.sent[0] ?? '{}');
+    expect(message.actions).toHaveLength(2);
+    expect(message.actions.map((entry: SyncAction) => entry.action)).toEqual(['delete', 'update']);
+    expect(message.actions[1]?.data).toEqual({ teamChanged: true, title: 'final arrival' });
+  });
+
+  it('keeps every departure identifier across consecutive moves', () => {
+    const { socket, connection } = build();
+    connection.queueDelta({
+      ...action('issue_a', 30, 'departure from A'),
+      action: 'delete',
+      data: { departure: true, identifier: 'A-1' },
+    });
+    connection.queueDelta({
+      ...action('issue_a', 30, 'arrival in B'),
+      data: { teamChanged: true, identifier: 'B-1' },
+    });
+    connection.queueDelta({
+      ...action('issue_a', 31, 'departure from B'),
+      action: 'delete',
+      data: { departure: true, identifier: 'B-1' },
+    });
+    connection.queueDelta({
+      ...action('issue_a', 31, 'arrival in C'),
+      data: { teamChanged: true, identifier: 'C-1' },
+    });
+    connection.flushDeltas();
+
+    const message = JSON.parse(socket.sent[0] ?? '{}');
+    expect(message.actions).toHaveLength(3);
+    expect(message.actions.map((entry: SyncAction) => entry.data['identifier'])).toEqual([
+      'A-1',
+      'B-1',
+      'C-1',
+    ]);
+    expect(message.actions.map((entry: SyncAction) => entry.action)).toEqual([
+      'delete',
+      'delete',
+      'update',
+    ]);
+  });
+
+  it('does not flush pending deltas while delivery is suspended', () => {
+    const { socket, connection } = build();
+    connection.queueDelta(action('issue_a', 40, 'restricted'));
+    connection.suspendDeltaFlush();
+
+    connection.flushDeltas();
+
+    expect(socket.sent).toHaveLength(0);
+    connection.resumeDeltaFlush(() => true);
+    connection.flushDeltas();
+    expect(socket.sent).toHaveLength(1);
+  });
+
+  it('waits for every overlapping delivery suspension before flushing', () => {
+    const { socket, connection } = build();
+    connection.queueDelta(action('issue_a', 41, 'restricted'));
+    connection.suspendDeltaFlush();
+    connection.suspendDeltaFlush();
+
+    connection.resumeDeltaFlush(() => true);
+    connection.flushDeltas();
+    expect(socket.sent).toHaveLength(0);
+
+    connection.resumeDeltaFlush(() => true);
+    connection.flushDeltas();
+    expect(socket.sent).toHaveLength(1);
+  });
+
   it('drops a connection whose outbound buffer exceeds the threshold', () => {
     const { socket, connection } = build({ maxBufferedBytes: 16 });
     socket.buffered = 17;

--- a/packages/realtime-server/tests/hub.test.ts
+++ b/packages/realtime-server/tests/hub.test.ts
@@ -2042,7 +2042,9 @@ describe('membership and session revocation', () => {
     const hub = await newHub();
     try {
       const wired = await connect(hub, home.readerUserId, home.organizationId);
+      const unaffected = await connect(hub, away.readerUserId, away.organizationId);
       await subscribe(wired, [`team:${home.teamCore}`]);
+      await subscribe(unaffected, [`team:${away.teamCore}`]);
 
       await publishDeltas([
         action({
@@ -2054,12 +2056,13 @@ describe('membership and session revocation', () => {
           syncId: 60,
         }),
         action({
-          modelId: home.issueOnCore,
-          scopes: [`team:${home.teamCore}`],
+          organizationId: away.organizationId,
+          modelId: away.issueOnCore,
+          scopes: [`team:${away.teamCore}`],
           data: {
-            id: home.issueOnCore,
-            teamId: home.teamCore,
-            title: 'Restricted after malformed removal',
+            id: away.issueOnCore,
+            teamId: away.teamCore,
+            title: 'Delivered after malformed removal',
           },
           syncId: 61,
         }),
@@ -2074,8 +2077,12 @@ describe('membership and session revocation', () => {
         code: ORGANIZATION_FORBIDDEN_CLOSE_CODE,
         reason: 'membership_revoked',
       });
-      expect(JSON.stringify(wired.socket.frames('delta'))).not.toContain(
-        'Restricted after malformed removal',
+      await waitFor(
+        () =>
+          JSON.stringify(unaffected.socket.frames('delta')).includes(
+            'Delivered after malformed removal',
+          ),
+        'the unaffected action after the malformed removal',
       );
     } finally {
       await hub.close();

--- a/packages/realtime-server/tests/hub.test.ts
+++ b/packages/realtime-server/tests/hub.test.ts
@@ -1,9 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test';
-import { db, eq, schema } from '@orbit/db';
+import { and, db, eq, schema, sql } from '@orbit/db';
 import {
   ORGANIZATION_FORBIDDEN_CLOSE_CODE,
   REDIS_CONTROL_CHANNEL,
   REDIS_DELTA_CHANNEL,
+  REDIS_PRESENCE_CHANNEL,
   SESSION_REVOKED_CLOSE_CODE,
   type SyncAction,
   UNAUTHORIZED_CLOSE_CODE,
@@ -19,9 +20,74 @@ import {
 } from './fixture.ts';
 
 const loggerModule = await import('../src/logger.ts');
+const authModule = await import('../src/auth.ts');
+const authorizeScopeActual = authModule.authorizeScope;
+const authorizedIssueTeamIdActual = authModule.authorizedIssueTeamId;
+
+type AuthorizationKind = 'scope' | 'issue';
+
+interface AuthorizationPause {
+  readonly kind: AuthorizationKind;
+  readonly key: string;
+  readonly started: Promise<void>;
+  readonly release: () => void;
+}
+
+interface ActiveAuthorizationPause {
+  readonly kind: AuthorizationKind;
+  readonly key: string;
+  readonly started: () => void;
+  readonly released: Promise<void>;
+}
+
+const authorizationPauses: ActiveAuthorizationPause[] = [];
+
+function holdAuthorization(kind: AuthorizationKind, key: string): AuthorizationPause {
+  let markStarted: () => void = () => undefined;
+  let releaseWaiter: () => void = () => undefined;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const released = new Promise<void>((resolve) => {
+    releaseWaiter = resolve;
+  });
+  const active = { kind, key, started: markStarted, released };
+  authorizationPauses.push(active);
+  return {
+    kind,
+    key,
+    started,
+    release: () => {
+      const index = authorizationPauses.indexOf(active);
+      if (index >= 0) authorizationPauses.splice(index, 1);
+      releaseWaiter();
+    },
+  };
+}
+
+async function waitAfterAuthorization(kind: AuthorizationKind, key: string): Promise<void> {
+  const pause = authorizationPauses.find((entry) => entry.kind === kind && entry.key === key);
+  if (pause === undefined) return;
+  pause.started();
+  await pause.released;
+}
+
 mock.module('../src/logger.ts', () => ({
   ...loggerModule,
   logger: { info: () => undefined, warn: () => undefined, error: () => undefined },
+}));
+mock.module('../src/auth.ts', () => ({
+  ...authModule,
+  authorizeScope: async (...args: Parameters<typeof authModule.authorizeScope>) => {
+    const allowed = await authorizeScopeActual(...args);
+    await waitAfterAuthorization('scope', args[0]);
+    return allowed;
+  },
+  authorizedIssueTeamId: async (...args: Parameters<typeof authModule.authorizedIssueTeamId>) => {
+    const teamId = await authorizedIssueTeamIdActual(...args);
+    await waitAfterAuthorization('issue', args[0]);
+    return teamId;
+  },
 }));
 mock.module('ioredis', () => ({ Redis: FakeRedis }));
 
@@ -43,6 +109,7 @@ afterAll(async () => {
   await dropSeededWorkspaces();
   resetFakeRedis();
   mock.module('../src/logger.ts', () => loggerModule);
+  mock.module('../src/auth.ts', () => authModule);
 });
 
 async function newHub(overrides: Parameters<typeof createRealtimeHub>[0] = {}): Promise<Hub> {
@@ -92,7 +159,7 @@ function action(overrides: Partial<SyncAction> = {}): SyncAction {
     action: 'update',
     model: 'issue',
     modelId: 'issue_1',
-    data: { id: 'issue_1' },
+    data: { id: 'issue_1', teamId: home.teamCore },
     actor: { type: 'user', id: home.adminUserId },
     at: '2026-01-01T00:00:00.000Z',
     ...overrides,
@@ -105,6 +172,10 @@ function driver(): FakeRedis {
 
 async function publishDelta(entry: SyncAction): Promise<void> {
   await driver().publish(REDIS_DELTA_CHANNEL, JSON.stringify([entry]));
+}
+
+async function publishDeltas(entries: readonly SyncAction[]): Promise<void> {
+  await driver().publish(REDIS_DELTA_CHANNEL, JSON.stringify(entries));
 }
 
 describe('subscribe is the authorization gate', () => {
@@ -206,6 +277,1425 @@ describe('delta fan out', () => {
     }
   });
 
+  it('blocks a foreign-team issue with a matching organization and forged team scope', async () => {
+    const hub = await newHub();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`org:${home.organizationId}`]);
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnOther,
+          scopes: [`org:${home.organizationId}`, `team:${home.teamCore}`],
+          data: {
+            id: home.issueOnOther,
+            teamId: home.teamOther,
+            title: 'Other team secret',
+          },
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(wired.socket.frames('delta')).toHaveLength(0);
+    } finally {
+      await hub.close();
+    }
+  });
+
+  it('fails closed when an issue-bound action omits its team scope', async () => {
+    const hub = await newHub();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`issue:${home.issueOnCore}`]);
+
+      await publishDelta(
+        action({
+          model: 'attachment',
+          modelId: 'attachment_without_team',
+          scopes: [`issue:${home.issueOnCore}`],
+          data: { id: 'attachment_without_team', parentId: home.issueOnCore },
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(wired.socket.frames('delta')).toHaveLength(0);
+    } finally {
+      await hub.close();
+    }
+  });
+
+  it('delivers an issue tombstone after its database row is gone', async () => {
+    const hub = await newHub();
+    const deletedIssueId = 'issue_already_deleted';
+    const issueScope = `issue:${deletedIssueId}`;
+    try {
+      const [template] = await db
+        .select()
+        .from(schema.issue)
+        .where(eq(schema.issue.id, home.issueOnCore))
+        .limit(1);
+      if (template === undefined) throw new Error('missing issue template');
+      await db.insert(schema.issue).values({
+        ...template,
+        id: deletedIssueId,
+        number: 999_992,
+        identifier: 'CORE-999992',
+      });
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      const admin = await connect(hub, home.adminUserId, home.organizationId);
+      await subscribe(wired, [`team:${home.teamCore}`, issueScope]);
+      await subscribe(admin, [issueScope]);
+      wired.session.message(
+        JSON.stringify({ type: 'presence', scope: issueScope, kind: 'viewing' }),
+      );
+      await waitFor(
+        () => admin.socket.frames('presence').length > 0,
+        'the issue presence before deletion',
+      );
+      const stalePresence = admin.socket.last('presence')?.messages[0];
+      if (stalePresence === undefined) throw new Error('missing issue presence');
+      await db.delete(schema.issue).where(eq(schema.issue.id, deletedIssueId));
+
+      await publishDelta(
+        action({
+          action: 'delete',
+          modelId: deletedIssueId,
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: deletedIssueId,
+            teamId: home.teamCore,
+            identifier: 'CORE-404',
+          },
+          syncId: 24,
+        }),
+      );
+      await waitFor(() => wired.socket.frames('delta').length > 0, 'the issue tombstone');
+      await waitFor(() => hub.stats().subscriptions === 1, 'the deleted issue scope cleanup');
+      await driver().publish(
+        REDIS_PRESENCE_CHANNEL,
+        JSON.stringify({ ...stalePresence, audience: { teamId: home.teamCore } }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(wired.socket.last('delta')?.actions[0]?.modelId).toBe(deletedIssueId);
+      expect(admin.socket.frames('presence')).toHaveLength(1);
+    } finally {
+      await db.delete(schema.issue).where(eq(schema.issue.id, deletedIssueId));
+      await hub.close();
+    }
+  });
+
+  it('delivers a newer hard delete despite an older cached team boundary', async () => {
+    const hub = await newHub();
+    const deletedIssueId = 'issue_deleted_after_move';
+    const issueScope = `issue:${deletedIssueId}`;
+    const destinationMembershipId = `tm_delete_${home.strangerUserId.slice(-8)}`;
+    try {
+      const [template] = await db
+        .select()
+        .from(schema.issue)
+        .where(eq(schema.issue.id, home.issueOnCore))
+        .limit(1);
+      if (template === undefined) throw new Error('missing issue template');
+      await db.insert(schema.issue).values({
+        ...template,
+        id: deletedIssueId,
+        number: 999_986,
+        identifier: 'CORE-999986',
+        syncId: 170,
+      });
+      await db.insert(schema.teamMember).values({
+        id: destinationMembershipId,
+        teamId: home.teamOther,
+        userId: home.strangerUserId,
+      });
+      await publishDelta(
+        action({
+          modelId: deletedIssueId,
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: deletedIssueId,
+            teamId: home.teamCore,
+            teamChanged: true,
+          },
+          syncId: 170,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_985, syncId: 180 })
+        .where(eq(schema.issue.id, deletedIssueId));
+      const destination = await connect(hub, home.strangerUserId, home.organizationId);
+      await subscribe(destination, [issueScope]);
+      await db.delete(schema.issue).where(eq(schema.issue.id, deletedIssueId));
+
+      await publishDelta(
+        action({
+          action: 'delete',
+          modelId: deletedIssueId,
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: deletedIssueId,
+            teamId: home.teamOther,
+            identifier: 'OTHER-999985',
+          },
+          syncId: 180,
+        }),
+      );
+      await waitFor(() => destination.socket.frames('delta').length > 0, 'the moved hard delete');
+
+      expect(destination.socket.last('delta')?.actions[0]?.modelId).toBe(deletedIssueId);
+      expect(hub.stats().subscriptions).toBe(0);
+    } finally {
+      await db.delete(schema.issue).where(eq(schema.issue.id, deletedIssueId));
+      await db.delete(schema.teamMember).where(eq(schema.teamMember.id, destinationMembershipId));
+      await hub.close();
+    }
+  });
+
+  it('rejects a hard delete while its authoritative issue row is still live', async () => {
+    const hub = await newHub();
+    const issueScope = `issue:${home.issueOnCore}`;
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [issueScope]);
+
+      await publishDelta(
+        action({
+          action: 'delete',
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamCore,
+            identifier: 'CORE-LIVE',
+          },
+          syncId: 200,
+        }),
+      );
+      await publishDelta(
+        action({
+          model: 'comment',
+          modelId: 'comment_after_forged_delete',
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: 'comment_after_forged_delete',
+            issueId: home.issueOnCore,
+            body: 'Still live after forged delete',
+          },
+          syncId: 201,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      const delivered = JSON.stringify(wired.socket.frames('delta'));
+      expect(delivered).not.toContain('CORE-LIVE');
+      expect(delivered).toContain('Still live after forged delete');
+      expect(hub.stats().subscriptions).toBe(1);
+    } finally {
+      await hub.close();
+    }
+  });
+
+  it('retries an in-flight issue subscription across a hard delete', async () => {
+    const hub = await newHub();
+    const deletedIssueId = 'issue_deleted_during_subscribe';
+    const issueScope = `issue:${deletedIssueId}`;
+    const pause = holdAuthorization('scope', issueScope);
+    try {
+      const [template] = await db
+        .select()
+        .from(schema.issue)
+        .where(eq(schema.issue.id, home.issueOnCore))
+        .limit(1);
+      if (template === undefined) throw new Error('missing issue template');
+      await db.insert(schema.issue).values({
+        ...template,
+        id: deletedIssueId,
+        number: 999_984,
+        identifier: 'CORE-999984',
+        syncId: 190,
+      });
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      wired.session.message(JSON.stringify({ type: 'subscribe', scopes: [issueScope] }));
+      await pause.started;
+      await db.delete(schema.issue).where(eq(schema.issue.id, deletedIssueId));
+
+      await publishDelta(
+        action({
+          action: 'delete',
+          modelId: deletedIssueId,
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: deletedIssueId,
+            teamId: home.teamCore,
+            identifier: 'CORE-999984',
+          },
+          syncId: 190,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      pause.release();
+      await waitFor(
+        () => wired.socket.frames('subscribed').length > 0,
+        'the retried deleted issue subscription',
+      );
+
+      expect(wired.socket.last('subscribed')?.scopes).not.toContain(issueScope);
+      expect(wired.socket.last('subscribed')?.denied).toContain(issueScope);
+      expect(hub.stats().subscriptions).toBe(0);
+    } finally {
+      pause.release();
+      await db.delete(schema.issue).where(eq(schema.issue.id, deletedIssueId));
+      await hub.close();
+    }
+  });
+
+  it('drops a retained issue scope before a cross-team arrival can disclose the new row', async () => {
+    const hub = await newHub();
+    const issueScope = `issue:${home.issueOnCore}`;
+    const projectScope = `project:${home.projectWithoutTeams}`;
+    const destinationMembershipId = `tm_move_${home.strangerUserId.slice(-8)}`;
+    try {
+      await db.insert(schema.teamMember).values({
+        id: destinationMembershipId,
+        teamId: home.teamOther,
+        userId: home.strangerUserId,
+      });
+      const oldTeam = await connect(hub, home.readerUserId, home.organizationId);
+      const admin = await connect(hub, home.adminUserId, home.organizationId);
+      await subscribe(oldTeam, [`team:${home.teamCore}`, issueScope, projectScope]);
+      await subscribe(admin, [issueScope]);
+      oldTeam.session.message(
+        JSON.stringify({ type: 'presence', scope: issueScope, kind: 'viewing' }),
+      );
+      await waitFor(
+        () => admin.socket.frames('presence').length > 0,
+        'the source presence before the move',
+      );
+      const stalePresence = admin.socket.last('presence')?.messages[0];
+      if (stalePresence === undefined) throw new Error('missing source presence');
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_999, syncId: 30 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      const destination = await connect(hub, home.strangerUserId, home.organizationId);
+      await subscribe(destination, [issueScope]);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(destination.socket.frames('presence')).toHaveLength(0);
+      await driver().publish(
+        REDIS_PRESENCE_CHANNEL,
+        JSON.stringify({
+          ...stalePresence,
+          audience: { teamId: home.teamCore },
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(destination.socket.frames('presence')).toHaveLength(0);
+
+      await publishDeltas([
+        action({
+          model: 'comment',
+          modelId: 'comment_overtook_move',
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: 'comment_overtook_move',
+            issueId: home.issueOnCore,
+            body: 'Destination comment before move delta',
+          },
+          syncId: 29,
+        }),
+        action({
+          model: 'attachment',
+          modelId: 'attachment_overtook_move',
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: 'attachment_overtook_move',
+            parentType: 'issue',
+            parentId: home.issueOnCore,
+            fileName: 'destination-secret.txt',
+          },
+          syncId: 29,
+        }),
+      ]);
+      await waitFor(
+        () => admin.socket.frames('delta').flatMap((frame) => frame.actions).length === 2,
+        'the destination payloads that overtook the move',
+      );
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(oldTeam.socket.frames('delta')).toHaveLength(0);
+
+      await publishDeltas([
+        action({
+          action: 'delete',
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamCore}`, issueScope, projectScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamCore,
+            identifier: 'CORE-1',
+            departure: true,
+            syncId: 30,
+          },
+          syncId: 30,
+        }),
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamOther}`, issueScope, projectScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamOther,
+            identifier: 'OTHER-1',
+            title: 'Destination secret',
+            teamChanged: true,
+            syncId: 30,
+          },
+          syncId: 30,
+        }),
+      ]);
+      await waitFor(() => oldTeam.socket.frames('delta').length > 0, 'the departure delta');
+      await waitFor(() => admin.socket.frames('delta').length > 0, 'the admin move delta');
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamOther}`, issueScope, projectScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamOther,
+            identifier: 'OTHER-1',
+            title: 'Later destination secret',
+            syncId: 31,
+          },
+          syncId: 31,
+        }),
+      );
+      await waitFor(
+        () =>
+          admin.socket
+            .frames('delta')
+            .flatMap((frame) => frame.actions)
+            .filter((entry) => entry.model === 'issue').length === 3,
+        'the ordinary destination update',
+      );
+      await driver().publish(
+        REDIS_PRESENCE_CHANNEL,
+        JSON.stringify({
+          ...stalePresence,
+          audience: { teamId: home.teamCore },
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      const oldActions = oldTeam.socket.frames('delta').flatMap((frame) => frame.actions);
+      const adminActions = admin.socket.frames('delta').flatMap((frame) => frame.actions);
+      const adminIssueActions = adminActions.filter((entry) => entry.model === 'issue');
+      expect(oldActions.map((entry) => entry.action)).toEqual(['delete']);
+      expect(JSON.stringify(oldActions)).not.toContain('Destination secret');
+      expect(JSON.stringify(oldActions)).not.toContain('Later destination secret');
+      expect(adminIssueActions.map((entry) => entry.action)).toEqual([
+        'delete',
+        'update',
+        'update',
+      ]);
+      expect(hub.stats().subscriptions).toBe(4);
+
+      oldTeam.session.message(
+        JSON.stringify({ type: 'presence', scope: issueScope, kind: 'viewing' }),
+      );
+      await waitFor(
+        () => oldTeam.socket.frames('error').length > 0,
+        'the departed issue scope to reject presence',
+      );
+      expect(oldTeam.socket.last('error')?.code).toBe('forbidden_scope');
+
+      expect(destination.socket.frames('presence')).toHaveLength(0);
+    } finally {
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await db.delete(schema.teamMember).where(eq(schema.teamMember.id, destinationMembershipId));
+      await hub.close();
+    }
+  });
+
+  it('revokes an issue scope before any split move payload can reuse it', async () => {
+    const hub = await newHub();
+    const issueScope = `issue:${home.issueOnCore}`;
+    try {
+      const source = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(source, [issueScope]);
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_998, syncId: 44 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+
+      await publishDelta(
+        action({
+          action: 'delete',
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamCore,
+            identifier: 'CORE-1',
+            departure: true,
+            syncId: 44,
+          },
+          syncId: 44,
+        }),
+      );
+      await waitFor(() => source.socket.frames('delta').length > 0, 'the split departure');
+      await waitFor(() => hub.stats().subscriptions === 0, 'the split issue scope revocation');
+
+      await publishDelta(
+        action({
+          model: 'comment',
+          modelId: 'comment_secret',
+          scopes: [issueScope],
+          data: { id: 'comment_secret', issueId: home.issueOnCore, body: 'Destination comment' },
+          syncId: 45,
+        }),
+      );
+      await driver().publish(
+        REDIS_PRESENCE_CHANNEL,
+        JSON.stringify({
+          organizationId: home.organizationId,
+          scope: issueScope,
+          kind: 'viewing',
+          userId: home.adminUserId,
+          name: 'Ada Admin',
+          image: null,
+          at: new Date().toISOString(),
+          audience: { teamId: home.teamOther },
+        }),
+      );
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamOther,
+            identifier: 'OTHER-1',
+            title: 'Still allowed',
+            teamChanged: true,
+            syncId: 44,
+          },
+          syncId: 44,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const received = source.socket.frames('delta').flatMap((frame) => frame.actions);
+      expect(received.map((entry) => entry.action)).toEqual(['delete']);
+      expect(JSON.stringify(received)).not.toContain('Destination comment');
+      expect(JSON.stringify(received)).not.toContain('Still allowed');
+      expect(source.socket.frames('presence')).toHaveLength(0);
+      expect(hub.stats().subscriptions).toBe(0);
+    } finally {
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await hub.close();
+    }
+  });
+
+  it('keeps the destination boundary when a split move departure arrives late', async () => {
+    const hub = await newHub();
+    const issueScope = `issue:${home.issueOnCore}`;
+    const destinationMembershipId = `tm_late_${home.strangerUserId.slice(-8)}`;
+    try {
+      await db.insert(schema.teamMember).values({
+        id: destinationMembershipId,
+        teamId: home.teamOther,
+        userId: home.strangerUserId,
+      });
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_997, syncId: 54 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      const destination = await connect(hub, home.strangerUserId, home.organizationId);
+      await subscribe(destination, [issueScope]);
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamOther,
+            identifier: 'OTHER-1',
+            title: 'Destination arrival',
+            teamChanged: true,
+          },
+          syncId: 54,
+        }),
+      );
+      await publishDelta(
+        action({
+          action: 'delete',
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamCore,
+            identifier: 'CORE-1',
+            departure: true,
+          },
+          syncId: 54,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(hub.stats().subscriptions).toBe(1);
+
+      await publishDelta(
+        action({
+          model: 'comment',
+          modelId: 'comment_after_late_departure',
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: 'comment_after_late_departure',
+            issueId: home.issueOnCore,
+            body: 'Still in destination',
+          },
+          syncId: 55,
+        }),
+      );
+      await driver().publish(
+        REDIS_PRESENCE_CHANNEL,
+        JSON.stringify({
+          organizationId: home.organizationId,
+          scope: issueScope,
+          kind: 'viewing',
+          userId: home.adminUserId,
+          name: 'Ada Admin',
+          image: null,
+          at: new Date().toISOString(),
+          audience: { teamId: home.teamOther },
+        }),
+      );
+      await waitFor(
+        () =>
+          destination.socket
+            .frames('delta')
+            .flatMap((frame) => frame.actions)
+            .some((entry) => entry.modelId === 'comment_after_late_departure'),
+        'the destination delta after the late departure',
+      );
+      await waitFor(
+        () => destination.socket.frames('presence').length > 0,
+        'the destination presence after the late departure',
+      );
+    } finally {
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await db.delete(schema.teamMember).where(eq(schema.teamMember.id, destinationMembershipId));
+      await hub.close();
+    }
+  });
+
+  it('rejects delayed source-team metadata after an issue crosses the team boundary', async () => {
+    const hub = await newHub();
+    const issueScope = `issue:${home.issueOnCore}`;
+    try {
+      const source = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(source, [`team:${home.teamCore}`]);
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_996, syncId: 64 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamOther,
+            identifier: 'OTHER-2',
+            title: 'Destination issue',
+            teamChanged: true,
+          },
+          syncId: 64,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      await publishDeltas([
+        action({
+          model: 'comment',
+          modelId: 'comment_delayed_from_source',
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: 'comment_delayed_from_source',
+            issueId: home.issueOnCore,
+            body: 'Delayed source comment',
+          },
+          syncId: 63,
+        }),
+        action({
+          model: 'attachment',
+          modelId: 'attachment_delayed_from_source',
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: 'attachment_delayed_from_source',
+            parentType: 'issue',
+            parentId: home.issueOnCore,
+            fileName: 'delayed-source.txt',
+          },
+          syncId: 63,
+        }),
+      ]);
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(source.socket.frames('delta')).toHaveLength(0);
+      expect(source.socket.last('subscribed')?.scopes).toContain(`team:${home.teamCore}`);
+    } finally {
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await hub.close();
+    }
+  });
+
+  it('falls back to authoritative reach after a move boundary is evicted', async () => {
+    const hub = await newHub({ maxIssueTeamBoundaries: 1 });
+    const issueScope = `issue:${home.issueOnCore}`;
+    try {
+      const source = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(source, [`team:${home.teamCore}`]);
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_994, syncId: 84 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamOther,
+            teamChanged: true,
+          },
+          syncId: 84,
+        }),
+      );
+      await db
+        .update(schema.issue)
+        .set({ syncId: 85 })
+        .where(eq(schema.issue.id, home.issueOnOther));
+      await publishDelta(
+        action({
+          modelId: home.issueOnOther,
+          scopes: [`team:${home.teamOther}`, `issue:${home.issueOnOther}`],
+          data: {
+            id: home.issueOnOther,
+            teamId: home.teamOther,
+            teamChanged: true,
+          },
+          syncId: 85,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      await publishDelta(
+        action({
+          model: 'attachment',
+          modelId: 'attachment_after_boundary_eviction',
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: 'attachment_after_boundary_eviction',
+            parentType: 'issue',
+            parentId: home.issueOnCore,
+            fileName: 'evicted-source.txt',
+          },
+          syncId: 83,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(JSON.stringify(source.socket.frames('delta'))).not.toContain('evicted-source.txt');
+    } finally {
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await db
+        .update(schema.issue)
+        .set({ syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnOther));
+      await hub.close();
+    }
+  });
+
+  it('rejects a stale move arrival after its cached boundary expires', async () => {
+    const hub = await newHub({ issueTeamBoundaryTtlMs: 5 });
+    const issueScope = `issue:${home.issueOnCore}`;
+    const destinationMembershipId = `tm_expire_${home.strangerUserId.slice(-8)}`;
+    try {
+      await db.insert(schema.teamMember).values({
+        id: destinationMembershipId,
+        teamId: home.teamOther,
+        userId: home.strangerUserId,
+      });
+      const source = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(source, [issueScope]);
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_993, syncId: 94 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      const destination = await connect(hub, home.strangerUserId, home.organizationId);
+      await subscribe(destination, [issueScope]);
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamOther,
+            teamChanged: true,
+          },
+          syncId: 94,
+        }),
+      );
+      await waitFor(() => hub.stats().subscriptions === 1, 'the source scope removal');
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamCore,
+            title: 'Stale source arrival',
+            teamChanged: true,
+          },
+          syncId: 93,
+        }),
+      );
+      await publishDelta(
+        action({
+          model: 'comment',
+          modelId: 'comment_after_expired_boundary',
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: 'comment_after_expired_boundary',
+            issueId: home.issueOnCore,
+            body: 'Current destination comment',
+          },
+          syncId: 95,
+        }),
+      );
+      await waitFor(
+        () =>
+          destination.socket
+            .frames('delta')
+            .flatMap((frame) => frame.actions)
+            .some((entry) => entry.modelId === 'comment_after_expired_boundary'),
+        'the destination delta after a stale expired arrival',
+      );
+
+      expect(hub.stats().subscriptions).toBe(1);
+      expect(JSON.stringify(source.socket.frames('delta'))).not.toContain('Stale source arrival');
+    } finally {
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await db.delete(schema.teamMember).where(eq(schema.teamMember.id, destinationMembershipId));
+      await hub.close();
+    }
+  });
+
+  it('rejects a cache-cold stale move whose old destination is current again', async () => {
+    const hub = await newHub();
+    const issueScope = `issue:${home.issueOnCore}`;
+    const destinationMembershipId = `tm_return_${home.strangerUserId.slice(-8)}`;
+    try {
+      await db.insert(schema.teamMember).values({
+        id: destinationMembershipId,
+        teamId: home.teamOther,
+        userId: home.strangerUserId,
+      });
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_989, syncId: 130 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      const destination = await connect(hub, home.strangerUserId, home.organizationId);
+      await subscribe(destination, [issueScope]);
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamOther,
+            title: 'Obsolete same-team arrival',
+            teamChanged: true,
+          },
+          syncId: 120,
+        }),
+      );
+      await publishDelta(
+        action({
+          model: 'comment',
+          modelId: 'comment_after_same_team_replay',
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: 'comment_after_same_team_replay',
+            issueId: home.issueOnCore,
+            body: 'Current destination metadata',
+          },
+          syncId: 131,
+        }),
+      );
+      await waitFor(
+        () =>
+          destination.socket
+            .frames('delta')
+            .flatMap((frame) => frame.actions)
+            .some((entry) => entry.modelId === 'comment_after_same_team_replay'),
+        'the current metadata after a same-team replay',
+      );
+
+      expect(JSON.stringify(destination.socket.frames('delta'))).not.toContain(
+        'Obsolete same-team arrival',
+      );
+      expect(hub.stats().subscriptions).toBe(1);
+    } finally {
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await db.delete(schema.teamMember).where(eq(schema.teamMember.id, destinationMembershipId));
+      await hub.close();
+    }
+  });
+
+  it('rejects a cache-cold future move that could poison the current boundary', async () => {
+    const hub = await newHub();
+    const issueScope = `issue:${home.issueOnCore}`;
+    const destinationMembershipId = `tm_future_${home.strangerUserId.slice(-8)}`;
+    try {
+      await db.insert(schema.teamMember).values({
+        id: destinationMembershipId,
+        teamId: home.teamOther,
+        userId: home.strangerUserId,
+      });
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_988, syncId: 130 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      const destination = await connect(hub, home.strangerUserId, home.organizationId);
+      await subscribe(destination, [issueScope]);
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamOther,
+            title: 'Forged future arrival',
+            teamChanged: true,
+          },
+          syncId: 140,
+        }),
+      );
+      await publishDelta(
+        action({
+          model: 'comment',
+          modelId: 'comment_after_future_replay',
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: 'comment_after_future_replay',
+            issueId: home.issueOnCore,
+            body: 'Authoritative current metadata',
+          },
+          syncId: 131,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      const delivered = JSON.stringify(destination.socket.frames('delta'));
+      expect(delivered).not.toContain('Forged future arrival');
+      expect(delivered).toContain('Authoritative current metadata');
+      expect(hub.stats().subscriptions).toBe(1);
+    } finally {
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await db.delete(schema.teamMember).where(eq(schema.teamMember.id, destinationMembershipId));
+      await hub.close();
+    }
+  });
+
+  it('rejects a cache-cold stale departure after the issue returned to its source', async () => {
+    const hub = await newHub();
+    const issueScope = `issue:${home.issueOnCore}`;
+    const currentMembershipId = `tm_departure_${home.strangerUserId.slice(-8)}`;
+    try {
+      await db.insert(schema.teamMember).values({
+        id: currentMembershipId,
+        teamId: home.teamOther,
+        userId: home.strangerUserId,
+      });
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_987, syncId: 160 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      const currentReader = await connect(hub, home.strangerUserId, home.organizationId);
+      await subscribe(currentReader, [issueScope]);
+
+      await publishDeltas([
+        action({
+          action: 'delete',
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamOther,
+            identifier: 'OLD-150',
+            departure: true,
+          },
+          syncId: 150,
+        }),
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamCore,
+            title: 'Stale return departure destination',
+            teamChanged: true,
+          },
+          syncId: 150,
+        }),
+      ]);
+      await publishDelta(
+        action({
+          model: 'comment',
+          modelId: 'comment_after_stale_departure',
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: 'comment_after_stale_departure',
+            issueId: home.issueOnCore,
+            body: 'Current metadata after stale departure',
+          },
+          syncId: 161,
+        }),
+      );
+      await waitFor(
+        () =>
+          JSON.stringify(currentReader.socket.frames('delta')).includes(
+            'Current metadata after stale departure',
+          ),
+        'the current metadata after the stale departure',
+      );
+
+      const delivered = JSON.stringify(currentReader.socket.frames('delta'));
+      expect(delivered).not.toContain('OLD-150');
+      expect(delivered).not.toContain('Stale return departure destination');
+      expect(delivered).toContain('Current metadata after stale departure');
+      expect(hub.stats().subscriptions).toBe(1);
+    } finally {
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await db.delete(schema.teamMember).where(eq(schema.teamMember.id, currentMembershipId));
+      await hub.close();
+    }
+  });
+
+  it('delivers a cache-cold delayed departure after the destination issue advanced', async () => {
+    const hub = await newHub();
+    const issueScope = `issue:${home.issueOnCore}`;
+    try {
+      const source = await connect(hub, home.readerUserId, home.organizationId);
+      const destination = await connect(hub, home.adminUserId, home.organizationId);
+      await subscribe(source, [`team:${home.teamCore}`, issueScope]);
+      await subscribe(destination, [`team:${home.teamOther}`]);
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_983, syncId: 160 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+
+      await publishDelta(
+        action({
+          action: 'delete',
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamCore,
+            identifier: 'CORE-DELAYED-150',
+            departure: true,
+          },
+          syncId: 150,
+        }),
+      );
+      await waitFor(
+        () => JSON.stringify(source.socket.frames('delta')).includes('CORE-DELAYED-150'),
+        'the delayed source departure',
+      );
+
+      await publishDelta(
+        action({
+          model: 'comment',
+          modelId: 'comment_after_delayed_departure',
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: 'comment_after_delayed_departure',
+            issueId: home.issueOnCore,
+            body: 'Current destination after delayed departure',
+          },
+          syncId: 161,
+        }),
+      );
+      await waitFor(
+        () =>
+          JSON.stringify(destination.socket.frames('delta')).includes(
+            'Current destination after delayed departure',
+          ),
+        'the current destination metadata',
+      );
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(JSON.stringify(source.socket.frames('delta'))).not.toContain(
+        'Current destination after delayed departure',
+      );
+      expect(hub.stats().subscriptions).toBe(2);
+    } finally {
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await hub.close();
+    }
+  });
+
+  it('delivers an accepted delayed departure across a newer cached boundary', async () => {
+    const hub = await newHub();
+    const issueScope = `issue:${home.issueOnCore}`;
+    try {
+      const source = await connect(hub, home.readerUserId, home.organizationId);
+      const destination = await connect(hub, home.adminUserId, home.organizationId);
+      await subscribe(source, [`team:${home.teamCore}`, issueScope]);
+      await subscribe(destination, [`team:${home.teamOther}`]);
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_982, syncId: 180 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamOther,
+            title: 'Newer cached destination',
+            teamChanged: true,
+          },
+          syncId: 180,
+        }),
+      );
+      await waitFor(
+        () =>
+          JSON.stringify(destination.socket.frames('delta')).includes('Newer cached destination'),
+        'the newer cached destination arrival',
+      );
+      await db
+        .update(schema.issue)
+        .set({ title: 'Advanced destination row', syncId: 190 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+
+      await publishDelta(
+        action({
+          action: 'delete',
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamCore,
+            identifier: 'CORE-CACHED-170',
+            departure: true,
+          },
+          syncId: 170,
+        }),
+      );
+      await waitFor(
+        () => JSON.stringify(source.socket.frames('delta')).includes('CORE-CACHED-170'),
+        'the departure behind a newer boundary',
+      );
+
+      expect(hub.stats().subscriptions).toBe(2);
+    } finally {
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, title: 'On the core team', syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await hub.close();
+    }
+  });
+
+  it('uses a delayed departure as a safe tombstone after a later hard delete', async () => {
+    const hub = await newHub();
+    const deletedIssueId = 'issue_deleted_after_delayed_departure';
+    const issueScope = `issue:${deletedIssueId}`;
+    try {
+      const [template] = await db
+        .select()
+        .from(schema.issue)
+        .where(eq(schema.issue.id, home.issueOnCore))
+        .limit(1);
+      if (template === undefined) throw new Error('missing issue template');
+      await db.insert(schema.issue).values({
+        ...template,
+        id: deletedIssueId,
+        number: 999_981,
+        identifier: 'CORE-999981',
+        syncId: 200,
+      });
+      const source = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(source, [`team:${home.teamCore}`, issueScope]);
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_980, syncId: 210 })
+        .where(eq(schema.issue.id, deletedIssueId));
+      await db.delete(schema.issue).where(eq(schema.issue.id, deletedIssueId));
+
+      await publishDelta(
+        action({
+          action: 'delete',
+          modelId: deletedIssueId,
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: deletedIssueId,
+            teamId: home.teamCore,
+            identifier: 'CORE-DELETED-200',
+            departure: true,
+          },
+          syncId: 200,
+        }),
+      );
+      await waitFor(
+        () => JSON.stringify(source.socket.frames('delta')).includes('CORE-DELETED-200'),
+        'the delayed departure after hard deletion',
+      );
+
+      expect(hub.stats().subscriptions).toBe(1);
+    } finally {
+      await db.delete(schema.issue).where(eq(schema.issue.id, deletedIssueId));
+      await hub.close();
+    }
+  });
+
+  it('retries an in-flight source subscription across an issue move', async () => {
+    const hub = await newHub();
+    const issueScope = `issue:${home.issueOnCore}`;
+    let subscriptionPause: AuthorizationPause | null = null;
+    try {
+      const source = await connect(hub, home.readerUserId, home.organizationId);
+      subscriptionPause = holdAuthorization('scope', issueScope);
+
+      source.session.message(JSON.stringify({ type: 'subscribe', scopes: [issueScope] }));
+      await subscriptionPause.started;
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_991, syncId: 104 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamOther,
+            teamChanged: true,
+          },
+          syncId: 104,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      subscriptionPause.release();
+      await waitFor(
+        () => source.socket.frames('subscribed').length > 0,
+        'the retried issue subscription',
+      );
+
+      expect(source.socket.last('subscribed')?.scopes).not.toContain(issueScope);
+      expect(source.socket.last('subscribed')?.denied).toContain(issueScope);
+    } finally {
+      subscriptionPause?.release();
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await hub.close();
+    }
+  });
+
+  it('retries in-flight source presence across an issue move', async () => {
+    const hub = await newHub();
+    const issueScope = `issue:${home.issueOnCore}`;
+    let pause: AuthorizationPause | null = null;
+    try {
+      const source = await connect(hub, home.readerUserId, home.organizationId);
+      const admin = await connect(hub, home.adminUserId, home.organizationId);
+      await subscribe(admin, [issueScope]);
+      pause = holdAuthorization('issue', home.issueOnCore);
+      source.session.message(
+        JSON.stringify({ type: 'presence', scope: issueScope, kind: 'viewing' }),
+      );
+      await pause.started;
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_990, syncId: 105 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamOther,
+            teamChanged: true,
+          },
+          syncId: 105,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      pause.release();
+      await waitFor(
+        () => source.socket.frames('error').length > 0,
+        'the retried issue presence rejection',
+      );
+
+      expect(source.socket.last('error')?.code).toBe('forbidden_scope');
+      expect(admin.socket.frames('presence')).toHaveLength(0);
+    } finally {
+      pause?.release();
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await hub.close();
+    }
+  });
+
+  it('retains a destination reader when a split departure arrives before its arrival', async () => {
+    const hub = await newHub();
+    const issueScope = `issue:${home.issueOnCore}`;
+    const destinationMembershipId = `tm_depart_${home.strangerUserId.slice(-8)}`;
+    try {
+      await db.insert(schema.teamMember).values({
+        id: destinationMembershipId,
+        teamId: home.teamOther,
+        userId: home.strangerUserId,
+      });
+      const source = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(source, [issueScope]);
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamOther, number: 999_995, syncId: 74 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      const destination = await connect(hub, home.strangerUserId, home.organizationId);
+      await subscribe(destination, [issueScope]);
+
+      await publishDelta(
+        action({
+          action: 'delete',
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamCore}`, issueScope],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamCore,
+            identifier: 'CORE-1',
+            departure: true,
+          },
+          syncId: 74,
+        }),
+      );
+      await waitFor(
+        () => source.socket.frames('delta').flatMap((frame) => frame.actions).length > 0,
+        'the source departure',
+      );
+
+      await publishDelta(
+        action({
+          model: 'comment',
+          modelId: 'comment_after_departure_first',
+          scopes: [`team:${home.teamOther}`, issueScope],
+          data: {
+            id: 'comment_after_departure_first',
+            issueId: home.issueOnCore,
+            body: 'Destination comment',
+          },
+          syncId: 75,
+        }),
+      );
+      await driver().publish(
+        REDIS_PRESENCE_CHANNEL,
+        JSON.stringify({
+          organizationId: home.organizationId,
+          scope: issueScope,
+          kind: 'viewing',
+          userId: home.adminUserId,
+          name: 'Ada Admin',
+          image: null,
+          at: new Date().toISOString(),
+          audience: { teamId: home.teamOther },
+        }),
+      );
+      await waitFor(
+        () =>
+          destination.socket
+            .frames('delta')
+            .flatMap((frame) => frame.actions)
+            .some((entry) => entry.modelId === 'comment_after_departure_first'),
+        'the destination delta after a departure-first move',
+      );
+      await waitFor(
+        () => destination.socket.frames('presence').length > 0,
+        'the destination presence after a departure-first move',
+      );
+
+      source.session.message(
+        JSON.stringify({ type: 'presence', scope: issueScope, kind: 'viewing' }),
+      );
+      await waitFor(
+        () => source.socket.frames('error').length > 0,
+        'the source issue scope revocation',
+      );
+      expect(source.socket.last('error')?.code).toBe('forbidden_scope');
+      expect(destination.socket.last('subscribed')?.scopes).toContain(issueScope);
+    } finally {
+      await db
+        .update(schema.issue)
+        .set({ teamId: home.teamCore, number: 1, syncId: 0 })
+        .where(eq(schema.issue.id, home.issueOnCore));
+      await db.delete(schema.teamMember).where(eq(schema.teamMember.id, destinationMembershipId));
+      await hub.close();
+    }
+  });
+
   it('discards a delta that does not parse rather than dropping the connection', async () => {
     const hub = await newHub();
     try {
@@ -273,6 +1763,168 @@ describe('presence', () => {
 });
 
 describe('a doc delta re-authorizes every reader holding that scope', () => {
+  it('delivers a doc tombstone after removing its held scope', async () => {
+    const hub = await newHub();
+    const deletedDocId = 'doc_already_deleted';
+    const docScope = `doc:${deletedDocId}`;
+    await db.insert(schema.doc).values({
+      id: deletedDocId,
+      organizationId: home.organizationId,
+      title: 'Deleted doc',
+      authorId: home.adminUserId,
+      visibility: 'workspace',
+    });
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [docScope]);
+      await db.delete(schema.doc).where(eq(schema.doc.id, deletedDocId));
+
+      await publishDelta(
+        action({
+          action: 'delete',
+          model: 'doc',
+          modelId: deletedDocId,
+          scopes: [docScope],
+          data: { id: deletedDocId },
+          syncId: 14,
+        }),
+      );
+      await waitFor(() => hub.stats().subscriptions === 0, 'the deleted doc scope cleanup');
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(wired.socket.last('delta')?.actions[0]?.modelId).toBe(deletedDocId);
+    } finally {
+      await db.delete(schema.doc).where(eq(schema.doc.id, deletedDocId));
+      await hub.close();
+    }
+  });
+
+  it('retries an in-flight doc subscription after access changes', async () => {
+    const hub = await newHub();
+    const grant = `acc_subscribe_${home.readerUserId.slice(-8)}`;
+    const docId = home.workspaceDoc;
+    const docScope = `doc:${docId}`;
+    const pause = holdAuthorization('scope', docScope);
+    await db.update(schema.doc).set({ visibility: 'private' }).where(eq(schema.doc.id, docId));
+    await db.insert(schema.docAccess).values({
+      id: grant,
+      organizationId: home.organizationId,
+      docId,
+      subjectType: 'user',
+      subjectId: home.readerUserId,
+    });
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      wired.session.message(JSON.stringify({ type: 'subscribe', scopes: [docScope] }));
+      await pause.started;
+      await db.delete(schema.docAccess).where(eq(schema.docAccess.id, grant));
+
+      await publishDelta(action({ model: 'doc', modelId: docId, scopes: [docScope], syncId: 13 }));
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      pause.release();
+      await waitFor(
+        () => wired.socket.frames('subscribed').length > 0,
+        'the retried doc subscription',
+      );
+
+      expect(wired.socket.last('subscribed')?.scopes).not.toContain(docScope);
+      expect(wired.socket.last('subscribed')?.denied).toContain(docScope);
+    } finally {
+      pause.release();
+      await db.update(schema.doc).set({ visibility: 'workspace' }).where(eq(schema.doc.id, docId));
+      await db.delete(schema.docAccess).where(eq(schema.docAccess.id, grant));
+      await hub.close();
+    }
+  });
+
+  it('rejects in-flight doc presence after access changes', async () => {
+    const hub = await newHub();
+    const grant = `acc_presence_${home.readerUserId.slice(-8)}`;
+    const docId = home.workspaceDoc;
+    const docScope = `doc:${docId}`;
+    await db.update(schema.doc).set({ visibility: 'private' }).where(eq(schema.doc.id, docId));
+    await db.insert(schema.docAccess).values({
+      id: grant,
+      organizationId: home.organizationId,
+      docId,
+      subjectType: 'user',
+      subjectId: home.readerUserId,
+    });
+    let pause: AuthorizationPause | null = null;
+    try {
+      const author = await connect(hub, home.readerUserId, home.organizationId);
+      const watcher = await connect(hub, home.adminUserId, home.organizationId);
+      await subscribe(watcher, [docScope]);
+      pause = holdAuthorization('scope', docScope);
+      author.session.message(
+        JSON.stringify({ type: 'presence', scope: docScope, kind: 'viewing' }),
+      );
+      await pause.started;
+      await db.delete(schema.docAccess).where(eq(schema.docAccess.id, grant));
+
+      await publishDelta(action({ model: 'doc', modelId: docId, scopes: [docScope], syncId: 14 }));
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      pause.release();
+      await waitFor(
+        () => author.socket.frames('error').length > 0,
+        'the retried doc presence rejection',
+      );
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(author.socket.last('error')?.code).toBe('forbidden_scope');
+      expect(watcher.socket.frames('presence')).toHaveLength(0);
+    } finally {
+      pause?.release();
+      await db.update(schema.doc).set({ visibility: 'workspace' }).where(eq(schema.doc.id, docId));
+      await db.delete(schema.docAccess).where(eq(schema.docAccess.id, grant));
+      await hub.close();
+    }
+  });
+
+  it('filters the revocation delta and later doc payloads before they can flush', async () => {
+    const hub = await newHub({ batchWindowMs: 1 });
+    const grant = `acc_fenced_${home.readerUserId.slice(-8)}`;
+    const docId = home.workspaceDoc;
+    await db.update(schema.doc).set({ visibility: 'private' }).where(eq(schema.doc.id, docId));
+    await db.insert(schema.docAccess).values({
+      id: grant,
+      organizationId: home.organizationId,
+      docId,
+      subjectType: 'user',
+      subjectId: home.readerUserId,
+    });
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`doc:${docId}`]);
+      await db.delete(schema.docAccess).where(eq(schema.docAccess.id, grant));
+
+      await publishDeltas([
+        action({
+          model: 'doc',
+          modelId: docId,
+          scopes: [`doc:${docId}`],
+          data: { id: docId, title: 'Revoked doc title' },
+          syncId: 15,
+        }),
+        action({
+          model: 'doc_comment',
+          modelId: 'doc_comment_after_revoke',
+          scopes: [`doc:${docId}`],
+          data: { id: 'doc_comment_after_revoke', body: 'Revoked doc comment' },
+          syncId: 16,
+        }),
+      ]);
+      await waitFor(() => hub.stats().subscriptions === 0, 'the fenced doc revocation');
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(JSON.stringify(wired.socket.frames('delta'))).not.toContain('Revoked doc title');
+      expect(JSON.stringify(wired.socket.frames('delta'))).not.toContain('Revoked doc comment');
+    } finally {
+      await db.update(schema.doc).set({ visibility: 'workspace' }).where(eq(schema.doc.id, docId));
+      await hub.close();
+    }
+  });
+
   it('drops the scope of a reader whose grant was revoked', async () => {
     const hub = await newHub();
     const grant = `acc_revoked_${home.readerUserId.slice(-8)}`;
@@ -336,7 +1988,100 @@ describe('a doc delta re-authorizes every reader holding that scope', () => {
   });
 });
 
+describe('a project-scoped delta re-authorizes readers after team links change', () => {
+  it('drops retained project reach before later attachment metadata can flush', async () => {
+    const hub = await newHub({ batchWindowMs: 1 });
+    const linkId = `pt_fenced_${home.readerUserId.slice(-8)}`;
+    const projectScope = `project:${home.projectWithoutTeams}`;
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [projectScope]);
+      await db.insert(schema.projectTeam).values({
+        id: linkId,
+        projectId: home.projectWithoutTeams,
+        teamId: home.teamOther,
+      });
+
+      await publishDeltas([
+        action({
+          model: 'project',
+          modelId: home.projectWithoutTeams,
+          scopes: [projectScope, `team:${home.teamOther}`],
+          data: {
+            projectId: home.projectWithoutTeams,
+            teamId: home.teamOther,
+          },
+          syncId: 25,
+        }),
+        action({
+          model: 'attachment',
+          modelId: 'project_attachment_after_restrict',
+          scopes: [projectScope],
+          data: {
+            id: 'project_attachment_after_restrict',
+            parentType: 'project',
+            parentId: home.projectWithoutTeams,
+            fileName: 'restricted-project.txt',
+          },
+          syncId: 26,
+        }),
+      ]);
+      await waitFor(() => hub.stats().subscriptions === 0, 'the project scope revocation');
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(JSON.stringify(wired.socket.frames('delta'))).not.toContain('restricted-project.txt');
+    } finally {
+      await db.delete(schema.projectTeam).where(eq(schema.projectTeam.id, linkId));
+      await hub.close();
+    }
+  });
+});
+
 describe('membership and session revocation', () => {
+  it('closes affected connections when a member removal cannot be revalidated', async () => {
+    const hub = await newHub();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`team:${home.teamCore}`]);
+
+      await publishDeltas([
+        action({
+          model: 'member',
+          action: 'delete',
+          modelId: 'malformed_member_row',
+          data: {},
+          scopes: [`org:${home.organizationId}`],
+          syncId: 60,
+        }),
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamCore}`],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamCore,
+            title: 'Restricted after malformed removal',
+          },
+          syncId: 61,
+        }),
+      ]);
+      await waitFor(
+        () => wired.socket.closures.length > 0,
+        'the malformed removal connection closure',
+      );
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(wired.socket.closures[0]).toEqual({
+        code: ORGANIZATION_FORBIDDEN_CLOSE_CODE,
+        reason: 'membership_revoked',
+      });
+      expect(JSON.stringify(wired.socket.frames('delta'))).not.toContain(
+        'Restricted after malformed removal',
+      );
+    } finally {
+      await hub.close();
+    }
+  });
+
   it('closes the connections of a removed member with the workspace forbidden code', async () => {
     const hub = await newHub();
     try {
@@ -517,6 +2262,243 @@ describe('the periodic session sweep closes what no control message ever announc
 });
 
 describe('a team membership delta re-checks what each connection can still reach', () => {
+  async function coreMembershipId(): Promise<string> {
+    const [row] = await db
+      .select({ id: schema.teamMember.id })
+      .from(schema.teamMember)
+      .where(
+        and(
+          eq(schema.teamMember.teamId, home.teamCore),
+          eq(schema.teamMember.userId, home.readerUserId),
+        ),
+      )
+      .limit(1);
+    if (row === undefined) throw new Error('missing core team membership');
+    return row.id;
+  }
+
+  async function restoreCoreMembership(id: string): Promise<void> {
+    await db
+      .insert(schema.teamMember)
+      .values({ id, teamId: home.teamCore, userId: home.readerUserId })
+      .onConflictDoNothing();
+  }
+
+  it('holds subscribe and presence until membership reach is refreshed', async () => {
+    const hub = await newHub();
+    const membershipId = await coreMembershipId();
+    try {
+      const removed = await connect(hub, home.readerUserId, home.organizationId);
+      const watcher = await connect(hub, home.adminUserId, home.organizationId);
+      await subscribe(watcher, [`team:${home.teamCore}`]);
+
+      await db.transaction(async (tx) => {
+        await tx.execute(sql`lock table ${schema.teamMember} in access exclusive mode`);
+        await tx.delete(schema.teamMember).where(eq(schema.teamMember.id, membershipId));
+        await publishDelta(
+          action({
+            model: 'team_member',
+            action: 'delete',
+            modelId: membershipId,
+            scopes: [`org:${home.organizationId}`],
+            syncId: 65,
+          }),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 30));
+
+        removed.session.message(
+          JSON.stringify({ type: 'subscribe', scopes: [`team:${home.teamCore}`] }),
+        );
+        removed.session.message(
+          JSON.stringify({
+            type: 'presence',
+            scope: `team:${home.teamCore}`,
+            kind: 'viewing',
+          }),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 30));
+      });
+
+      await waitFor(
+        () => removed.socket.frames('subscribed').length > 0,
+        'the post-refresh subscribe result',
+      );
+      await waitFor(
+        () => removed.socket.frames('error').length > 0,
+        'the post-refresh presence rejection',
+      );
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(removed.socket.last('subscribed')?.scopes).not.toContain(`team:${home.teamCore}`);
+      expect(removed.socket.last('subscribed')?.denied).toContain(`team:${home.teamCore}`);
+      expect(removed.socket.last('error')?.code).toBe('forbidden_scope');
+      expect(watcher.socket.frames('presence')).toHaveLength(0);
+    } finally {
+      await restoreCoreMembership(membershipId);
+      await hub.close();
+    }
+  });
+
+  it('blocks restricted data later in the membership removal envelope', async () => {
+    const hub = await newHub({ batchWindowMs: 1 });
+    const membershipId = await coreMembershipId();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`team:${home.teamCore}`]);
+      await db.delete(schema.teamMember).where(eq(schema.teamMember.id, membershipId));
+
+      await publishDeltas([
+        action({
+          model: 'team_member',
+          action: 'delete',
+          modelId: membershipId,
+          scopes: [`org:${home.organizationId}`],
+          syncId: 70,
+        }),
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamCore}`],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamCore,
+            title: 'Restricted after same-envelope removal',
+          },
+          syncId: 71,
+        }),
+      ]);
+      await waitFor(() => hub.stats().subscriptions === 0, 'the same-envelope reach revocation');
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(JSON.stringify(wired.socket.frames('delta'))).not.toContain(
+        'Restricted after same-envelope removal',
+      );
+    } finally {
+      await restoreCoreMembership(membershipId);
+      await hub.close();
+    }
+  });
+
+  it('blocks restricted data in the next membership removal envelope', async () => {
+    const hub = await newHub({ batchWindowMs: 1 });
+    const membershipId = await coreMembershipId();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`team:${home.teamCore}`]);
+      await db.delete(schema.teamMember).where(eq(schema.teamMember.id, membershipId));
+
+      await publishDelta(
+        action({
+          model: 'team_member',
+          action: 'delete',
+          modelId: membershipId,
+          scopes: [`org:${home.organizationId}`],
+          syncId: 80,
+        }),
+      );
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamCore}`],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamCore,
+            title: 'Restricted after next-envelope removal',
+          },
+          syncId: 81,
+        }),
+      );
+      await waitFor(() => hub.stats().subscriptions === 0, 'the next-envelope reach revocation');
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(JSON.stringify(wired.socket.frames('delta'))).not.toContain(
+        'Restricted after next-envelope removal',
+      );
+    } finally {
+      await restoreCoreMembership(membershipId);
+      await hub.close();
+    }
+  });
+
+  it('drops restricted data already pending when membership removal arrives', async () => {
+    const hub = await newHub({ batchWindowMs: 100 });
+    const membershipId = await coreMembershipId();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`team:${home.teamCore}`]);
+      await db.delete(schema.teamMember).where(eq(schema.teamMember.id, membershipId));
+
+      await publishDelta(
+        action({
+          modelId: home.issueOnCore,
+          scopes: [`team:${home.teamCore}`],
+          data: {
+            id: home.issueOnCore,
+            teamId: home.teamCore,
+            title: 'Restricted while pending',
+          },
+          syncId: 90,
+        }),
+      );
+      await publishDelta(
+        action({
+          model: 'team_member',
+          action: 'delete',
+          modelId: membershipId,
+          scopes: [`org:${home.organizationId}`],
+          syncId: 91,
+        }),
+      );
+      await waitFor(() => hub.stats().subscriptions === 0, 'the pending reach revocation');
+      await new Promise((resolve) => setTimeout(resolve, 130));
+
+      expect(JSON.stringify(wired.socket.frames('delta'))).not.toContain(
+        'Restricted while pending',
+      );
+    } finally {
+      await restoreCoreMembership(membershipId);
+      await hub.close();
+    }
+  });
+
+  it('blocks presence delivered after membership removal starts revalidation', async () => {
+    const hub = await newHub();
+    const membershipId = await coreMembershipId();
+    try {
+      const wired = await connect(hub, home.readerUserId, home.organizationId);
+      await subscribe(wired, [`team:${home.teamCore}`]);
+      await db.delete(schema.teamMember).where(eq(schema.teamMember.id, membershipId));
+
+      await publishDelta(
+        action({
+          model: 'team_member',
+          action: 'delete',
+          modelId: membershipId,
+          scopes: [`org:${home.organizationId}`],
+          syncId: 100,
+        }),
+      );
+      await driver().publish(
+        REDIS_PRESENCE_CHANNEL,
+        JSON.stringify({
+          organizationId: home.organizationId,
+          scope: `team:${home.teamCore}`,
+          kind: 'viewing',
+          userId: home.adminUserId,
+          name: 'Ada Admin',
+          image: null,
+          at: new Date().toISOString(),
+        }),
+      );
+      await waitFor(() => hub.stats().subscriptions === 0, 'the presence reach revocation');
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(wired.socket.frames('presence')).toHaveLength(0);
+    } finally {
+      await restoreCoreMembership(membershipId);
+      await hub.close();
+    }
+  });
+
   it('drops the team scope of a member who was taken off the team', async () => {
     const hub = await newHub();
     try {

--- a/packages/realtime-server/tests/issue-team-boundaries.test.ts
+++ b/packages/realtime-server/tests/issue-team-boundaries.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test';
+import { IssueTeamBoundaries } from '../src/issue-team-boundaries.ts';
+
+describe('IssueTeamBoundaries', () => {
+  it('expires entries and removes them during a sweep', () => {
+    const boundaries = new IssueTeamBoundaries(100, 4);
+
+    boundaries.rememberMove('org_1|issue_1', 20, 'team_b', 1_000);
+
+    expect(boundaries.get('org_1|issue_1', 1_099)).toEqual({
+      teamId: 'team_b',
+      moveSyncId: 20,
+    });
+    boundaries.sweep(1_100);
+    expect(boundaries.get('org_1|issue_1', 1_100)).toBeUndefined();
+    expect(boundaries.size).toBe(0);
+  });
+
+  it('evicts the least recently used entry at its configured bound', () => {
+    const boundaries = new IssueTeamBoundaries(1_000, 2);
+
+    boundaries.rememberCurrent('org_1|issue_1', 'team_a', 1_000);
+    boundaries.rememberMove('org_1|issue_2', 30, 'team_b', 1_001);
+    expect(boundaries.get('org_1|issue_1', 1_002)).toEqual({
+      teamId: 'team_a',
+      moveSyncId: null,
+    });
+    boundaries.rememberMove('org_1|issue_3', 40, 'team_c', 1_003);
+
+    expect(boundaries.get('org_1|issue_2', 1_004)).toBeUndefined();
+    expect(boundaries.get('org_1|issue_1', 1_004)).toBeDefined();
+    expect(boundaries.get('org_1|issue_3', 1_004)).toBeDefined();
+    expect(boundaries.size).toBe(2);
+  });
+
+  it('never lets an older move replace a newer boundary', () => {
+    const boundaries = new IssueTeamBoundaries(1_000, 2);
+
+    boundaries.rememberMove('org_1|issue_1', 50, 'team_c', 1_000);
+    boundaries.rememberMove('org_1|issue_1', 40, 'team_b', 1_001);
+
+    expect(boundaries.get('org_1|issue_1', 1_002)).toEqual({
+      teamId: 'team_c',
+      moveSyncId: 50,
+    });
+  });
+
+  it('adopts an authoritative team without lowering the known move boundary', () => {
+    const boundaries = new IssueTeamBoundaries(1_000, 2);
+
+    boundaries.rememberMove('org_1|issue_1', 50, 'team_b', 1_000);
+    boundaries.rememberAuthoritative('org_1|issue_1', 40, 'team_c', 1_001);
+
+    expect(boundaries.get('org_1|issue_1', 1_002)).toEqual({
+      teamId: 'team_c',
+      moveSyncId: 50,
+    });
+  });
+});

--- a/packages/realtime-server/tests/presence.test.ts
+++ b/packages/realtime-server/tests/presence.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'bun:test';
+import type { PresenceMessage } from '@orbit/shared/events';
+import { PresenceStore } from '../src/presence.ts';
+
+function message(at: number, overrides: Partial<PresenceMessage> = {}): PresenceMessage {
+  return {
+    organizationId: 'org_1',
+    scope: 'issue:issue_1',
+    kind: 'viewing',
+    userId: 'user_1',
+    name: 'Ada',
+    image: null,
+    at: new Date(at).toISOString(),
+    ...overrides,
+  };
+}
+
+describe('PresenceStore', () => {
+  it('clears moved issue presence and admits only the destination audience', () => {
+    const store = new PresenceStore(1_000);
+    const now = Date.parse('2026-01-01T00:00:00.000Z');
+    expect(store.record(message(now), { teamId: 'team_old' }, now)).toBe(true);
+
+    store.move('issue:issue_1', 'team_new', now + 10);
+
+    expect(
+      store.snapshot('issue:issue_1', { admin: false, teamIds: ['team_new'] }, now + 20),
+    ).toEqual([]);
+    expect(store.record(message(now + 20), { teamId: 'team_old' }, now + 20)).toBe(false);
+    expect(store.record(message(now + 20), { teamId: 'team_new' }, now + 20)).toBe(true);
+  });
+
+  it('fails closed for issue messages without exact audience metadata', () => {
+    const store = new PresenceStore(1_000);
+    const now = Date.parse('2026-01-01T00:00:00.000Z');
+
+    expect(store.record(message(now + 10), null, now + 10)).toBe(false);
+    expect(store.record(message(now + 10), { teamId: null }, now + 10)).toBe(false);
+  });
+
+  it('filters issue snapshots by the exact publishing team', () => {
+    const store = new PresenceStore(1_000);
+    const now = Date.parse('2026-01-01T00:00:00.000Z');
+    expect(store.record(message(now), { teamId: 'team_old' }, now)).toBe(true);
+
+    expect(
+      store.snapshot('issue:issue_1', { admin: false, teamIds: ['team_old'] }, now + 10),
+    ).toHaveLength(1);
+    expect(
+      store.snapshot('issue:issue_1', { admin: false, teamIds: ['team_new'] }, now + 10),
+    ).toEqual([]);
+    expect(store.snapshot('issue:issue_1', { admin: true, teamIds: [] }, now + 10)).toHaveLength(1);
+  });
+
+  it('rejects a message whose original lifetime already elapsed', () => {
+    const store = new PresenceStore(1_000);
+    const now = Date.parse('2026-01-01T00:00:02.000Z');
+
+    expect(store.record(message(now - 1_001), { teamId: 'team_old' }, now)).toBe(false);
+    expect(store.snapshot('issue:issue_1', { admin: true, teamIds: [] }, now)).toEqual([]);
+  });
+});

--- a/packages/services/tests/notifications/notifications.test.ts
+++ b/packages/services/tests/notifications/notifications.test.ts
@@ -550,10 +550,12 @@ describe('notifyMany', () => {
     await withRollback(async (tx) => {
       const fixture = await seed(tx);
       await seedSlackDmConnection(tx, fixture);
+      const now = new Date('2026-07-22T12:00:00Z');
       await notifyMany(tx, [eventFor(fixture, { userIds: [fixture.adaId], reason: 'mentioned' })], {
+        now,
         slackEnabled: true,
       });
-      const [delivery] = await claimSlackDmDeliveries(tx, 10, new Date());
+      const [delivery] = await claimSlackDmDeliveries(tx, 10, now);
       if (delivery === undefined) throw new Error('Expected an unavailable Slack DM claim.');
       await markSlackDmUnavailable(
         tx,
@@ -561,7 +563,7 @@ describe('notifyMany', () => {
         delivery.claimedAt ?? new Date(0),
         'missing_scope',
       );
-      expect(await claimSlackDmDeliveries(tx, 10, new Date())).toHaveLength(0);
+      expect(await claimSlackDmDeliveries(tx, 10, now)).toHaveLength(0);
       const [stored] = await tx
         .select({ status: notificationDelivery.status, lastError: notificationDelivery.lastError })
         .from(notificationDelivery)


### PR DESCRIPTION
Closes #228

## Summary

- Adds keyboard operation to issue Kanban boards. Arrow keys move focus between cards and columns, Space or Enter picks up and drops, and Escape cancels without writing.
- Supports cross-column moves and same-column reordering through the existing issue move mutation.
- Adds list-item semantics, meaningful card labels, screen-reader instructions, and an assertive live status for pickup, target changes, invalid drops, cancellation, pending commits, success, failure, and concurrent changes.
- Restores focus to the moved card after settlement, or to the destination column when an active filter removes the moved card.

## Realtime and optimistic safety

- Tracks each drag by session and stable group identity so an older mutation cannot replace feedback from a newer drag.
- Reconciles non-positional realtime updates while a card is held. If the held issue or its target moves, reorders, disappears, or becomes ambiguous, the drag cancels with an announcement.
- Prevents another drag for a card while its move is pending.
- Rolls back only cache entries still owned by the failed optimistic move, preserving intervening issue and sibling updates. When the cache cannot provide an unambiguous restoration, the affected list is refreshed.
- Prevents stale successful responses from re-admitting or resurrecting issues removed by newer cache or realtime state.
- Adds deterministic keyboard and pointer sensor cancellation so board teardown and context changes do not leave active drag listeners behind.

## Scope

This covers issue board surfaces, including filtered My Issues boards. Existing regrouping permissions and supported grouping fields remain unchanged. Saved-view ordering, the docs tree, and milestone ordering are not changed.

## Verification

- Repository lint, comment policy, source byte checks, Bun import checks, dependency checks, and all package TypeScript checks passed on the pushed head.
- Focused keyboard drag, cache settlement, and view lifetime regressions: 208 passed with 679 assertions.
- Full Board component suite: 36 passed with 124 assertions.
- Playwright board drag suite: 7 passed, covering pointer persistence, keyboard movement, filtered-board focus, cancellation, realtime move and deletion, failed-move rollback, same-column reorder, and post-drop focus handoff.
- The unchanged LinePlot file passed all 16 tests with 77 assertions when rerun alone after Bun 1.3.14 trapped during the repository-wide process.












<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds accessible keyboard drag-and-drop to issue boards while coordinating optimistic mutation settlement, realtime reconciliation, focus restoration, and screen-reader feedback.

- Adds keyboard and pointer sensor lifecycle management.
- Validates and announces drag targets and terminal outcomes against current board state.
- Protects optimistic issue moves from stale mutation and realtime cache updates.
- Adds focused unit, component, and browser coverage for movement, cancellation, rollback, filtering, and concurrent updates.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/features/issues/board.tsx | Implements session-owned keyboard drag state, validated target feedback, settlement-aware announcements, realtime reconciliation, and focus restoration without leaving the previously reported failures reachable. |
| apps/web/src/features/issues/board-sensors.ts | Adds controlled keyboard and pointer sensors with deterministic cancellation during context changes and teardown. |
| apps/web/src/lib/query/use-issues.ts | Adds ownership-aware optimistic move settlement and rollback behavior used by the board’s terminal feedback. |
| apps/web/src/lib/realtime/delta-bridge.tsx | Reconciles issue deltas with cache generations so concurrent updates are preserved during pending moves. |
| apps/web/tests/features/issues/board.test.tsx | Covers drag reconciliation, terminal announcements, focus behavior, and concurrent board changes. |
| apps/web/e2e/board-drag.spec.ts | Exercises keyboard movement, cancellation, filtered visibility, failed rollback, realtime deletion and movement, reordering, and focus handoff. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as Keyboard user
    participant B as Board
    participant C as Issue cache
    participant A as Move API
    participant R as Realtime bridge
    U->>B: Pick up and select destination
    B->>B: Validate current source and target
    alt Invalid or changed destination
        B-->>U: Announce cancellation or rejected drop
    else Valid destination
        B->>C: Apply optimistic move
        B->>A: Submit issue move
        R->>C: Reconcile concurrent updates
        alt Move succeeds and remains current
            A-->>B: Authoritative settlement
            B-->>U: Announce final position and restore focus
        else Move fails or is superseded
            A-->>B: Error or stale settlement
            C->>C: Roll back owned cache state or refresh
            B-->>U: Announce restored or latest state
        end
    end
```
</details>

<sub>Reviews (15): Last reviewed commit: ["fix(realtime): preserve delivery and det..."](https://github.com/noveum/orbit/commit/486ff28724ac7e6b518b8a3f095df943b513e182) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55833070)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Issue lifecycle and views](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/docs/issue-lifecycle.md)
- Knowledge Base — [Web application experience](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/docs/web-application-experience.md)
- Knowledge Base — [Realtime collaboration](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/docs/realtime-collaboration.md)
</details>


<!-- /greptile_comment -->