### PR TITLE
Fix Windows verification portability

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun --env-file=../../.env next dev --port 3000",
-    "build": "bun --env-file=../../.env ../../packages/db/src/check-drift.ts --guard-deploy && bun --env-file=../../.env next build && if [ \"${VERCEL:-}\" != \"1\" ]; then test -d .next/standalone/apps/web || { echo \"Missing standalone output\" >&2; exit 1; }; mkdir -p .next/standalone/apps/web/.next && cp -R public .next/standalone/apps/web/ && cp -R .next/static .next/standalone/apps/web/.next/ && bun build src/start.ts --target=node --format=esm --outfile=.next/standalone/apps/web/start.mjs; fi",
+    "build": "bun --env-file=../../.env ../../packages/db/src/check-drift.ts --guard-deploy && bun --env-file=../../.env next build && bun scripts/prepare-standalone.ts",
     "start": "node --env-file=../../.env .next/standalone/apps/web/start.mjs",
     "typecheck": "tsc --noEmit",
     "test": "bun --env-file=../../.env test tests --timeout 20000",

--- a/apps/web/scripts/prepare-standalone.ts
+++ b/apps/web/scripts/prepare-standalone.ts
@@ -1,0 +1,37 @@
+import { cp, mkdir, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+async function requireDirectory(path: string): Promise<void> {
+  try {
+    if ((await stat(path)).isDirectory()) return;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      throw new Error('Missing standalone output');
+    }
+    throw error;
+  }
+  throw new Error('Missing standalone output');
+}
+
+export async function prepareStandalone(root: string, vercel: string | undefined): Promise<void> {
+  if (vercel === '1') return;
+  const standalone = join(root, '.next', 'standalone', 'apps', 'web');
+  await requireDirectory(standalone);
+  await mkdir(join(standalone, '.next'), { recursive: true });
+  await cp(join(root, 'public'), join(standalone, 'public'), { recursive: true });
+  await cp(join(root, '.next', 'static'), join(standalone, '.next', 'static'), {
+    recursive: true,
+  });
+  const result = await Bun.build({
+    entrypoints: [join(root, 'src', 'start.ts')],
+    target: 'node',
+    format: 'esm',
+    outdir: standalone,
+    naming: 'start.mjs',
+  });
+  if (!result.success)
+    throw new AggregateError(result.logs, 'Failed to build standalone entrypoint');
+}
+
+if (import.meta.main)
+  await prepareStandalone(resolve(import.meta.dir, '..'), process.env['VERCEL']);

--- a/apps/web/tests/components/ui/relative-time.test.tsx
+++ b/apps/web/tests/components/ui/relative-time.test.tsx
@@ -83,7 +83,7 @@ describe('relative timestamps across apps/web', () => {
     let scanned = 0;
     for await (const relative of new Glob('**/*.{ts,tsx}').scan(sourceRoot)) {
       scanned += 1;
-      if (relative === 'components/ui/relative-time.tsx') continue;
+      if (relative.replaceAll('\\', '/') === 'components/ui/relative-time.tsx') continue;
       const source = await Bun.file(`${sourceRoot}${relative}`).text();
       if (source.includes('relativeTime(')) offenders.push(relative);
     }

--- a/apps/web/tests/features/analytics/analytics-drilldown-dialog.test.tsx
+++ b/apps/web/tests/features/analytics/analytics-drilldown-dialog.test.tsx
@@ -111,7 +111,10 @@ describe('AnalyticsDrilldownDialog', () => {
     expect(await screen.findByRole('dialog', { name: 'Completed work' })).toBeVisible();
     expect(await screen.findByText('Ship analytics')).toBeVisible();
     expect(screen.getByText(/Predicate: completed/)).toBeVisible();
-    expect(screen.getByText(/Data through Aug 13, 2026/)).toBeVisible();
+    const coverageDate = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(
+      new Date('2026-08-13T12:00:00.000Z'),
+    );
+    expect(screen.getByText(new RegExp(`Data through ${coverageDate}`))).toBeVisible();
     expect(screen.queryByRole('link', { name: 'Export CSV' })).not.toBeInTheDocument();
 
     const evidence = screen.getByRole('table', { name: 'Completed work evidence' });

--- a/apps/web/tests/scripts/prepare-standalone.test.ts
+++ b/apps/web/tests/scripts/prepare-standalone.test.ts
@@ -17,6 +17,12 @@ describe('prepareStandalone', () => {
     await expect(prepareStandalone(root, '1')).resolves.toBeUndefined();
   });
 
+  it('refuses a local build without standalone output', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orbit-standalone-'));
+    roots.push(root);
+    await expect(prepareStandalone(root, undefined)).rejects.toThrow('Missing standalone output');
+  });
+
   it('copies public assets and static output and builds the node entrypoint', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orbit-standalone-'));
     roots.push(root);

--- a/apps/web/tests/scripts/prepare-standalone.test.ts
+++ b/apps/web/tests/scripts/prepare-standalone.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { prepareStandalone } from '../../scripts/prepare-standalone.ts';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe('prepareStandalone', () => {
+  it('leaves Vercel builds for the platform to trace', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orbit-standalone-'));
+    roots.push(root);
+    await expect(prepareStandalone(root, '1')).resolves.toBeUndefined();
+  });
+
+  it('copies public assets and static output and builds the node entrypoint', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orbit-standalone-'));
+    roots.push(root);
+    await mkdir(join(root, 'public'), { recursive: true });
+    await mkdir(join(root, '.next', 'static'), { recursive: true });
+    await mkdir(join(root, '.next', 'standalone', 'apps', 'web'), { recursive: true });
+    await mkdir(join(root, 'src'), { recursive: true });
+    await writeFile(join(root, 'public', 'asset.txt'), 'public asset');
+    await writeFile(join(root, '.next', 'static', 'chunk.js'), 'static chunk');
+    await writeFile(join(root, 'src', 'start.ts'), "process.stdout.write('ready');\n");
+
+    await prepareStandalone(root, undefined);
+
+    const standalone = join(root, '.next', 'standalone', 'apps', 'web');
+    expect(await readFile(join(standalone, 'public', 'asset.txt'), 'utf8')).toBe('public asset');
+    expect(await readFile(join(standalone, '.next', 'static', 'chunk.js'), 'utf8')).toBe(
+      'static chunk',
+    );
+    expect(await readFile(join(standalone, 'start.mjs'), 'utf8')).toContain('ready');
+  });
+});

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,7 +16,7 @@
     "push": "bun src/ensure-extensions.ts && drizzle-kit push --force",
     "studio": "drizzle-kit studio",
     "seed": "bun --env-file=../../.env src/seed/index.ts",
-    "test": "bun --env-file=../../.env test --timeout 20000",
+    "test": "bun --env-file=../../.env test --timeout 20000 --max-concurrency 1",
     "check-drift": "bun --env-file=../../.env src/check-drift.ts",
     "catchup": "bun --env-file=../../.env src/apply-catchup.ts",
     "test-setup": "bun --env-file=../../.env src/ensure-test-databases.ts",

--- a/packages/db/tests/apply-catchup.test.ts
+++ b/packages/db/tests/apply-catchup.test.ts
@@ -1,20 +1,21 @@
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { readFile } from 'node:fs/promises';
+import { basename, dirname } from 'node:path';
 import postgres from 'postgres';
 import { currentLane, laneDatabase } from '../../../scripts/test-env.ts';
 import { applyCatchup, catchupPath, targetName } from '../src/apply-catchup.ts';
 
 describe('catchupPath', () => {
   it('resolves a script by name inside the catchup directory', () => {
-    expect(catchupPath('doc-tree-schema-catchup.sql')).toEndWith(
-      '/catchup/doc-tree-schema-catchup.sql',
-    );
+    const path = catchupPath('doc-tree-schema-catchup.sql');
+    expect(basename(path)).toBe('doc-tree-schema-catchup.sql');
+    expect(basename(dirname(path))).toBe('catchup');
   });
 
   it('accepts the repository relative path the runbook prints', () => {
-    expect(catchupPath('packages/db/catchup/doc-tree-order-catchup.sql')).toEndWith(
-      '/catchup/doc-tree-order-catchup.sql',
-    );
+    const path = catchupPath('packages/db/catchup/doc-tree-order-catchup.sql');
+    expect(basename(path)).toBe('doc-tree-order-catchup.sql');
+    expect(basename(dirname(path))).toBe('catchup');
   });
 
   it('refuses a file outside the catchup directory', () => {

--- a/packages/db/tests/apply-catchup.test.ts
+++ b/packages/db/tests/apply-catchup.test.ts
@@ -54,7 +54,7 @@ async function run<T>(url: string, work: (sql: postgres.Sql) => Promise<T>): Pro
   try {
     return await work(sql);
   } finally {
-    await sql.end();
+    await sql.end({ timeout: 1 });
   }
 }
 


### PR DESCRIPTION
## Summary

Make `bun run verify` reliable on Windows while preserving the existing Linux, macOS, Vercel, and Node runtime behavior.

This PR is intentionally limited to verification portability and test infrastructure. It contains no product feature, database schema, authorization, API, or UI behavior changes.

## Problem

The repository verification command was blocked on Windows for several independent platform assumptions. Fixing only the first failure exposed the next one, so the full failure chain had to be addressed before `bun run verify` could complete.

The observed failures were:

1. The web build script embedded Unix shell syntax such as `if`, `test`, `mkdir -p`, and `cp -R`. Bun starts that script through the host shell, so it cannot run under Windows PowerShell.
2. Catchup path tests compared paths using literal POSIX separators. Windows returns backslash-separated paths.
3. A source scan expected Bun Glob results to use forward slashes. Bun returns native separators on Windows.
4. An analytics test hard-coded the English `Aug 13, 2026` rendering even though the component intentionally uses the host locale.
5. Database integration tests could time out in cleanup. Several migration-heavy tests ran concurrently, and the scratch connection helper used an unbounded `sql.end()`. Under Windows load, the hook could wait until Bun's 30 second timeout even after the assertions passed.

These were verification failures rather than application failures, but they prevented Windows contributors from using the required repository completion gate.

## Changes

### Portable standalone preparation

The inline Unix shell fragment in `apps/web/package.json` is replaced with `apps/web/scripts/prepare-standalone.ts`.

The helper uses Bun and Node APIs to:

- keep the existing Vercel skip behavior when `VERCEL=1`
- verify that Next.js produced the expected standalone directory
- copy `public` and `.next/static` into the standalone output
- build `src/start.ts` as the Node ESM entrypoint
- fail with an explicit error when standalone output is missing

A dedicated test covers both the Vercel path and the local standalone preparation path.

### Native path handling

The catchup tests now inspect paths with `node:path` instead of assuming `/` separators. The relative-time source scan normalizes Bun Glob output before comparing a repository-relative path.

This keeps the assertions equivalent on Windows, Linux, and macOS.

### Locale-independent assertion

The analytics drilldown test now derives its expected date using the same `Intl.DateTimeFormat` configuration as the component. The test still verifies the exact displayed coverage date, but no longer assumes the machine locale is English.

### Bounded database test cleanup

The database package test command uses `--max-concurrency 1` because its suite creates, migrates, and drops real scratch databases. These operations are isolation-sensitive and do not benefit from file-level concurrency.

The catchup test helper also closes its one-connection pool with a one-second bound. This matches the bounded shutdown already used by the production catchup helper and prevents a completed cleanup hook from waiting indefinitely for pool shutdown.

## Why this approach

The implementation keeps platform concerns at the boundary:

- filesystem work uses structured APIs instead of shell-specific commands
- path assertions use native path semantics
- locale assertions follow the component's actual formatting contract
- database tests serialize only inside `@orbit/db`, not across the entire repository
- production server code remains on Node-compatible APIs

The alternative of adding Windows-specific command branches would duplicate build behavior and create two paths that could drift. A single Bun/TypeScript implementation is smaller and exercises the same logic on every development platform.

## Cross-platform impact

Linux and macOS continue to run the same `bun run verify` command. The standalone helper uses `node:fs/promises` and `node:path`, both of which are portable across the supported environments.

The only expected trade-off is that `@orbit/db` tests run serially. This makes that package slightly less parallel, but removes nondeterministic contention between tests that create and migrate real databases. It does not serialize the other workspace packages.

Vercel behavior is unchanged because standalone preparation still exits immediately when `VERCEL=1`.

## Validation

Validated from a clean `fix/windows-verify-pr` worktree rebased onto the latest `upstream/main`:

- `bun run verify`: passed with exit code 0
- `@orbit/db`: 258 passed, 0 failed
- `@orbit/web`: 2336 passed, 0 failed
- focused Windows path and locale tests: 6 passed, 0 failed
- standalone preparation tests: 3 passed, 0 failed
- lint, comment policy, source byte checks, Bun import checks, dependency checks, and all typechecks passed

The branch contains 5 commits and changes 7 files. Every changed file is directly tied to the Windows verification failure chain.

## Review guide

The main review points are:

1. Confirm that `prepare-standalone.ts` preserves the previous shell script behavior.
2. Confirm that the path and locale test changes retain the original assertions while removing host assumptions.
3. Confirm that serializing `@orbit/db` and bounding its scratch connection shutdown are acceptable for deterministic integration tests.

## Checklist

- [x] `bun run verify` is green
- [x] Tests added or updated for the affected behavior
- [x] No comments added to code
- [x] No em-dash characters added
- [x] No `any` or non-null assertions added
- [x] No production authorization or external input behavior changed
- [x] No visual changes
- [x] No database schema or migration changes


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes repository verification portable across Windows while preserving existing build and deployment behavior.
- Replaces the web build’s Unix shell fragment with a Bun/TypeScript standalone-preparation script.
- Makes path and locale assertions platform-independent.
- Serializes database integration tests and bounds scratch connection shutdown.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/package.json | Delegates post-build standalone preparation to the new portable Bun script while retaining drift and Next.js build sequencing. |
| apps/web/scripts/prepare-standalone.ts | Reproduces the previous standalone-output check, asset copies, Vercel bypass, and Node entrypoint build using portable APIs. |
| apps/web/tests/scripts/prepare-standalone.test.ts | Covers Vercel bypass, missing standalone output, asset copying, and entrypoint generation. |
| packages/db/package.json | Serializes database tests to avoid contention among migration-heavy scratch database suites. |
| packages/db/tests/apply-catchup.test.ts | Uses platform-native path assertions and bounds test connection shutdown after awaited database work completes. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Verify[bun run verify] --> Drift[Check database drift]
  Drift --> Next[Run Next.js build]
  Next --> Vercel{VERCEL equals 1?}
  Vercel -->|Yes| Trace[Leave tracing to Vercel]
  Vercel -->|No| Check[Require standalone output]
  Check --> Assets[Copy public and static assets]
  Assets --> Entry[Build Node ESM start.mjs]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(web): cover missing standalone outp..."](https://github.com/noveum/orbit/commit/191d39425d6c113340cd9eda812a0672e8bab9a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57854254)</sub>

<!-- /greptile_comment -->