### PR TITLE
feat(docs): drag to resize the html split view

### DIFF
--- a/apps/web/src/features/docs/html-doc-editor.tsx
+++ b/apps/web/src/features/docs/html-doc-editor.tsx
@@ -7,6 +7,9 @@ import { cn } from '@/lib/cn.ts';
 import { tabHover } from '@/lib/interaction.ts';
 import { HtmlCodeEditor } from './editor/html-code-editor.tsx';
 import { HtmlPreview } from './html-preview.tsx';
+import { SplitPane } from './split-pane.tsx';
+
+const SPLIT_STORAGE_KEY = 'orbit:docs:html-split';
 
 const VIEW_OPTIONS = [
   { id: 'split', label: 'Split', Icon: Columns2 },
@@ -86,27 +89,21 @@ export function HtmlDocEditor({ title, content, onChange, footer }: HtmlDocEdito
           );
         })}
       </div>
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        {showSource ? (
-          <div
-            className={cn(
-              'min-h-0 min-w-0 flex-1 overflow-hidden',
-              showPreview ? 'border-border border-r' : '',
-            )}
-          >
+      <SplitPane
+        storageKey={SPLIT_STORAGE_KEY}
+        label="Resize source and preview"
+        secondClassName="bg-white"
+        first={
+          showSource ? (
             <HtmlCodeEditor
               value={content}
               onChange={onChange}
               ariaLabel={`HTML source for ${title}`}
             />
-          </div>
-        ) : null}
-        {showPreview ? (
-          <div className="min-h-0 min-w-0 flex-1 overflow-hidden bg-white">
-            <HtmlPreview title={title} html={content} />
-          </div>
-        ) : null}
-      </div>
+          ) : null
+        }
+        second={showPreview ? <HtmlPreview title={title} html={content} /> : null}
+      />
       {footer === undefined ? null : <HtmlDocDock>{footer}</HtmlDocDock>}
     </div>
   );

--- a/apps/web/src/features/docs/split-pane.tsx
+++ b/apps/web/src/features/docs/split-pane.tsx
@@ -5,6 +5,7 @@ import {
   type ReactNode,
   type PointerEvent as ReactPointerEvent,
   useEffect,
+  useId,
   useRef,
   useState,
 } from 'react';
@@ -59,6 +60,7 @@ export function SplitPane({
   const [ratio, setRatio] = useState(DEFAULT_SPLIT_RATIO);
   const [dragging, setDragging] = useState(false);
   const container = useRef<HTMLDivElement>(null);
+  const paneId = useId();
 
   useEffect(() => {
     setRatio(readStoredRatio(storageKey));
@@ -131,6 +133,7 @@ export function SplitPane({
       data-testid="split-pane"
     >
       <div
+        id={`${paneId}-first`}
         style={{ flexBasis: `${ratio * 100}%` }}
         className={cn('min-h-0 min-w-0 shrink-0 grow-0 overflow-hidden', firstClassName)}
       >
@@ -138,6 +141,7 @@ export function SplitPane({
       </div>
       <hr
         tabIndex={0}
+        aria-controls={`${paneId}-first ${paneId}-second`}
         aria-label={label}
         aria-orientation="vertical"
         aria-valuenow={Math.round(ratio * 100)}
@@ -154,7 +158,12 @@ export function SplitPane({
           dragging ? 'bg-accent' : null,
         )}
       />
-      <div className={cn('min-h-0 min-w-0 flex-1 overflow-hidden', secondClassName)}>{second}</div>
+      <div
+        id={`${paneId}-second`}
+        className={cn('min-h-0 min-w-0 flex-1 overflow-hidden', secondClassName)}
+      >
+        {second}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/docs/split-pane.tsx
+++ b/apps/web/src/features/docs/split-pane.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  type PointerEvent as ReactPointerEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { cn } from '@/lib/cn.ts';
+
+export const MIN_SPLIT_RATIO = 0.2;
+export const MAX_SPLIT_RATIO = 0.8;
+export const DEFAULT_SPLIT_RATIO = 0.5;
+const KEYBOARD_STEP = 0.02;
+
+export function clampSplitRatio(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_SPLIT_RATIO;
+  return Math.max(MIN_SPLIT_RATIO, Math.min(value, MAX_SPLIT_RATIO));
+}
+
+function readStoredRatio(key: string): number {
+  if (typeof window === 'undefined') return DEFAULT_SPLIT_RATIO;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw === null ? DEFAULT_SPLIT_RATIO : clampSplitRatio(Number.parseFloat(raw));
+  } catch {
+    return DEFAULT_SPLIT_RATIO;
+  }
+}
+
+function storeRatio(key: string, value: number): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, value.toFixed(4));
+  } catch {
+    return;
+  }
+}
+
+export interface SplitPaneProps {
+  readonly storageKey: string;
+  readonly label: string;
+  readonly first: ReactNode | null;
+  readonly second: ReactNode | null;
+  readonly firstClassName?: string;
+  readonly secondClassName?: string;
+}
+
+export function SplitPane({
+  storageKey,
+  label,
+  first,
+  second,
+  firstClassName,
+  secondClassName,
+}: SplitPaneProps) {
+  const [ratio, setRatio] = useState(DEFAULT_SPLIT_RATIO);
+  const [dragging, setDragging] = useState(false);
+  const container = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setRatio(readStoredRatio(storageKey));
+  }, [storageKey]);
+
+  const commit = (next: number) => {
+    setRatio(next);
+    storeRatio(storageKey, next);
+  };
+
+  const startResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const bounds = container.current?.getBoundingClientRect();
+    if (bounds === undefined || bounds.width === 0) return;
+    event.preventDefault();
+    const handle = event.currentTarget;
+    handle.setPointerCapture(event.pointerId);
+    setDragging(true);
+    let next = ratio;
+    const onMove = (moveEvent: PointerEvent) => {
+      next = clampSplitRatio((moveEvent.clientX - bounds.left) / bounds.width);
+      setRatio(next);
+    };
+    const stop = () => {
+      handle.removeEventListener('pointermove', onMove);
+      handle.removeEventListener('pointerup', stop);
+      handle.removeEventListener('pointercancel', stop);
+      setDragging(false);
+      commit(next);
+    };
+    handle.addEventListener('pointermove', onMove);
+    handle.addEventListener('pointerup', stop);
+    handle.addEventListener('pointercancel', stop);
+  };
+
+  const nudge = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Home') {
+      event.preventDefault();
+      commit(MIN_SPLIT_RATIO);
+      return;
+    }
+    if (event.key === 'End') {
+      event.preventDefault();
+      commit(MAX_SPLIT_RATIO);
+      return;
+    }
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+    event.preventDefault();
+    commit(clampSplitRatio(ratio + (event.key === 'ArrowLeft' ? -KEYBOARD_STEP : KEYBOARD_STEP)));
+  };
+
+  if (first === null || second === null) {
+    return (
+      <div className="flex min-h-0 flex-1 overflow-hidden" data-testid="split-pane">
+        <div
+          className={cn(
+            'min-h-0 min-w-0 flex-1 overflow-hidden',
+            first === null ? secondClassName : firstClassName,
+          )}
+        >
+          {first ?? second}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={container}
+      className={cn('flex min-h-0 flex-1 overflow-hidden', dragging ? 'select-none' : null)}
+      data-testid="split-pane"
+    >
+      <div
+        style={{ flexBasis: `${ratio * 100}%` }}
+        className={cn('min-h-0 min-w-0 shrink-0 grow-0 overflow-hidden', firstClassName)}
+      >
+        {first}
+      </div>
+      <hr
+        tabIndex={0}
+        aria-label={label}
+        aria-orientation="vertical"
+        aria-valuenow={Math.round(ratio * 100)}
+        aria-valuemin={Math.round(MIN_SPLIT_RATIO * 100)}
+        aria-valuemax={Math.round(MAX_SPLIT_RATIO * 100)}
+        data-testid="split-pane-handle"
+        onPointerDown={startResize}
+        onKeyDown={nudge}
+        onDoubleClick={() => commit(DEFAULT_SPLIT_RATIO)}
+        className={cn(
+          'm-0 h-auto w-1 shrink-0 cursor-col-resize touch-none self-stretch border-0 bg-border',
+          'transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)] motion-reduce:transition-none',
+          'hover:bg-accent focus-visible:bg-accent focus-visible:outline-none',
+          dragging ? 'bg-accent' : null,
+        )}
+      />
+      <div className={cn('min-h-0 min-w-0 flex-1 overflow-hidden', secondClassName)}>{second}</div>
+    </div>
+  );
+}

--- a/apps/web/tests/features/docs/html-doc-editor.test.tsx
+++ b/apps/web/tests/features/docs/html-doc-editor.test.tsx
@@ -15,12 +15,20 @@ describe('the html page editor', () => {
     expect(screen.getByTestId('html-view-split').getAttribute('aria-pressed')).toBe('true');
   });
 
+  it('puts a drag handle between source and preview', () => {
+    render(<HtmlDocEditor title="Board" content="<p>ok</p>" onChange={() => undefined} />);
+    const handle = screen.getByTestId('split-pane-handle');
+    expect(handle.getAttribute('aria-label')).toBe('Resize source and preview');
+    expect(handle.getAttribute('aria-orientation')).toBe('vertical');
+  });
+
   it('hides the source when preview is selected', async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(<HtmlDocEditor title="Board" content="<p>ok</p>" onChange={() => undefined} />);
     await user.click(screen.getByTestId('html-view-preview'));
     expect(screen.queryByTestId('html-code-editor-host')).toBeNull();
     expect(screen.getByTestId('html-preview')).toBeTruthy();
+    expect(screen.queryByTestId('split-pane-handle')).toBeNull();
   });
 
   it('keeps comments collapsed so the page fills the pane', async () => {

--- a/apps/web/tests/features/docs/split-pane.test.tsx
+++ b/apps/web/tests/features/docs/split-pane.test.tsx
@@ -128,7 +128,8 @@ describe('the split pane', () => {
     renderSplit();
     const handle = screen.getByTestId('split-pane-handle');
 
-    await user.tab();
+    expect(handle.tabIndex).toBe(0);
+    handle.focus();
     expect(handle).toHaveFocus();
 
     await user.keyboard('{ArrowRight}');

--- a/apps/web/tests/features/docs/split-pane.test.tsx
+++ b/apps/web/tests/features/docs/split-pane.test.tsx
@@ -123,22 +123,40 @@ describe('the split pane', () => {
     expect(basis()).toBeCloseTo(70, 5);
   });
 
-  it('moves a step at a time from the keyboard and jumps to either end', () => {
+  it('moves a step at a time from the keyboard and jumps to either end', async () => {
+    const user = userEvent.setup();
     renderSplit();
     const handle = screen.getByTestId('split-pane-handle');
 
-    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+    await user.tab();
+    expect(handle).toHaveFocus();
+
+    await user.keyboard('{ArrowRight}');
     expect(basis()).toBeCloseTo(52, 5);
 
-    fireEvent.keyDown(handle, { key: 'ArrowLeft' });
-    fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+    await user.keyboard('{ArrowLeft}{ArrowLeft}');
     expect(basis()).toBeCloseTo(48, 5);
 
-    fireEvent.keyDown(handle, { key: 'End' });
+    await user.keyboard('{End}');
     expect(basis()).toBeCloseTo(MAX_SPLIT_RATIO * 100, 5);
 
-    fireEvent.keyDown(handle, { key: 'Home' });
+    await user.keyboard('{Home}');
     expect(basis()).toBeCloseTo(MIN_SPLIT_RATIO * 100, 5);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('0.2000');
+  });
+
+  it('names the panes it resizes for a screen reader', () => {
+    renderSplit();
+    const handle = screen.getByTestId('split-pane-handle');
+    const controls = (handle.getAttribute('aria-controls') ?? '').split(' ');
+
+    expect(controls).toHaveLength(2);
+    expect(document.getElementById(controls[0] ?? '')).toContainElement(
+      screen.getByTestId('first-pane'),
+    );
+    expect(document.getElementById(controls[1] ?? '')).toContainElement(
+      screen.getByTestId('second-pane'),
+    );
   });
 
   it('goes back to an even split on a double click', async () => {

--- a/apps/web/tests/features/docs/split-pane.test.tsx
+++ b/apps/web/tests/features/docs/split-pane.test.tsx
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import userEvent from '@testing-library/user-event';
+import {
+  clampSplitRatio,
+  DEFAULT_SPLIT_RATIO,
+  MAX_SPLIT_RATIO,
+  MIN_SPLIT_RATIO,
+  SplitPane,
+} from '@/features/docs/split-pane.tsx';
+import { cleanup, fireEvent, render, screen } from '@/test/render.tsx';
+
+const STORAGE_KEY = 'orbit:test:split';
+
+function measure(width: number, left = 0): void {
+  const pane = screen.getByTestId('split-pane');
+  pane.getBoundingClientRect = () =>
+    ({ left, right: left + width, width, top: 0, bottom: 0, height: 0, x: left, y: 0 }) as DOMRect;
+}
+
+function basis(): number {
+  const first = screen.getByTestId('first-pane').parentElement;
+  const value = first?.style.flexBasis ?? '';
+  return Number.parseFloat(value.replace('%', ''));
+}
+
+function renderSplit(): void {
+  render(
+    <SplitPane
+      storageKey={STORAGE_KEY}
+      label="Resize source and preview"
+      first={<div data-testid="first-pane">source</div>}
+      second={<div data-testid="second-pane">preview</div>}
+    />,
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  if (typeof Element.prototype.setPointerCapture !== 'function') {
+    Element.prototype.setPointerCapture = () => undefined;
+    Element.prototype.releasePointerCapture = () => undefined;
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+
+describe('the split ratio', () => {
+  it('stays inside the range the handle can reach', () => {
+    expect(clampSplitRatio(0)).toBe(MIN_SPLIT_RATIO);
+    expect(clampSplitRatio(1)).toBe(MAX_SPLIT_RATIO);
+    expect(clampSplitRatio(0.5)).toBe(0.5);
+  });
+
+  it('falls back to an even split when the stored value is not a number', () => {
+    expect(clampSplitRatio(Number.NaN)).toBe(DEFAULT_SPLIT_RATIO);
+    expect(clampSplitRatio(Number.POSITIVE_INFINITY)).toBe(DEFAULT_SPLIT_RATIO);
+  });
+});
+
+describe('the split pane', () => {
+  it('opens on an even split with a handle between the two panes', () => {
+    renderSplit();
+
+    expect(screen.getByTestId('first-pane')).toBeInTheDocument();
+    expect(screen.getByTestId('second-pane')).toBeInTheDocument();
+    expect(basis()).toBe(DEFAULT_SPLIT_RATIO * 100);
+    expect(screen.getByTestId('split-pane-handle').getAttribute('aria-valuenow')).toBe('50');
+  });
+
+  it('drops the handle when only one pane is shown', () => {
+    render(
+      <SplitPane
+        storageKey={STORAGE_KEY}
+        label="Resize source and preview"
+        first={null}
+        second={<div data-testid="second-pane">preview</div>}
+      />,
+    );
+
+    expect(screen.getByTestId('second-pane')).toBeInTheDocument();
+    expect(screen.queryByTestId('split-pane-handle')).toBeNull();
+  });
+
+  it('moves the boundary to where the pointer is dragged', () => {
+    renderSplit();
+    measure(1000);
+    const handle = screen.getByTestId('split-pane-handle');
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 500 });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 700 });
+
+    expect(basis()).toBeCloseTo(70, 5);
+
+    fireEvent.pointerUp(handle, { pointerId: 1 });
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('0.7000');
+  });
+
+  it('refuses to drag a pane past the limits', () => {
+    renderSplit();
+    measure(1000);
+    const handle = screen.getByTestId('split-pane-handle');
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 500 });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 40 });
+    expect(basis()).toBeCloseTo(MIN_SPLIT_RATIO * 100, 5);
+
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 4000 });
+    expect(basis()).toBeCloseTo(MAX_SPLIT_RATIO * 100, 5);
+  });
+
+  it('measures from the left edge of the panes, not the window', () => {
+    renderSplit();
+    measure(1000, 200);
+    const handle = screen.getByTestId('split-pane-handle');
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 700 });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 900 });
+
+    expect(basis()).toBeCloseTo(70, 5);
+  });
+
+  it('moves a step at a time from the keyboard and jumps to either end', () => {
+    renderSplit();
+    const handle = screen.getByTestId('split-pane-handle');
+
+    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+    expect(basis()).toBeCloseTo(52, 5);
+
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+    expect(basis()).toBeCloseTo(48, 5);
+
+    fireEvent.keyDown(handle, { key: 'End' });
+    expect(basis()).toBeCloseTo(MAX_SPLIT_RATIO * 100, 5);
+
+    fireEvent.keyDown(handle, { key: 'Home' });
+    expect(basis()).toBeCloseTo(MIN_SPLIT_RATIO * 100, 5);
+  });
+
+  it('goes back to an even split on a double click', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderSplit();
+    const handle = screen.getByTestId('split-pane-handle');
+
+    fireEvent.keyDown(handle, { key: 'End' });
+    expect(basis()).toBeCloseTo(MAX_SPLIT_RATIO * 100, 5);
+
+    await user.dblClick(handle);
+
+    expect(basis()).toBe(DEFAULT_SPLIT_RATIO * 100);
+  });
+
+  it('opens at the width the last drag left behind', () => {
+    window.localStorage.setItem(STORAGE_KEY, '0.35');
+    renderSplit();
+
+    expect(basis()).toBeCloseTo(35, 5);
+  });
+
+  it('ignores a stored value that is out of range or unreadable', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'not a ratio');
+    renderSplit();
+    expect(basis()).toBe(DEFAULT_SPLIT_RATIO * 100);
+
+    cleanup();
+    window.localStorage.setItem(STORAGE_KEY, '9');
+    renderSplit();
+    expect(basis()).toBeCloseTo(MAX_SPLIT_RATIO * 100, 5);
+  });
+});


### PR DESCRIPTION
Drag the divider between the HTML source and preview panes to set the split, with keyboard control and a remembered width.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a reusable split-pane component so users can resize the HTML source and preview panes by pointer or keyboard while retaining the chosen ratio.
- Persists a bounded split ratio in browser storage.
- Supports pointer dragging, keyboard adjustment, and double-click reset.
- Associates the adjustable separator with both controlled panes.
- Adds coverage for resizing, bounds, persistence, view switching, and accessibility wiring.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/features/docs/split-pane.tsx | Implements the resizable, persistent, keyboard-accessible split pane and now correctly associates the separator with both pane elements. |
| apps/web/src/features/docs/html-doc-editor.tsx | Replaces the fixed HTML editor layout with SplitPane while preserving source-only and preview-only modes. |
| apps/web/tests/features/docs/split-pane.test.tsx | Covers ratio clamping, drag and keyboard behavior, persistence, single-pane rendering, reset behavior, and pane associations. |
| apps/web/tests/features/docs/html-doc-editor.test.tsx | Verifies the editor exposes the resize handle in split mode and removes it in single-pane mode. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(docs): focus the split handle direc..."](https://github.com/noveum/orbit/commit/7060eee2c65801386a6c62fca721935bfbf8d376) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57061595)</sub>

<!-- /greptile_comment -->