### PR TITLE
fix(web): stop relative timestamps breaking hydration

### DIFF
--- a/apps/web/src/components/ui/relative-time.tsx
+++ b/apps/web/src/components/ui/relative-time.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { relativeTime } from '@orbit/shared/utils';
+
+export interface RelativeTimeProps {
+  readonly at: string;
+}
+
+export function RelativeTime({ at }: RelativeTimeProps) {
+  return (
+    <time dateTime={at} suppressHydrationWarning>
+      {relativeTime(new Date(at))}
+    </time>
+  );
+}

--- a/apps/web/src/features/account/passkeys-panel.tsx
+++ b/apps/web/src/features/account/passkeys-panel.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { relativeTime } from '@orbit/shared/utils';
 import { Fingerprint, Loader2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -8,6 +7,7 @@ import { Badge } from '@/components/ui/badge.tsx';
 import { Button } from '@/components/ui/button.tsx';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
 import { Input } from '@/components/ui/input.tsx';
+import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import { useToast } from '@/components/ui/toast.tsx';
 import { apiRequest, messageOf } from '@/lib/api/client.ts';
 import { authClient } from '@/lib/auth/client.ts';
@@ -189,9 +189,13 @@ export function PasskeysPanel({ passkeys, accountCount }: PasskeysPanelProps) {
                     </span>
                     <span className="truncate text-2xs text-faint">
                       Added {formatDate(passkey.createdAt)}
-                      {passkey.lastUsedAt === null
-                        ? ', never used yet'
-                        : `, last used ${relativeTime(new Date(passkey.lastUsedAt))}`}
+                      {passkey.lastUsedAt === null ? (
+                        ', never used yet'
+                      ) : (
+                        <>
+                          , last used <RelativeTime at={passkey.lastUsedAt} />
+                        </>
+                      )}
                     </span>
                   </span>
                   <Button

--- a/apps/web/src/features/account/sessions-panel.tsx
+++ b/apps/web/src/features/account/sessions-panel.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { relativeTime } from '@orbit/shared/utils';
 import { MonitorSmartphone } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { Badge } from '@/components/ui/badge.tsx';
 import { Button } from '@/components/ui/button.tsx';
+import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import { useToast } from '@/components/ui/toast.tsx';
 import { messageOf } from '@/lib/api/client.ts';
 import { authClient } from '@/lib/auth/client.ts';
@@ -62,7 +62,7 @@ export function SessionsPanel({ sessions }: SessionsPanelProps) {
               </span>
               <span className="truncate text-2xs text-faint">
                 {session.ipAddress ?? 'Unknown IP'}, last seen{' '}
-                {relativeTime(new Date(session.lastSeenAt))}
+                <RelativeTime at={session.lastSeenAt} />
               </span>
             </span>
             {session.current ? null : (

--- a/apps/web/src/features/comments/comment-thread.tsx
+++ b/apps/web/src/features/comments/comment-thread.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { commentAnchorId, relativeTime } from '@orbit/shared/utils';
+import { commentAnchorId } from '@orbit/shared/utils';
 import { type QueryClient, useQueryClient } from '@tanstack/react-query';
 import { SmilePlus } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
@@ -12,6 +12,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu.tsx';
+import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import { proseOverflowClassName, taskListClassName } from '@/features/docs/doc-body.tsx';
 import { useHashScroll } from '@/features/docs/use-hash-scroll.ts';
 import { ActivityEntry } from '@/features/issues/activity-feed.tsx';
@@ -281,7 +282,7 @@ function CommentItem({
         <div className="flex items-center gap-2 text-2xs">
           <span className="font-medium text-text">{author?.name ?? 'Unknown'}</span>
           <span className="text-faint">
-            {relativeTime(new Date(entry.comment.createdAt), new Date())}
+            <RelativeTime at={entry.comment.createdAt} />
           </span>
           {entry.comment.editedAt === null ? null : <span className="text-faint">edited</span>}
         </div>

--- a/apps/web/src/features/docs/doc-comments.tsx
+++ b/apps/web/src/features/docs/doc-comments.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { docCommentAnchorId, isDocAnchorOrphaned, relativeTime } from '@orbit/shared/utils';
+import { docCommentAnchorId, isDocAnchorOrphaned } from '@orbit/shared/utils';
 import type { DocCommentAnchor } from '@orbit/shared/validators';
 import { Quote, X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Avatar } from '@/components/ui/avatar.tsx';
 import { Button } from '@/components/ui/button.tsx';
+import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import { CommentComposer } from '@/features/comments/comment-composer.tsx';
 import { CommentBody } from '@/features/comments/comment-thread.tsx';
 import { cn } from '@/lib/cn.ts';
@@ -194,7 +195,7 @@ function DocCommentItem({
         <div className="flex items-center gap-2 text-2xs">
           <span className="font-medium text-text">{author?.name ?? 'Unknown'}</span>
           <span className="text-faint">
-            {relativeTime(new Date(entry.comment.createdAt), new Date())}
+            <RelativeTime at={entry.comment.createdAt} />
           </span>
           {entry.comment.editedAt === null ? null : <span className="text-faint">edited</span>}
         </div>

--- a/apps/web/src/features/docs/doc-history.tsx
+++ b/apps/web/src/features/docs/doc-history.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { relativeTime } from '@orbit/shared/utils';
 import { Button } from '@/components/ui/button.tsx';
 import {
   Dialog,
@@ -9,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog.tsx';
+import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import { Skeleton } from '@/components/ui/skeleton.tsx';
 import type { DocVersion } from '@/lib/query/schemas.ts';
 import { useDocVersions, useRestoreDocVersion } from '@/lib/query/use-docs.ts';
@@ -83,7 +83,7 @@ function VersionList({
           <span className="min-w-0 flex-1">
             <span className="block truncate text-dense text-text">{version.title}</span>
             <span className="block text-2xs text-faint">
-              {relativeTime(new Date(version.lastSavedAt))}
+              <RelativeTime at={version.lastSavedAt} />
               {version.restoredFromId === null ? '' : ' · restored'}
             </span>
           </span>

--- a/apps/web/src/features/docs/doc-reader.tsx
+++ b/apps/web/src/features/docs/doc-reader.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { relativeTime } from '@orbit/shared/utils';
 import { Book, GitBranch, Link2, Users } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { Avatar } from '@/components/ui/avatar.tsx';
+import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import { cn } from '@/lib/cn.ts';
 import type { Attachment, Doc } from '@/lib/query/schemas.ts';
 import { DocAttachments } from './doc-attachments.tsx';
@@ -55,7 +55,9 @@ export function DocContextRow({
           Synced from <code className="font-mono">{binding.path}</code>
         </span>
       )}
-      <span className="text-2xs text-faint">Updated {relativeTime(new Date(doc.updatedAt))}</span>
+      <span className="text-2xs text-faint">
+        Updated <RelativeTime at={doc.updatedAt} />
+      </span>
       <span data-testid="doc-stats" className="text-2xs text-faint tabular-nums">
         {wordCount(doc.content).toLocaleString()} words · {readTimeMinutes(doc.content)} min read
       </span>

--- a/apps/web/src/features/docs/docs-home.tsx
+++ b/apps/web/src/features/docs/docs-home.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { relativeTime } from '@orbit/shared/utils';
 import type { LucideIcon } from 'lucide-react';
 import { Clock, FileText, History, Star } from 'lucide-react';
 import Link from 'next/link';
+import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import { Skeleton } from '@/components/ui/skeleton.tsx';
 import { cn } from '@/lib/cn.ts';
 import { rowHover } from '@/lib/interaction.ts';
@@ -16,7 +16,6 @@ export interface DocsHomeSectionProps {
   readonly icon: LucideIcon;
   readonly entries: readonly DocHomeEntry[];
   readonly emptyLabel: string;
-  readonly now: Date;
 }
 
 export function DocsHomeSection({
@@ -25,7 +24,6 @@ export function DocsHomeSection({
   icon: Icon,
   entries,
   emptyLabel,
-  now,
 }: DocsHomeSectionProps) {
   return (
     <section data-testid={`docs-home-${id}`} className="flex min-w-0 flex-col gap-1">
@@ -50,7 +48,7 @@ export function DocsHomeSection({
                 <FileText className="size-3.5 shrink-0 text-faint" aria-hidden="true" />
                 <span className="min-w-0 flex-1 truncate">{entry.title}</span>
                 <span className="shrink-0 text-2xs text-faint tabular-nums">
-                  {relativeTime(new Date(entry.updatedAt), now)}
+                  <RelativeTime at={entry.updatedAt} />
                 </span>
               </Link>
             </li>
@@ -63,7 +61,6 @@ export function DocsHomeSection({
 
 export function DocsHome() {
   const home = useDocsHome();
-  const now = new Date();
 
   if (home.isPending) {
     return (
@@ -88,7 +85,6 @@ export function DocsHome() {
         icon={Clock}
         entries={data.recent}
         emptyLabel="Docs you open show up here."
-        now={now}
       />
       <DocsHomeSection
         id="favorites"
@@ -96,7 +92,6 @@ export function DocsHome() {
         icon={Star}
         entries={data.favorites}
         emptyLabel="Star a doc to keep it here."
-        now={now}
       />
       <DocsHomeSection
         id="updated"
@@ -104,7 +99,6 @@ export function DocsHome() {
         icon={History}
         entries={data.updated}
         emptyLabel="Nothing has changed yet."
-        now={now}
       />
     </div>
   );

--- a/apps/web/src/features/inbox/inbox-view.tsx
+++ b/apps/web/src/features/inbox/inbox-view.tsx
@@ -9,7 +9,6 @@ import {
 } from '@orbit/shared/constants';
 import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
-import { relativeTime } from '@orbit/shared/utils';
 import type { LucideIcon } from 'lucide-react';
 import {
   AlertTriangle,
@@ -34,6 +33,7 @@ import { z } from 'zod';
 import { Badge } from '@/components/ui/badge.tsx';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
 import { Kbd } from '@/components/ui/kbd.tsx';
+import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import { CommentBody } from '@/features/comments/comment-thread.tsx';
 import { DocSurface } from '@/features/docs/doc-surface.tsx';
 import { IssueDetailView } from '@/features/issues/issue-detail.tsx';
@@ -343,7 +343,7 @@ function NotificationRow({
             {row.title}
           </span>
           <span className="truncate text-2xs text-faint">
-            {row.actorName} · {relativeTime(new Date(row.createdAt))}
+            {row.actorName} · <RelativeTime at={row.createdAt} />
           </span>
         </span>
       </button>
@@ -417,7 +417,7 @@ function NotificationDetail({
       <div className="flex items-center gap-3 border-border border-b px-5 py-2">
         <p className="min-w-0 flex-1 truncate text-2xs text-faint">
           <span className="text-muted">{item.title}</span> · {item.actorName} ·{' '}
-          {relativeTime(new Date(item.createdAt))}
+          <RelativeTime at={item.createdAt} />
           {item.snoozedUntil === null ? '' : ' · snoozed'}
         </p>
         <span className="flex shrink-0 items-center gap-3">

--- a/apps/web/src/features/issues/activity-feed.tsx
+++ b/apps/web/src/features/issues/activity-feed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { relativeTime } from '@orbit/shared/utils';
+import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import type { Activity } from '@/lib/query/schemas.ts';
 
 export function ActivityEntry({ entry }: { entry: Activity }) {
@@ -8,7 +8,9 @@ export function ActivityEntry({ entry }: { entry: Activity }) {
     <li className="flex items-baseline gap-2 text-2xs text-faint">
       <span className="font-medium text-muted">{entry.actorName}</span>
       <span>{entry.summary}</span>
-      <span className="ml-auto">{relativeTime(new Date(entry.createdAt), new Date())}</span>
+      <span className="ml-auto">
+        <RelativeTime at={entry.createdAt} />
+      </span>
     </li>
   );
 }

--- a/apps/web/src/features/pulls/pull-detail.tsx
+++ b/apps/web/src/features/pulls/pull-detail.tsx
@@ -1,4 +1,3 @@
-import { relativeTime } from '@orbit/shared/utils';
 import {
   ArrowLeft,
   CircleCheck,
@@ -11,6 +10,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge.tsx';
+import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import { CommentBody } from '@/features/comments/comment-thread.tsx';
 import { DocBody } from '@/features/docs/doc-body.tsx';
 import { IssueLink } from '@/features/issues/issue-link.tsx';
@@ -171,7 +171,7 @@ export function PullDetail({ pull }: { readonly pull: PullRequestDetail }) {
                         <span className="font-medium text-text">{activity.actorLogin}</span>
                         <span className="text-muted">{activityLabel(activity)}</span>
                         <span className="text-faint text-xs">
-                          {relativeTime(new Date(activity.occurredAt))}
+                          <RelativeTime at={activity.occurredAt} />
                         </span>
                       </div>
                       {activity.path === null ? null : (

--- a/apps/web/src/features/pulls/pulls-view.tsx
+++ b/apps/web/src/features/pulls/pulls-view.tsx
@@ -2,7 +2,6 @@
 
 import { useDeltaHandler, useScopeSubscription } from '@orbit/realtime-client/react';
 import { scopes } from '@orbit/shared/events';
-import { relativeTime } from '@orbit/shared/utils';
 import {
   CircleCheck,
   CircleX,
@@ -16,6 +15,7 @@ import { useCallback } from 'react';
 import { Badge } from '@/components/ui/badge.tsx';
 import { Button } from '@/components/ui/button.tsx';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
+import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import { IssueLink } from '@/features/issues/issue-link.tsx';
 import { cn } from '@/lib/cn.ts';
 import { rowHover, tabHover } from '@/lib/interaction.ts';
@@ -237,7 +237,7 @@ export function PullsView({
                         )}
                       </div>
                       <span className="hidden shrink-0 text-2xs text-faint sm:block">
-                        {relativeTime(new Date(pull.updatedAt))}
+                        <RelativeTime at={pull.updatedAt} />
                       </span>
                       {pull.checkStatus === 'success' ? (
                         <CircleCheck

--- a/apps/web/src/features/settings/github-deliveries.tsx
+++ b/apps/web/src/features/settings/github-deliveries.tsx
@@ -1,5 +1,5 @@
-import { relativeTime } from '@orbit/shared/utils';
 import { Badge } from '@/components/ui/badge.tsx';
+import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import type { GithubDeliveryView } from './integrations-data.ts';
 
 const REASON_COPY: Record<string, string> = {
@@ -67,7 +67,9 @@ export function GithubDeliveries({
             <span data-numeric className="text-muted">
               {delivery.event}
             </span>
-            <span className="text-faint">{relativeTime(new Date(delivery.receivedAt))}</span>
+            <span className="text-faint">
+              <RelativeTime at={delivery.receivedAt} />
+            </span>
             {delivery.reason === null ? null : (
               <span className="text-muted">{deliveryReasonCopy(delivery.reason)}</span>
             )}

--- a/apps/web/tests/components/ui/relative-time.test.tsx
+++ b/apps/web/tests/components/ui/relative-time.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, setSystemTime } from 'bun:test';
 import { relativeTime } from '@orbit/shared/utils';
 import { act, render, screen } from '@testing-library/react';
+import { Glob } from 'bun';
 import type { ReactElement } from 'react';
 import type { Root } from 'react-dom/client';
 import { hydrateRoot } from 'react-dom/client';
@@ -72,5 +73,21 @@ describe('RelativeTime', () => {
     const stamp = screen.getByText('just now');
     expect(stamp.tagName).toBe('TIME');
     expect(stamp).toHaveAttribute('datetime', LAST_SEEN);
+  });
+});
+
+describe('relative timestamps across apps/web', () => {
+  it('are rendered through RelativeTime and never inline', async () => {
+    const sourceRoot = `${import.meta.dir}/../../../src/`;
+    const offenders: string[] = [];
+    let scanned = 0;
+    for await (const relative of new Glob('**/*.{ts,tsx}').scan(sourceRoot)) {
+      scanned += 1;
+      if (relative === 'components/ui/relative-time.tsx') continue;
+      const source = await Bun.file(`${sourceRoot}${relative}`).text();
+      if (source.includes('relativeTime(')) offenders.push(relative);
+    }
+    expect(scanned).toBeGreaterThan(100);
+    expect(offenders).toEqual([]);
   });
 });

--- a/apps/web/tests/components/ui/relative-time.test.tsx
+++ b/apps/web/tests/components/ui/relative-time.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, setSystemTime } from 'bun:test';
+import { relativeTime } from '@orbit/shared/utils';
+import { act, render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import type { Root } from 'react-dom/client';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
+import { RelativeTime } from '../../../src/components/ui/relative-time.tsx';
+
+const SERVER_NOW = new Date('2026-05-01T12:00:00.000Z');
+const CLIENT_NOW = new Date('2026-05-01T12:00:10.000Z');
+const LAST_SEEN = '2026-05-01T11:59:20.000Z';
+
+function UnguardedRelativeTime({ at }: { readonly at: string }) {
+  return <span>{relativeTime(new Date(at))}</span>;
+}
+
+function hydrationComplaints(node: ReactElement): string[] {
+  setSystemTime(SERVER_NOW);
+  const html = renderToString(node);
+  setSystemTime(CLIENT_NOW);
+
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  document.body.append(container);
+
+  const complaints: string[] = [];
+  const reportedError = console.error;
+  console.error = (...args: unknown[]) => {
+    complaints.push(args.map(String).join(' '));
+  };
+  let root: Root | undefined;
+  try {
+    act(() => {
+      root = hydrateRoot(container, node, {
+        onRecoverableError: (error) => {
+          complaints.push(String(error));
+        },
+      });
+    });
+  } finally {
+    console.error = reportedError;
+  }
+  act(() => root?.unmount());
+  container.remove();
+  return complaints.filter((line) => line.toLowerCase().includes('hydrat'));
+}
+
+describe('RelativeTime', () => {
+  afterEach(() => {
+    setSystemTime();
+  });
+
+  it('spans a relativeTime boundary between the server render and hydration', () => {
+    setSystemTime(SERVER_NOW);
+    expect(relativeTime(new Date(LAST_SEEN))).toBe('just now');
+    setSystemTime(CLIENT_NOW);
+    expect(relativeTime(new Date(LAST_SEEN))).toBe('1m ago');
+  });
+
+  it('hydrates cleanly when the client clock has crossed that boundary', () => {
+    expect(hydrationComplaints(<RelativeTime at={LAST_SEEN} />)).toEqual([]);
+  });
+
+  it('reports a mismatch when the same timestamp is rendered without it', () => {
+    expect(hydrationComplaints(<UnguardedRelativeTime at={LAST_SEEN} />).length).toBeGreaterThan(0);
+  });
+
+  it('carries the machine readable timestamp', () => {
+    setSystemTime(SERVER_NOW);
+    render(<RelativeTime at={LAST_SEEN} />);
+    const stamp = screen.getByText('just now');
+    expect(stamp.tagName).toBe('TIME');
+    expect(stamp).toHaveAttribute('datetime', LAST_SEEN);
+  });
+});


### PR DESCRIPTION
## What this changes

Relative timestamps now render through a single `RelativeTime` element instead of calling `relativeTime()` inline in twelve places. The element confines the value to one `<time>` node and marks it `suppressHydrationWarning`, so the string can no longer fail hydration.

## Why

`relativeTime(from, now = new Date())` reads the wall clock through its default second argument. In a client component that default runs twice, once during the server render and once during hydration. When the two straddle the 45 second `just now` cutoff or a minute boundary, the strings differ and React throws `Hydration failed because the server rendered text didn't match the client`.

That is a real intermittent bug on dev builds, and it also makes CI flaky. It failed the End-to-end (Playwright) job on #358 at `apps/web/e2e/account-and-workspaces.spec.ts:123`, on a pull request that does not touch `apps/web/src/features/account` at all. The Next dev overlay renders a codeframe of `sessions-panel.tsx` line 61, whose source text contains `This device`, so `page.getByText('This device')` matched two elements and failed strict mode.

Every other call site had the same latent flake, and it was not theoretical: the app dehydrates prefetched query state into the server render (`app/(app)/layout.tsx` plus six page level `HydrationBoundary`s), so the inbox, docs, pulls and activity lists all ship real rows rather than skeletons.

## How you know it works

`apps/web/tests/components/ui/relative-time.test.tsx` renders to HTML at one system time, moves the clock across the `just now` boundary with `setSystemTime`, then hydrates and collects both `onRecoverableError` and `console.error`.

It is a real guard rather than a green rubber stamp, two ways:

- A control case in the same file renders the old inline pattern through the same harness and asserts React **does** complain. It passes, so the harness detects mismatches.
- Removing `suppressHydrationWarning` and re-running turns the suite red with React's own `+ 1m ago / - just now` diff.

A fifth test scans every `.ts` and `.tsx` under `apps/web/src` and fails if anything but the component calls `relativeTime(` again, so a new call site cannot silently reintroduce this.

`bun run lint`, `check-comments`, `check-bytes`, `check-bun-imports`, `check-deps` and the `apps/web` typecheck are green. Root `bun run typecheck` halts on two pre-existing `Buffer` errors in `scripts/`, identical with and without this branch.

On tests, rather than claim a clean sweep: this suite flakes locally on full process runs, so each touched directory was baselined against a stash of the same tree. `features/docs` fails 3 and `features/issues` fails 10 both with and without the change, identically. `inbox`, `pulls`, `account`, `comments`, `settings` and `components/ui` are green in isolation. Nothing here moved the failure set.

## Anything reviewers should know

**Why `suppressHydrationWarning` and not a stable server `now`.** Threading a server timestamp down to every call site works, but it is a rule every future call site has to remember, and it silently rots the first time someone forgets. React documents this attribute for exactly a rendered timestamp. Confining it to one `<time>` element means the only text it can ever mask is the relative string itself, never sibling content. The source scan is what keeps the rule enforced.

**The value is the server's, not the client's.** React keeps the server text and does not correct it after hydration, so when the two renders straddle a boundary the DOM sits one bucket behind, `just now` where the client would say `1m ago`. I measured this rather than assuming it, and two things came out of it.

The first is that the obvious fix does not work. Neither a `useState` initializer with an effect that recomputes, nor a deterministic `null` sentinel with an effect that stores `Date.now()`, changes the DOM. The effect runs and the re-render happens, but `suppressHydrationWarning` has already told React to accept the server text, so React's committed value is `1m ago` while the DOM says `just now`, and a re-render producing `1m ago` again is a no-op. Once the attribute accepts the server text, no later render producing the same string can correct that node. Correcting it needs a hydration render that matches the server byte for byte, which means threading the server's `now` through every call site, which is the option rejected above.

The second is that what ships is narrower than "stale text". The drift is at most one bucket, only on a straddled boundary, and it self-heals on the next re-render that crosses a bucket, because that render does produce a different string and React does patch it. Left with no re-render, the label sits where the server put it, which is where it would have sat anyway had hydration not straddled a boundary. That is not worth a timestamp threaded through twelve call sites.

**Two server components gained a client island.** `github-deliveries.tsx` and `pull-detail.tsx` are reached from a server page and a client parent respectively, and neither could mismatch as it stood. Migrating them anyway keeps the rule uniform and the scan simple, which seemed worth a `<time>` element of JavaScript.

**`DocsHomeSection` lost its `now` prop.** It existed only to keep the rows of one section consistent with each other, which `RelativeTime` now gets for free.

**Adjacent, deliberately not in this PR.** `toLocaleDateString(undefined, ...)` and `Intl.DateTimeFormat(undefined, ...)` in client components carry the same hazard through locale and timezone rather than the clock, and `sprint-header.tsx:44` passes `new Date()` to `sprintDay`. The date cases need a midnight straddle to bite, so they are far less likely than a 45 second cutoff, and folding them in would balloon this diff. Worth their own issue.

## Checklist

- [ ] `bun run verify` is green, all four checks (lint, comments, bytes, bun imports, deps and the `apps/web` typecheck are green; root `typecheck` halts on two pre-existing `Buffer` errors in `scripts/` that are identical on `main`, so `verify` never reaches the test step)
- [x] Tests added or updated, and they fail without the change
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions
- [ ] External input is parsed with a Zod schema from `@orbit/shared` (not applicable, no external input)
- [ ] Authorization is enforced on the server (not applicable, presentation only)
- [ ] Docs updated if behaviour, configuration or setup changed (not applicable)
- [ ] `bun run db:release` and `bun run db:check-drift` (not applicable, no schema change)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Centralizes relative timestamp rendering in a hydration-warning-suppressed `<time>` component.
- Replaces inline `relativeTime()` calls across account, comments, documents, inbox, issues, pull requests, and settings.
- Adds hydration-boundary regression tests and a source scan preventing new inline relative-time rendering.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/ui/relative-time.tsx | Introduces a focused client component that confines clock-dependent text to one hydration-warning-suppressed `<time>` element. |
| apps/web/tests/components/ui/relative-time.test.tsx | Tests the server/client clock-boundary mismatch, verifies suppression behavior and semantic markup, and guards against future inline call sites. |
| apps/web/src/features/docs/docs-home.tsx | Migrates document timestamps to the shared component and removes the now-unnecessary shared `now` prop. |
| apps/web/src/features/inbox/inbox-view.tsx | Migrates both notification-row and notification-detail timestamps without changing their surrounding content. |
| apps/web/src/features/pulls/pull-detail.tsx | Replaces server-rendered inline relative-time formatting with the shared client component. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/noveum/orbit/commit/0d040de705a5980aff9951d9be75d51bb488dcbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56978100)</sub>

<!-- /greptile_comment -->