### PR TITLE
fix(ci): give the heaviest e2e test the suite timeout back

### DIFF
--- a/apps/web/e2e/issues.spec.ts
+++ b/apps/web/e2e/issues.spec.ts
@@ -89,7 +89,7 @@ test.fixme('two viewers see issue, board and comment changes without reloading',
 test('every issue surface says a failed request failed rather than looking empty', async ({
   browser,
 }) => {
-  test.setTimeout(120_000);
+  test.setTimeout(180_000);
   const context = await browser.newContext({ viewport: { width: 1400, height: 800 } });
   const page = await context.newPage();
   await page.goto(`${BASE}/login`);

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   expect: { timeout: 45_000 },
   fullyParallel: false,
   workers: 1,
+  retries: process.env['CI'] === undefined ? 0 : 2,
   reporter: [['list']],
   use: {
     baseURL: BASE,

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
   expect: { timeout: 45_000 },
   fullyParallel: false,
   workers: 1,
-  retries: process.env['CI'] === undefined ? 0 : 2,
   reporter: [['list']],
   use: {
     baseURL: BASE,


### PR DESCRIPTION
## Why

`e2e/issues.spec.ts:89` timed out on `d7df6fc4` and took main red. The tree of that commit is byte identical to the branch head that had just passed the same gate, and re-running the job on the unchanged commit went green, so nothing in the change caused it.

## The cause

The ceiling was the test's own. The suite default has been `180_000` since #16, and 0c0b3017 added `test.setTimeout(120_000)` to this one test, which lowers it. So the heaviest test in the suite had the shortest budget, while `issues.spec.ts:18` in the same file keeps 180s and `docs.spec.ts:90` takes 240s.

That test walks eight distinct routes, several of which no earlier test reaches, and CI runs against a dev server so each of those pays a first compile. It takes 56s on a good run and hit exactly 2.0m on a bad one, its own limit rather than the suite's.

It gets the default back. That is the whole change.

## What this deliberately does not do

**Retries.** The first version of this PR added `retries: 2` under CI as a safety net. Greptile pointed out the hole: global setup seeds the database once per run and Playwright does not run it again between attempts, so a retry inherits whatever a failed attempt left behind. Most of the suite tolerates that, because creators carry a `Date.now()` suffix and count assertions are scoped to what the test just made, but a retry that passes because the previous attempt already created the record is a false green. A flaky red is annoying, a flaky green ships bugs. The timeout was the cause anyway, so the net bought nothing here and was dropped.

**Running against a built server.** That would remove the compile variance entirely and was the first thing I tried. It does not work: `devLoginEnabled()` requires `NODE_ENV !== 'production'`, so a built server answers the dev sign in route with a 404 and every test fails to authenticate. Moving the suite off `dev` means giving e2e another way in first, which is its own piece of work.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the slow issue-surface error-state test to Playwright’s 180-second suite timeout while leaving CI retries disabled.
- Raises the test-specific timeout from 120 seconds to 180 seconds.
- Preserves the resolution of the prior shared-state concern by keeping retries at zero.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported shared-state issue is resolved because CI retries are no longer enabled.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/e2e/issues.spec.ts | Restores the multi-route issue error-state test’s timeout to the suite default without reintroducing retry behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): drop the retry net and keep the..."](https://github.com/noveum/orbit/commit/8b3716f9bdfdf42119bf0b78ceea00189fbddcf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56970362)</sub>

<!-- /greptile_comment -->