### PR TITLE
test(web): isolate issue row focus from leaked guards

### DIFF
--- a/apps/web/tests/features/issues/issue-row.test.tsx
+++ b/apps/web/tests/features/issues/issue-row.test.tsx
@@ -120,20 +120,29 @@ describe('IssueRow', () => {
     expect(onToggleSelected).toHaveBeenCalledTimes(1);
   });
 
-  it('reveals the checkbox on hover and keeps it reachable from the keyboard', async () => {
+  it('reveals the checkbox on hover and preserves the row-local tab order', async () => {
     const user = userEvent.setup();
     render(
-      <IssueRow
-        issue={issue()}
-        state={todo}
-        labels={[]}
-        assignee={undefined}
-        active={false}
-        selected={false}
-        onOpen={mock()}
-        onToggleSelected={mock()}
-        onFocus={mock()}
-      />,
+      <>
+        {/* biome-ignore lint/a11y/noNoninteractiveTabindex: Match Radix focus guard markup */}
+        <span data-radix-focus-guard="" tabIndex={0} />
+      </>,
+    );
+    render(
+      <>
+        <button data-testid="issue-row-focus-start" type="button" />
+        <IssueRow
+          issue={issue()}
+          state={todo}
+          labels={[]}
+          assignee={undefined}
+          active={false}
+          selected={false}
+          onOpen={mock()}
+          onToggleSelected={mock()}
+          onFocus={mock()}
+        />
+      </>,
     );
 
     const checkbox = screen.getByLabelText('Select ENG-7');
@@ -141,6 +150,9 @@ describe('IssueRow', () => {
     expect(checkbox.className).toContain('group-hover:opacity-100');
     expect(checkbox.className).toContain('focus-visible:opacity-100');
 
+    const focusStart = screen.getByTestId('issue-row-focus-start');
+    focusStart.focus();
+    expect(focusStart).toHaveFocus();
     await user.tab();
     expect(checkbox).toHaveFocus();
   });


### PR DESCRIPTION
## What this changes

The IssueRow keyboard test now renders a known focus boundary immediately before the row and starts tab navigation there. An earlier Radix focus guard remains in the document as a regression fixture, so unrelated tabbable elements can no longer invalidate the row-local assertion.

Production code is unchanged.

## Why

The previous test assumed the checkbox was the first tabbable element in the whole document. Portals or focus guards left by aggregate test execution could receive the first tab even when IssueRow's own keyboard order was correct.

Closes #347

## How you know it works

- The regression fixture failed before the local focus boundary was added: 9 passed, 1 failed.
- The focused file passes: 10 passed.
- Twenty repeated focused runs pass: 200 passed, 0 failed.
- `bun run lint`, `bun run check-comments`, `bun run check-bytes`, `bun run check-bun-imports`, `bun run check-deps`, and `bun run typecheck` pass with Bun 1.3.14.
- The complete local test matrix requires the repository PostgreSQL, Redis, and MinIO stack. This machine has no Docker runtime, so the database-backed portion is left to CI.

## Checklist

- [ ] `bun run verify` is green, all four checks. Static checks are green; full infrastructure tests await CI.
- [x] Tests added or updated, and they fail without the change
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions
- [x] External input parsing is not applicable to this test-only change
- [x] Authorization is not affected by this test-only change
- [x] Documentation is not affected by this test-only change
- [x] Database release and drift checks are not applicable because there are no schema changes

## Anything reviewers should know

The focus guard fixture intentionally matches Radix's focusable `span` markup. Its Biome directive is required by the accessibility lint rule and is accepted by the repository comment policy.






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This test-only change isolates IssueRow keyboard navigation from unrelated focus guards left in the document.
- Adds a Radix-style focus guard as a regression fixture.
- Establishes an explicit row-local focus boundary before asserting that Tab reaches the checkbox.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/tests/features/issues/issue-row.test.tsx | Updates the keyboard-focus test to start from an explicit local boundary while retaining a leaked focus guard fixture. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into test/issue-row-..."](https://github.com/noveum/orbit/commit/567b4225edcf69a65563617cf12808996a2124d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56124604)</sub>

<!-- /greptile_comment -->