### PR TITLE
fix(auth): explain hosted access restriction (#344)

### DIFF
--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -5,9 +5,10 @@ import { DevSignIn } from '@/components/auth/dev-sign-in.tsx';
 import { LoginForm } from '@/components/auth/login-form.tsx';
 import { devLoginEnabled } from '@/lib/api/dev-login.ts';
 import { listDevUsers } from '@/lib/api/dev-users.ts';
-import { authErrorCode } from '@/lib/auth/oauth-error.ts';
+import { authErrorCode, hostedAccessNoticeFor } from '@/lib/auth/oauth-error.ts';
 import { enabledSocialProviders, passwordAuthEnabled } from '@/lib/auth/server.ts';
 import { getSession } from '@/lib/auth/session.ts';
+import { publicAppUrl } from '@/lib/env.ts';
 import { mcpContinueUrl, safeCallback } from './continue-url.ts';
 
 export const metadata: Metadata = { title: 'Sign in' };
@@ -24,12 +25,14 @@ export default async function LoginPage({
   if (session !== null) redirect(callbackUrl ?? '/my-issues');
 
   const devUsers = devLoginEnabled() ? await listDevUsers() : [];
+  const hostedAccessNotice = hostedAccessNoticeFor(publicAppUrl());
 
   return (
     <main className="flex min-h-dvh items-center justify-center bg-bg px-5 py-12">
       <div className="w-full max-w-sm rounded-xl border border-border bg-surface p-6 shadow-pop sm:p-7">
         <LoginForm
           providers={enabledSocialProviders}
+          {...(hostedAccessNotice === undefined ? {} : { hostedAccessNotice })}
           passwordEnabled={passwordAuthEnabled}
           {...(callbackUrl === undefined ? {} : { callbackUrl })}
         />

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -16,6 +16,7 @@ const MIN_PASSWORD_LENGTH = 12;
 export interface LoginFormProps {
   readonly providers: readonly string[];
   readonly callbackUrl?: string;
+  readonly hostedAccessNotice?: string;
   readonly passwordEnabled?: boolean;
 }
 
@@ -163,6 +164,11 @@ interface OtpFieldsProps {
   readonly onChangeEmail: () => void;
 }
 
+function HostedAccessNotice({ message }: { readonly message: string | undefined }) {
+  if (message === undefined) return null;
+  return <p className="text-center text-2xs text-muted">{message}</p>;
+}
+
 function OtpFields({ sent, value, pending, onChange, onResend, onChangeEmail }: OtpFieldsProps) {
   if (!sent) return null;
   return (
@@ -238,6 +244,7 @@ function LoginFooter({
 export function LoginForm({
   providers,
   callbackUrl = DEFAULT_CALLBACK_URL,
+  hostedAccessNotice,
   passwordEnabled = false,
 }: LoginFormProps) {
   const { toast } = useToast();
@@ -350,6 +357,7 @@ export function LoginForm({
             ? 'Pick how you want in.'
             : 'Passwordless by design. Pick how you want in.'}
         </p>
+        <HostedAccessNotice message={hostedAccessNotice} />
       </div>
 
       <Button

--- a/apps/web/src/features/landing/landing-page.tsx
+++ b/apps/web/src/features/landing/landing-page.tsx
@@ -26,7 +26,9 @@ import Link from 'next/link';
 import type { CSSProperties, ReactNode } from 'react';
 import { OrbitWordmark } from '@/components/brand/orbit-logo.tsx';
 import { Kbd } from '@/components/ui/kbd.tsx';
+import { hostedAccessNoticeFor } from '@/lib/auth/oauth-error.ts';
 import { cn } from '@/lib/cn.ts';
+import { publicAppUrl } from '@/lib/env.ts';
 import { EnterToSignIn } from './enter-to-sign-in.tsx';
 
 const SIGN_IN_HREF = '/login';
@@ -390,7 +392,7 @@ function ProductWindow() {
   );
 }
 
-function Hero() {
+function Hero({ hostedAccessNotice }: { hostedAccessNotice: string | undefined }) {
   return (
     <section className="relative">
       <HeroBackdrop />
@@ -415,6 +417,14 @@ function Hero() {
           synced to every open screen the instant anything changes, driven entirely from the
           keyboard.
         </p>
+        {hostedAccessNotice === undefined ? null : (
+          <p
+            className="landing-lede landing-rise mx-auto mt-3 max-w-xl text-sm text-muted"
+            style={{ animationDelay: '180ms' }}
+          >
+            {hostedAccessNotice}
+          </p>
+        )}
         <div
           className="landing-rise mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row"
           style={{ animationDelay: '210ms' }}
@@ -930,12 +940,14 @@ function LandingFooter() {
 }
 
 export function LandingPage() {
+  const hostedAccessNotice = hostedAccessNoticeFor(publicAppUrl());
+
   return (
     <div className="flex min-h-dvh flex-col">
       <EnterToSignIn />
       <LandingHeader />
       <main className="flex-1">
-        <Hero />
+        <Hero hostedAccessNotice={hostedAccessNotice} />
         <FeaturesSection />
         <RealtimeSection />
         <KeyboardSection />

--- a/apps/web/src/lib/auth/oauth-error.ts
+++ b/apps/web/src/lib/auth/oauth-error.ts
@@ -1,3 +1,15 @@
+export const HOSTED_ACCESS_NOTICE =
+  'The hosted Orbit demo is currently limited to Noveum employees. To use Orbit with your own team, self-host it.';
+
+const HOSTED_APP_ORIGIN = 'https://orbit.noveum.ai';
+
+export function hostedAccessNoticeFor(appUrl: string): string | undefined {
+  return new URL(appUrl).origin === HOSTED_APP_ORIGIN ? HOSTED_ACCESS_NOTICE : undefined;
+}
+
+const EMAIL_DOMAIN_NOT_ALLOWED_MESSAGE =
+  'This Orbit instance is restricted to approved email domains. Ask an admin for access, or self-host Orbit for your team.';
+
 const OAUTH_ERROR_MESSAGES: Record<string, string> = {
   "email_doesn't_match":
     'That provider account uses a different email than your Orbit account. Connect one whose primary email matches, or line up the emails first.',
@@ -8,8 +20,7 @@ const OAUTH_ERROR_MESSAGES: Record<string, string> = {
   unable_to_get_user_info:
     'The provider did not share your account details. Check the connection permissions and try again.',
   email_not_found: 'No Orbit account matches that provider email. Sign up first, then connect it.',
-  email_domain_not_allowed:
-    'Your email domain is not allowed on this workspace. Ask an admin to invite you.',
+  email_domain_not_allowed: EMAIL_DOMAIN_NOT_ALLOWED_MESSAGE,
   signup_disabled: 'New accounts are not open on this server. Ask an admin for an invite.',
   access_denied: 'You cancelled before granting access. Try again when you are ready.',
   no_code: 'The sign in did not finish. Start again.',

--- a/apps/web/tests/app/page.test.tsx
+++ b/apps/web/tests/app/page.test.tsx
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 import { render, screen } from '@testing-library/react';
 import * as navigation from 'next/navigation';
+import { HOSTED_ACCESS_NOTICE } from '../../src/lib/auth/oauth-error.ts';
 import { mockSession } from '../../tests-support.ts';
 
 const sessionHolder: { value: { user: { id: string } } | null } = { value: null };
@@ -16,10 +17,20 @@ mock.module('next/navigation', () => ({
 }));
 
 const { default: HomePage } = await import('../../src/app/page.tsx');
+const previousAppUrl = process.env['NEXT_PUBLIC_APP_URL'];
 
 describe('HomePage', () => {
   beforeEach(() => {
     sessionHolder.value = null;
+    process.env['NEXT_PUBLIC_APP_URL'] = 'https://orbit.noveum.ai';
+  });
+
+  afterAll(() => {
+    if (previousAppUrl === undefined) {
+      delete process.env['NEXT_PUBLIC_APP_URL'];
+    } else {
+      process.env['NEXT_PUBLIC_APP_URL'] = previousAppUrl;
+    }
   });
 
   it('renders the landing hero for a logged-out visitor', async () => {
@@ -27,6 +38,7 @@ describe('HomePage', () => {
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
       'Issue tracking at the speed of typing.',
     );
+    expect(screen.getByText(HOSTED_ACCESS_NOTICE)).toBeDefined();
     expect(screen.getAllByRole('link', { name: /sign in/i }).length).toBeGreaterThan(0);
   });
 

--- a/apps/web/tests/components/auth/auth-error-notice.test.tsx
+++ b/apps/web/tests/components/auth/auth-error-notice.test.tsx
@@ -34,6 +34,18 @@ describe('AuthErrorNotice', () => {
     expect(options.description).toContain('cancelled');
   });
 
+  it('toasts the restricted-access message for a domain callback error', async () => {
+    window.history.replaceState({}, '', '/login?error=EMAIL_DOMAIN_NOT_ALLOWED');
+    render(<AuthErrorNotice code="EMAIL_DOMAIN_NOT_ALLOWED" />);
+    await waitFor(() => expect(toast).toHaveBeenCalledTimes(1));
+    expect(toast).toHaveBeenCalledWith({
+      title: 'Sign in failed',
+      description:
+        'This Orbit instance is restricted to approved email domains. Ask an admin for access, or self-host Orbit for your team.',
+      tone: 'danger',
+    });
+  });
+
   it('uses a custom title when provided', async () => {
     window.history.replaceState({}, '', "/settings/account/connections?error=email_doesn't_match");
     render(<AuthErrorNotice code="email_doesn't_match" title="Couldn't connect account" />);

--- a/apps/web/tests/components/auth/login-form.test.tsx
+++ b/apps/web/tests/components/auth/login-form.test.tsx
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { HOSTED_ACCESS_NOTICE } from '../../../src/lib/auth/oauth-error.ts';
 import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
 
 const requestPasswordReset = mock();
@@ -69,6 +70,26 @@ describe('LoginForm', () => {
     expect(screen.getByText('Create an account with a password')).toBeDefined();
     expect(screen.getByText('Email me a code')).toBeDefined();
     expect(screen.getByText('Continue with passkey')).toBeDefined();
+  });
+
+  it('explains hosted access before social sign in', () => {
+    render(
+      <LoginForm providers={['google', 'github']} hostedAccessNotice={HOSTED_ACCESS_NOTICE} />,
+    );
+
+    expect(
+      screen.getByText(
+        'The hosted Orbit demo is currently limited to Noveum employees. To use Orbit with your own team, self-host it.',
+      ),
+    ).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Continue with Google' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Continue with GitHub' })).toBeDefined();
+  });
+
+  it('does not show hosted access copy when the deployment does not provide it', () => {
+    render(<LoginForm providers={['google', 'github']} />);
+
+    expect(screen.queryByText(HOSTED_ACCESS_NOTICE)).toBeNull();
   });
 
   it('hides the forgot password affordance while password auth is off', () => {

--- a/apps/web/tests/lib/auth/oauth-error.test.ts
+++ b/apps/web/tests/lib/auth/oauth-error.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'bun:test';
-import { authErrorCode, describeAuthError } from '../../../src/lib/auth/oauth-error.ts';
+import {
+  authErrorCode,
+  describeAuthError,
+  HOSTED_ACCESS_NOTICE,
+  hostedAccessNoticeFor,
+} from '../../../src/lib/auth/oauth-error.ts';
 
 describe('describeAuthError', () => {
   it('maps the email mismatch code returned by the GitHub callback', () => {
@@ -11,7 +16,9 @@ describe('describeAuthError', () => {
   });
 
   it('maps the server domain-restriction code', () => {
-    expect(describeAuthError('EMAIL_DOMAIN_NOT_ALLOWED')).toContain('domain is not allowed');
+    expect(describeAuthError('EMAIL_DOMAIN_NOT_ALLOWED')).toBe(
+      'This Orbit instance is restricted to approved email domains. Ask an admin for access, or self-host Orbit for your team.',
+    );
   });
 
   it('falls back to a friendly message for unknown codes', () => {
@@ -34,5 +41,15 @@ describe('authErrorCode', () => {
     expect(authErrorCode(undefined)).toBeUndefined();
     expect(authErrorCode('')).toBeUndefined();
     expect(authErrorCode([])).toBeUndefined();
+  });
+});
+
+describe('hostedAccessNoticeFor', () => {
+  it('shows the hosted access notice for the official deployment', () => {
+    expect(hostedAccessNoticeFor('https://orbit.noveum.ai')).toBe(HOSTED_ACCESS_NOTICE);
+  });
+
+  it('does not advertise the hosted restriction on another deployment', () => {
+    expect(hostedAccessNoticeFor('https://orbit.example.com')).toBeUndefined();
   });
 });

--- a/apps/web/tests/lib/auth/server-session-domain.test.ts
+++ b/apps/web/tests/lib/auth/server-session-domain.test.ts
@@ -4,6 +4,7 @@ import { db, schema } from '@orbit/db';
 import { auth } from '../../../src/lib/auth/server.ts';
 
 const previousDomains = process.env['ALLOWED_EMAIL_DOMAINS'];
+const SOCIAL_PROVIDERS = [['google'], ['github']] as const;
 
 beforeEach(() => {
   process.env['ALLOWED_EMAIL_DOMAINS'] = 'magicapi.com,noveum.ai';
@@ -38,17 +39,20 @@ function sessionHook() {
 }
 
 describe('session domain allowlist', () => {
-  it('rejects an existing user whose domain is not allowed on any sign in', async () => {
-    const userId = await userWith(`kpulkit${randomUUID().slice(0, 8)}@gmail.com`);
+  it.each(SOCIAL_PROVIDERS)(
+    'rejects an existing ineligible %s account on sign in',
+    async (provider) => {
+      const userId = await userWith(`${provider}${randomUUID().slice(0, 8)}@gmail.com`);
 
-    let thrown: unknown;
-    try {
-      await sessionHook()(userId);
-    } catch (error) {
-      thrown = error;
-    }
-    expect(thrown).toMatchObject({ status: 'FORBIDDEN' });
-  });
+      let thrown: unknown;
+      try {
+        await sessionHook()(userId);
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toMatchObject({ status: 'FORBIDDEN' });
+    },
+  );
 
   it('lets an allowed domain start a session', async () => {
     const userId = await userWith(`shashank${randomUUID().slice(0, 8)}@magicapi.com`);

--- a/apps/web/tests/lib/auth/server.test.ts
+++ b/apps/web/tests/lib/auth/server.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import { auth, passwordAuthEnabled } from '../../../src/lib/auth/server.ts';
 
+const SOCIAL_PROVIDERS = [['google'], ['github']] as const;
+
 describe('password authentication', () => {
   it('stays off unless ORBIT_PASSWORD_AUTH is set', () => {
     expect(process.env['ORBIT_PASSWORD_AUTH']).toBeUndefined();
@@ -61,19 +63,22 @@ describe('email domain allowlist', () => {
       });
   }
 
-  it('rejects an address outside the allowlist whichever provider created it', async () => {
+  it.each(SOCIAL_PROVIDERS)('rejects an ineligible first-time %s account', async (provider) => {
     process.env['ALLOWED_EMAIL_DOMAINS'] = 'magicapi.com,noveum.ai';
     const hook = createUserHook();
 
     let thrown: unknown;
     try {
-      await hook('kpulkit15234@gmail.com');
+      await hook(`${provider}-kpulkit15234@gmail.com`);
     } catch (error) {
       thrown = error;
     }
     expect(thrown).toMatchObject({ status: 'FORBIDDEN' });
+  });
 
-    const allowed = await hook('shashank@magicapi.com');
+  it('allows an address from the configured domain', async () => {
+    process.env['ALLOWED_EMAIL_DOMAINS'] = 'magicapi.com,noveum.ai';
+    const allowed = await createUserHook()('shashank@magicapi.com');
     expect(allowed.data.email).toBe('shashank@magicapi.com');
   });
 


### PR DESCRIPTION
## What this changes

Closes #344

- Show the hosted access restriction before sign-in on the landing and login surfaces.
- Keep the notice limited to the official hosted deployment so self-hosted instances are not mislabelled.
- Map the shared email-domain restriction code to an actionable message for Google and GitHub OAuth callbacks.
- Add regression coverage for both providers, first-time account rejection, existing-account session rejection, and the callback toast.

## Why

The hosted demo intentionally accepts only Noveum employee email domains, but the landing and login pages did not explain that policy. Ineligible accounts could therefore see a generic sign-in failure even when the OAuth provider was working.

## How know works

- `ORBIT_TEST_LANE=issue344final3 bun --env-file=../../.env test tests/app/page.test.tsx tests/components/auth/login-form.test.tsx tests/components/auth/auth-error-notice.test.tsx tests/lib/auth/oauth-error.test.ts tests/lib/auth/server.test.ts tests/lib/auth/server-session-domain.test.ts --timeout 20000` (40 passed)
- `bun run lint` (passed with existing warning/info output)
- `bun run typecheck` (passed)
- `bun run check-comments`, `bun run check-bytes`, `bun run check-bun-imports`, and `bun run check-deps` (passed)
- `bun --env-file=../../.env ../../packages/db/src/check-drift.ts --guard-deploy` (passed)
- `bun --env-file=../../.env next build` from `apps/web` (passed)
- `git diff --check` (passed)

## Screenshots

Not applicable; this is a small copy and behavior change with no layout or visual asset changes.

## Checklist

- [x] The server-side email-domain policy is unchanged.
- [x] The hosted notice is deployment-aware.
- [x] Regression tests cover the affected paths.

## Anything reviewers should know

The repository's outer `bun run verify` and `bun run build` wrappers hit existing Windows POSIX-shell/test-environment limitations. The focused tests, static checks, typecheck, schema drift guard, and direct Next production build passed. Real Google/GitHub provider E2E was not run because it requires provider credentials and an external hosted account.
