### PR TITLE
fix(analytics): scope drilldown rows to the principal teams

### DIFF
--- a/packages/core/src/analytics/drilldown.ts
+++ b/packages/core/src/analytics/drilldown.ts
@@ -953,6 +953,8 @@ function cursorRequestBinding(
 ): string {
   return JSON.stringify({
     organizationId: principal.organizationId,
+    role: principal.role,
+    teamIds: [...principal.teamIds].sort(),
     query: {
       version: query.version,
       lens: query.lens,

--- a/packages/core/src/analytics/drilldown.ts
+++ b/packages/core/src/analytics/drilldown.ts
@@ -14,7 +14,7 @@ import type { AnalyticsDrilldownCohort, AnalyticsQuery } from '@orbit/shared/val
 import { calendarDateSchema, issueFilterSchema } from '@orbit/shared/validators';
 import type { SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
-import { buildIssueWhere } from '../work/issue-query.ts';
+import { buildIssueWhere, visibleTeamFilters } from '../work/issue-query.ts';
 import {
   bucketDates,
   calendarDateLabel,
@@ -160,6 +160,7 @@ export interface AnalyticsDrilldownPage {
   readonly totalValue: number;
   readonly details: AnalyticsDrilldownDetails;
   readonly issues: readonly AnalyticsIssueRow[];
+  readonly withheldCount: number;
   readonly nextCursor: string | null;
   readonly limit: number;
   readonly asOf: string;
@@ -1050,6 +1051,11 @@ function decodeCursor(cursor: string, binding: string, secret: string): CursorVa
   }
 }
 
+function scopedWhere(base: SQL<unknown>, cohort: SQL | undefined, teamScope: SQL[]): SQL<unknown> {
+  if (teamScope.length === 0) return and(base, cohort) ?? sql`false`;
+  return and(base, cohort, ...teamScope) ?? sql`false`;
+}
+
 export async function listAnalyticsDrilldown(
   principal: Principal,
   input: AnalyticsDrilldownInput,
@@ -1081,6 +1087,30 @@ export async function listAnalyticsDrilldown(
   const limit = Number.isFinite(requestedLimit)
     ? Math.max(1, Math.min(MAX_LIMIT, Math.trunc(requestedLimit)))
     : 50;
+  return execDrilldownPage(
+    principal,
+    resolved,
+    semanticCohort,
+    base,
+    cohort,
+    cursor,
+    limit,
+    binding,
+    secret,
+  );
+}
+
+async function execDrilldownPage(
+  principal: Principal,
+  resolved: ResolvedAnalyticsQuery,
+  semanticCohort: AnalyticsDrilldownCohort,
+  base: SQL<unknown>,
+  cohort: SQL | undefined,
+  cursor: CursorValue | null,
+  limit: number,
+  binding: string,
+  secret: string,
+): Promise<AnalyticsDrilldownPage> {
   const weight =
     resolved.measure === 'points' ? sql`coalesce(${schema.issue.estimate}, 1)` : sql`1`;
   const [aggregate] = await db.execute<AggregateRow>(sql`
@@ -1103,6 +1133,8 @@ export async function listAnalyticsDrilldown(
     where ${base} and ${cohort}
   `);
   const cursorPredicate = cursor === null ? sql`true` : gt(schema.issue.id, cursor.id);
+  const teamScope = visibleTeamFilters(principal);
+  const scoped = scopedWhere(base, cohort, teamScope);
   const rows = await db.execute<PageRow>(sql`
     select
       issue.id,
@@ -1130,9 +1162,15 @@ export async function listAnalyticsDrilldown(
     join workflow_state on workflow_state.id = issue.state_id
     left join project on project.id = issue.project_id
     left join "user" assignee on assignee.id = issue.assignee_id
-    where ${base} and ${cohort} and ${cursorPredicate}
+    where ${scoped} and ${cursorPredicate}
     order by issue.id asc
     limit ${limit + 1}
+  `);
+  const [scopedAggregate] = await db.execute<{ total: number }>(sql`
+    select count(*) as total
+    from issue
+    join workflow_state on workflow_state.id = issue.state_id
+    where ${scoped}
   `);
   const page = rows.slice(0, limit);
   const last = page.at(-1);
@@ -1175,6 +1213,10 @@ export async function listAnalyticsDrilldown(
           ? null
           : { id: row.assignee_id, name: row.assignee_name, image: row.assignee_image },
     })),
+    withheldCount: Math.max(
+      0,
+      Number(aggregate?.['total'] ?? 0) - Number(scopedAggregate?.['total'] ?? 0),
+    ),
     nextCursor,
     limit,
     asOf: resolved.asOf.toISOString(),

--- a/packages/core/tests/analytics/drilldown.test.ts
+++ b/packages/core/tests/analytics/drilldown.test.ts
@@ -509,4 +509,35 @@ describe('listAnalyticsDrilldown', () => {
       ),
     ).rejects.toMatchObject({ code: 'validation_failed' });
   });
+
+  it('invalidates a cursor minted as admin once the principal is demoted to member', async () => {
+    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Alpha' });
+    const member = await addMember(workspace, 'admin', { teamIds: [workspace.teamId] });
+
+    const first = await listAnalyticsDrilldown(
+      member.principal,
+      { query: query(), cohort: { cohort: 'current' }, limit: 1 },
+      { now, timezone: 'UTC' },
+    );
+    expect(first.nextCursor).not.toBeNull();
+
+    await db
+      .update(schema.member)
+      .set({ role: 'member' })
+      .where(eq(schema.member.userId, member.user.id));
+    const demoted = await resolvePrincipal(member.user.id, workspace.organizationId);
+
+    await expect(
+      listAnalyticsDrilldown(
+        demoted,
+        {
+          query: query(),
+          cohort: { cohort: 'current' },
+          cursor: first.nextCursor as string,
+          limit: 1,
+        },
+        { now, timezone: 'UTC' },
+      ),
+    ).rejects.toMatchObject({ code: 'validation_failed' });
+  });
 });

--- a/packages/core/tests/analytics/drilldown.test.ts
+++ b/packages/core/tests/analytics/drilldown.test.ts
@@ -8,6 +8,7 @@ import {
 import { listAnalyticsDrilldown } from '../../src/analytics/drilldown.ts';
 import { createLabel, insertLabelOn } from '../../src/analytics/test-fixtures.ts';
 import { newId } from '../../src/internal.ts';
+import { createTeam } from '../../src/org/team-service.ts';
 import {
   addMember,
   createWorkspace,
@@ -419,5 +420,51 @@ describe('listAnalyticsDrilldown', () => {
         ),
       ).rejects.toMatchObject({ code: 'validation_failed' });
     }
+  });
+
+  it('scopes drilldown rows to the principal teams but keeps totals workspace wide and reports what was withheld', async () => {
+    const operations = await createTeam(workspace.admin, { name: 'Operations', key: 'OPS' });
+    const operationsTodo = operations.states.find((state) => state.category === 'unstarted');
+    if (operationsTodo === undefined) throw new Error('Missing Operations state.');
+    for (const title of ['Alpha', 'Beta', 'Gamma']) {
+      await createIssue(workspace.admin, { teamId: workspace.teamId, title });
+    }
+    await createIssue(workspace.admin, { teamId: operations.team.id, title: 'Other team issue' });
+
+    const member = await addMember(workspace, 'member', { teamIds: [workspace.teamId] });
+
+    const page = await listAnalyticsDrilldown(
+      member.principal,
+      { query: query(), cohort: { cohort: 'current' } },
+      { now, timezone: 'UTC' },
+    );
+
+    expect(page.total).toBe(4);
+    expect(page.issues.map((entry) => entry.title)).toEqual(['Alpha', 'Beta', 'Gamma']);
+    expect(page.withheldCount).toBe(1);
+
+    const adminPage = await listAnalyticsDrilldown(
+      workspace.admin,
+      { query: query(), cohort: { cohort: 'current' } },
+      { now, timezone: 'UTC' },
+    );
+    expect(adminPage.total).toBe(4);
+    expect(adminPage.issues).toHaveLength(4);
+    expect(adminPage.withheldCount).toBe(0);
+  });
+
+  it('withholds every row for a principal with no team membership', async () => {
+    await createIssue(workspace.admin, { teamId: workspace.teamId, title: 'Alpha' });
+    const guest = await addMember(workspace, 'guest', { teamIds: [] });
+
+    const page = await listAnalyticsDrilldown(
+      guest.principal,
+      { query: query(), cohort: { cohort: 'current' } },
+      { now, timezone: 'UTC' },
+    );
+
+    expect(page.total).toBe(1);
+    expect(page.issues).toHaveLength(0);
+    expect(page.withheldCount).toBe(1);
   });
 });

--- a/packages/core/tests/analytics/drilldown.test.ts
+++ b/packages/core/tests/analytics/drilldown.test.ts
@@ -8,6 +8,7 @@ import {
 import { listAnalyticsDrilldown } from '../../src/analytics/drilldown.ts';
 import { createLabel, insertLabelOn } from '../../src/analytics/test-fixtures.ts';
 import { newId } from '../../src/internal.ts';
+import { resolvePrincipal } from '../../src/org/member-service.ts';
 import { createTeam } from '../../src/org/team-service.ts';
 import {
   addMember,
@@ -466,5 +467,46 @@ describe('listAnalyticsDrilldown', () => {
     expect(page.total).toBe(1);
     expect(page.issues).toHaveLength(0);
     expect(page.withheldCount).toBe(1);
+  });
+
+  it('invalidates a cursor minted under a wider team scope once membership narrows', async () => {
+    const operations = await createTeam(workspace.admin, { name: 'Operations', key: 'OPS' });
+    for (const title of ['Alpha', 'Beta']) {
+      await createIssue(workspace.admin, { teamId: workspace.teamId, title });
+    }
+    await createIssue(workspace.admin, { teamId: operations.team.id, title: 'Other team issue' });
+    const member = await addMember(workspace, 'member', {
+      teamIds: [workspace.teamId, operations.team.id],
+    });
+
+    const first = await listAnalyticsDrilldown(
+      member.principal,
+      { query: query(), cohort: { cohort: 'current' }, limit: 2 },
+      { now, timezone: 'UTC' },
+    );
+    expect(first.nextCursor).not.toBeNull();
+    expect(first.issues.map((entry) => entry.title)).toEqual(['Alpha', 'Beta']);
+
+    await db.delete(schema.teamMember).where(eq(schema.teamMember.userId, member.user.id));
+    await db.insert(schema.teamMember).values({
+      id: newId(),
+      teamId: workspace.teamId,
+      userId: member.user.id,
+    });
+
+    const narrowed = await resolvePrincipal(member.user.id, workspace.organizationId);
+
+    await expect(
+      listAnalyticsDrilldown(
+        narrowed,
+        {
+          query: query(),
+          cohort: { cohort: 'current' },
+          cursor: first.nextCursor as string,
+          limit: 2,
+        },
+        { now, timezone: 'UTC' },
+      ),
+    ).rejects.toMatchObject({ code: 'validation_failed' });
   });
 });


### PR DESCRIPTION
Closes #317

## What changed

listAnalyticsDrilldown now applies visibleTeamFilters to the row listing and to a scoped count, while the aggregate query stays workspace wide per the decision on #317 (Option 2). The page response gains withheldCount so the UI can explain a short list ("3 of 14 shown, the rest belong to teams you are not on") instead of silently returning fewer rows.

## How it works

- Aggregates (total, totalValue, cycle time) keep workspace-analytics visibility: no team filter, every lens counts the whole workspace
- Rows query gets the team filter via a scopedWhere helper (and(base, cohort) plus the team filters, or just the combination when the principal has no teams)
- withheldCount = workspace aggregate total minus the scoped-visible count, clamped at 0

## Tests

Two new tests in packages/core/tests/analytics/drilldown.test.ts:

1. A member sees only their team's rows (total stays 4, issues are the 3 they can see, withheldCount is 1), while an admin sees all 4 and withheldCount 0
2. A guest with no team membership sees 0 rows and withheldCount equals the workspace total

## Verification

- biome check: clean on both files (complexity budget handled by extracting execDrilldownPage)
- check-comments: 0 disallowed
- typecheck: zero new errors; the two errors in packages/services/src/storage/parent.ts are pre-existing on main (verified by stashing the diff) and are a local dual-drizzle-install artifact
- The DB-backed test suite requires Postgres via db:test-setup; no docker daemon is available in this environment, so the new tests were not executed locally. CI runs them.

## Notes

The UI panel consuming withheldCount was not in scope for this fix; the field is additive and the API type carries it for the follow-up.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR scopes analytics drilldown rows to the principal’s visible teams while preserving workspace-wide aggregates and reporting the withheld count. It also binds pagination cursors to principal visibility, but the binding is stricter than the effective visibility model.
- Applies team visibility filters to row and scoped-count queries.
- Adds withheldCount to distinguish workspace totals from visible evidence.
- Invalidates cursors after role or team-scope changes.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because an unchanged team-visible cohort can lose pagination whenever the principal moves between member and contributor roles.

The cursor binds the literal role while row visibility treats member and contributor identically, causing otherwise valid next-page requests to fail after a supported role update that preserves team membership and analytics access.

**Files Needing Attention:** packages/core/src/analytics/drilldown.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/analytics/drilldown.ts | Adds team-scoped rows, withheld-count calculation, and cursor scope binding; literal role binding rejects pagination across non-admin role changes that preserve visibility. |
| packages/core/tests/analytics/drilldown.test.ts | Covers team filtering, empty team membership, membership narrowing, and admin demotion, but not equivalent-scope member/contributor transitions. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20noveum%2Forbit%20PR%20%23365%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=noveum%2Forbit&pr=365&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcore%2Fsrc%2Fanalytics%2Fdrilldown.ts%3A956%0A**Equivalent%20scopes%20invalidate%20cursors**%0A%0AWhen%20an%20administrator%20changes%20a%20principal%20between%20%60member%60%20and%20%60contributor%60%20without%20changing%20their%20team%20memberships%2C%20the%20literal%20role%20in%20the%20cursor%20binding%20changes%20even%20though%20%60visibleTeamFilters%60%20produces%20the%20same%20row%20scope.%20The%20next-page%20request%20therefore%20returns%20%60validation_failed%60%20despite%20the%20principal%20retaining%20access%20to%20exactly%20the%20same%20issue%20cohort.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=noveum%2Forbit&pr=365&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/core/src/analytics/drilldown.ts:956
**Equivalent scopes invalidate cursors**

When an administrator changes a principal between `member` and `contributor` without changing their team memberships, the literal role in the cursor binding changes even though `visibleTeamFilters` produces the same row scope. The next-page request therefore returns `validation_failed` despite the principal retaining access to exactly the same issue cohort.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["test(analytics): cover cursor invalidati..."](https://github.com/noveum/orbit/commit/140986ef81e910fb0bfdd3c5751859fe72582435) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57478193)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Analytics and planning insights](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/docs/analytics-and-insights.md)

<!-- /greptile_comment -->