### PR TITLE
feat(projects): add workspace updates feed and document project health

### DIFF
--- a/apps/web/src/app/(app)/projects/page.tsx
+++ b/apps/web/src/app/(app)/projects/page.tsx
@@ -6,10 +6,11 @@ import Link from 'next/link';
 import { Avatar } from '@/components/ui/avatar.tsx';
 import { EmptyState } from '@/components/ui/empty-state.tsx';
 import { Donut } from '@/features/charts/donut.tsx';
-import { listProjectSummaries } from '@/features/projects/data.ts';
+import { listProjectSummaries, listWorkspaceProjectUpdateViews } from '@/features/projects/data.ts';
 import { formatDay } from '@/features/projects/dates.ts';
 import { HealthChip, STATUS_LABELS } from '@/features/projects/health-chip.tsx';
 import { NewProjectDialog } from '@/features/projects/new-project-dialog.tsx';
+import { ProjectUpdatesFeed } from '@/features/projects/project-feed.tsx';
 import { pageContext } from '@/lib/api/handler.ts';
 import { cn } from '@/lib/cn.ts';
 import { rowHover } from '@/lib/interaction.ts';
@@ -20,11 +21,19 @@ function formatDate(value: string | null): string {
   return formatDay(value, { withYear: false, missing: 'No target' });
 }
 
-export default async function ProjectsPage() {
+interface ProjectsPageProps {
+  readonly searchParams?: Promise<{ view?: string }>;
+}
+
+export default async function ProjectsPage({ searchParams }: ProjectsPageProps) {
   const { principal } = await pageContext();
-  const [projects, teams] = await Promise.all([
+  const { view } = (await searchParams) ?? {};
+  const isFeed = view === 'feed' || view === 'updates';
+
+  const [projects, teams, updates] = await Promise.all([
     listProjectSummaries(principal),
     listTeams(principal),
+    isFeed ? listWorkspaceProjectUpdateViews(principal) : Promise.resolve([]),
   ]);
   const canManage = can(principal, 'project:manage');
   const teamOptions = teams.map((team) => ({ id: team.id, key: team.key, name: team.name }));
@@ -55,78 +64,109 @@ export default async function ProjectsPage() {
             {projects.length} active {projects.length === 1 ? 'project' : 'projects'}.
           </p>
         </div>
-        <NewProjectDialog teams={teamOptions} canManage={canManage} />
+        <div className="flex flex-wrap items-center gap-3">
+          <nav
+            className="flex items-center gap-1 rounded-lg border border-border bg-surface p-0.5"
+            aria-label="Project views"
+          >
+            <Link
+              href="/projects"
+              aria-current={isFeed ? undefined : 'page'}
+              className={cn(
+                'rounded-md px-2.5 py-1 text-2xs font-medium transition-colors',
+                isFeed ? 'text-faint hover:text-muted' : 'bg-surface-2 text-text shadow-xs',
+              )}
+            >
+              Projects
+            </Link>
+            <Link
+              href="/projects?view=feed"
+              aria-current={isFeed ? 'page' : undefined}
+              className={cn(
+                'rounded-md px-2.5 py-1 text-2xs font-medium transition-colors',
+                isFeed ? 'bg-surface-2 text-text shadow-xs' : 'text-faint hover:text-muted',
+              )}
+            >
+              Updates
+            </Link>
+          </nav>
+          <NewProjectDialog teams={teamOptions} canManage={canManage} />
+        </div>
       </header>
 
-      <div className="overflow-x-auto rounded-lg border border-border">
-        <table className="row-stack w-full border-collapse md:min-w-[52rem] text-dense">
-          <thead>
-            <tr className="border-border border-b text-2xs text-faint uppercase">
-              <th scope="col" className="px-3 py-2 text-left font-medium">
-                Project
-              </th>
-              <th scope="col" className="px-3 py-2 text-left font-medium">
-                Health
-              </th>
-              <th scope="col" className="px-3 py-2 text-left font-medium">
-                Lead
-              </th>
-              <th scope="col" className="px-3 py-2 text-left font-medium">
-                Target
-              </th>
-              <th scope="col" className="px-3 py-2 text-right font-medium">
-                Issues
-              </th>
-              <th scope="col" className="px-3 py-2 text-left font-medium">
-                Progress
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {projects.map((project) => (
-              <tr
-                key={project.id}
-                className={cn('border-border border-b last:border-b-0', rowHover)}
-              >
-                <td className="px-3 py-2">
-                  <Link
-                    href={`/projects/${project.slug}`}
-                    className="flex flex-col gap-0.5 rounded-sm text-text hover:text-accent"
-                  >
-                    <span className="font-medium">{project.name}</span>
-                    <span className="text-faint text-2xs">
-                      {STATUS_LABELS[project.status]}
-                      {project.summary.length === 0 ? '' : ` · ${project.summary}`}
-                    </span>
-                  </Link>
-                </td>
-                <td data-label="Health" className="px-3 py-2">
-                  <HealthChip health={project.health} />
-                </td>
-                <td data-label="Lead" className="px-3 py-2">
-                  {project.lead === null ? (
-                    <span className="text-faint text-xs">Unassigned</span>
-                  ) : (
-                    <span className="flex items-center gap-1.5 text-muted">
-                      <Avatar name={project.lead.name} src={project.lead.image} size="xs" />
-                      {project.lead.name}
-                    </span>
-                  )}
-                </td>
-                <td data-label="Target" className="px-3 py-2 text-muted tabular">
-                  {formatDate(project.targetDate)}
-                </td>
-                <td data-label="Issues" className="px-3 py-2 text-right text-muted tabular">
-                  {project.issueCount}
-                </td>
-                <td data-label="Progress" className="px-3 py-2">
-                  <Donut completed={project.completedCount} scope={project.issueCount} />
-                </td>
+      {isFeed ? (
+        <ProjectUpdatesFeed updates={updates} />
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <table className="row-stack w-full border-collapse md:min-w-[52rem] text-dense">
+            <thead>
+              <tr className="border-border border-b text-2xs text-faint uppercase">
+                <th scope="col" className="px-3 py-2 text-left font-medium">
+                  Project
+                </th>
+                <th scope="col" className="px-3 py-2 text-left font-medium">
+                  Health
+                </th>
+                <th scope="col" className="px-3 py-2 text-left font-medium">
+                  Lead
+                </th>
+                <th scope="col" className="px-3 py-2 text-left font-medium">
+                  Target
+                </th>
+                <th scope="col" className="px-3 py-2 text-right font-medium">
+                  Issues
+                </th>
+                <th scope="col" className="px-3 py-2 text-left font-medium">
+                  Progress
+                </th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody>
+              {projects.map((project) => (
+                <tr
+                  key={project.id}
+                  className={cn('border-border border-b last:border-b-0', rowHover)}
+                >
+                  <td className="px-3 py-2">
+                    <Link
+                      href={`/projects/${project.slug}`}
+                      className="flex flex-col gap-0.5 rounded-sm text-text hover:text-accent"
+                    >
+                      <span className="font-medium">{project.name}</span>
+                      <span className="text-faint text-2xs">
+                        {STATUS_LABELS[project.status]}
+                        {project.summary.length === 0 ? '' : ` · ${project.summary}`}
+                      </span>
+                    </Link>
+                  </td>
+                  <td data-label="Health" className="px-3 py-2">
+                    <HealthChip health={project.health} />
+                  </td>
+                  <td data-label="Lead" className="px-3 py-2">
+                    {project.lead === null ? (
+                      <span className="text-faint text-xs">Unassigned</span>
+                    ) : (
+                      <span className="flex items-center gap-1.5 text-muted">
+                        <Avatar name={project.lead.name} src={project.lead.image} size="xs" />
+                        {project.lead.name}
+                      </span>
+                    )}
+                  </td>
+                  <td data-label="Target" className="px-3 py-2 text-muted tabular">
+                    {formatDate(project.targetDate)}
+                  </td>
+                  <td data-label="Issues" className="px-3 py-2 text-right text-muted tabular">
+                    {project.issueCount}
+                  </td>
+                  <td data-label="Progress" className="px-3 py-2">
+                    <Donut completed={project.completedCount} scope={project.issueCount} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/(app)/projects/page.tsx
+++ b/apps/web/src/app/(app)/projects/page.tsx
@@ -13,7 +13,7 @@ import { NewProjectDialog } from '@/features/projects/new-project-dialog.tsx';
 import { ProjectUpdatesFeed } from '@/features/projects/project-feed.tsx';
 import { pageContext } from '@/lib/api/handler.ts';
 import { cn } from '@/lib/cn.ts';
-import { rowHover } from '@/lib/interaction.ts';
+import { rowHover, tabHover } from '@/lib/interaction.ts';
 
 export const metadata: Metadata = { title: 'Projects' };
 
@@ -73,8 +73,8 @@ export default async function ProjectsPage({ searchParams }: ProjectsPageProps) 
               href="/projects"
               aria-current={isFeed ? undefined : 'page'}
               className={cn(
-                'rounded-md px-2.5 py-1 text-2xs font-medium transition-colors',
-                isFeed ? 'text-faint hover:text-muted' : 'bg-surface-2 text-text shadow-xs',
+                'rounded-md px-2.5 py-1 text-2xs font-medium',
+                isFeed ? cn('text-faint', tabHover) : 'bg-surface-2 text-text shadow-xs',
               )}
             >
               Projects
@@ -83,8 +83,8 @@ export default async function ProjectsPage({ searchParams }: ProjectsPageProps) 
               href="/projects?view=feed"
               aria-current={isFeed ? 'page' : undefined}
               className={cn(
-                'rounded-md px-2.5 py-1 text-2xs font-medium transition-colors',
-                isFeed ? 'bg-surface-2 text-text shadow-xs' : 'text-faint hover:text-muted',
+                'rounded-md px-2.5 py-1 text-2xs font-medium',
+                isFeed ? 'bg-surface-2 text-text shadow-xs' : cn('text-faint', tabHover),
               )}
             >
               Updates

--- a/apps/web/src/features/projects/data.ts
+++ b/apps/web/src/features/projects/data.ts
@@ -2,6 +2,7 @@ import {
   listMilestones,
   listProjects,
   listProjectUpdates,
+  listWorkspaceProjectUpdates,
   type ProjectProgress,
   projectProgress,
   projectProgressSeries,
@@ -201,4 +202,34 @@ export async function findProjectDetail(
     if (error instanceof DomainError && MISSING_CODES.has(error.code)) return null;
     throw error;
   }
+}
+
+export interface WorkspaceProjectUpdateView {
+  readonly id: string;
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly projectSlug: string;
+  readonly health: ProjectHealth;
+  readonly body: string;
+  readonly createdAt: string;
+  readonly author: PersonRef | null;
+}
+
+export async function listWorkspaceProjectUpdateViews(
+  principal: Principal,
+  limit = 50,
+): Promise<WorkspaceProjectUpdateView[]> {
+  const updates = await listWorkspaceProjectUpdates(principal, limit);
+  const people = await loadPeople(updates.map((update) => update.authorId));
+
+  return updates.map((update) => ({
+    id: update.id,
+    projectId: update.projectId,
+    projectName: update.projectName,
+    projectSlug: update.projectSlug,
+    health: toHealth(update.health),
+    body: renderPlainText(update.body),
+    createdAt: update.createdAt.toISOString(),
+    author: people.get(update.authorId) ?? null,
+  }));
 }

--- a/apps/web/src/features/projects/data.ts
+++ b/apps/web/src/features/projects/data.ts
@@ -217,9 +217,8 @@ export interface WorkspaceProjectUpdateView {
 
 export async function listWorkspaceProjectUpdateViews(
   principal: Principal,
-  limit = 50,
 ): Promise<WorkspaceProjectUpdateView[]> {
-  const updates = await listWorkspaceProjectUpdates(principal, limit);
+  const updates = await listWorkspaceProjectUpdates(principal);
   const people = await loadPeople(updates.map((update) => update.authorId));
 
   return updates.map((update) => ({

--- a/apps/web/src/features/projects/project-feed.tsx
+++ b/apps/web/src/features/projects/project-feed.tsx
@@ -3,14 +3,11 @@ import { Avatar } from '@/components/ui/avatar.tsx';
 import { cn } from '@/lib/cn.ts';
 import { cardHover } from '@/lib/interaction.ts';
 import type { WorkspaceProjectUpdateView } from './data.ts';
+import { formatDay } from './dates.ts';
 import { HealthChip } from './health-chip.tsx';
 
 function formatDate(value: string): string {
-  return new Date(value).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  });
+  return formatDay(value, { withYear: true, missing: 'No date' });
 }
 
 export function ProjectUpdatesFeed({

--- a/apps/web/src/features/projects/project-feed.tsx
+++ b/apps/web/src/features/projects/project-feed.tsx
@@ -1,0 +1,72 @@
+import Link from 'next/link';
+import { Avatar } from '@/components/ui/avatar.tsx';
+import { cn } from '@/lib/cn.ts';
+import { cardHover } from '@/lib/interaction.ts';
+import type { WorkspaceProjectUpdateView } from './data.ts';
+import { HealthChip } from './health-chip.tsx';
+
+function formatDate(value: string): string {
+  return new Date(value).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export function ProjectUpdatesFeed({
+  updates,
+}: {
+  readonly updates: readonly WorkspaceProjectUpdateView[];
+}) {
+  if (updates.length === 0) {
+    return (
+      <div className="rounded-lg border border-border p-8 text-center">
+        <p className="font-medium text-muted text-sm">No project updates posted yet</p>
+        <p className="mt-1 text-faint text-xs">
+          When team leads post health updates to their projects, they will appear here in a single
+          stream.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-3" aria-label="Project updates feed">
+      {updates.map((update) => (
+        <li
+          key={update.id}
+          className={cn(
+            'flex flex-col gap-2 rounded-lg border border-border bg-surface p-4',
+            cardHover,
+          )}
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <Link
+                href={`/projects/${update.projectSlug}`}
+                className="font-medium text-sm text-text transition-colors hover:text-accent"
+              >
+                {update.projectName}
+              </Link>
+              <HealthChip health={update.health} />
+            </div>
+            <time className="text-2xs text-faint tabular" dateTime={update.createdAt}>
+              {formatDate(update.createdAt)}
+            </time>
+          </div>
+
+          <p className="whitespace-pre-wrap text-muted text-xs leading-relaxed">{update.body}</p>
+
+          {update.author === null ? null : (
+            <div className="flex items-center gap-1.5 border-border/50 border-t pt-1 text-2xs text-faint">
+              <Avatar name={update.author.name} src={update.author.image} size="xs" />
+              <span>
+                Posted by <span className="font-medium text-text">{update.author.name}</span>
+              </span>
+            </div>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/features/projects/project-feed.tsx
+++ b/apps/web/src/features/projects/project-feed.tsx
@@ -41,7 +41,7 @@ export function ProjectUpdatesFeed({
             <div className="flex flex-wrap items-center gap-2">
               <Link
                 href={`/projects/${update.projectSlug}`}
-                className="font-medium text-sm text-text transition-colors hover:text-accent"
+                className="font-medium text-sm text-text hover:text-accent"
               >
                 {update.projectName}
               </Link>

--- a/apps/web/tests/features/projects/project-feed.test.tsx
+++ b/apps/web/tests/features/projects/project-feed.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { ProjectUpdatesFeed } from '@/features/projects/project-feed.tsx';
+
+describe('ProjectUpdatesFeed', () => {
+  it('renders an empty state when there are no updates', () => {
+    render(<ProjectUpdatesFeed updates={[]} />);
+    expect(screen.getByText('No project updates posted yet')).toBeInTheDocument();
+  });
+
+  it('renders update cards with project link, health chip, and author', () => {
+    const updates = [
+      {
+        id: 'update_1',
+        projectId: 'proj_1',
+        projectName: 'Realtime Sync',
+        projectSlug: 'realtime-sync',
+        health: 'on_track' as const,
+        body: 'Completed initial socket tests.',
+        createdAt: '2026-08-30T10:00:00.000Z',
+        author: {
+          id: 'user_1',
+          name: 'Alex Rivera',
+          image: null,
+        },
+      },
+      {
+        id: 'update_2',
+        projectId: 'proj_2',
+        projectName: 'Mobile App',
+        projectSlug: 'mobile-app',
+        health: 'at_risk' as const,
+        body: 'Waiting on auth designs.',
+        createdAt: '2026-08-29T15:30:00.000Z',
+        author: {
+          id: 'user_2',
+          name: 'Sam Chen',
+          image: 'https://example.com/sam.png',
+        },
+      },
+    ];
+
+    render(<ProjectUpdatesFeed updates={updates} />);
+
+    expect(screen.getByText('Realtime Sync')).toBeInTheDocument();
+    expect(screen.getByText('Mobile App')).toBeInTheDocument();
+    expect(screen.getByText('On track')).toBeInTheDocument();
+    expect(screen.getByText('At risk')).toBeInTheDocument();
+    expect(screen.getByText('Completed initial socket tests.')).toBeInTheDocument();
+    expect(screen.getByText('Alex Rivera')).toBeInTheDocument();
+    expect(screen.getByText('Sam Chen')).toBeInTheDocument();
+
+    const link = screen.getByRole('link', { name: 'Realtime Sync' });
+    expect(link).toHaveAttribute('href', '/projects/realtime-sync');
+  });
+});

--- a/apps/web/tests/features/projects/project-feed.test.tsx
+++ b/apps/web/tests/features/projects/project-feed.test.tsx
@@ -50,6 +50,14 @@ describe('ProjectUpdatesFeed', () => {
     expect(screen.getByText('Alex Rivera')).toBeInTheDocument();
     expect(screen.getByText('Sam Chen')).toBeInTheDocument();
 
+    const firstTime = screen.getByText('30 Aug 2026');
+    expect(firstTime).toBeInTheDocument();
+    expect(firstTime).toHaveAttribute('dateTime', '2026-08-30T10:00:00.000Z');
+
+    const secondTime = screen.getByText('29 Aug 2026');
+    expect(secondTime).toBeInTheDocument();
+    expect(secondTime).toHaveAttribute('dateTime', '2026-08-29T15:30:00.000Z');
+
     const link = screen.getByRole('link', { name: 'Realtime Sync' });
     expect(link).toHaveAttribute('href', '/projects/realtime-sync');
   });

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -173,8 +173,8 @@ captures a health category, markdown notes, the author, and a timestamp:
 - **No update** (`no_update`): The initial state before a lead posts the first update.
 
 The workspace feed on the Projects page surfaces the latest update from every
-project in a single stream, giving leads and stakeholders visibility without
-having to inspect each project individually.
+visible project in a single stream, giving leads and stakeholders visibility
+across the workspace without having to inspect each project individually.
 
 The difference from sprints in one line: a sprint is a period of time, a project
 is a body of work. An issue is usually in both.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -164,6 +164,18 @@ runs across several sprints, and has a lead, a target date and a status.
 **Milestones** divide a project into stages, so progress is measured against
 something real rather than a percentage of a moving total.
 
+**Health and updates** track qualitative project status over time. An update
+captures a health category, markdown notes, the author, and a timestamp:
+
+- **On track** (`on_track`): The project is progressing according to schedule.
+- **At risk** (`at_risk`): Blockers, dependency delays, or capacity risks exist.
+- **Off track** (`off_track`): Key milestones or target dates will be missed without intervention.
+- **No update** (`no_update`): The initial state before a lead posts the first update.
+
+The workspace feed on the Projects page surfaces the latest update from every
+project in a single stream, giving leads and stakeholders visibility without
+having to inspect each project individually.
+
 The difference from sprints in one line: a sprint is a period of time, a project
 is a body of work. An issue is usually in both.
 

--- a/packages/core/src/work/project-service.ts
+++ b/packages/core/src/work/project-service.ts
@@ -610,7 +610,6 @@ export interface WorkspaceProjectUpdateRow {
 
 export async function listWorkspaceProjectUpdates(
   principal: Principal,
-  limit = 50,
 ): Promise<WorkspaceProjectUpdateRow[]> {
   assertCan(principal, 'project:read');
 
@@ -625,7 +624,7 @@ export async function listWorkspaceProjectUpdates(
       body: schema.projectUpdate.body,
       createdAt: schema.projectUpdate.createdAt,
       rowNumber:
-        sql<number>`row_number() over (partition by ${schema.projectUpdate.projectId} order by ${schema.projectUpdate.createdAt} desc)`.as(
+        sql<number>`row_number() over (partition by ${schema.projectUpdate.projectId} order by ${schema.projectUpdate.createdAt} desc, ${schema.projectUpdate.id} desc)`.as(
           'rn',
         ),
     })
@@ -654,8 +653,7 @@ export async function listWorkspaceProjectUpdates(
     })
     .from(ranked)
     .where(eq(ranked.rowNumber, 1))
-    .orderBy(desc(ranked.createdAt))
-    .limit(limit);
+    .orderBy(desc(ranked.createdAt), desc(ranked.id));
 }
 
 export interface MilestoneProgress {

--- a/packages/core/src/work/project-service.ts
+++ b/packages/core/src/work/project-service.ts
@@ -613,7 +613,8 @@ export async function listWorkspaceProjectUpdates(
   limit = 50,
 ): Promise<WorkspaceProjectUpdateRow[]> {
   assertCan(principal, 'project:read');
-  return await db
+
+  const ranked = db
     .select({
       id: schema.projectUpdate.id,
       projectId: schema.projectUpdate.projectId,
@@ -623,6 +624,10 @@ export async function listWorkspaceProjectUpdates(
       health: schema.projectUpdate.health,
       body: schema.projectUpdate.body,
       createdAt: schema.projectUpdate.createdAt,
+      rowNumber:
+        sql<number>`row_number() over (partition by ${schema.projectUpdate.projectId} order by ${schema.projectUpdate.createdAt} desc)`.as(
+          'rn',
+        ),
     })
     .from(schema.projectUpdate)
     .innerJoin(schema.project, eq(schema.project.id, schema.projectUpdate.projectId))
@@ -634,7 +639,22 @@ export async function listWorkspaceProjectUpdates(
         visibleProjectFilter(principal),
       ),
     )
-    .orderBy(desc(schema.projectUpdate.createdAt))
+    .as('ranked_project_updates');
+
+  return await db
+    .select({
+      id: ranked.id,
+      projectId: ranked.projectId,
+      projectName: ranked.projectName,
+      projectSlug: ranked.projectSlug,
+      authorId: ranked.authorId,
+      health: ranked.health,
+      body: ranked.body,
+      createdAt: ranked.createdAt,
+    })
+    .from(ranked)
+    .where(eq(ranked.rowNumber, 1))
+    .orderBy(desc(ranked.createdAt))
     .limit(limit);
 }
 

--- a/packages/core/src/work/project-service.ts
+++ b/packages/core/src/work/project-service.ts
@@ -597,6 +597,47 @@ export async function listProjectUpdates(
     .limit(limit);
 }
 
+export interface WorkspaceProjectUpdateRow {
+  readonly id: string;
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly projectSlug: string;
+  readonly authorId: string;
+  readonly health: string;
+  readonly body: string;
+  readonly createdAt: Date;
+}
+
+export async function listWorkspaceProjectUpdates(
+  principal: Principal,
+  limit = 50,
+): Promise<WorkspaceProjectUpdateRow[]> {
+  assertCan(principal, 'project:read');
+  return await db
+    .select({
+      id: schema.projectUpdate.id,
+      projectId: schema.projectUpdate.projectId,
+      projectName: schema.project.name,
+      projectSlug: schema.project.slug,
+      authorId: schema.projectUpdate.authorId,
+      health: schema.projectUpdate.health,
+      body: schema.projectUpdate.body,
+      createdAt: schema.projectUpdate.createdAt,
+    })
+    .from(schema.projectUpdate)
+    .innerJoin(schema.project, eq(schema.project.id, schema.projectUpdate.projectId))
+    .where(
+      and(
+        eq(schema.projectUpdate.organizationId, principal.organizationId),
+        eq(schema.project.organizationId, principal.organizationId),
+        isNull(schema.project.archivedAt),
+        visibleProjectFilter(principal),
+      ),
+    )
+    .orderBy(desc(schema.projectUpdate.createdAt))
+    .limit(limit);
+}
+
 export interface MilestoneProgress {
   readonly milestoneId: string;
   readonly name: string;

--- a/packages/core/tests/work/project-service.test.ts
+++ b/packages/core/tests/work/project-service.test.ts
@@ -705,7 +705,7 @@ describe('listWorkspaceProjectUpdates', () => {
       body: 'Alpha update 2',
     });
 
-    const updates = await listWorkspaceProjectUpdates(workspace.admin, 10);
+    const updates = await listWorkspaceProjectUpdates(workspace.admin);
 
     expect(updates).toHaveLength(2);
     expect(updates[0]?.body).toBe('Alpha update 2');

--- a/packages/core/tests/work/project-service.test.ts
+++ b/packages/core/tests/work/project-service.test.ts
@@ -682,7 +682,7 @@ describe('deleteProject and watched repositories', () => {
 });
 
 describe('listWorkspaceProjectUpdates', () => {
-  it('lists updates across visible projects ordered newest first', async () => {
+  it('lists the most recent update for each visible project ordered newest first', async () => {
     const { project: alpha } = await createProject(workspace.admin, {
       name: 'Alpha',
       teamIds: [workspace.teamId],
@@ -707,13 +707,13 @@ describe('listWorkspaceProjectUpdates', () => {
 
     const updates = await listWorkspaceProjectUpdates(workspace.admin, 10);
 
-    expect(updates).toHaveLength(3);
+    expect(updates).toHaveLength(2);
     expect(updates[0]?.body).toBe('Alpha update 2');
     expect(updates[0]?.projectName).toBe('Alpha');
     expect(updates[0]?.health).toBe('off_track');
     expect(updates[1]?.body).toBe('Beta update 1');
     expect(updates[1]?.projectName).toBe('Beta');
-    expect(updates[2]?.body).toBe('Alpha update 1');
+    expect(updates[1]?.health).toBe('at_risk');
   });
 
   it('hides updates for projects belonging to other teams that the member cannot see', async () => {

--- a/packages/core/tests/work/project-service.test.ts
+++ b/packages/core/tests/work/project-service.test.ts
@@ -32,6 +32,7 @@ import {
   listProjectsForTeams,
   listProjectTeams,
   listProjectUpdates,
+  listWorkspaceProjectUpdates,
   postProjectUpdate,
   projectProgress,
   removeProjectTeam,
@@ -677,5 +678,98 @@ describe('deleteProject and watched repositories', () => {
     await deleteProject(workspace.admin, doomed.id);
 
     expect(await counts()).toEqual({ links: 1, watched: 1 });
+  });
+});
+
+describe('listWorkspaceProjectUpdates', () => {
+  it('lists updates across visible projects ordered newest first', async () => {
+    const { project: alpha } = await createProject(workspace.admin, {
+      name: 'Alpha',
+      teamIds: [workspace.teamId],
+    });
+    const { project: beta } = await createProject(workspace.admin, {
+      name: 'Beta',
+      teamIds: [workspace.teamId],
+    });
+
+    await postProjectUpdate(workspace.admin, alpha.id, {
+      health: 'on_track',
+      body: 'Alpha update 1',
+    });
+    await postProjectUpdate(workspace.admin, beta.id, {
+      health: 'at_risk',
+      body: 'Beta update 1',
+    });
+    await postProjectUpdate(workspace.admin, alpha.id, {
+      health: 'off_track',
+      body: 'Alpha update 2',
+    });
+
+    const updates = await listWorkspaceProjectUpdates(workspace.admin, 10);
+
+    expect(updates).toHaveLength(3);
+    expect(updates[0]?.body).toBe('Alpha update 2');
+    expect(updates[0]?.projectName).toBe('Alpha');
+    expect(updates[0]?.health).toBe('off_track');
+    expect(updates[1]?.body).toBe('Beta update 1');
+    expect(updates[1]?.projectName).toBe('Beta');
+    expect(updates[2]?.body).toBe('Alpha update 1');
+  });
+
+  it('hides updates for projects belonging to other teams that the member cannot see', async () => {
+    const otherTeam = await createTeam(workspace.admin, { name: 'Design', key: 'DSGN' });
+    const { project: secretProject } = await createProject(workspace.admin, {
+      name: 'Secret Design',
+      teamIds: [otherTeam.team.id],
+    });
+    const { project: publicProject } = await createProject(workspace.admin, {
+      name: 'General Public',
+      teamIds: [workspace.teamId],
+    });
+
+    await postProjectUpdate(workspace.admin, secretProject.id, {
+      health: 'on_track',
+      body: 'Secret update',
+    });
+    await postProjectUpdate(workspace.admin, publicProject.id, {
+      health: 'on_track',
+      body: 'Public update',
+    });
+
+    const { principal: engineer } = await addMember(workspace, 'member');
+    const updates = await listWorkspaceProjectUpdates(engineer);
+
+    expect(updates.map((u) => u.projectId)).toContain(publicProject.id);
+    expect(updates.map((u) => u.projectId)).not.toContain(secretProject.id);
+  });
+
+  it('excludes updates from archived projects', async () => {
+    const { project } = await createProject(workspace.admin, {
+      name: 'Soon archived',
+      teamIds: [workspace.teamId],
+    });
+    await postProjectUpdate(workspace.admin, project.id, {
+      health: 'on_track',
+      body: 'Archived project update',
+    });
+
+    await archiveProject(workspace.admin, project.id);
+
+    const updates = await listWorkspaceProjectUpdates(workspace.admin);
+    expect(updates.map((u) => u.projectId)).not.toContain(project.id);
+  });
+
+  it('enforces workspace isolation', async () => {
+    const otherWorkspace = await createWorkspace();
+    const { project: otherProject } = await createProject(otherWorkspace.admin, {
+      name: 'Other Org Project',
+    });
+    await postProjectUpdate(otherWorkspace.admin, otherProject.id, {
+      health: 'on_track',
+      body: 'Other org update',
+    });
+
+    const updates = await listWorkspaceProjectUpdates(workspace.admin);
+    expect(updates.map((u) => u.projectId)).not.toContain(otherProject.id);
   });
 });

--- a/packages/db/src/ensure-test-databases.ts
+++ b/packages/db/src/ensure-test-databases.ts
@@ -83,7 +83,7 @@ console.log(`\n${TEST_DATABASES.length} test databases ready. Applying the schem
 
 for (const name of TEST_DATABASES) {
   const url = databaseUrl(connectionString, name);
-  const push = Bun.spawn(['bunx', 'drizzle-kit', 'push', '--force'], {
+  const push = Bun.spawn([process.execPath, 'x', 'drizzle-kit', 'push', '--force'], {
     env: { ...process.env, DATABASE_URL: url },
     stdout: 'pipe',
     stderr: 'pipe',

--- a/packages/db/src/ensure-test-databases.ts
+++ b/packages/db/src/ensure-test-databases.ts
@@ -83,7 +83,7 @@ console.log(`\n${TEST_DATABASES.length} test databases ready. Applying the schem
 
 for (const name of TEST_DATABASES) {
   const url = databaseUrl(connectionString, name);
-  const push = Bun.spawn([process.execPath, 'x', 'drizzle-kit', 'push', '--force'], {
+  const push = Bun.spawn(['bunx', 'drizzle-kit', 'push', '--force'], {
     env: { ...process.env, DATABASE_URL: url },
     stdout: 'pipe',
     stderr: 'pipe',


### PR DESCRIPTION
## What this changes

Adds a workspace-level project updates feed on `/projects` with a view switcher between the project overview table and the recent updates stream, and documents project health states in concepts documentation.

## Why

Project updates were stored in the database but could only be read by navigating into individual projects. This gives leads and members a single central surface to read the latest updates and health across all visible projects in the workspace.

Part of #213

## How you know it works

- Added unit/integration tests in `packages/core/tests/work/project-service.test.ts` verifying `listWorkspaceProjectUpdates` handles multi-project ordering (newest first), team visibility isolation, archived project exclusion, and workspace tenant boundaries.
- Added component tests in `apps/web/tests/features/projects/project-feed.test.tsx` verifying empty state and update cards rendering with health chips and author attribution.
- Tested locally on `http://localhost:3000/projects` verifying seamless switching between table and feed views.

## Screenshots

### Projects Table View
<img width="1160" height="477" alt="image" src="https://github.com/user-attachments/assets/17fffea0-9dd4-45ea-9c8c-41e45b308ede" />


### Workspace Updates Feed View
<img width="1140" height="327" alt="image" src="https://github.com/user-attachments/assets/cc8273b5-a267-4292-83eb-e445da521f18" />

## Checklist

- [x] `bun run verify` is green, all four checks
- [x] Tests added or updated, and they fail without the change
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions
- [x] External input is parsed with a Zod schema from `@orbit/shared`
- [x] Authorization is enforced on the server through `packages/shared/src/policy`, not only in the UI
- [x] Docs updated if behaviour, configuration or setup changed
- [x] `bun run db:release` and `bun run db:check-drift` passed against the target database before this ships

## Anything reviewers should know

Reused existing `HealthChip` and `visibleProjectFilter` helpers so styling and team scoping remain consistent across project views.








<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a Projects-page view switcher and a workspace feed containing the latest update from every visible active project, along with project-health documentation.
- Uses a ranked query to select one latest update per project without globally truncating the result.
- Applies existing workspace, team-visibility, and archived-project filters.
- Adds feed rendering and coverage for ordering, visibility, tenant isolation, archived projects, empty state, health, and author attribution.
- Documents project health categories and the workspace feed.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/work/project-service.ts | Selects the latest update per visible active project through a ranked subquery and removes the residual global limit raised in the prior threads. |
| apps/web/src/features/projects/data.ts | Maps workspace update records into display-ready project, health, author, body, and timestamp data. |
| apps/web/src/app/(app)/projects/page.tsx | Adds the table/feed view switcher and conditionally loads and renders workspace updates. |
| apps/web/src/features/projects/project-feed.tsx | Renders the updates feed, project links, health chips, dates, author attribution, and empty state. |
| packages/core/tests/work/project-service.test.ts | Covers latest-per-project ordering, team visibility, archived-project exclusion, and workspace isolation. |
| apps/web/tests/features/projects/project-feed.test.tsx | Covers feed empty-state and populated-card rendering behavior. |
| docs/concepts.md | Documents project health categories and workspace-feed behavior. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(projects): use tabHover in view swit..."](https://github.com/noveum/orbit/commit/fcbb82f64db9bc4b1295e3cdf9744fe6293b50a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58358874)</sub>

<!-- /greptile_comment -->