### PR TITLE
feat(auth): open sign-up to anyone

### DIFF
--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,4 +1,3 @@
-import { configuredEmailDomains } from '@orbit/core';
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { AuthErrorNotice } from '@/components/auth/auth-error-notice.tsx';
@@ -9,6 +8,7 @@ import { listDevUsers } from '@/lib/api/dev-users.ts';
 import { authErrorCode } from '@/lib/auth/oauth-error.ts';
 import { enabledSocialProviders, passwordAuthEnabled } from '@/lib/auth/server.ts';
 import { getSession } from '@/lib/auth/session.ts';
+import { signUpIsOpen } from '@/lib/env.ts';
 import { mcpContinueUrl, safeCallback } from './continue-url.ts';
 
 export const metadata: Metadata = { title: 'Sign in' };
@@ -32,7 +32,7 @@ export default async function LoginPage({
         <LoginForm
           providers={enabledSocialProviders}
           passwordEnabled={passwordAuthEnabled}
-          openSignUp={configuredEmailDomains().length === 0}
+          openSignUp={signUpIsOpen()}
           {...(callbackUrl === undefined ? {} : { callbackUrl })}
         />
         {devUsers.length > 0 ? (

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,3 +1,4 @@
+import { configuredEmailDomains } from '@orbit/core';
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { AuthErrorNotice } from '@/components/auth/auth-error-notice.tsx';
@@ -31,6 +32,7 @@ export default async function LoginPage({
         <LoginForm
           providers={enabledSocialProviders}
           passwordEnabled={passwordAuthEnabled}
+          openSignUp={configuredEmailDomains().length === 0}
           {...(callbackUrl === undefined ? {} : { callbackUrl })}
         />
         {devUsers.length > 0 ? (

--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -1,6 +1,6 @@
-import { configuredEmailDomains } from '@orbit/core';
 import { landingMetadata, landingStructuredData } from '@/features/landing/landing-meta.ts';
 import { LandingPage } from '@/features/landing/landing-page.tsx';
+import { signUpIsOpen } from '@/lib/env.ts';
 
 export const metadata = landingMetadata('/');
 
@@ -12,7 +12,7 @@ export default function HomeLandingPage() {
         // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD built from constants
         dangerouslySetInnerHTML={{ __html: landingStructuredData() }}
       />
-      <LandingPage openSignUp={configuredEmailDomains().length === 0} />
+      <LandingPage openSignUp={signUpIsOpen()} />
     </>
   );
 }

--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -1,3 +1,4 @@
+import { configuredEmailDomains } from '@orbit/core';
 import { landingMetadata, landingStructuredData } from '@/features/landing/landing-meta.ts';
 import { LandingPage } from '@/features/landing/landing-page.tsx';
 
@@ -11,7 +12,7 @@ export default function HomeLandingPage() {
         // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD built from constants
         dangerouslySetInnerHTML={{ __html: landingStructuredData() }}
       />
-      <LandingPage />
+      <LandingPage openSignUp={configuredEmailDomains().length === 0} />
     </>
   );
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { configuredEmailDomains } from '@orbit/core';
 import { redirect } from 'next/navigation';
 import { AuthErrorNotice } from '@/components/auth/auth-error-notice.tsx';
 import { landingMetadata, landingStructuredData } from '@/features/landing/landing-meta.ts';
@@ -24,7 +25,7 @@ export default async function HomePage({
         // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD built from constants
         dangerouslySetInnerHTML={{ __html: landingStructuredData() }}
       />
-      <LandingPage />
+      <LandingPage openSignUp={configuredEmailDomains().length === 0} />
       {errorCode === undefined ? null : <AuthErrorNotice code={errorCode} />}
     </>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,10 +1,10 @@
-import { configuredEmailDomains } from '@orbit/core';
 import { redirect } from 'next/navigation';
 import { AuthErrorNotice } from '@/components/auth/auth-error-notice.tsx';
 import { landingMetadata, landingStructuredData } from '@/features/landing/landing-meta.ts';
 import { LandingPage } from '@/features/landing/landing-page.tsx';
 import { authErrorCode } from '@/lib/auth/oauth-error.ts';
 import { getSession } from '@/lib/auth/session.ts';
+import { signUpIsOpen } from '@/lib/env.ts';
 
 export const metadata = landingMetadata('/');
 
@@ -25,7 +25,7 @@ export default async function HomePage({
         // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD built from constants
         dangerouslySetInnerHTML={{ __html: landingStructuredData() }}
       />
-      <LandingPage openSignUp={configuredEmailDomains().length === 0} />
+      <LandingPage openSignUp={signUpIsOpen()} />
       {errorCode === undefined ? null : <AuthErrorNotice code={errorCode} />}
     </>
   );

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -17,6 +17,7 @@ export interface LoginFormProps {
   readonly providers: readonly string[];
   readonly callbackUrl?: string;
   readonly passwordEnabled?: boolean;
+  readonly openSignUp?: boolean;
 }
 
 type Pending =
@@ -209,10 +210,12 @@ function OtpFields({ sent, value, pending, onChange, onResend, onChangeEmail }: 
 function LoginFooter({
   passwordEnabled,
   creatingAccount,
+  openSignUp,
   onToggleAccount,
 }: {
   readonly passwordEnabled: boolean;
   readonly creatingAccount: boolean;
+  readonly openSignUp: boolean;
   readonly onToggleAccount: () => void;
 }) {
   return (
@@ -226,9 +229,11 @@ function LoginFooter({
           {creatingAccount ? 'I already have an account' : 'Create an account with a password'}
         </button>
       ) : null}
-      <p className="text-center text-2xs text-faint">
-        New to Orbit? Signing in creates your account and your first workspace.
-      </p>
+      {openSignUp && !creatingAccount ? (
+        <p className="text-center text-2xs text-faint">
+          New here? Signing in creates your account and your first workspace.
+        </p>
+      ) : null}
       <p className="text-center text-2xs text-faint">
         {passwordEnabled
           ? 'Passkeys and email codes still work. Sessions expire after 30 days.'
@@ -242,6 +247,7 @@ export function LoginForm({
   providers,
   callbackUrl = DEFAULT_CALLBACK_URL,
   passwordEnabled = false,
+  openSignUp = false,
 }: LoginFormProps) {
   const { toast } = useToast();
   const [email, setEmail] = useState('');
@@ -458,6 +464,7 @@ export function LoginForm({
       <LoginFooter
         passwordEnabled={passwordEnabled}
         creatingAccount={creatingAccount}
+        openSignUp={openSignUp}
         onToggleAccount={() => setCreatingAccount((current) => !current)}
       />
     </div>

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -231,7 +231,7 @@ function LoginFooter({
       ) : null}
       {openSignUp && !creatingAccount ? (
         <p className="text-center text-2xs text-faint">
-          New here? Signing in creates your account and your first workspace.
+          New here? Signing in creates your account, then you set up a workspace.
         </p>
       ) : null}
       <p className="text-center text-2xs text-faint">

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -227,6 +227,9 @@ function LoginFooter({
         </button>
       ) : null}
       <p className="text-center text-2xs text-faint">
+        New to Orbit? Signing in creates your account and your first workspace.
+      </p>
+      <p className="text-center text-2xs text-faint">
         {passwordEnabled
           ? 'Passkeys and email codes still work. Sessions expire after 30 days.'
           : 'Orbit never asks for a password. Sessions expire after 30 days.'}

--- a/apps/web/src/features/landing/landing-page.tsx
+++ b/apps/web/src/features/landing/landing-page.tsx
@@ -431,7 +431,8 @@ function Hero() {
           </span>
         </div>
         <p className="landing-rise mt-4 text-xs text-faint" style={{ animationDelay: '250ms' }}>
-          Google, GitHub, passkey, or email code. No password to invent. Or{' '}
+          Anyone can sign up, free. Google, GitHub, passkey, or email code. No password to invent.
+          Or{' '}
           <a href={SELF_HOST_HREF} className="underline" target="_blank" rel="noopener noreferrer">
             run the whole thing yourself
           </a>
@@ -845,8 +846,8 @@ function ClosingCta() {
       <div className="relative mx-auto w-full max-w-6xl 2xl:max-w-7xl px-5 py-28 text-center sm:px-8">
         <h2 className="landing-h2">Ready when you are.</h2>
         <p className="landing-lede mx-auto mt-4 max-w-xl text-muted">
-          Sign in with Google, GitHub, a passkey, or an email code, and bring your team with you. Or
-          clone the repository and run it on your own infrastructure.
+          Sign up with Google, GitHub, a passkey, or an email code, and bring your team with you. No
+          invite needed. Or clone the repository and run it on your own infrastructure.
         </p>
         <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
           <Link href={SIGN_IN_HREF} className={primaryCta}>

--- a/apps/web/src/features/landing/landing-page.tsx
+++ b/apps/web/src/features/landing/landing-page.tsx
@@ -390,7 +390,7 @@ function ProductWindow() {
   );
 }
 
-function Hero() {
+function Hero({ openSignUp }: { readonly openSignUp: boolean }) {
   return (
     <section className="relative">
       <HeroBackdrop />
@@ -431,8 +431,8 @@ function Hero() {
           </span>
         </div>
         <p className="landing-rise mt-4 text-xs text-faint" style={{ animationDelay: '250ms' }}>
-          Anyone can sign up, free. Google, GitHub, passkey, or email code. No password to invent.
-          Or{' '}
+          {openSignUp ? 'Anyone can sign up, free. ' : ''}Google, GitHub, passkey, or email code. No
+          password to invent. Or{' '}
           <a href={SELF_HOST_HREF} className="underline" target="_blank" rel="noopener noreferrer">
             run the whole thing yourself
           </a>
@@ -836,7 +836,7 @@ function OpenSourceSection() {
   );
 }
 
-function ClosingCta() {
+function ClosingCta({ openSignUp }: { readonly openSignUp: boolean }) {
   return (
     <section className="relative overflow-hidden">
       <div
@@ -846,8 +846,9 @@ function ClosingCta() {
       <div className="relative mx-auto w-full max-w-6xl 2xl:max-w-7xl px-5 py-28 text-center sm:px-8">
         <h2 className="landing-h2">Ready when you are.</h2>
         <p className="landing-lede mx-auto mt-4 max-w-xl text-muted">
-          Sign up with Google, GitHub, a passkey, or an email code, and bring your team with you. No
-          invite needed. Or clone the repository and run it on your own infrastructure.
+          {openSignUp ? 'Sign up' : 'Sign in'} with Google, GitHub, a passkey, or an email code, and
+          bring your team with you.{openSignUp ? ' No invite needed.' : ''} Or clone the repository
+          and run it on your own infrastructure.
         </p>
         <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
           <Link href={SIGN_IN_HREF} className={primaryCta}>
@@ -930,19 +931,19 @@ function LandingFooter() {
   );
 }
 
-export function LandingPage() {
+export function LandingPage({ openSignUp }: { readonly openSignUp: boolean }) {
   return (
     <div className="flex min-h-dvh flex-col">
       <EnterToSignIn />
       <LandingHeader />
       <main className="flex-1">
-        <Hero />
+        <Hero openSignUp={openSignUp} />
         <FeaturesSection />
         <RealtimeSection />
         <KeyboardSection />
         <PricingSection />
         <OpenSourceSection />
-        <ClosingCta />
+        <ClosingCta openSignUp={openSignUp} />
       </main>
       <LandingFooter />
     </div>

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -98,6 +98,8 @@ export const passwordAuthEnabled: boolean = serverEnv().ORBIT_PASSWORD_AUTH;
 
 const SIGN_IN_ATTEMPTS_PER_MINUTE = 5;
 const SIGN_UP_ATTEMPTS_PER_HOUR = 5;
+const SIGN_IN_CODE_SENDS_PER_HOUR = 20;
+const SIGN_IN_CODE_ATTEMPTS_PER_QUARTER_HOUR = 20;
 
 async function takenHandles(candidates: readonly string[]): Promise<Set<string>> {
   const rows = await db
@@ -140,13 +142,13 @@ function emailAndPassword() {
 }
 
 function rateLimit() {
-  if (!passwordAuthEnabled) return {};
   return {
     rateLimit: {
-      enabled: true,
       customRules: {
         '/sign-in/email': { window: 60, max: SIGN_IN_ATTEMPTS_PER_MINUTE },
         '/sign-up/email': { window: 3600, max: SIGN_UP_ATTEMPTS_PER_HOUR },
+        '/email-otp/send-verification-otp': { window: 3600, max: SIGN_IN_CODE_SENDS_PER_HOUR },
+        '/sign-in/email-otp': { window: 900, max: SIGN_IN_CODE_ATTEMPTS_PER_QUARTER_HOUR },
       },
     },
   };

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -5,6 +5,7 @@ import {
   ingestExternalAvatar,
   isExternalImageUrl,
   publishSessionRevoked,
+  redisRateLimitStorage,
 } from '@orbit/core';
 import { db, eq, inArray, schema } from '@orbit/db';
 import { inviteEmail, resetPasswordEmail, sendEmail, signInCodeEmail } from '@orbit/services/email';
@@ -102,6 +103,15 @@ const SIGN_UP_ATTEMPTS_PER_HOUR = 5;
 const SIGN_IN_CODES_PER_TEN_MINUTES = 10;
 const SIGN_IN_CODE_PATH = '/email-otp/send-verification-otp';
 
+function authRateLimit() {
+  const customStorage =
+    process.env['NODE_ENV'] === 'production' ? redisRateLimitStorage() : undefined;
+  return {
+    customRules: AUTH_RATE_LIMIT_RULES,
+    ...(customStorage === undefined ? {} : { customStorage }),
+  };
+}
+
 const AUTH_RATE_LIMIT_RULES = {
   '/sign-in/email': { window: 60, max: SIGN_IN_ATTEMPTS_PER_MINUTE },
   '/sign-up/email': { window: 3600, max: SIGN_UP_ATTEMPTS_PER_HOUR },
@@ -175,7 +185,7 @@ export const auth = betterAuth({
   secret: serverEnv().BETTER_AUTH_SECRET,
   database: drizzleAdapter(db, { provider: 'pg', schema }),
   emailAndPassword: emailAndPassword(),
-  rateLimit: { customRules: AUTH_RATE_LIMIT_RULES },
+  rateLimit: authRateLimit(),
   socialProviders: socialProviders(),
   account: {
     accountLinking: { enabled: true, allowUnlinkingAll: true, allowDifferentEmails: true },

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -99,7 +99,12 @@ export const passwordAuthEnabled: boolean = serverEnv().ORBIT_PASSWORD_AUTH;
 const SIGN_IN_ATTEMPTS_PER_MINUTE = 5;
 const SIGN_UP_ATTEMPTS_PER_HOUR = 5;
 const SIGN_IN_CODE_SENDS_PER_HOUR = 20;
-const SIGN_IN_CODE_ATTEMPTS_PER_QUARTER_HOUR = 20;
+
+const AUTH_RATE_LIMIT_RULES = {
+  '/sign-in/email': { window: 60, max: SIGN_IN_ATTEMPTS_PER_MINUTE },
+  '/sign-up/email': { window: 3600, max: SIGN_UP_ATTEMPTS_PER_HOUR },
+  '/email-otp/send-verification-otp': { window: 3600, max: SIGN_IN_CODE_SENDS_PER_HOUR },
+};
 
 async function takenHandles(candidates: readonly string[]): Promise<Set<string>> {
   const rows = await db
@@ -141,19 +146,6 @@ function emailAndPassword() {
   } as const;
 }
 
-function rateLimit() {
-  return {
-    rateLimit: {
-      customRules: {
-        '/sign-in/email': { window: 60, max: SIGN_IN_ATTEMPTS_PER_MINUTE },
-        '/sign-up/email': { window: 3600, max: SIGN_UP_ATTEMPTS_PER_HOUR },
-        '/email-otp/send-verification-otp': { window: 3600, max: SIGN_IN_CODE_SENDS_PER_HOUR },
-        '/sign-in/email-otp': { window: 900, max: SIGN_IN_CODE_ATTEMPTS_PER_QUARTER_HOUR },
-      },
-    },
-  };
-}
-
 function assertSignUpAllowed(email: string): void {
   try {
     assertEmailDomainAllowed(email);
@@ -181,7 +173,7 @@ export const auth = betterAuth({
   secret: serverEnv().BETTER_AUTH_SECRET,
   database: drizzleAdapter(db, { provider: 'pg', schema }),
   emailAndPassword: emailAndPassword(),
-  ...rateLimit(),
+  rateLimit: { customRules: AUTH_RATE_LIMIT_RULES },
   socialProviders: socialProviders(),
   account: {
     accountLinking: { enabled: true, allowUnlinkingAll: true, allowDifferentEmails: true },

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -9,6 +9,7 @@ import {
 import { db, eq, inArray, schema } from '@orbit/db';
 import { inviteEmail, resetPasswordEmail, sendEmail, signInCodeEmail } from '@orbit/services/email';
 import { DomainError } from '@orbit/shared/errors';
+import { signInCodeRequestSchema } from '@orbit/shared/validators';
 import { type BetterAuthPlugin, betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { APIError, createAuthMiddleware, getSessionFromCtx } from 'better-auth/api';
@@ -98,12 +99,13 @@ export const passwordAuthEnabled: boolean = serverEnv().ORBIT_PASSWORD_AUTH;
 
 const SIGN_IN_ATTEMPTS_PER_MINUTE = 5;
 const SIGN_UP_ATTEMPTS_PER_HOUR = 5;
-const SIGN_IN_CODE_SENDS_PER_HOUR = 20;
+const SIGN_IN_CODES_PER_TEN_MINUTES = 10;
+const SIGN_IN_CODE_PATH = '/email-otp/send-verification-otp';
 
 const AUTH_RATE_LIMIT_RULES = {
   '/sign-in/email': { window: 60, max: SIGN_IN_ATTEMPTS_PER_MINUTE },
   '/sign-up/email': { window: 3600, max: SIGN_UP_ATTEMPTS_PER_HOUR },
-  '/email-otp/send-verification-otp': { window: 3600, max: SIGN_IN_CODE_SENDS_PER_HOUR },
+  [SIGN_IN_CODE_PATH]: { window: 600, max: SIGN_IN_CODES_PER_TEN_MINUTES },
 };
 
 async function takenHandles(candidates: readonly string[]): Promise<Set<string>> {
@@ -189,6 +191,13 @@ export const auth = betterAuth({
     },
   },
   hooks: {
+    before: createAuthMiddleware((ctx) => {
+      if (ctx.path === SIGN_IN_CODE_PATH) {
+        const parsed = signInCodeRequestSchema.safeParse(ctx.body);
+        if (parsed.success) assertSignUpAllowed(parsed.data.email);
+      }
+      return Promise.resolve();
+    }),
     after: createAuthMiddleware(async (ctx) => {
       if (ctx.path === '/passkey/verify-authentication' && verificationSucceeded(ctx)) {
         await touchPasskeyLastUsed(ctx.body);

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -89,7 +89,9 @@ export function serverEnv(): ServerEnv {
 }
 
 export function signUpIsOpen(): boolean {
-  return parseDomainList(process.env['ALLOWED_EMAIL_DOMAINS']).length === 0;
+  return (
+    parseDomainList(process.env['ALLOWED_EMAIL_DOMAINS'], 'ALLOWED_EMAIL_DOMAINS').length === 0
+  );
 }
 
 export interface GithubAppConfig {

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -1,3 +1,4 @@
+import { parseDomainList } from '@orbit/shared/utils';
 import { z } from 'zod';
 
 type Environment = Readonly<Record<string, string | undefined>>;
@@ -85,6 +86,10 @@ let cached: ServerEnv | null = null;
 export function serverEnv(): ServerEnv {
   if (cached === null) cached = serverEnvSchema.parse(process.env);
   return cached;
+}
+
+export function signUpIsOpen(): boolean {
+  return parseDomainList(process.env['ALLOWED_EMAIL_DOMAINS']).length === 0;
 }
 
 export interface GithubAppConfig {

--- a/apps/web/tests/app/api/auth/[...all]/route.test.ts
+++ b/apps/web/tests/app/api/auth/[...all]/route.test.ts
@@ -186,6 +186,40 @@ describe('MCP authorize consent boundary', () => {
   });
 });
 
+describe('sign in code rate limit', () => {
+  it('caps sign in code sends by their own rule, not the global one', async () => {
+    await withNativeFetchGlobals(async () => {
+      const context = await auth.$context;
+      const previous = {
+        enabled: context.rateLimit.enabled,
+        max: context.rateLimit.max,
+        window: context.rateLimit.window,
+      };
+      Object.assign(context.rateLimit, { enabled: true, max: 1, window: 60 });
+      try {
+        const post = (path: string, ip: string) =>
+          authPost(
+            new Request(`${APP_ORIGIN}/api/auth/${path}`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json', 'x-forwarded-for': ip },
+              body: JSON.stringify({}),
+            }),
+          );
+
+        expect((await post('mcp/token', '198.51.100.10')).status).not.toBe(429);
+        expect((await post('mcp/token', '198.51.100.10')).status).toBe(429);
+
+        const codes = 'email-otp/send-verification-otp';
+        for (let attempt = 0; attempt < 4; attempt += 1) {
+          expect((await post(codes, '198.51.100.11')).status).not.toBe(429);
+        }
+      } finally {
+        Object.assign(context.rateLimit, previous);
+      }
+    });
+  });
+});
+
 describe('MCP authorize PKCE boundary', () => {
   let workspace: Workspace;
   let cookie: string;

--- a/apps/web/tests/app/api/auth/[...all]/route.test.ts
+++ b/apps/web/tests/app/api/auth/[...all]/route.test.ts
@@ -186,6 +186,31 @@ describe('MCP authorize consent boundary', () => {
   });
 });
 
+describe('sign in code domain refusal', () => {
+  it('refuses a disallowed domain instead of claiming a code is on its way', async () => {
+    await withNativeFetchGlobals(async () => {
+      const previous = process.env['ALLOWED_EMAIL_DOMAINS'];
+      process.env['ALLOWED_EMAIL_DOMAINS'] = 'noveum.ai';
+      try {
+        const request = (email: string) =>
+          authPost(
+            new Request(`${APP_ORIGIN}/api/auth/email-otp/send-verification-otp`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json', 'x-forwarded-for': '198.51.100.20' },
+              body: JSON.stringify({ email, type: 'sign-in' }),
+            }),
+          );
+
+        const refused = await request('outsider@gmail.com');
+        expect(refused.status).toBe(403);
+        expect(await refused.json()).toMatchObject({ code: 'EMAIL_DOMAIN_NOT_ALLOWED' });
+      } finally {
+        process.env['ALLOWED_EMAIL_DOMAINS'] = previous ?? '';
+      }
+    });
+  });
+});
+
 describe('sign in code rate limit', () => {
   it('caps sign in code sends by their own rule, not the global one', async () => {
     await withNativeFetchGlobals(async () => {

--- a/apps/web/tests/app/page.test.tsx
+++ b/apps/web/tests/app/page.test.tsx
@@ -36,6 +36,17 @@ describe('HomePage', () => {
     expect(screen.getByText(/no invite needed/i)).toBeDefined();
   });
 
+  it('promises nobody a signup the allowlist would refuse', async () => {
+    process.env['ALLOWED_EMAIL_DOMAINS'] = 'noveum.ai';
+    try {
+      render(await HomePage({ searchParams: Promise.resolve({}) }));
+      expect(screen.queryAllByText(/anyone can sign up, free/i).length).toBe(0);
+      expect(screen.queryAllByText(/no invite needed/i).length).toBe(0);
+    } finally {
+      process.env['ALLOWED_EMAIL_DOMAINS'] = '';
+    }
+  });
+
   it('redirects a logged-in visitor to their issues', async () => {
     sessionHolder.value = { user: { id: 'user-1' } };
     await expect(HomePage({ searchParams: Promise.resolve({}) })).rejects.toThrow(

--- a/apps/web/tests/app/page.test.tsx
+++ b/apps/web/tests/app/page.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 import { render, screen } from '@testing-library/react';
 import * as navigation from 'next/navigation';
 import { mockSession } from '../../tests-support.ts';
@@ -17,9 +17,16 @@ mock.module('next/navigation', () => ({
 
 const { default: HomePage } = await import('../../src/app/page.tsx');
 
+const previousDomains = process.env['ALLOWED_EMAIL_DOMAINS'];
+
+afterAll(() => {
+  process.env['ALLOWED_EMAIL_DOMAINS'] = previousDomains ?? '';
+});
+
 describe('HomePage', () => {
   beforeEach(() => {
     sessionHolder.value = null;
+    process.env['ALLOWED_EMAIL_DOMAINS'] = '';
   });
 
   it('renders the landing hero for a logged-out visitor', async () => {
@@ -38,13 +45,9 @@ describe('HomePage', () => {
 
   it('promises nobody a signup the allowlist would refuse', async () => {
     process.env['ALLOWED_EMAIL_DOMAINS'] = 'noveum.ai';
-    try {
-      render(await HomePage({ searchParams: Promise.resolve({}) }));
-      expect(screen.queryAllByText(/anyone can sign up, free/i).length).toBe(0);
-      expect(screen.queryAllByText(/no invite needed/i).length).toBe(0);
-    } finally {
-      process.env['ALLOWED_EMAIL_DOMAINS'] = '';
-    }
+    render(await HomePage({ searchParams: Promise.resolve({}) }));
+    expect(screen.queryAllByText(/anyone can sign up, free/i).length).toBe(0);
+    expect(screen.queryAllByText(/no invite needed/i).length).toBe(0);
   });
 
   it('redirects a logged-in visitor to their issues', async () => {

--- a/apps/web/tests/app/page.test.tsx
+++ b/apps/web/tests/app/page.test.tsx
@@ -30,6 +30,12 @@ describe('HomePage', () => {
     expect(screen.getAllByRole('link', { name: /sign in/i }).length).toBeGreaterThan(0);
   });
 
+  it('tells a visitor that signing up is open to anyone', async () => {
+    render(await HomePage({ searchParams: Promise.resolve({}) }));
+    expect(screen.getByText(/anyone can sign up, free/i)).toBeDefined();
+    expect(screen.getByText(/no invite needed/i)).toBeDefined();
+  });
+
   it('redirects a logged-in visitor to their issues', async () => {
     sessionHolder.value = { user: { id: 'user-1' } };
     await expect(HomePage({ searchParams: Promise.resolve({}) })).rejects.toThrow(

--- a/apps/web/tests/components/auth/login-form.test.tsx
+++ b/apps/web/tests/components/auth/login-form.test.tsx
@@ -51,7 +51,7 @@ function renderForm(passwordEnabled: boolean, openSignUp = false) {
   render(<LoginForm providers={[]} passwordEnabled={passwordEnabled} openSignUp={openSignUp} />);
 }
 
-const SIGN_UP_NOTE = 'New here? Signing in creates your account and your first workspace.';
+const SIGN_UP_NOTE = 'New here? Signing in creates your account, then you set up a workspace.';
 
 describe('LoginForm', () => {
   it('renders no password field while password auth is off', () => {

--- a/apps/web/tests/components/auth/login-form.test.tsx
+++ b/apps/web/tests/components/auth/login-form.test.tsx
@@ -47,9 +47,11 @@ afterAll(() => {
   Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
 });
 
-function renderForm(passwordEnabled: boolean) {
-  render(<LoginForm providers={[]} passwordEnabled={passwordEnabled} />);
+function renderForm(passwordEnabled: boolean, openSignUp = false) {
+  render(<LoginForm providers={[]} passwordEnabled={passwordEnabled} openSignUp={openSignUp} />);
 }
+
+const SIGN_UP_NOTE = 'New here? Signing in creates your account and your first workspace.';
 
 describe('LoginForm', () => {
   it('renders no password field while password auth is off', () => {
@@ -71,11 +73,23 @@ describe('LoginForm', () => {
     expect(screen.getByText('Continue with passkey')).toBeDefined();
   });
 
-  it('says signing in creates an account whichever methods are on', () => {
-    renderForm(false);
-    expect(
-      screen.getByText('New to Orbit? Signing in creates your account and your first workspace.'),
-    ).toBeDefined();
+  it('says signing in creates an account when signup is open', () => {
+    renderForm(false, true);
+    expect(screen.getByText(SIGN_UP_NOTE)).toBeDefined();
+  });
+
+  it('stays quiet about signing up on a domain restricted instance', () => {
+    renderForm(false, false);
+    expect(screen.queryAllByText(SIGN_UP_NOTE).length).toBe(0);
+  });
+
+  it('drops the note once the user is explicitly creating an account', async () => {
+    const user = userEvent.setup();
+    renderForm(true, true);
+    expect(screen.getByText(SIGN_UP_NOTE)).toBeDefined();
+
+    await user.click(screen.getByText('Create an account with a password'));
+    expect(screen.queryAllByText(SIGN_UP_NOTE).length).toBe(0);
   });
 
   it('hides the forgot password affordance while password auth is off', () => {

--- a/apps/web/tests/components/auth/login-form.test.tsx
+++ b/apps/web/tests/components/auth/login-form.test.tsx
@@ -71,6 +71,13 @@ describe('LoginForm', () => {
     expect(screen.getByText('Continue with passkey')).toBeDefined();
   });
 
+  it('says signing in creates an account whichever methods are on', () => {
+    renderForm(false);
+    expect(
+      screen.getByText('New to Orbit? Signing in creates your account and your first workspace.'),
+    ).toBeDefined();
+  });
+
   it('hides the forgot password affordance while password auth is off', () => {
     renderForm(false);
     expect(screen.queryByText('Forgot password?')).toBeNull();

--- a/apps/web/tests/lib/auth/server-session-domain.test.ts
+++ b/apps/web/tests/lib/auth/server-session-domain.test.ts
@@ -56,6 +56,13 @@ describe('session domain allowlist', () => {
     expect(result).toMatchObject({ data: { userId } });
   });
 
+  it('lets any address start a session once the allowlist is cleared', async () => {
+    process.env['ALLOWED_EMAIL_DOMAINS'] = '';
+    const userId = await userWith(`anyone${randomUUID().slice(0, 8)}@gmail.com`);
+    const result = await sessionHook()(userId);
+    expect(result).toMatchObject({ data: { userId } });
+  });
+
   it('does nothing when the user cannot be found', async () => {
     const result = await sessionHook()('ghost');
     expect(result).toMatchObject({ data: { userId: 'ghost' } });

--- a/apps/web/tests/lib/auth/server.test.ts
+++ b/apps/web/tests/lib/auth/server.test.ts
@@ -41,15 +41,34 @@ describe('password authentication', () => {
 describe('open signup rate limits', () => {
   const rules = auth.options.rateLimit?.customRules ?? {};
 
+  function registeredPaths(): Set<string> {
+    const paths = new Set<string>();
+    for (const endpoint of Object.values(auth.api)) {
+      const path = (endpoint as { path?: unknown }).path;
+      if (typeof path === 'string') paths.add(path);
+    }
+    return paths;
+  }
+
   it('caps sign in codes even though password auth is off', () => {
     expect(passwordAuthEnabled).toBe(false);
     expect(rules['/email-otp/send-verification-otp']).toEqual({ window: 3600, max: 20 });
-    expect(rules['/sign-in/email-otp']).toEqual({ window: 900, max: 20 });
   });
 
   it('keeps the password rules for deployments that enable them', () => {
     expect(rules['/sign-in/email']).toEqual({ window: 60, max: 5 });
     expect(rules['/sign-up/email']).toEqual({ window: 3600, max: 5 });
+  });
+
+  it('names paths that better-auth actually serves, so no rule is dead', () => {
+    const served = registeredPaths();
+    expect(served.size).toBeGreaterThan(0);
+    for (const path of Object.keys(rules)) expect(served).toContain(path);
+  });
+
+  it('matches rules against the path better-auth strips the base from', async () => {
+    const context = await auth.$context;
+    expect(new URL(context.baseURL).pathname).toBe('/api/auth');
   });
 });
 

--- a/apps/web/tests/lib/auth/server.test.ts
+++ b/apps/web/tests/lib/auth/server.test.ts
@@ -6,7 +6,6 @@ describe('password authentication', () => {
     expect(process.env['ORBIT_PASSWORD_AUTH']).toBeUndefined();
     expect(passwordAuthEnabled).toBe(false);
     expect(auth.options.emailAndPassword?.enabled).toBe(false);
-    expect(auth.options.rateLimit).toBeUndefined();
   });
 
   it('keeps the passwordless methods available', () => {
@@ -36,6 +35,21 @@ describe('password authentication', () => {
     expect(hash.startsWith('$argon2id$')).toBe(true);
     expect(await Bun.password.verify('a-very-long-password', hash)).toBe(true);
     expect(await Bun.password.verify('wrong', hash)).toBe(false);
+  });
+});
+
+describe('open signup rate limits', () => {
+  const rules = auth.options.rateLimit?.customRules ?? {};
+
+  it('caps sign in codes even though password auth is off', () => {
+    expect(passwordAuthEnabled).toBe(false);
+    expect(rules['/email-otp/send-verification-otp']).toEqual({ window: 3600, max: 20 });
+    expect(rules['/sign-in/email-otp']).toEqual({ window: 900, max: 20 });
+  });
+
+  it('keeps the password rules for deployments that enable them', () => {
+    expect(rules['/sign-in/email']).toEqual({ window: 60, max: 5 });
+    expect(rules['/sign-up/email']).toEqual({ window: 3600, max: 5 });
   });
 });
 

--- a/apps/web/tests/lib/auth/server.test.ts
+++ b/apps/web/tests/lib/auth/server.test.ts
@@ -52,7 +52,7 @@ describe('open signup rate limits', () => {
 
   it('caps sign in codes even though password auth is off', () => {
     expect(passwordAuthEnabled).toBe(false);
-    expect(rules['/email-otp/send-verification-otp']).toEqual({ window: 3600, max: 20 });
+    expect(rules['/email-otp/send-verification-otp']).toEqual({ window: 600, max: 10 });
   });
 
   it('keeps the password rules for deployments that enable them', () => {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,10 +104,17 @@ access. Set it when an instance should only admit one organisation. A workspace
 can narrow it further with its own `allowedEmailDomains` setting. The hosted
 instance at <https://orbit.noveum.ai> leaves it unset.
 
-Signing in is rate limited per IP whatever the method, so an open instance
-cannot be used to send sign-in codes in bulk: 20 code requests an hour, 20 code
-attempts each quarter hour, 5 password sign-ins a minute, and 5 password sign-ups
-an hour. Better-auth applies these in production only.
+Signing in is rate limited per IP whatever the method: 20 sign-in code requests
+an hour, 5 password sign-ins a minute, and 5 password sign-ups an hour, on top of
+better-auth's own defaults for the paths without a rule of their own. Better-auth
+applies them in production only, and a sign-in code additionally dies after three
+wrong guesses.
+
+Those counters live in better-auth's default in-memory store, which is per
+process. On a serverless host each instance keeps its own, so treat the caps as
+a brake on casual abuse rather than a fleet-wide guarantee. An instance that
+needs a real ceiling should give better-auth durable storage for them, and should
+watch what its email provider is being asked to send either way.
 
 ```bash
 ALLOWED_EMAIL_DOMAINS=example.com,example.org

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,18 +97,27 @@ Signing up is open unless you close it. A new account creates its own workspace
 through the onboarding flow, and a workspace admits nobody else until it invites
 them, so an open instance is still one tenant per workspace.
 
-`ALLOWED_EMAIL_DOMAINS` closes that door. It is enforced both on invite creation
-and on user creation, so it covers every provider rather than just invites, and
-it is checked again on every session so an address that stops qualifying loses
-access. Set it when an instance should only admit one organisation. A workspace
-can narrow it further with its own `allowedEmailDomains` setting. The hosted
-instance at <https://orbit.noveum.ai> leaves it unset.
+`ALLOWED_EMAIL_DOMAINS` closes that door. It is enforced on invite creation, on
+user creation and when a sign-in code is requested, so it covers every provider
+rather than just invites, and it is checked again on every session so an address
+that stops qualifying loses access. A refused address is told so, rather than
+being left waiting for a code that will never arrive.
 
-Signing in is rate limited per IP whatever the method: 20 sign-in code requests
-an hour, 5 password sign-ins a minute, and 5 password sign-ups an hour, on top of
-better-auth's own defaults for the paths without a rule of their own. Better-auth
-applies them in production only, and a sign-in code additionally dies after three
-wrong guesses.
+Set it when an instance should only admit one organisation. A workspace can
+narrow it further with its own `allowedEmailDomains` setting. The hosted instance
+at <https://orbit.noveum.ai> leaves it unset.
+
+Signing in is rate limited per IP whatever the method: 10 sign-in code requests
+each ten minutes, 5 password sign-ins a minute, and 5 password sign-ups an hour,
+on top of better-auth's own defaults for the paths without a rule of their own.
+Better-auth applies them in production only, and a sign-in code additionally dies
+after three wrong guesses.
+
+A custom rule replaces better-auth's matching default rather than stacking with
+it, which is why the sign-in code window is ten minutes and not an hour. An
+hourly rule would have to allow a whole hour of sends in a single burst, and a
+per-IP hourly cap tight enough to be worth having would lock out an office that
+shares one address.
 
 Those counters live in better-auth's default in-memory store, which is per
 process. On a serverless host each instance keeps its own, so treat the caps as

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,11 +119,12 @@ hourly rule would have to allow a whole hour of sends in a single burst, and a
 per-IP hourly cap tight enough to be worth having would lock out an office that
 shares one address.
 
-Those counters live in better-auth's default in-memory store, which is per
-process. On a serverless host each instance keeps its own, so treat the caps as
-a brake on casual abuse rather than a fleet-wide guarantee. An instance that
-needs a real ceiling should give better-auth durable storage for them, and should
-watch what its email provider is being asked to send either way.
+In production those counters live in Redis, on the `REDIS_URL` the app already
+needs, so the caps hold across every serverless instance rather than resetting
+with each one. If Redis cannot be reached the check lets the request through
+rather than locking everybody out, which means an outage costs you the ceiling
+and not sign-in. Outside production better-auth keeps its own in-process store,
+which is all a single development server needs.
 
 ```bash
 ALLOWED_EMAIL_DOMAINS=example.com,example.org

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,16 +86,28 @@ one, but cannot bootstrap a new installation. Local development is unaffected.
 | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` | Google sign-in. Redirect URI is `<app>/api/auth/callback/google` |
 | `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` | GitHub sign-in. Callback is `<app>/api/auth/callback/github` |
 | `ORBIT_PASSWORD_AUTH` | `false` by default. `true` enables email and password |
-| `ALLOWED_EMAIL_DOMAINS` | Comma separated. Empty means no restriction |
+| `ALLOWED_EMAIL_DOMAINS` | Unset by default, which means anyone can sign up. Comma separated to restrict |
 | `ORBIT_DEV_LOGIN` | **Local only.** One-click sign-in as any seeded user |
 
 Email and password is off by default and hashed with `@node-rs/argon2`
 (argon2id) when on. It is rate limited, and it is never a replacement for the
 passwordless methods. Leave it off unless you have a reason.
 
-`ALLOWED_EMAIL_DOMAINS` is enforced both on invite creation and on user
-creation, so it covers every provider rather than just invites. A workspace can
-narrow it further with its own `allowedEmailDomains` setting.
+Signing up is open unless you close it. A new account creates its own workspace
+through the onboarding flow, and a workspace admits nobody else until it invites
+them, so an open instance is still one tenant per workspace.
+
+`ALLOWED_EMAIL_DOMAINS` closes that door. It is enforced both on invite creation
+and on user creation, so it covers every provider rather than just invites, and
+it is checked again on every session so an address that stops qualifying loses
+access. Set it when an instance should only admit one organisation. A workspace
+can narrow it further with its own `allowedEmailDomains` setting. The hosted
+instance at <https://orbit.noveum.ai> leaves it unset.
+
+Signing in is rate limited per IP whatever the method, so an open instance
+cannot be used to send sign-in codes in bulk: 20 code requests an hour, 20 code
+attempts each quarter hour, 5 password sign-ins a minute, and 5 password sign-ups
+an hour. Better-auth applies these in production only.
 
 ```bash
 ALLOWED_EMAIL_DOMAINS=example.com,example.org
@@ -228,3 +240,7 @@ S3_SECRET_ACCESS_KEY=...
 ```
 
 Note what is absent: no `NEXT_PUBLIC_REALTIME_URL`, and no `ORBIT_DEV_LOGIN`.
+
+`ALLOWED_EMAIL_DOMAINS` appears here because this example is a single-company
+deployment. Drop the line to let anyone sign up, which is what the hosted
+instance does.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,11 +103,14 @@ rather than just invites, and it is checked again on every session so an address
 that stops qualifying loses access. A refused address is told so, rather than
 being left waiting for a code that will never arrive.
 
-Set it when an instance should only admit one organisation. A workspace can
-narrow it further with its own `allowedEmailDomains` setting. The hosted instance
-at <https://orbit.noveum.ai> leaves it unset.
+Set it when an instance should only admit one organisation. A value that is set
+but names no domain, such as a bare `@`, is refused rather than read as no
+restriction, so a typo cannot quietly open an instance you meant to close.
 
-Signing in is rate limited per IP whatever the method: 10 sign-in code requests
+A workspace can narrow it further with its own `allowedEmailDomains` setting. The
+hosted instance at <https://orbit.noveum.ai> leaves it unset.
+
+Authentication is rate limited per IP whatever the method: 10 sign-in code requests
 each ten minutes, 5 password sign-ins a minute, and 5 password sign-ups an hour,
 on top of better-auth's own defaults for the paths without a rule of their own.
 Better-auth applies them in production only, and a sign-in code additionally dies

--- a/packages/core/src/auth/rate-limit-storage.ts
+++ b/packages/core/src/auth/rate-limit-storage.ts
@@ -1,0 +1,124 @@
+import { Redis } from 'ioredis';
+
+const KEY_PREFIX = 'orbit:auth:rate-limit:';
+const FALLBACK_TTL_SECONDS = 3600;
+
+export interface RateLimitRecord {
+  readonly key: string;
+  readonly count: number;
+  readonly lastRequest: number;
+}
+
+export interface RateLimitRule {
+  readonly window: number;
+  readonly max: number;
+}
+
+export interface RateLimitDecision {
+  readonly allowed: boolean;
+  readonly retryAfter: number | null;
+}
+
+export interface RateLimitStorage {
+  get(key: string): Promise<RateLimitRecord | null>;
+  set(key: string, value: RateLimitRecord): Promise<void>;
+  consume(key: string, rule: RateLimitRule): Promise<RateLimitDecision>;
+}
+
+const CONSUME_SCRIPT = `
+local count = redis.call('HINCRBY', KEYS[1], 'count', 1)
+if count == 1 then
+  redis.call('PEXPIRE', KEYS[1], ARGV[2])
+end
+redis.call('HSET', KEYS[1], 'lastRequest', ARGV[1])
+if count > tonumber(ARGV[3]) then
+  return {0, redis.call('PTTL', KEYS[1])}
+end
+return {1, 0}
+`;
+
+let client: Redis | null = null;
+
+function connection(): Redis | null {
+  const url = process.env['REDIS_URL'];
+  if (url === undefined || url.length === 0) return null;
+  if (client === null) {
+    const created = new Redis(url, {
+      maxRetriesPerRequest: 1,
+      enableOfflineQueue: true,
+      connectTimeout: 2000,
+    });
+    created.on('error', (error: Error) => {
+      if (client !== created) return;
+      console.error('[orbit] auth rate limit redis error:', error.message);
+    });
+    client = created;
+  }
+  return client;
+}
+
+function toRecord(key: string, fields: Record<string, string>): RateLimitRecord | null {
+  const count = Number.parseInt(fields['count'] ?? '', 10);
+  const lastRequest = Number.parseInt(fields['lastRequest'] ?? '', 10);
+  if (!(Number.isFinite(count) && Number.isFinite(lastRequest))) return null;
+  return { key, count, lastRequest };
+}
+
+function decisionFrom(result: unknown, window: number): RateLimitDecision {
+  if (!Array.isArray(result)) return { allowed: true, retryAfter: null };
+  const [allowed, remainingMs] = result;
+  if (allowed === 1) return { allowed: true, retryAfter: null };
+  const milliseconds = typeof remainingMs === 'number' ? remainingMs : 0;
+  const seconds = milliseconds > 0 ? Math.ceil(milliseconds / 1000) : window;
+  return { allowed: false, retryAfter: seconds };
+}
+
+export function redisRateLimitStorage(): RateLimitStorage | undefined {
+  if (connection() === null) return undefined;
+  return {
+    async get(key: string): Promise<RateLimitRecord | null> {
+      const redis = connection();
+      if (redis === null) return null;
+      try {
+        const fields = await redis.hgetall(`${KEY_PREFIX}${key}`);
+        return Object.keys(fields).length === 0 ? null : toRecord(key, fields);
+      } catch {
+        return null;
+      }
+    },
+    async set(key: string, value: RateLimitRecord): Promise<void> {
+      const redis = connection();
+      if (redis === null) return;
+      const target = `${KEY_PREFIX}${key}`;
+      try {
+        await redis.hset(target, 'count', value.count, 'lastRequest', value.lastRequest);
+        if ((await redis.ttl(target)) < 0) await redis.expire(target, FALLBACK_TTL_SECONDS);
+      } catch {
+        return;
+      }
+    },
+    async consume(key: string, rule: RateLimitRule): Promise<RateLimitDecision> {
+      const redis = connection();
+      if (redis === null) return { allowed: true, retryAfter: null };
+      try {
+        const result = await redis.eval(
+          CONSUME_SCRIPT,
+          1,
+          `${KEY_PREFIX}${key}`,
+          Date.now(),
+          rule.window * 1000,
+          rule.max,
+        );
+        return decisionFrom(result, rule.window);
+      } catch {
+        return { allowed: true, retryAfter: null };
+      }
+    },
+  };
+}
+
+export function closeAuthRateLimitStorage(): void {
+  const open = client;
+  client = null;
+  open?.disconnect();
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './activity/activity-service.ts';
 export * from './analytics/index.ts';
 export * from './auth/mcp-token.ts';
+export * from './auth/rate-limit-storage.ts';
 export * from './content/attachment-service.ts';
 export * from './content/comment-service.ts';
 export * from './content/doc-access-request-service.ts';

--- a/packages/core/src/org/organization-service.ts
+++ b/packages/core/src/org/organization-service.ts
@@ -227,7 +227,7 @@ export function matchAllowedDomain(
 }
 
 export function configuredEmailDomains(): string[] {
-  return parseDomainList(process.env['ALLOWED_EMAIL_DOMAINS']);
+  return parseDomainList(process.env['ALLOWED_EMAIL_DOMAINS'], 'ALLOWED_EMAIL_DOMAINS');
 }
 
 export function assertEmailDomainAllowed(

--- a/packages/core/src/org/organization-service.ts
+++ b/packages/core/src/org/organization-service.ts
@@ -4,8 +4,8 @@ import type { SyncAction } from '@orbit/shared/events';
 import { scopes } from '@orbit/shared/events';
 import type { Principal } from '@orbit/shared/policy';
 import { assertCan } from '@orbit/shared/policy';
+import { emailDomain, normalizeDomains, parseDomainList } from '@orbit/shared/utils';
 import { organizationCreateSchema, organizationUpdateSchema } from '@orbit/shared/validators';
-import { z } from 'zod';
 import { newId, requireRow } from '../internal.ts';
 import { buildSyncAction } from '../realtime/publisher.ts';
 import { nextSyncId } from '../sync/sync-id.ts';
@@ -214,6 +214,8 @@ export async function listOrganizationsForUser(
   return rows;
 }
 
+export { emailDomain };
+
 export function matchAllowedDomain(
   organization: Pick<OrganizationRow, 'allowedEmailDomains'>,
   email: string,
@@ -224,25 +226,8 @@ export function matchAllowedDomain(
   return allowed.includes(domain) ? domain : null;
 }
 
-const domainListSchema = z
-  .string()
-  .optional()
-  .transform((value) => normalizeDomains((value ?? '').split(',')));
-
-function normalizeDomains(entries: readonly string[]): string[] {
-  return entries
-    .map((entry) => entry.trim().toLowerCase().replace(/^@/, ''))
-    .filter((entry) => entry.length > 0);
-}
-
-export function emailDomain(email: string): string | null {
-  const at = email.lastIndexOf('@');
-  if (at < 0 || at === email.length - 1) return null;
-  return email.slice(at + 1).toLowerCase();
-}
-
 export function configuredEmailDomains(): string[] {
-  return domainListSchema.parse(process.env['ALLOWED_EMAIL_DOMAINS']);
+  return parseDomainList(process.env['ALLOWED_EMAIL_DOMAINS']);
 }
 
 export function assertEmailDomainAllowed(

--- a/packages/core/tests-preload.ts
+++ b/packages/core/tests-preload.ts
@@ -4,5 +4,6 @@ import { resolveTestDatabaseUrl } from '../../scripts/test-env.ts';
 const databaseUrl = resolveTestDatabaseUrl('orbit_test_core');
 await ensureLaneDatabase(databaseUrl, 'orbit_test_core');
 process.env['DATABASE_URL'] = databaseUrl;
+process.env['ORBIT_TEST_REDIS_URL'] = process.env['REDIS_URL'] ?? '';
 process.env['REDIS_URL'] = '';
 process.env['DATABASE_POOL_MAX'] = '1';

--- a/packages/core/tests/auth/rate-limit-storage.test.ts
+++ b/packages/core/tests/auth/rate-limit-storage.test.ts
@@ -1,0 +1,86 @@
+import { afterAll, beforeEach, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import {
+  closeAuthRateLimitStorage,
+  redisRateLimitStorage,
+} from '../../src/auth/rate-limit-storage.ts';
+
+const RULE = { window: 60, max: 3 } as const;
+const REDIS_URL = process.env['ORBIT_TEST_REDIS_URL'] ?? '';
+
+function freshKey(): string {
+  return `test:${randomUUID()}`;
+}
+
+function connectedStorage() {
+  if (REDIS_URL.length === 0) {
+    throw new Error('ORBIT_TEST_REDIS_URL is unset. Run bun run infra:up before this suite.');
+  }
+  process.env['REDIS_URL'] = REDIS_URL;
+  closeAuthRateLimitStorage();
+  const storage = redisRateLimitStorage();
+  if (storage === undefined) throw new Error('a storage is expected for a configured url');
+  return storage;
+}
+
+afterAll(() => {
+  closeAuthRateLimitStorage();
+});
+
+describe('redisRateLimitStorage', () => {
+  beforeEach(() => {
+    closeAuthRateLimitStorage();
+    process.env['REDIS_URL'] = '';
+  });
+
+  it('is absent when no Redis is configured, so better-auth keeps its own store', () => {
+    expect(redisRateLimitStorage()).toBeUndefined();
+  });
+
+  it('allows a request up to the maximum and refuses the one after it', async () => {
+    const storage = connectedStorage();
+    const key = freshKey();
+
+    for (let attempt = 0; attempt < RULE.max; attempt += 1) {
+      expect(await storage.consume(key, RULE)).toMatchObject({ allowed: true });
+    }
+
+    const refused = await storage.consume(key, RULE);
+    expect(refused.allowed).toBe(false);
+    expect(refused.retryAfter).toBeGreaterThan(0);
+    expect(refused.retryAfter).toBeLessThanOrEqual(RULE.window);
+  });
+
+  it('counts each key separately', async () => {
+    const storage = connectedStorage();
+    const busy = freshKey();
+    for (let attempt = 0; attempt <= RULE.max; attempt += 1) await storage.consume(busy, RULE);
+
+    expect(await storage.consume(busy, RULE)).toMatchObject({ allowed: false });
+    expect(await storage.consume(freshKey(), RULE)).toMatchObject({ allowed: true });
+  });
+
+  it('reads back what it counted', async () => {
+    const storage = connectedStorage();
+    const key = freshKey();
+    expect(await storage.get(key)).toBeNull();
+
+    await storage.consume(key, RULE);
+    await storage.consume(key, RULE);
+
+    const record = await storage.get(key);
+    expect(record).toMatchObject({ key, count: 2 });
+    expect(record?.lastRequest).toBeGreaterThan(0);
+  });
+
+  it('lets requests through when Redis cannot be reached', async () => {
+    process.env['REDIS_URL'] = 'redis://127.0.0.1:6399';
+    closeAuthRateLimitStorage();
+    const storage = redisRateLimitStorage();
+    if (storage === undefined) throw new Error('a storage is expected for a configured url');
+
+    expect(await storage.consume(freshKey(), RULE)).toEqual({ allowed: true, retryAfter: null });
+    expect(await storage.get(freshKey())).toBeNull();
+    closeAuthRateLimitStorage();
+  });
+});

--- a/packages/shared/src/utils/email-domain.ts
+++ b/packages/shared/src/utils/email-domain.ts
@@ -4,8 +4,19 @@ export function normalizeDomains(entries: readonly string[]): string[] {
     .filter((entry) => entry.length > 0);
 }
 
-export function parseDomainList(value: string | undefined): string[] {
-  return normalizeDomains((value ?? '').split(','));
+export function parseDomainList(
+  value: string | undefined,
+  name = 'The domain allowlist',
+): string[] {
+  const raw = (value ?? '').trim();
+  if (raw.length === 0) return [];
+  const domains = normalizeDomains(raw.split(','));
+  if (domains.length === 0) {
+    throw new Error(
+      `${name} is set to ${JSON.stringify(value)}, which names no domain. Leave it unset to admit every domain.`,
+    );
+  }
+  return domains;
 }
 
 export function emailDomain(email: string): string | null {

--- a/packages/shared/src/utils/email-domain.ts
+++ b/packages/shared/src/utils/email-domain.ts
@@ -1,0 +1,15 @@
+export function normalizeDomains(entries: readonly string[]): string[] {
+  return entries
+    .map((entry) => entry.trim().toLowerCase().replace(/^@/, ''))
+    .filter((entry) => entry.length > 0);
+}
+
+export function parseDomainList(value: string | undefined): string[] {
+  return normalizeDomains((value ?? '').split(','));
+}
+
+export function emailDomain(email: string): string | null {
+  const at = email.lastIndexOf('@');
+  if (at < 0 || at === email.length - 1) return null;
+  return email.slice(at + 1).toLowerCase();
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -2,6 +2,7 @@ import { v7 as uuidv7 } from 'uuid';
 import { SORT_ORDER_STEP } from '../constants/index.ts';
 
 export * from './doc-anchor.ts';
+export * from './email-domain.ts';
 export * from './error-fields.ts';
 export * from './highlight.ts';
 

--- a/packages/shared/tests/utils/email-domain.test.ts
+++ b/packages/shared/tests/utils/email-domain.test.ts
@@ -32,10 +32,19 @@ describe('parseDomainList', () => {
     expect(parseDomainList('example.com, @orbit.test')).toEqual(['example.com', 'orbit.test']);
   });
 
-  it('treats unset, empty and separator only values as no restriction', () => {
+  it('treats unset and empty values as no restriction', () => {
     expect(parseDomainList(undefined)).toEqual([]);
     expect(parseDomainList('')).toEqual([]);
     expect(parseDomainList('  ')).toEqual([]);
-    expect(parseDomainList(',,')).toEqual([]);
+  });
+
+  it('refuses a value that is set but names no domain, rather than admitting everyone', () => {
+    expect(() => parseDomainList('@')).toThrow(/names no domain/);
+    expect(() => parseDomainList(',,')).toThrow(/names no domain/);
+    expect(() => parseDomainList('@, @')).toThrow(/names no domain/);
+  });
+
+  it('names the variable it was given so the message is actionable', () => {
+    expect(() => parseDomainList('@', 'ALLOWED_EMAIL_DOMAINS')).toThrow(/ALLOWED_EMAIL_DOMAINS/);
   });
 });

--- a/packages/shared/tests/utils/email-domain.test.ts
+++ b/packages/shared/tests/utils/email-domain.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test';
+import { emailDomain, normalizeDomains, parseDomainList } from '../../src/utils/email-domain.ts';
+
+describe('emailDomain', () => {
+  it('takes the part after the last at sign, lowercased', () => {
+    expect(emailDomain('Person@Example.COM')).toBe('example.com');
+    expect(emailDomain('odd@name@example.com')).toBe('example.com');
+  });
+
+  it('returns null when there is no domain to read', () => {
+    expect(emailDomain('not-an-email')).toBeNull();
+    expect(emailDomain('trailing@')).toBeNull();
+    expect(emailDomain('')).toBeNull();
+  });
+});
+
+describe('normalizeDomains', () => {
+  it('trims, lowercases and drops a leading at sign', () => {
+    expect(normalizeDomains([' @Example.com ', 'ORBIT.test'])).toEqual([
+      'example.com',
+      'orbit.test',
+    ]);
+  });
+
+  it('drops entries that are empty once trimmed', () => {
+    expect(normalizeDomains(['', '  ', 'example.com'])).toEqual(['example.com']);
+  });
+});
+
+describe('parseDomainList', () => {
+  it('reads a comma separated list', () => {
+    expect(parseDomainList('example.com, @orbit.test')).toEqual(['example.com', 'orbit.test']);
+  });
+
+  it('treats unset, empty and separator only values as no restriction', () => {
+    expect(parseDomainList(undefined)).toEqual([]);
+    expect(parseDomainList('')).toEqual([]);
+    expect(parseDomainList('  ')).toEqual([]);
+    expect(parseDomainList(',,')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What this changes

Opens the hosted instance to anyone, and adds the abuse protection an open sign-up needs.

- Sign-in code sends are rate limited whatever else is configured, and in production the counters live in Redis so they hold across serverless instances.
- A sign-in code request from a disallowed domain is now refused, instead of answering `200 {"success":true}` and sending nothing.
- The landing page and the login form say signing up is open, but only on a deployment where that is true.
- `docs/configuration.md` states the default, which is that anyone can sign up, and is explicit about what the limits do and do not guarantee.

Closes #344.

## Why

Access to <https://orbit.noveum.ai> was gated by `ALLOWED_EMAIL_DOMAINS`, enforced on user creation and again on every session. An address outside the list got a bare "Sign in failed" toast, which is what #344 reports. The variable has now been removed from the Vercel production environment, so this branch is what production should be running when that takes effect on the next deploy.

The code already defaulted to open, and self-serve already worked end to end: onboarding creates a workspace, `createOrganization` leaves `allowedEmailDomains` empty so a new workspace admits nobody by domain, and the invite step is skippable. What needed building is everything around it.

**Rate limiting.** `rateLimit()` returned `{}` unless `ORBIT_PASSWORD_AUTH` was on, which left email OTP, the method every hosted sign-in actually uses, on better-auth's defaults alone. Every send is a Resend send, so an instance anyone can join can be asked to pay for mail to any address. The send path is now capped, and the counters are durable: better-auth keeps them in process memory by default, which on Vercel means each instance has its own and a cold start begins at zero.

**A silent refusal.** better-auth runs the email OTP callback through `runInBackgroundOrAwait`, which catches whatever the callback throws and only logs it. The domain check lived inside that callback, so it never reached the caller. Confirmed against the route: a request from an address outside the allowlist answered `200 {"success":true}`, the screen said a code was on its way, and no code was ever sent. The check now runs in a `before` hook, where throwing reaches the client as `403 EMAIL_DOMAIN_NOT_ALLOWED`.

## How you know it works

Every new test fails without its change, verified by reverting each in turn:

- Removing the `before` hook fails `refuses a disallowed domain instead of claiming a code is on its way` with the original `200`.
- Deleting the sign-in code rule fails `caps sign in code sends by their own rule, not the global one`, which drives real requests through the route handler and proves better-auth matches the path the rule names.
- Typing a rule path as `/email-otp/send-otp` fails `names paths that better-auth actually serves, so no rule is dead`.
- Making the landing copy unconditional fails `promises nobody a signup the allowlist would refuse`.
- Dropping the `creatingAccount` guard fails `drops the note once the user is explicitly creating an account`.
- Reintroducing a default domain list in `configuredEmailDomains` fails both `lets any address start a session once the allowlist is cleared` and the existing `allows every address when nothing is configured`.

The Redis store is covered against a live Redis: it enforces the maximum, counts keys separately, reads back what it counted, and lets requests through when Redis is unreachable.

Checks run:

- `apps/web`: 460 pass across `tests/lib`, `tests/components/auth`, `tests/app/page.test.tsx`, `tests/app/api/auth`.
- `packages/core`: 132 pass across `tests/auth` and `tests/org`. `packages/shared`: 278 pass.
- `bun run typecheck` in `apps/web`: clean. `bun run lint`, `check-comments`, `check-bytes`, `check-bun-imports`, `check-deps`: all pass.
- The rate limit route tests were run twice in a row to confirm they do not leave state behind.

Two notes on the local suite, both pre-existing and reproduced on an unmodified checkout of `main` at 74899a56:

- The full `apps/web` run dies with SIGTRAP (exit 133) inside `tests/features/issues/quick-create.test.tsx`, with and without this branch.
- `tsc -p scripts/tsconfig.json` reports two `Buffer` assignability errors under `scripts/`. This branch touches no file there and does not change the lockfile, and CI is green on `main` with the same code.

## Screenshots

Copy-only changes to existing paragraphs, no layout or styling change.

## Deployment

`ALLOWED_EMAIL_DOMAINS` has been removed from the Vercel production environment. Vercel applies an environment change on the next deployment, so signup opens when this merges and deploys, which is the order that puts the caps in place before the door opens.

## Anything reviewers should know

- **A custom rule replaces better-auth's matching default rather than stacking with it.** That is why the sign-in code window is ten minutes rather than an hour: an hourly rule has to let a whole hour of sends through in one burst, and a per-IP hourly cap tight enough to be worth having would lock out an office behind one address. It is also why there is no rule on `/sign-in/email-otp`, where a custom rule would have loosened better-auth's own burst guard to defend against a brute force the plugin already stops by killing a code after three wrong guesses.
- **The rate limit store fails open.** If Redis is unreachable the request is allowed rather than sign-in going down with the cache. An outage costs the ceiling, not the front door.
- **The offline queue is enabled deliberately.** Disabling it fails the first command of a fresh client before the socket finishes connecting, which on serverless would let the first request of every new instance past unmeasured. This was caught by the storage tests failing open against a live Redis.
- Reading one environment variable through `@orbit/core` gave the landing route the whole server stack as a transitive dependency, including a database client that throws at import without `DATABASE_URL`. `/home` had no server dependency at all before this branch. The pure parsing moved to `@orbit/shared/utils` and the env read joins the web app's own server-only env module.
- #366 is open and adds copy explaining that access is restricted to Noveum employees. This supersedes it, and it should close rather than merge.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR opens signup by default while adding durable authentication rate limiting and explicit domain-policy rejection.
- Adds Redis-backed production counters for authentication rate limits.
- Rejects disallowed email-code requests before reporting success.
- Gates open-signup messaging on the effective domain configuration.
- Moves shared email-domain parsing into the shared package and documents the resulting behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/lib/auth/server.ts | Enables authentication rate limiting independently of password authentication and moves email-domain rejection into a request-visible before hook. |
| packages/core/src/auth/rate-limit-storage.ts | Adds atomic Redis-backed rate-limit storage with the documented fail-open behavior. |
| apps/web/src/features/landing/landing-page.tsx | Makes open-signup claims conditional on the deployment’s effective domain policy. |
| apps/web/src/components/auth/login-form.tsx | Revises signup guidance to accurately describe the subsequent workspace onboarding step. |
| packages/shared/src/utils/email-domain.ts | Centralizes domain normalization, parsing, and malformed-configuration rejection. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant W as Web app
  participant A as Authentication
  participant R as Redis
  U->>W: Request sign-in code
  W->>A: Submit email
  A->>A: Check configured domain policy
  alt Domain is disallowed
    A-->>U: 403 EMAIL_DOMAIN_NOT_ALLOWED
  else Domain is allowed
    A->>R: Consume rate-limit allowance
    alt Limit exceeded
      A-->>U: 429 Too Many Requests
    else Request allowed
      A-->>U: Send sign-in code
    end
  end
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(shared): refuse an allowlist that na..."](https://github.com/noveum/orbit/commit/ed1e956b4ff06612f9a74f27bab29d0bb493e932) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58116816)</sub>

**Context used:**

- Knowledge Base — [Membership, invitations, and onboarding](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/docs/membership-and-onboarding.md)
- Knowledge Base — [Web application experience](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/docs/web-application-experience.md)

<!-- /greptile_comment -->