### PR TITLE
chore(ci): enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## What this changes

Adds a repository-level Git attributes policy so text files use LF line endings across platforms.

## Why

Windows Git configurations can check files out with CRLF line endings, while Orbit's Biome configuration requires LF. This keeps checkout behavior consistent without changing source content or application behavior.

## How you know it works

- The diff contains only .gitattributes with * text=auto eol=lf.
- bun run lint passes on the branch.
- The pre-push checks complete successfully.
- No source files are mechanically rewritten in this PR.

## Checklist

- [x] bun run lint passes locally
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No source files were reformatted
- [ ] Full bun run verify is not applicable to this configuration-only change
- [ ] bun run db:release and bun run db:check-drift are not applicable to this configuration-only change

## Anything reviewers should know

This is intentionally a separate, narrowly scoped cross-platform tooling change. It does not include mass line-ending rewrites.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a repository-wide Git attributes policy that normalizes detected text files to LF across platforms.
- Adds `* text=auto eol=lf` in `.gitattributes`.
- Aligns Git checkout behavior with the repository's existing LF formatting configuration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .gitattributes | Adds a standard repository-wide LF normalization rule without changing application behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(ci): enforce LF line endings"](https://github.com/noveum/orbit/commit/efb39465eba84e3aa13b9fd227551dc1f7823a5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56300685)</sub>

<!-- /greptile_comment -->