### PR TITLE
fix(analytics): scope drilldown rows to authorized teams and report withheld counts

### DIFF
--- a/apps/realtime/src/test-helpers.ts
+++ b/apps/realtime/src/test-helpers.ts
@@ -311,7 +311,7 @@ export function maskedTextFrame(text: string): Buffer {
   } else {
     header.push(0x80 | 126, (payload.length >> 8) & 0xff, payload.length & 0xff);
   }
-  return Buffer.concat([Buffer.from(header), mask, masked]);
+  return Buffer.concat([new Uint8Array(header), new Uint8Array(mask), new Uint8Array(masked)]);
 }
 
 export function createPublisher(): Redis {

--- a/apps/web/src/app/api/analytics/export/route.ts
+++ b/apps/web/src/app/api/analytics/export/route.ts
@@ -25,7 +25,8 @@ export async function GET(request: Request): Promise<Response> {
     } while (cursor !== undefined && issues.length < EXPORT_LIMIT);
 
     const page = first;
-    const truncated = page !== undefined && page.total > issues.length;
+    const visibleTotal = page === undefined ? 0 : page.total - page.withheldCount;
+    const truncated = page !== undefined && visibleTotal > issues.length;
     const metadata: ReadonlyArray<ReadonlyArray<string | number>> =
       page === undefined
         ? []
@@ -44,7 +45,9 @@ export async function GET(request: Request): Promise<Response> {
             ['From', page.from],
             ['To', page.to],
             ['Data through', page.asOf],
-            ['Matching issues', page.total],
+            ['Total workspace issues in cohort', page.total],
+            ['Issues withheld due to permissions', page.withheldCount],
+            ['Visible exported issues', issues.length],
             [],
           ];
     const rows = issues.map((issue) => [

--- a/apps/web/src/features/analytics/analytics-drilldown-dialog.tsx
+++ b/apps/web/src/features/analytics/analytics-drilldown-dialog.tsx
@@ -100,7 +100,15 @@ export function AnalyticsDrilldownDialog({
       </div>
     );
   } else if (issues.length === 0) {
-    body = <p className="py-12 text-center text-muted text-sm">No matching issues.</p>;
+    body = (
+      <p className="py-12 text-center text-muted text-sm">
+        {firstPage !== undefined &&
+        firstPage.total > 0 &&
+        firstPage.withheldCount === firstPage.total
+          ? 'You do not have permission to view the issues in this cohort.'
+          : 'No matching issues.'}
+      </p>
+    );
   } else {
     body = (
       <ScrollArea className="h-[calc(100dvh-12rem)] sm:h-[min(60vh,36rem)]">
@@ -186,7 +194,11 @@ export function AnalyticsDrilldownDialog({
           <DialogDescription>
             {firstPage === undefined
               ? 'Loading issue evidence.'
-              : `${firstPage.total} matching issues, ${firstPage.totalValue} in the selected measure. Predicate: ${firstPage.predicate}. Data through ${new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(firstPage.asOf))}.`}
+              : `${firstPage.total} matching issues${
+                  firstPage.withheldCount > 0
+                    ? ` (${firstPage.withheldCount} withheld due to team permissions)`
+                    : ''
+                }, ${firstPage.totalValue} in the selected measure. Predicate: ${firstPage.predicate}. Data through ${new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(firstPage.asOf))}.`}
           </DialogDescription>
         </DialogHeader>
         {body}

--- a/apps/web/src/features/analytics/contracts.ts
+++ b/apps/web/src/features/analytics/contracts.ts
@@ -68,6 +68,7 @@ export const analyticsOverviewResponseSchema = z.object({
       cohort: analyticsDrilldownCohortSchema,
     }),
   ),
+  outliersWithheldCount: z.number().int().nonnegative(),
 });
 
 const sprintSummarySchema = z.object({

--- a/apps/web/src/features/analytics/contracts.ts
+++ b/apps/web/src/features/analytics/contracts.ts
@@ -402,6 +402,7 @@ export const analyticsDrilldownResponseSchema = z.object({
   predicate: z.string(),
   total: z.number().int().nonnegative(),
   totalValue: numberSchema,
+  withheldCount: z.number().int().nonnegative(),
   details: z.object({
     validCycleCount: z.number().int().nonnegative(),
     cycleTimeP50: numberSchema.nullable(),

--- a/apps/web/src/features/analytics/overview-lens.tsx
+++ b/apps/web/src/features/analytics/overview-lens.tsx
@@ -18,6 +18,12 @@ function valueLabel(value: number, unit: string): string {
   return unit === 'days' ? `${formatted}d` : formatted;
 }
 
+function hiddenOutlierLabel(count: number, allHidden: boolean): string {
+  const noun = count === 1 ? 'outlier' : 'outliers';
+  const verb = count === 1 ? 'is' : 'are';
+  return `${allHidden ? 'All ' : ''}${count}${allHidden ? '' : ' additional'} workspace ${noun} ${verb} hidden due to team permissions.`;
+}
+
 export function OverviewLens({
   data,
   query,
@@ -168,26 +174,33 @@ export function OverviewLens({
         ))}
       </div>
 
-      {data.outliers.length === 0 ? null : (
+      {data.outliers.length === 0 && data.outliersWithheldCount === 0 ? null : (
         <AnalyticsCard title="Longest cycle time">
-          <div className="divide-y divide-border">
-            {data.outliers.map((outlier) => (
-              <button
-                className="flex w-full items-center justify-between gap-4 px-2 py-2 text-left hover:bg-surface-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
-                key={outlier.issueId}
-                onClick={() => activate(outlier.title, outlier.cohort)}
-                type="button"
-              >
-                <span className="min-w-0 truncate text-sm text-text">
-                  <span className="mr-2 text-faint">{outlier.identifier}</span>
-                  {outlier.title}
-                </span>
-                <span className="shrink-0 text-muted text-xs tabular">
-                  {valueLabel(outlier.cycleTimeDays, 'days')}
-                </span>
-              </button>
-            ))}
-          </div>
+          {data.outliers.length === 0 ? null : (
+            <div className="divide-y divide-border">
+              {data.outliers.map((outlier) => (
+                <button
+                  className="flex w-full items-center justify-between gap-4 px-2 py-2 text-left hover:bg-surface-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                  key={outlier.issueId}
+                  onClick={() => activate(outlier.title, outlier.cohort)}
+                  type="button"
+                >
+                  <span className="min-w-0 truncate text-sm text-text">
+                    <span className="mr-2 text-faint">{outlier.identifier}</span>
+                    {outlier.title}
+                  </span>
+                  <span className="shrink-0 text-muted text-xs tabular">
+                    {valueLabel(outlier.cycleTimeDays, 'days')}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+          {data.outliersWithheldCount === 0 ? null : (
+            <p className="py-3 text-center text-muted text-xs">
+              {hiddenOutlierLabel(data.outliersWithheldCount, data.outliers.length === 0)}
+            </p>
+          )}
         </AnalyticsCard>
       )}
 

--- a/apps/web/src/features/issues/estimate-glyph.tsx
+++ b/apps/web/src/features/issues/estimate-glyph.tsx
@@ -12,11 +12,11 @@ export function estimateLabel(points: number | null): string {
 }
 
 function fillFraction(points: number): number {
-  const steps = DEFAULT_ESTIMATE_SCALE.length - 1;
+  const scale: readonly number[] = DEFAULT_ESTIMATE_SCALE;
+  const steps = scale.length - 1;
   if (steps <= 0) return points > 0 ? 1 : 0;
-  const exact = DEFAULT_ESTIMATE_SCALE.findIndex((entry) => entry === points);
-  const rank =
-    exact === -1 ? DEFAULT_ESTIMATE_SCALE.filter((entry) => entry <= points).length - 1 : exact;
+  const exact = scale.indexOf(points);
+  const rank = exact === -1 ? scale.filter((entry) => entry <= points).length - 1 : exact;
   return Math.min(Math.max(rank, 0) / steps, 1);
 }
 

--- a/apps/web/tests/app/(app)/analytics/page.test.tsx
+++ b/apps/web/tests/app/(app)/analytics/page.test.tsx
@@ -35,6 +35,7 @@ const payload = {
   projects: [],
   priorities: [],
   outliers: [],
+  outliersWithheldCount: 0,
 };
 const insightsPayload = {
   kind: 'bars' as const,

--- a/apps/web/tests/app/api/analytics/export/route.test.ts
+++ b/apps/web/tests/app/api/analytics/export/route.test.ts
@@ -1,15 +1,23 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import { createIssue } from '@orbit/core';
-import { createWorkspace, resetDatabase, type Workspace } from '@orbit/core/test-support';
+import { createIssue, createTeam } from '@orbit/core';
+import {
+  addMember,
+  createWorkspace,
+  resetDatabase,
+  type Workspace,
+} from '@orbit/core/test-support';
+import { db, schema } from '@orbit/db';
+import { randomUUIDv7 } from '@orbit/shared/utils';
 import { mockSession } from '../../../../../tests-support.ts';
 
 let workspace: Workspace;
 let signedIn = false;
+let signedInUser: Workspace['adminUser'];
 
 mockSession(() =>
   signedIn
     ? {
-        user: workspace.adminUser,
+        user: signedInUser,
         session: { activeOrganizationId: workspace.organizationId },
       }
     : null,
@@ -21,6 +29,7 @@ beforeEach(async () => {
   await resetDatabase();
   workspace = await createWorkspace('Nova');
   signedIn = true;
+  signedInUser = workspace.adminUser;
 });
 
 describe('GET /api/analytics/export', () => {
@@ -61,4 +70,80 @@ describe('GET /api/analytics/export', () => {
     expect(unauthorized.status).toBe(401);
     expect(invalid.status).toBe(422);
   });
+
+  it('exports only authorized rows while retaining workspace totals and withheld count', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Operations', key: 'OPS' });
+    const otherState = other.states.find((state) => state.category === 'unstarted');
+    if (otherState === undefined) throw new Error('Missing Operations state.');
+    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Visible evidence' });
+    await createIssue(workspace.admin, {
+      teamId: other.team.id,
+      stateId: otherState.id,
+      title: 'Hidden evidence',
+    });
+    const reader = await addMember(workspace, 'guest', { teamIds: [workspace.teamId] });
+    signedInUser = reader.user;
+
+    const response = await route.GET(
+      new Request('http://localhost:3000/api/analytics/export?cohort=current'),
+    );
+    const csv = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-orbit-export-truncated')).toBe('false');
+    expect(csv).toContain('Total workspace issues in cohort,2');
+    expect(csv).toContain('Issues withheld due to permissions,1');
+    expect(csv).toContain('Visible exported issues,1');
+    expect(csv).toContain('Visible evidence');
+    expect(csv).not.toContain('Hidden evidence');
+  });
+
+  it('marks the export truncated only when visible rows exceed the cap', async () => {
+    const state = workspace.states.find((entry) => entry.category === 'unstarted');
+    if (state === undefined) throw new Error('Missing workspace state.');
+    const createdAt = new Date('2026-08-01T00:00:00.000Z');
+    for (let offset = 0; offset < 10_000; offset += 1_000) {
+      await db.insert(schema.issue).values(
+        Array.from({ length: 1_000 }, (_, index) => {
+          const number = offset + index + 1;
+          return {
+            id: randomUUIDv7(createdAt),
+            organizationId: workspace.organizationId,
+            teamId: workspace.teamId,
+            number,
+            identifier: `CAP-${number}`,
+            title: `Visible cap issue ${number}`,
+            stateId: state.id,
+            creatorId: workspace.adminUser.id,
+            createdAt,
+          };
+        }),
+      );
+    }
+    const other = await createTeam(workspace.admin, { name: 'Operations', key: 'OPS' });
+    const otherState = other.states.find((entry) => entry.category === 'unstarted');
+    if (otherState === undefined) throw new Error('Missing Operations state.');
+    await createIssue(workspace.admin, {
+      teamId: other.team.id,
+      stateId: otherState.id,
+      title: 'Withheld cap issue',
+    });
+    const reader = await addMember(workspace, 'guest', { teamIds: [workspace.teamId] });
+
+    signedInUser = workspace.adminUser;
+    const workspaceResponse = await route.GET(
+      new Request('http://localhost:3000/api/analytics/export?cohort=current'),
+    );
+    signedInUser = reader.user;
+    const restrictedResponse = await route.GET(
+      new Request('http://localhost:3000/api/analytics/export?cohort=current'),
+    );
+    const restrictedCsv = await restrictedResponse.text();
+
+    expect(workspaceResponse.headers.get('x-orbit-export-truncated')).toBe('true');
+    expect(restrictedResponse.headers.get('x-orbit-export-truncated')).toBe('false');
+    expect(restrictedCsv).toContain('Total workspace issues in cohort,10001');
+    expect(restrictedCsv).toContain('Issues withheld due to permissions,1');
+    expect(restrictedCsv).toContain('Visible exported issues,10000');
+  }, 30_000);
 });

--- a/apps/web/tests/features/analytics/analytics-cockpit.test.tsx
+++ b/apps/web/tests/features/analytics/analytics-cockpit.test.tsx
@@ -42,6 +42,7 @@ const overview: AnalyticsOverviewResponse = {
   projects: [],
   priorities: [],
   outliers: [],
+  outliersWithheldCount: 0,
 };
 
 const projectId = '00000000-0000-7000-8000-000000000001';

--- a/apps/web/tests/features/analytics/analytics-drilldown-dialog.test.tsx
+++ b/apps/web/tests/features/analytics/analytics-drilldown-dialog.test.tsx
@@ -58,6 +58,7 @@ function page(nextCursor: string | null, identifier: string) {
     ],
     nextCursor,
     limit: 1,
+    withheldCount: 0,
     asOf: '2026-08-13T12:00:00.000Z',
     from: '2026-08-01T00:00:00.000Z',
     to: '2026-08-14T00:00:00.000Z',

--- a/apps/web/tests/features/analytics/analytics-drilldown-dialog.test.tsx
+++ b/apps/web/tests/features/analytics/analytics-drilldown-dialog.test.tsx
@@ -130,4 +130,30 @@ describe('AnalyticsDrilldownDialog', () => {
     await user.click(screen.getByRole('button', { name: 'Close' }));
     await waitFor(() => expect(trigger).toHaveFocus());
   });
+
+  test('explains when every matching issue is withheld by team permissions', async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            ...page(null, 'ORB-1'),
+            issues: [],
+            total: 2,
+            totalValue: 2,
+            withheldCount: 2,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole('button', { name: 'Completed work' }));
+
+    expect(
+      await screen.findByText('You do not have permission to view the issues in this cohort.'),
+    ).toBeVisible();
+    expect(screen.queryByText('No matching issues.')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/tests/features/analytics/contracts.test.ts
+++ b/apps/web/tests/features/analytics/contracts.test.ts
@@ -14,6 +14,7 @@ const emptyOverview = {
   projects: [],
   priorities: [],
   outliers: [],
+  outliersWithheldCount: 0,
 };
 
 describe('analytics wire contracts', () => {
@@ -41,6 +42,15 @@ describe('analytics wire contracts', () => {
   it('rejects a payload from a different lens', () => {
     expect(() =>
       analyticsWireResponse('projects', { ...emptyOverview, lens: 'overview' }),
+    ).toThrow();
+  });
+
+  it('requires a nonnegative outlier withheld count', () => {
+    const { outliersWithheldCount: _outliersWithheldCount, ...missingCount } = emptyOverview;
+
+    expect(() => analyticsOverviewResponseSchema.parse(missingCount)).toThrow();
+    expect(() =>
+      analyticsOverviewResponseSchema.parse({ ...emptyOverview, outliersWithheldCount: -1 }),
     ).toThrow();
   });
 });

--- a/apps/web/tests/features/analytics/insights-lens.test.tsx
+++ b/apps/web/tests/features/analytics/insights-lens.test.tsx
@@ -121,6 +121,7 @@ describe('InsightsLens', () => {
             issues: [],
             nextCursor: null,
             limit: 50,
+            withheldCount: 0,
             asOf: '2026-08-15T00:00:00.000Z',
             from: '2026-08-01T00:00:00.000Z',
             to: '2026-08-15T00:00:00.000Z',

--- a/apps/web/tests/features/analytics/overview-lens.test.tsx
+++ b/apps/web/tests/features/analytics/overview-lens.test.tsx
@@ -73,6 +73,7 @@ describe('OverviewLens', () => {
             issues: [],
             nextCursor: null,
             limit: 50,
+            withheldCount: 0,
             asOf,
             from: '2026-08-01T00:00:00.000Z',
             to: '2026-08-15T00:00:00.000Z',

--- a/apps/web/tests/features/analytics/overview-lens.test.tsx
+++ b/apps/web/tests/features/analytics/overview-lens.test.tsx
@@ -54,6 +54,7 @@ const data: AnalyticsOverviewResponse = {
   projects: [],
   priorities: [],
   outliers: [],
+  outliersWithheldCount: 0,
 };
 
 afterEach(() => {
@@ -104,5 +105,41 @@ describe('OverviewLens', () => {
     await user.click(screen.getByRole('button', { name: 'Blocked work, 3 issues' }));
     expect(await screen.findByRole('dialog', { name: 'Blocked work' })).toBeVisible();
     expect(screen.getByText(/Predicate: blocked work/)).toBeVisible();
+  });
+
+  test('discloses workspace outliers hidden alongside visible rows', () => {
+    render(
+      <OverviewLens
+        data={{
+          ...data,
+          outliers: [
+            {
+              issueId: '00000000-0000-7000-8000-000000000001',
+              identifier: 'NOV-1',
+              title: 'Visible slow issue',
+              cycleTimeDays: 12,
+              cohort: { cohort: 'outlier:00000000-0000-7000-8000-000000000001' },
+            },
+          ],
+          outliersWithheldCount: 2,
+        }}
+        query={analyticsQuerySchema.parse({})}
+      />,
+    );
+
+    expect(screen.getByText('Visible slow issue')).toBeVisible();
+    expect(screen.getByText(/2 additional workspace outliers are hidden/)).toBeVisible();
+  });
+
+  test('keeps the outlier card visible when every workspace candidate is hidden', () => {
+    render(
+      <OverviewLens
+        data={{ ...data, outliersWithheldCount: 3 }}
+        query={analyticsQuerySchema.parse({})}
+      />,
+    );
+
+    expect(screen.getByText('Longest cycle time')).toBeVisible();
+    expect(screen.getByText(/All 3 workspace outliers are hidden/)).toBeVisible();
   });
 });

--- a/apps/web/tests/features/analytics/use-analytics-query.test.tsx
+++ b/apps/web/tests/features/analytics/use-analytics-query.test.tsx
@@ -16,6 +16,7 @@ const response = {
   projects: [],
   priorities: [],
   outliers: [],
+  outliersWithheldCount: 0,
 };
 
 const calls: Array<{ readonly path: string; readonly signal: AbortSignal | null }> = [];

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -34,6 +34,8 @@ uses it to hide buttons you cannot use, never as the only gate.
 Guests are the useful one to understand: a contractor or a stakeholder can be in
 the workspace, read the board and comment, without being able to change work.
 
+> **Analytics Visibility Rule:** Analytics totals and aggregate charts span the entire workspace for every role (including guests and contributors) to prevent misleading partial dashboards. However, issue-level drilldown rows and outliers strictly follow team membership and permissions; items from unauthorized teams are filtered out and reported as a withheld count.
+
 ## Teams
 
 Teams are how work is divided, and they own the parts of Orbit that need a

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -34,7 +34,7 @@ uses it to hide buttons you cannot use, never as the only gate.
 Guests are the useful one to understand: a contractor or a stakeholder can be in
 the workspace, read the board and comment, without being able to change work.
 
-> **Analytics Visibility Rule:** Analytics totals and aggregate charts span the entire workspace for every role (including guests and contributors) to prevent misleading partial dashboards. However, issue-level drilldown rows and outliers strictly follow team membership and permissions; items from unauthorized teams are filtered out and reported as a withheld count.
+> **Analytics Visibility Rule:** Analytics totals and aggregate charts span the entire workspace for every role (including guests and contributors) to prevent misleading partial dashboards. Issue-level drilldown rows follow team membership and report a withheld count. The longest cycle time list ranks the workspace candidates first, then removes rows outside the reader's team scope and reports how many ranked candidates were withheld.
 
 ## Teams
 

--- a/packages/core/src/analytics/drilldown.ts
+++ b/packages/core/src/analytics/drilldown.ts
@@ -1019,7 +1019,7 @@ function decodeCursor(cursor: string, binding: string, secret: string): CursorVa
     if (
       provided.toString('base64url') !== signature ||
       provided.length !== expected.length ||
-      !timingSafeEqual(provided, expected)
+      !timingSafeEqual(new Uint8Array(provided), new Uint8Array(expected))
     ) {
       throw new Error('invalid');
     }

--- a/packages/core/src/analytics/drilldown.ts
+++ b/packages/core/src/analytics/drilldown.ts
@@ -14,7 +14,7 @@ import type { AnalyticsDrilldownCohort, AnalyticsQuery } from '@orbit/shared/val
 import { calendarDateSchema, issueFilterSchema } from '@orbit/shared/validators';
 import type { SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
-import { buildIssueWhere } from '../work/issue-query.ts';
+import { buildIssueWhere, issueVisibilityScope } from '../work/issue-query.ts';
 import {
   bucketDates,
   calendarDateLabel,
@@ -953,6 +953,8 @@ function cursorRequestBinding(
 ): string {
   return JSON.stringify({
     organizationId: principal.organizationId,
+    userId: principal.userId,
+    issueVisibility: issueVisibilityScope(principal),
     query: {
       version: query.version,
       lens: query.lens,

--- a/packages/core/src/analytics/drilldown.ts
+++ b/packages/core/src/analytics/drilldown.ts
@@ -158,6 +158,7 @@ export interface AnalyticsDrilldownPage {
   readonly predicate: string;
   readonly total: number;
   readonly totalValue: number;
+  readonly withheldCount: number;
   readonly details: AnalyticsDrilldownDetails;
   readonly issues: readonly AnalyticsIssueRow[];
   readonly nextCursor: string | null;
@@ -1050,6 +1051,44 @@ function decodeCursor(cursor: string, binding: string, secret: string): CursorVa
   }
 }
 
+export function teamDrilldownBase(
+  principal: Principal,
+  resolved: ResolvedAnalyticsQuery,
+  cohort: AnalyticsDrilldownCohort,
+): SQL<unknown> {
+  const teamResolved = resolved;
+  if (!historicalPersonCohort(cohort)) {
+    const filters: SQL[] = [
+      buildIssueWhere(principal, {
+        visibility: 'team',
+        filter: analyticsIssueFilter(teamResolved),
+        now: teamResolved.asOf,
+        calendar: reportingCalendar(teamResolved.asOf, teamResolved.timezone),
+      }),
+    ];
+    if (!teamResolved.includeCanceled)
+      filters.push(sql`${schema.workflowState.category} <> 'canceled'`);
+    return and(...filters) ?? sql`false`;
+  }
+  const person = personCohort(cohort.cohort);
+  if (person === null)
+    return teamDrilldownBase(principal, resolved, { ...cohort, cohort: 'current' });
+  const historical = historicalPersonFilter(teamResolved, person.id);
+
+  const filters: SQL[] = [
+    buildIssueWhere(principal, {
+      visibility: 'team',
+      filter: analyticsIssueFilter(historical.query),
+      now: historical.query.asOf,
+      calendar: reportingCalendar(historical.query.asOf, historical.query.timezone),
+    }),
+  ];
+  if (!historical.query.includeCanceled)
+    filters.push(sql`${schema.workflowState.category} <> 'canceled'`);
+  const teamBase = and(...filters) ?? sql`false`;
+  return sql`${teamBase} and ${historical.matches}`;
+}
+
 export async function listAnalyticsDrilldown(
   principal: Principal,
   input: AnalyticsDrilldownInput,
@@ -1077,31 +1116,49 @@ export async function listAnalyticsDrilldown(
   }
   const base = drilldownBase(principal, resolved, semanticCohort);
   const cohort = cohortPredicate(resolved, semanticCohort, base);
+  const rowBase = teamDrilldownBase(principal, resolved, semanticCohort);
   const requestedLimit = input.limit ?? 50;
   const limit = Number.isFinite(requestedLimit)
     ? Math.max(1, Math.min(MAX_LIMIT, Math.trunc(requestedLimit)))
     : 50;
   const weight =
     resolved.measure === 'points' ? sql`coalesce(${schema.issue.estimate}, 1)` : sql`1`;
-  const [aggregate] = await db.execute<AggregateRow>(sql`
-    select
-      count(*) as total,
-      coalesce(sum(${weight}), 0) as total_value,
-      count(*) filter (where ${schema.issue.completedAt} is not null
-        and ${schema.issue.startedAt} is not null
-        and ${schema.issue.completedAt} >= ${schema.issue.startedAt}) as valid_cycle_count,
-      percentile_cont(0.5) within group (
-        order by extract(epoch from (${schema.issue.completedAt} - ${schema.issue.startedAt})) / 86400
-      ) filter (where ${schema.issue.completedAt} is not null and ${schema.issue.startedAt} is not null
-        and ${schema.issue.completedAt} >= ${schema.issue.startedAt}) as cycle_time_p50,
-      percentile_cont(0.85) within group (
-        order by extract(epoch from (${schema.issue.completedAt} - ${schema.issue.startedAt})) / 86400
-      ) filter (where ${schema.issue.completedAt} is not null and ${schema.issue.startedAt} is not null
-        and ${schema.issue.completedAt} >= ${schema.issue.startedAt}) as cycle_time_p85
-    from issue
-    join workflow_state on workflow_state.id = issue.state_id
-    where ${base} and ${cohort}
-  `);
+
+  const [aggregate, [scopedCountRow]] = await Promise.all([
+    db.execute<AggregateRow>(sql`
+      select
+        count(*) as total,
+        coalesce(sum(${weight}), 0) as total_value,
+        count(*) filter (where ${schema.issue.completedAt} is not null
+          and ${schema.issue.startedAt} is not null
+          and ${schema.issue.completedAt} >= ${schema.issue.startedAt}) as valid_cycle_count,
+        percentile_cont(0.5) within group (
+          order by extract(epoch from (${schema.issue.completedAt} - ${schema.issue.startedAt})) / 86400
+        ) filter (where ${schema.issue.completedAt} is not null and ${schema.issue.startedAt} is not null
+          and ${schema.issue.completedAt} >= ${schema.issue.startedAt}) as cycle_time_p50,
+        percentile_cont(0.85) within group (
+          order by extract(epoch from (${schema.issue.completedAt} - ${schema.issue.startedAt})) / 86400
+        ) filter (where ${schema.issue.completedAt} is not null and ${schema.issue.startedAt} is not null
+          and ${schema.issue.completedAt} >= ${schema.issue.startedAt}) as cycle_time_p85
+      from issue
+      join workflow_state on workflow_state.id = issue.state_id
+      where ${base} and ${cohort}
+    `),
+    db.execute<{ count: string | number }>(sql`
+      select count(*) as count
+      from issue
+      join workflow_state on workflow_state.id = issue.state_id
+      where ${rowBase} and ${cohort}
+    `),
+  ]);
+
+  const aggRow = aggregate[0] as AggregateRow | undefined;
+  const scopedRow = scopedCountRow as { readonly count?: unknown } | undefined;
+
+  const totalRows = Number(aggRow?.['total'] ?? 0);
+  const scopedRowsCount = Number(scopedRow?.['count'] ?? 0);
+  const withheldCount = Math.max(0, totalRows - scopedRowsCount);
+
   const cursorPredicate = cursor === null ? sql`true` : gt(schema.issue.id, cursor.id);
   const rows = await db.execute<PageRow>(sql`
     select
@@ -1130,30 +1187,33 @@ export async function listAnalyticsDrilldown(
     join workflow_state on workflow_state.id = issue.state_id
     left join project on project.id = issue.project_id
     left join "user" assignee on assignee.id = issue.assignee_id
-    where ${base} and ${cohort} and ${cursorPredicate}
+    where ${rowBase} and ${cohort} and ${cursorPredicate}
     order by issue.id asc
     limit ${limit + 1}
   `);
+
   const page = rows.slice(0, limit);
   const last = page.at(-1);
   const nextCursor =
     rows.length > limit && last !== undefined
       ? encodeCursor(last, cursorResolution(resolved), binding, secret)
       : null;
+
   return {
     predicate: predicateLabel(semanticCohort),
-    total: Number(aggregate?.['total'] ?? 0),
-    totalValue: Number(aggregate?.['total_value'] ?? 0),
+    total: totalRows,
+    totalValue: Number(aggRow?.['total_value'] ?? 0),
+    withheldCount,
     details: {
-      validCycleCount: Number(aggregate?.['valid_cycle_count'] ?? 0),
+      validCycleCount: Number(aggRow?.['valid_cycle_count'] ?? 0),
       cycleTimeP50:
-        aggregate?.['cycle_time_p50'] === null || aggregate?.['cycle_time_p50'] === undefined
+        aggRow?.['cycle_time_p50'] === null || aggRow?.['cycle_time_p50'] === undefined
           ? null
-          : Number(aggregate['cycle_time_p50']),
+          : Number(aggRow['cycle_time_p50']),
       cycleTimeP85:
-        aggregate?.['cycle_time_p85'] === null || aggregate?.['cycle_time_p85'] === undefined
+        aggRow?.['cycle_time_p85'] === null || aggRow?.['cycle_time_p85'] === undefined
           ? null
-          : Number(aggregate['cycle_time_p85']),
+          : Number(aggRow['cycle_time_p85']),
     },
     issues: page.map((row) => ({
       id: row.id,

--- a/packages/core/src/analytics/overview.ts
+++ b/packages/core/src/analytics/overview.ts
@@ -12,6 +12,7 @@ import {
   cohortPredicate,
   priorityLabel,
   resolveOverviewQuery,
+  teamDrilldownBase,
 } from './drilldown.ts';
 import { bucketDates } from './filter.ts';
 import type {
@@ -330,8 +331,9 @@ async function outliers(
   principal: Principal,
   resolved: ResolvedAnalyticsQuery,
 ): Promise<readonly OutlierRow[]> {
-  const base = baseAnalyticsPredicate(principal, resolved);
+  const base = teamDrilldownBase(principal, resolved, { cohort: 'cycle-time' });
   const current = cohortPredicate(resolved, { cohort: 'cycle-time' });
+
   return await db.execute<OutlierRow>(sql`
     select issue.id, issue.identifier, issue.title,
       extract(epoch from (issue.completed_at - issue.started_at)) / 86400 as cycle_time_days

--- a/packages/core/src/analytics/overview.ts
+++ b/packages/core/src/analytics/overview.ts
@@ -72,6 +72,7 @@ export interface AnalyticsOverview {
   readonly projects: readonly AnalyticsBucket[];
   readonly priorities: readonly AnalyticsBucket[];
   readonly outliers: readonly FlowOutlier[];
+  readonly outliersWithheldCount: number;
 }
 
 interface CardRow {
@@ -124,6 +125,7 @@ interface OutlierRow {
   readonly identifier: string;
   readonly title: string;
   readonly cycle_time_days: number | string;
+  readonly visible: boolean;
 }
 
 function metric(
@@ -331,15 +333,17 @@ async function outliers(
   principal: Principal,
   resolved: ResolvedAnalyticsQuery,
 ): Promise<readonly OutlierRow[]> {
-  const base = teamDrilldownBase(principal, resolved, { cohort: 'cycle-time' });
+  const base = baseAnalyticsPredicate(principal, resolved);
+  const visible = teamDrilldownBase(principal, resolved, { cohort: 'cycle-time' });
   const current = cohortPredicate(resolved, { cohort: 'cycle-time' });
 
   return await db.execute<OutlierRow>(sql`
     select issue.id, issue.identifier, issue.title,
-      extract(epoch from (issue.completed_at - issue.started_at)) / 86400 as cycle_time_days
+      extract(epoch from (issue.completed_at - issue.started_at)) / 86400 as cycle_time_days,
+      (${visible}) as visible
     from issue
     join workflow_state on workflow_state.id = issue.state_id
-    where ${base} and ${current} and issue.started_at is not null
+    where ${base} and ${current}
     order by cycle_time_days desc, issue.id asc
     limit 10
   `);
@@ -382,6 +386,7 @@ export async function loadAnalyticsOverview(
   const comparisonCycleP50 = optionalAmount(throughput, 'comparison_cycle_p50');
   const comparisonCycleP85 = optionalAmount(throughput, 'comparison_cycle_p85');
   const unit = resolved.measure;
+  const visibleOutliers = slow.filter((row) => row.visible);
   const cards: AnalyticsOverviewMetric[] = [
     metric({
       id: 'throughput',
@@ -490,12 +495,13 @@ export async function loadAnalyticsOverview(
     priorities: mix
       .filter((row) => row.dimension === 'priority')
       .map((row) => distributionBucket(row, unit)),
-    outliers: slow.map((row) => ({
+    outliers: visibleOutliers.map((row) => ({
       issueId: row.id,
       identifier: row.identifier,
       title: row.title,
       cycleTimeDays: Number(row.cycle_time_days),
       cohort: { cohort: `outlier:${row.id}` },
     })),
+    outliersWithheldCount: slow.length - visibleOutliers.length,
   };
 }

--- a/packages/core/src/auth/mcp-token.ts
+++ b/packages/core/src/auth/mcp-token.ts
@@ -51,7 +51,7 @@ export function unbindMcpCredential(
   const expectedBytes = Buffer.from(expected, 'utf8');
   if (
     providedBytes.length !== expectedBytes.length ||
-    !timingSafeEqual(providedBytes, expectedBytes)
+    !timingSafeEqual(new Uint8Array(providedBytes), new Uint8Array(expectedBytes))
   ) {
     return null;
   }

--- a/packages/core/src/work/issue-query.ts
+++ b/packages/core/src/work/issue-query.ts
@@ -17,10 +17,21 @@ export interface IssueWhereInput {
   readonly advancedFilter?: 'include' | 'omit';
 }
 
+export type IssueVisibilityScope =
+  | { readonly kind: 'workspace' }
+  | { readonly kind: 'teams'; readonly teamIds: readonly string[] };
+
+export function issueVisibilityScope(principal: Principal): IssueVisibilityScope {
+  return principal.role === 'admin'
+    ? { kind: 'workspace' }
+    : { kind: 'teams', teamIds: [...new Set(principal.teamIds)].sort() };
+}
+
 export function visibleTeamFilters(principal: Principal): SQL[] {
-  if (principal.role === 'admin') return [];
-  if (principal.teamIds.length === 0) return [sql`false`];
-  return [inArray(schema.issue.teamId, [...principal.teamIds])];
+  const scope = issueVisibilityScope(principal);
+  if (scope.kind === 'workspace') return [];
+  if (scope.teamIds.length === 0) return [sql`false`];
+  return [inArray(schema.issue.teamId, [...scope.teamIds])];
 }
 
 function visibilityFilters(principal: Principal, visibility: IssueVisibility): SQL[] {

--- a/packages/core/tests/analytics/drilldown.test.ts
+++ b/packages/core/tests/analytics/drilldown.test.ts
@@ -5,9 +5,11 @@ import {
   analyticsDrilldownQuerySchema,
   analyticsQuerySchema,
 } from '@orbit/shared';
+import type { Principal } from '@orbit/shared/policy';
 import { listAnalyticsDrilldown } from '../../src/analytics/drilldown.ts';
 import { createLabel, insertLabelOn } from '../../src/analytics/test-fixtures.ts';
 import { newId } from '../../src/internal.ts';
+import { createTeam } from '../../src/org/team-service.ts';
 import {
   addMember,
   createWorkspace,
@@ -24,6 +26,48 @@ function query(): AnalyticsQuery {
   return analyticsQuerySchema.parse({
     range: { preset: 'custom', from: '2026-08-01', to: '2026-08-10' },
     compare: 'none',
+  });
+}
+
+function personQuery(personId: string): AnalyticsQuery {
+  return analyticsQuerySchema.parse({
+    lens: 'people',
+    range: { preset: 'custom', from: '2026-08-01', to: '2026-08-10' },
+    compare: 'none',
+    focus: { personId },
+    filter: {
+      kind: 'group',
+      combinator: 'and',
+      children: [
+        {
+          kind: 'condition',
+          property: 'assignee',
+          operator: 'in',
+          values: [personId],
+          negate: false,
+        },
+      ],
+    },
+  });
+}
+
+async function assignmentActivity(
+  issueId: string,
+  from: { readonly id: string; readonly name: string } | null,
+  to: { readonly id: string; readonly name: string } | null,
+  createdAt: string,
+): Promise<void> {
+  await db.insert(schema.issueActivity).values({
+    id: newId(),
+    organizationId: workspace.organizationId,
+    issueId,
+    actorType: 'user',
+    actorId: workspace.adminUser.id,
+    actorName: workspace.adminUser.name,
+    field: 'assigneeId',
+    fromValue: from,
+    toValue: to,
+    createdAt: new Date(createdAt),
   });
 }
 
@@ -218,6 +262,267 @@ describe('listAnalyticsDrilldown', () => {
         { now: new Date('2026-08-14T12:00:00.000Z'), timezone: 'UTC', cursorSecret },
       ),
     ).rejects.toMatchObject({ code: 'validation_failed' });
+  });
+
+  it('rejects a cursor after the reader team scope narrows', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Operations', key: 'OPS' });
+    const reader = await addMember(workspace, 'member', {
+      teamIds: [workspace.teamId, other.team.id],
+    });
+    for (const title of ['First', 'Second']) {
+      await createIssue(workspace.admin, { teamId: workspace.teamId, title });
+    }
+    await createIssue(workspace.admin, {
+      teamId: other.team.id,
+      stateId: other.states[0]?.id,
+      title: 'Other team',
+    });
+    const context = { now, timezone: 'UTC', cursorSecret: 'analytics-test-secret' };
+    const first = await listAnalyticsDrilldown(
+      reader.principal,
+      { query: query(), cohort: { cohort: 'current' }, limit: 1 },
+      context,
+    );
+    if (first.nextCursor === null) throw new Error('Missing cursor.');
+    const narrowed: Principal = { ...reader.principal, teamIds: [workspace.teamId] };
+
+    await expect(
+      listAnalyticsDrilldown(
+        narrowed,
+        {
+          query: query(),
+          cohort: { cohort: 'current' },
+          cursor: first.nextCursor,
+          limit: 1,
+        },
+        context,
+      ),
+    ).rejects.toThrow('cursor');
+  });
+
+  it('rejects an admin cursor after workspace visibility is demoted to team visibility', async () => {
+    for (const title of ['First', 'Second']) {
+      await createIssue(workspace.admin, { teamId: workspace.teamId, title });
+    }
+    const context = { now, timezone: 'UTC', cursorSecret: 'analytics-test-secret' };
+    const first = await listAnalyticsDrilldown(
+      workspace.admin,
+      { query: query(), cohort: { cohort: 'current' }, limit: 1 },
+      context,
+    );
+    if (first.nextCursor === null) throw new Error('Missing cursor.');
+    const demoted: Principal = {
+      ...workspace.admin,
+      role: 'member',
+      teamIds: [workspace.teamId],
+    };
+
+    await expect(
+      listAnalyticsDrilldown(
+        demoted,
+        {
+          query: query(),
+          cohort: { cohort: 'current' },
+          cursor: first.nextCursor,
+          limit: 1,
+        },
+        context,
+      ),
+    ).rejects.toThrow('cursor');
+  });
+
+  it('keeps a cursor valid when the same reader changes role without changing team visibility', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Operations', key: 'OPS' });
+    const reader = await addMember(workspace, 'member', {
+      teamIds: [workspace.teamId, other.team.id],
+    });
+    for (const title of ['First', 'Second']) {
+      await createIssue(workspace.admin, { teamId: workspace.teamId, title });
+    }
+    const context = { now, timezone: 'UTC', cursorSecret: 'analytics-test-secret' };
+    const member: Principal = {
+      ...reader.principal,
+      role: 'member',
+      teamIds: [other.team.id, workspace.teamId],
+    };
+    const contributor: Principal = {
+      ...reader.principal,
+      role: 'contributor',
+      teamIds: [workspace.teamId, other.team.id],
+    };
+    const first = await listAnalyticsDrilldown(
+      member,
+      { query: query(), cohort: { cohort: 'current' }, limit: 1 },
+      context,
+    );
+    if (first.nextCursor === null) throw new Error('Missing cursor.');
+
+    const second = await listAnalyticsDrilldown(
+      contributor,
+      {
+        query: query(),
+        cohort: { cohort: 'current' },
+        cursor: first.nextCursor,
+        limit: 1,
+      },
+      context,
+    );
+
+    expect(second.issues[0]?.id).not.toBe(first.issues[0]?.id);
+  });
+
+  it('rejects a cursor presented by a different reader with the same team visibility', async () => {
+    const firstReader = await addMember(workspace, 'member', { teamIds: [workspace.teamId] });
+    const secondReader = await addMember(workspace, 'member', { teamIds: [workspace.teamId] });
+    for (const title of ['First', 'Second']) {
+      await createIssue(workspace.admin, { teamId: workspace.teamId, title });
+    }
+    const context = { now, timezone: 'UTC', cursorSecret: 'analytics-test-secret' };
+    const first = await listAnalyticsDrilldown(
+      firstReader.principal,
+      { query: query(), cohort: { cohort: 'current' }, limit: 1 },
+      context,
+    );
+    if (first.nextCursor === null) throw new Error('Missing cursor.');
+
+    await expect(
+      listAnalyticsDrilldown(
+        secondReader.principal,
+        {
+          query: query(),
+          cohort: { cohort: 'current' },
+          cursor: first.nextCursor,
+          limit: 1,
+        },
+        context,
+      ),
+    ).rejects.toThrow('cursor');
+  });
+
+  it('keeps current aggregates workspace wide while scoping rows to reader teams', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Operations', key: 'OPS' });
+    const otherState = other.states.find((state) => state.category === 'unstarted');
+    if (otherState === undefined) throw new Error('Missing Operations state.');
+    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Visible first' });
+    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Visible second' });
+    await createIssue(workspace.admin, {
+      teamId: other.team.id,
+      stateId: otherState.id,
+      title: 'Hidden other team',
+    });
+    const reader = await addMember(workspace, 'guest', { teamIds: [workspace.teamId] });
+
+    const page = await listAnalyticsDrilldown(
+      reader.principal,
+      { query: query(), cohort: { cohort: 'current' } },
+      { now, timezone: 'UTC', cursorSecret: 'analytics-test-secret' },
+    );
+
+    expect(page.total).toBe(3);
+    expect(page.issues.map((entry) => entry.title).sort()).toEqual([
+      'Visible first',
+      'Visible second',
+    ]);
+    expect(page.withheldCount).toBe(1);
+  });
+
+  it('reports historical completion rows within the reader team scope after reassignment', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Operations', key: 'OPS' });
+    const otherDone = other.states.find((state) => state.category === 'completed');
+    const workspaceDone = workspace.states.find((state) => state.category === 'completed');
+    if (otherDone === undefined || workspaceDone === undefined) {
+      throw new Error('Missing completed state.');
+    }
+    const currentOwner = await addMember(workspace, 'member', {
+      teamIds: [workspace.teamId, other.team.id],
+    });
+    const reader = await addMember(workspace, 'guest', { teamIds: [workspace.teamId] });
+    for (const entry of [
+      { teamId: workspace.teamId, stateId: workspaceDone.id, title: 'Visible completion' },
+      { teamId: other.team.id, stateId: otherDone.id, title: 'Hidden completion' },
+    ]) {
+      const created = await createIssue(workspace.admin, {
+        ...entry,
+        assigneeId: currentOwner.user.id,
+      });
+      await db
+        .update(schema.issue)
+        .set({
+          createdAt: new Date('2026-08-01T00:00:00.000Z'),
+          completedAt: new Date('2026-08-03T00:00:00.000Z'),
+        })
+        .where(eq(schema.issue.id, created.issue.id));
+      await assignmentActivity(
+        created.issue.id,
+        workspace.adminUser,
+        currentOwner.user,
+        '2026-08-04T00:00:00.000Z',
+      );
+    }
+
+    const page = await listAnalyticsDrilldown(
+      reader.principal,
+      {
+        query: personQuery(workspace.adminUser.id),
+        cohort: { cohort: `person-completed:${workspace.adminUser.id}` },
+        limit: 10,
+      },
+      { now, timezone: 'UTC', cursorSecret: 'analytics-test-secret' },
+    );
+
+    expect(page.total).toBe(2);
+    expect(page.issues.map((entry) => entry.title)).toEqual(['Visible completion']);
+    expect(page.withheldCount).toBe(1);
+  });
+
+  it('reports historical assignment rows within the reader team scope after reassignment', async () => {
+    const other = await createTeam(workspace.admin, { name: 'Operations', key: 'OPS' });
+    const currentOwner = await addMember(workspace, 'member', {
+      teamIds: [workspace.teamId, other.team.id],
+    });
+    const reader = await addMember(workspace, 'guest', { teamIds: [workspace.teamId] });
+    for (const entry of [
+      { teamId: workspace.teamId, title: 'Visible assignment' },
+      { teamId: other.team.id, stateId: other.states[0]?.id, title: 'Hidden assignment' },
+    ]) {
+      const created = await createIssue(workspace.admin, {
+        ...entry,
+        assigneeId: currentOwner.user.id,
+      });
+      await db
+        .update(schema.issue)
+        .set({ createdAt: new Date('2026-08-01T00:00:00.000Z') })
+        .where(eq(schema.issue.id, created.issue.id));
+      await assignmentActivity(
+        created.issue.id,
+        null,
+        workspace.adminUser,
+        '2026-08-04T09:00:00.000Z',
+      );
+      await assignmentActivity(
+        created.issue.id,
+        workspace.adminUser,
+        currentOwner.user,
+        '2026-08-05T09:00:00.000Z',
+      );
+    }
+
+    const page = await listAnalyticsDrilldown(
+      reader.principal,
+      {
+        query: personQuery(workspace.adminUser.id),
+        cohort: {
+          cohort: `person-assigned:${workspace.adminUser.id}`,
+          bucket: '2026-08-04',
+        },
+        limit: 10,
+      },
+      { now, timezone: 'UTC', cursorSecret: 'analytics-test-secret' },
+    );
+
+    expect(page.total).toBe(2);
+    expect(page.issues.map((entry) => entry.title)).toEqual(['Visible assignment']);
+    expect(page.withheldCount).toBe(1);
   });
 
   it('drills into the workflow state category the overview distribution links to', async () => {

--- a/packages/core/tests/analytics/overview.test.ts
+++ b/packages/core/tests/analytics/overview.test.ts
@@ -571,8 +571,8 @@ describe('loadAnalyticsOverview', () => {
         },
         { now, timezone: 'UTC' },
       );
-      expect(rows.issues.map((entry) => entry.title)).toEqual(['Other team issue']);
-      expect(Object.keys(rows.issues[0] ?? {}).includes('organizationId')).toBe(false);
+      expect(rows.issues.map((entry) => entry.title)).toEqual([]);
+      expect(rows.withheldCount).toBe(1);
     }
   });
 });

--- a/packages/core/tests/analytics/overview.test.ts
+++ b/packages/core/tests/analytics/overview.test.ts
@@ -575,4 +575,64 @@ describe('loadAnalyticsOverview', () => {
       expect(rows.withheldCount).toBe(1);
     }
   });
+
+  it('ranks workspace outliers before filtering rows to the reader team scope', async () => {
+    const { team, states } = await createTeam(workspace.admin, {
+      name: 'Operations',
+      key: 'OPS',
+    });
+    const operationsDone = states.find((state) => state.category === 'completed');
+    const engineeringDone = stateNamed(workspace, 'Done');
+    if (operationsDone === undefined) throw new Error('Missing Operations completed state.');
+
+    for (let index = 0; index < 9; index += 1) {
+      await issue(
+        workspace.admin,
+        {
+          teamId: team.id,
+          title: `Hidden workspace outlier ${index + 1}`,
+          stateId: operationsDone.id,
+        },
+        {
+          createdAt: new Date('2026-07-01T00:00:00.000Z'),
+          startedAt: new Date(`2026-07-${String(index + 1).padStart(2, '0')}T00:00:00.000Z`),
+          completedAt: new Date('2026-08-08T00:00:00.000Z'),
+        },
+      );
+    }
+    await issue(
+      workspace.admin,
+      { title: 'Visible workspace outlier', stateId: engineeringDone.id },
+      {
+        createdAt: new Date('2026-07-20T00:00:00.000Z'),
+        startedAt: new Date('2026-07-29T00:00:00.000Z'),
+        completedAt: new Date('2026-08-08T00:00:00.000Z'),
+      },
+    );
+    await issue(
+      workspace.admin,
+      { title: 'Visible outside workspace top ten', stateId: engineeringDone.id },
+      {
+        createdAt: new Date('2026-08-01T00:00:00.000Z'),
+        startedAt: new Date('2026-08-07T00:00:00.000Z'),
+        completedAt: new Date('2026-08-08T00:00:00.000Z'),
+      },
+    );
+    const guest = await addMember(workspace, 'guest', { teamIds: [workspace.teamId] });
+
+    const [adminOverview, guestOverview] = await Promise.all([
+      loadAnalyticsOverview(workspace.admin, query(), { now, timezone: 'UTC' }),
+      loadAnalyticsOverview(guest.principal, query(), { now, timezone: 'UTC' }),
+    ]);
+
+    expect(adminOverview.outliers).toHaveLength(10);
+    expect(adminOverview.outliers.map((entry) => entry.title)).not.toContain(
+      'Visible outside workspace top ten',
+    );
+    expect(adminOverview.outliersWithheldCount).toBe(0);
+    expect(guestOverview.outliers.map((entry) => entry.title)).toEqual([
+      'Visible workspace outlier',
+    ]);
+    expect(guestOverview.outliersWithheldCount).toBe(9);
+  });
 });

--- a/packages/core/tests/work/issue-query.test.ts
+++ b/packages/core/tests/work/issue-query.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { asc, db, eq, schema } from '@orbit/db';
 import type { FilterGroup } from '@orbit/shared/filters';
-import { inCondition } from '@orbit/shared/filters';
+import { emptyFilterGroup, inCondition } from '@orbit/shared/filters';
 import type { Principal } from '@orbit/shared/policy';
 import { type IssueFilterInput, issueFilterSchema } from '@orbit/shared/validators';
+import { listAnalyticsDrilldown } from '../../src/index.ts';
 import { createTeam } from '../../src/org/team-service.ts';
 import {
   addMember,
@@ -272,5 +273,54 @@ describe('buildIssueWhere predicate parity', () => {
     expect(await titlesMatching(workspace.admin, 'team', { filter })).toEqual([
       'Inside supplied window',
     ]);
+  });
+});
+
+describe('analytics drilldown team scoping (#317)', () => {
+  it('keeps analytics aggregates workspace-wide while scoping drilldown rows to authorized teams and reporting withheld count', async () => {
+    const { team: opsTeam, states: opsStates } = await createTeam(workspace.admin, {
+      name: 'Operations',
+      key: 'OPS',
+    });
+    const opsState = opsStates.find((s) => s.category === 'unstarted');
+    if (opsState === undefined) throw new Error('missing ops state');
+
+    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Engineering issue 1' });
+    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Engineering issue 2' });
+    await createIssue(workspace.admin, {
+      teamId: opsTeam.id,
+      stateId: opsState.id,
+      title: 'Operations issue 1',
+    });
+
+    const guestUser = await addMember(workspace, 'guest', { teamIds: [workspace.teamId] });
+
+    const drilldownInput = {
+      query: {
+        version: 1 as const,
+        lens: 'overview' as const,
+        range: { preset: 'last_30_days' as const },
+        compare: 'none' as const,
+        measure: 'issues' as const,
+        filter: emptyFilterGroup(),
+        includeArchived: false,
+        includeCanceled: true,
+        focus: {},
+      },
+      cohort: { cohort: 'current' as const },
+    };
+
+    const page = await listAnalyticsDrilldown(guestUser.principal, drilldownInput, {
+      now: injectedNow,
+    });
+
+    expect(page.total).toBe(3);
+
+    expect(page.issues.map((i) => i.title).sort()).toEqual([
+      'Engineering issue 1',
+      'Engineering issue 2',
+    ]);
+
+    expect(page.withheldCount).toBe(1);
   });
 });

--- a/packages/core/tests/work/issue-query.test.ts
+++ b/packages/core/tests/work/issue-query.test.ts
@@ -1,10 +1,9 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { asc, db, eq, schema } from '@orbit/db';
 import type { FilterGroup } from '@orbit/shared/filters';
-import { emptyFilterGroup, inCondition } from '@orbit/shared/filters';
+import { inCondition } from '@orbit/shared/filters';
 import type { Principal } from '@orbit/shared/policy';
 import { type IssueFilterInput, issueFilterSchema } from '@orbit/shared/validators';
-import { listAnalyticsDrilldown } from '../../src/index.ts';
 import { createTeam } from '../../src/org/team-service.ts';
 import {
   addMember,
@@ -273,54 +272,5 @@ describe('buildIssueWhere predicate parity', () => {
     expect(await titlesMatching(workspace.admin, 'team', { filter })).toEqual([
       'Inside supplied window',
     ]);
-  });
-});
-
-describe('analytics drilldown team scoping (#317)', () => {
-  it('keeps analytics aggregates workspace-wide while scoping drilldown rows to authorized teams and reporting withheld count', async () => {
-    const { team: opsTeam, states: opsStates } = await createTeam(workspace.admin, {
-      name: 'Operations',
-      key: 'OPS',
-    });
-    const opsState = opsStates.find((s) => s.category === 'unstarted');
-    if (opsState === undefined) throw new Error('missing ops state');
-
-    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Engineering issue 1' });
-    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Engineering issue 2' });
-    await createIssue(workspace.admin, {
-      teamId: opsTeam.id,
-      stateId: opsState.id,
-      title: 'Operations issue 1',
-    });
-
-    const guestUser = await addMember(workspace, 'guest', { teamIds: [workspace.teamId] });
-
-    const drilldownInput = {
-      query: {
-        version: 1 as const,
-        lens: 'overview' as const,
-        range: { preset: 'last_30_days' as const },
-        compare: 'none' as const,
-        measure: 'issues' as const,
-        filter: emptyFilterGroup(),
-        includeArchived: false,
-        includeCanceled: true,
-        focus: {},
-      },
-      cohort: { cohort: 'current' as const },
-    };
-
-    const page = await listAnalyticsDrilldown(guestUser.principal, drilldownInput, {
-      now: injectedNow,
-    });
-
-    expect(page.total).toBe(3);
-
-    expect(page.issues.map((i) => i.title).sort()).toEqual([
-      'Engineering issue 1',
-      'Engineering issue 2',
-    ]);
-
-    expect(page.withheldCount).toBe(1);
   });
 });

--- a/packages/services/src/github/index.ts
+++ b/packages/services/src/github/index.ts
@@ -21,7 +21,7 @@ export function verifyGithubSignature(
   const expected = Buffer.from(`sha256=${digest}`, 'utf8');
   const received = Buffer.from(signatureHeader, 'utf8');
   if (expected.length !== received.length) return false;
-  return timingSafeEqual(expected, received);
+  return timingSafeEqual(new Uint8Array(expected), new Uint8Array(received));
 }
 
 export const PULL_REQUEST_STATES = [

--- a/packages/services/src/markdown/sanitize.ts
+++ b/packages/services/src/markdown/sanitize.ts
@@ -325,7 +325,9 @@ function sanitizeInDom(html: string): string {
 export function sanitizeHtml(html: string): string {
   if (html.length === 0) return '';
   if (typeof HTMLRewriter === 'undefined') return sanitizeInDom(html);
-  return bunSanitizer().transform(html);
+  const sanitized: unknown = bunSanitizer().transform(html);
+  if (typeof sanitized !== 'string') throw new TypeError('Expected sanitized HTML text');
+  return sanitized;
 }
 
 const VOID_TEXT_TAGS = new Set(['br', 'hr', 'img', 'input']);

--- a/packages/services/src/slack/index.ts
+++ b/packages/services/src/slack/index.ts
@@ -32,7 +32,7 @@ export function verifySlackSignature(
   const expected = Buffer.from(`v0=${digest}`, 'utf8');
   const received = Buffer.from(signature, 'utf8');
   if (expected.length !== received.length) return false;
-  return timingSafeEqual(expected, received);
+  return timingSafeEqual(new Uint8Array(expected), new Uint8Array(received));
 }
 
 export type SlackBlock = Record<string, unknown>;

--- a/packages/shared/src/events/ticket.ts
+++ b/packages/shared/src/events/ticket.ts
@@ -40,7 +40,7 @@ export function verifyRealtimeTicket(
   const provided = Buffer.from(ticket.slice(separator + 1), 'base64url');
   const expected = digest(body, secret);
   if (provided.length !== expected.length) return null;
-  if (!timingSafeEqual(provided, expected)) return null;
+  if (!timingSafeEqual(new Uint8Array(provided), new Uint8Array(expected))) return null;
   let parsed: unknown;
   try {
     parsed = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));

--- a/scripts/check-bun-imports.ts
+++ b/scripts/check-bun-imports.ts
@@ -93,8 +93,8 @@ export function describe(entry: BunImport): string {
 }
 
 function trackedFiles(): string[] {
-  return new TextDecoder()
-    .decode(Bun.spawnSync(['git', 'ls-files', '-z']).stdout)
+  return Bun.spawnSync(['git', 'ls-files', '-z'])
+    .stdout.toString('utf8')
     .split('\0')
     .filter((entry) => entry.length > 0);
 }

--- a/scripts/check-source-bytes.ts
+++ b/scripts/check-source-bytes.ts
@@ -82,7 +82,9 @@ async function main(): Promise<void> {
   for (const file of files) {
     const data = await readFile(file).catch(() => null);
     if (data === null) continue;
-    for (const entry of controlBytes(data)) problems.push(describe(file, entry));
+    for (const entry of controlBytes(new Uint8Array(data))) {
+      problems.push(describe(file, entry));
+    }
   }
 
   if (problems.length > 0) {


### PR DESCRIPTION
### Summary

Resolves #317 by preserving workspace-wide analytics aggregates while restricting issue-level evidence to teams the principal can read.

### Changes

- Applies team visibility only to drilldown rows and visible row counts, while retaining workspace totals and aggregate values.
- Reports `withheldCount` for drilldowns and `outliersWithheldCount` for overview outliers.
- Ranks the workspace top ten cycle-time outliers before applying row visibility, so restricted readers receive the authorized subset of the same workspace ranking.
- Binds pagination cursors to the effective issue visibility scope and current user, preventing replay after role, team, or principal changes.
- Makes CSV truncation depend on visible rows and reports workspace, withheld, and exported counts separately.
- Distinguishes all-withheld evidence from genuinely empty cohorts in the UI.
- Adds regressions for current and historical completed and assigned cohorts, restricted exports, the 10,001-row cap, all-withheld views, and cursor replay.
- Updates the analytics visibility documentation.

### Verification

- Core analytics: 34 tests passing with 212 assertions.
- Web analytics: 13 tests passing with 55 assertions.
- Full monorepo typecheck passing.
- Lint, comment policy, source-byte policy, Bun import policy, dependency dedupe, and diff checks passing.
- Focused compatibility tests passing across core, services, shared, realtime, web, and repository scripts.

A local cumulative web test run under Bun 1.3.14 reproducibly hits a Bun `SIGTRAP` at `line-plot.test.tsx`; that file passes 16/16 alone. Exact-head GitHub checks remain the merge authority.

### Unblocks

- #336

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves workspace-wide analytics aggregates while limiting issue-level evidence to teams the reader can access.
- Adds withheld counts to drilldowns, exports, and cycle-time outliers.
- Binds pagination cursors to the current user and effective visibility scope.
- Aligns historical person-cohort row filtering with aggregate attribution after reassignment.
- Distinguishes fully withheld cohorts from genuinely empty results in the UI.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/analytics/drilldown.ts | Separates workspace aggregates from team-visible evidence, correctly reconstructs historical person filters for both paths, reports withheld counts, and scope-binds cursors. |
| packages/core/src/analytics/overview.ts | Ranks workspace cycle-time outliers before filtering the resulting rows by team visibility and reports the hidden subset. |
| apps/web/src/app/api/analytics/export/route.ts | Bases truncation on visible rows and reports workspace, withheld, and exported counts independently. |
| apps/web/src/features/analytics/analytics-drilldown-dialog.tsx | Presents withheld evidence clearly and distinguishes fully restricted cohorts from empty cohorts. |
| packages/core/tests/analytics/drilldown.test.ts | Adds regressions covering team scope, cursor replay, and historical completion and assignment attribution after reassignment. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Q[Analytics query] --> A[Workspace-wide aggregate]
  Q --> H[Historical cohort attribution]
  H --> A
  H --> V[Team visibility scope]
  V --> R[Authorized drilldown rows]
  A --> W[Withheld count]
  R --> W
  R --> E[CSV export and UI evidence]
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(build): normalize Bun binary boundar..."](https://github.com/noveum/orbit/commit/98f75ee18b0120490a4473c003bf29c2e514f247) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55838539)</sub>

**Context used:**

- Knowledge Base — [Analytics and planning insights](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/docs/analytics-and-insights.md)
- Knowledge Base — [Issue lifecycle and views](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/docs/issue-lifecycle.md)

<!-- /greptile_comment -->