### PR TITLE
fix(charts): render a dot for single-point series instead of an empty path

### DIFF
--- a/apps/web/src/features/charts/line-chart.tsx
+++ b/apps/web/src/features/charts/line-chart.tsx
@@ -40,12 +40,18 @@ const LEGEND_DOT: Record<SeriesTone, string> = {
 function SeriesPath({ series, max }: { readonly series: ChartSeries; readonly max: number }) {
   const ref = useDrawOnMount<SVGPathElement>();
   if (series.values.length === 1) {
+    const x = chartX(0, 1);
+    const y = chartY(series.values[0] ?? 0, max);
     return (
-      <circle
-        cx={chartX(0, 1)}
-        cy={chartY(series.values[0] ?? 0, max)}
-        r={3.5}
-        fill={STROKE[series.tone]}
+      <line
+        x1={x}
+        x2={x}
+        y1={y}
+        y2={y}
+        stroke={STROKE[series.tone]}
+        strokeWidth={7}
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
         data-testid={`chart-line-${series.id}`}
       />
     );

--- a/apps/web/src/features/charts/line-chart.tsx
+++ b/apps/web/src/features/charts/line-chart.tsx
@@ -6,6 +6,7 @@ import {
   CHART_HEIGHT,
   CHART_PADDING,
   CHART_WIDTH,
+  chartX,
   chartY,
   linePath,
 } from './geometry.ts';
@@ -38,6 +39,17 @@ const LEGEND_DOT: Record<SeriesTone, string> = {
 
 function SeriesPath({ series, max }: { readonly series: ChartSeries; readonly max: number }) {
   const ref = useDrawOnMount<SVGPathElement>();
+  if (series.values.length === 1) {
+    return (
+      <circle
+        cx={chartX(0, 1)}
+        cy={chartY(series.values[0] ?? 0, max)}
+        r={3.5}
+        fill={STROKE[series.tone]}
+        data-testid={`chart-line-${series.id}`}
+      />
+    );
+  }
   return (
     <path
       ref={ref}
@@ -109,7 +121,7 @@ export function LineChart({ title, description, series, labels, max, className }
           />
         ))}
         {series
-          .filter((entry) => entry.filled === true)
+          .filter((entry) => entry.filled === true && entry.values.length > 1)
           .map((entry) => (
             <path
               key={`${entry.id}-fill`}

--- a/apps/web/tests/features/charts/line-chart.test.tsx
+++ b/apps/web/tests/features/charts/line-chart.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, render, screen } from '@testing-library/react';
+import { type ChartSeries, LineChart } from '../../../src/features/charts/line-chart.tsx';
+
+afterEach(cleanup);
+
+function singlePoint(max: number): ChartSeries {
+  return { id: 'scope', label: 'Scope', tone: 'accent', filled: false, values: [max] };
+}
+
+describe('LineChart with a single point', () => {
+  it('renders a dot instead of a zero-length path', () => {
+    const { container } = render(
+      <LineChart
+        title="Scope and completed over time"
+        description="Weekly scope"
+        series={[singlePoint(10)]}
+        labels={['2026-08-24']}
+        max={10}
+      />,
+    );
+    const circle = container.querySelector('circle');
+    expect(circle).not.toBeNull();
+    expect(Number(circle!.getAttribute('cx'))).toBe(160);
+    const paths = container.querySelectorAll('path');
+    for (const path of paths) {
+      expect(path.getAttribute('d')).not.toBe('');
+    }
+    expect(screen.getByLabelText('Weekly scope')).not.toBeNull();
+  });
+
+  it('still draws a line for multi-point series', () => {
+    const { container } = render(
+      <LineChart
+        title="Scope and completed over time"
+        description="Weekly scope"
+        series={[
+          { id: 'scope', label: 'Scope', tone: 'accent', filled: false, values: [0, 5, 10] },
+        ]}
+        labels={['w1', 'w2', 'w3']}
+        max={10}
+      />,
+    );
+    expect(container.querySelector('circle')).toBeNull();
+    expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/tests/features/charts/line-chart.test.tsx
+++ b/apps/web/tests/features/charts/line-chart.test.tsx
@@ -5,7 +5,7 @@ import { type ChartSeries, LineChart } from '../../../src/features/charts/line-c
 afterEach(cleanup);
 
 function singlePoint(max: number): ChartSeries {
-  return { id: 'scope', label: 'Scope', tone: 'accent', filled: false, values: [max] };
+  return { id: 'scope', label: 'Scope', tone: 'accent', filled: true, values: [max] };
 }
 
 describe('LineChart with a single point', () => {
@@ -19,13 +19,13 @@ describe('LineChart with a single point', () => {
         max={10}
       />,
     );
-    const circle = container.querySelector('circle');
-    expect(circle).not.toBeNull();
-    expect(Number(circle!.getAttribute('cx'))).toBe(160);
-    const paths = container.querySelectorAll('path');
-    for (const path of paths) {
-      expect(path.getAttribute('d')).not.toBe('');
-    }
+    const dot = screen.getByTestId('chart-line-scope');
+    expect(dot.tagName).toBe('line');
+    expect(Number(dot.getAttribute('x1'))).toBe(160);
+    expect(dot.getAttribute('x2')).toBe(dot.getAttribute('x1'));
+    expect(dot.getAttribute('stroke-linecap')).toBe('round');
+    expect(dot.getAttribute('vector-effect')).toBe('non-scaling-stroke');
+    expect(container.querySelectorAll('path')).toHaveLength(0);
     expect(screen.getByLabelText('Weekly scope')).not.toBeNull();
   });
 
@@ -34,14 +34,12 @@ describe('LineChart with a single point', () => {
       <LineChart
         title="Scope and completed over time"
         description="Weekly scope"
-        series={[
-          { id: 'scope', label: 'Scope', tone: 'accent', filled: false, values: [0, 5, 10] },
-        ]}
+        series={[{ id: 'scope', label: 'Scope', tone: 'accent', filled: true, values: [0, 5, 10] }]}
         labels={['w1', 'w2', 'w3']}
         max={10}
       />,
     );
-    expect(container.querySelector('circle')).toBeNull();
-    expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('chart-line-scope').tagName).toBe('path');
+    expect(container.querySelectorAll('path')).toHaveLength(2);
   });
 });


### PR DESCRIPTION
Closes #175

## What changed

A series with exactly one bucket previously produced only a move command, so the chart painted nothing. Single-point series now render a centered marker as a zero-length line with a round cap and a non-scaling stroke. This keeps the marker circular even though the chart SVG stretches its coordinate system non-uniformly.

Filled areas are omitted for one-point series because a zero-width area conveys no trend. Multi-point line and area behavior is unchanged.

## Review fixes

The initial circle implementation would stretch into an ellipse under `preserveAspectRatio="none"`. The final implementation uses:

- `strokeLinecap="round"`
- `strokeWidth={7}`
- `vectorEffect="non-scaling-stroke"`

Chromium renders confirmed a circular 7px marker at both 160px and 640px chart widths.

## Verification

- Focused chart and geometry suites: 10 passed, 20 assertions
- Adjacent `LinePlot` plus changed `LineChart` suites: 18 passed, 86 assertions
- Web typecheck: passed
- Repository lint, comment policy, source-byte policy, Bun-import policy, dependency checks, and every workspace typecheck: passed
- Independent code and browser audit: no blockers

The full local suite later encountered a Bun 1.3.14 `SIGTRAP` at the unchanged `line-plot.test.tsx` after the preceding lanes passed. That file immediately passed 16 of 16 in isolation. Hosted exact-head CI remains required before merge.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates single-point line-chart series to display a centered, circular marker while leaving multi-point rendering unchanged.
- Renders a zero-length line with a round, non-scaling stroke for one-point series.
- Omits zero-width area fills for one-point series.
- Adds focused coverage for single-point and multi-point rendering.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/features/charts/line-chart.tsx | Adds centered, non-scaling round markers for single-point series and suppresses their zero-width fills. |
| apps/web/tests/features/charts/line-chart.test.tsx | Verifies marker geometry and attributes while preserving multi-point line and fill behavior. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(charts): keep single-point markers c..."](https://github.com/noveum/orbit/commit/9ff350db6f8f103260f2870e2eecb35e93db40c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58198075)</sub>

<!-- /greptile_comment -->