### PR TITLE
test(e2e): wait for attachment completion

### DIFF
--- a/apps/web/e2e/issue-attachments.spec.ts
+++ b/apps/web/e2e/issue-attachments.spec.ts
@@ -36,7 +36,7 @@ async function signIn(context: BrowserContext, email: string): Promise<Page> {
 test('a screenshot dropped on an issue description is uploaded and shown inline', async ({
   browser,
 }) => {
-  test.setTimeout(240_000);
+  test.setTimeout(300_000);
   const context = await browser.newContext({ viewport: { width: 1500, height: 950 } });
   const page = await signIn(context, 'alex@orbit.example');
 
@@ -76,7 +76,7 @@ test('a screenshot dropped on an issue description is uploaded and shown inline'
 });
 
 test('an html artifact attached to an issue renders in a sandboxed frame', async ({ browser }) => {
-  test.setTimeout(240_000);
+  test.setTimeout(300_000);
   const context = await browser.newContext({ viewport: { width: 1500, height: 950 } });
   const page = await signIn(context, 'alex@orbit.example');
 

--- a/apps/web/e2e/issue-attachments.spec.ts
+++ b/apps/web/e2e/issue-attachments.spec.ts
@@ -1,9 +1,29 @@
-import { type BrowserContext, expect, type Page, test } from '@playwright/test';
+import {
+  type BrowserContext,
+  expect,
+  type Page,
+  type Response as PlaywrightResponse,
+  test,
+} from '@playwright/test';
 import { createIssue, descriptionOf, teamIdByKey } from './api.ts';
 import { BASE } from './base-url.ts';
 
 const PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+function waitForAttachmentCompletion(page: Page): Promise<PlaywrightResponse> {
+  return page.waitForResponse(
+    (response) => {
+      const path = new URL(response.url()).pathname;
+      return (
+        response.request().method() === 'POST' &&
+        path.startsWith('/api/attachments/') &&
+        path.endsWith('/complete')
+      );
+    },
+    { timeout: 90_000 },
+  );
+}
 
 async function signIn(context: BrowserContext, email: string): Promise<Page> {
   const page = await context.newPage();
@@ -16,7 +36,7 @@ async function signIn(context: BrowserContext, email: string): Promise<Page> {
 test('a screenshot dropped on an issue description is uploaded and shown inline', async ({
   browser,
 }) => {
-  test.setTimeout(180_000);
+  test.setTimeout(240_000);
   const context = await browser.newContext({ viewport: { width: 1500, height: 950 } });
   const page = await signIn(context, 'alex@orbit.example');
 
@@ -35,9 +55,11 @@ test('a screenshot dropped on an issue description is uploaded and shown inline'
     data.items.add(new File([binary], 'screenshot.png', { type: 'image/png' }));
     return data;
   }, PNG_BASE64);
+  const completion = waitForAttachmentCompletion(page);
   await editor.dispatchEvent('drop', { dataTransfer: transfer });
 
-  await expect(editor.locator('img')).toBeVisible({ timeout: 30_000 });
+  expect((await completion).ok()).toBe(true);
+  await expect(editor.locator('img')).toBeVisible();
   const src = await editor.locator('img').first().getAttribute('src');
   expect(src ?? '').toContain('/api/files/');
 
@@ -54,7 +76,7 @@ test('a screenshot dropped on an issue description is uploaded and shown inline'
 });
 
 test('an html artifact attached to an issue renders in a sandboxed frame', async ({ browser }) => {
-  test.setTimeout(180_000);
+  test.setTimeout(240_000);
   const context = await browser.newContext({ viewport: { width: 1500, height: 950 } });
   const page = await signIn(context, 'alex@orbit.example');
 
@@ -75,8 +97,10 @@ test('an html artifact attached to an issue renders in a sandboxed frame', async
     );
     return data;
   });
+  const completion = waitForAttachmentCompletion(page);
   await editor.dispatchEvent('drop', { dataTransfer: transfer });
 
+  expect((await completion).ok()).toBe(true);
   await expect
     .poll(async () => await descriptionOf(page, made.identifier), { timeout: 30_000 })
     .toContain('/api/files/');

--- a/apps/web/e2e/issue-attachments.spec.ts
+++ b/apps/web/e2e/issue-attachments.spec.ts
@@ -21,7 +21,7 @@ function waitForAttachmentCompletion(page: Page): Promise<PlaywrightResponse> {
         path.endsWith('/complete')
       );
     },
-    { timeout: 90_000 },
+    { timeout: 120_000 },
   );
 }
 


### PR DESCRIPTION
## What this changes

Wait for the attachment completion endpoint before asserting rendered and persisted upload state in the PNG and HTML attachment E2E coverage. The response listener is registered before the drop, requires a successful completion response, and allows enough overall test time for the remaining UI, persistence, reload, and sandbox assertions.

## Why

[Main CI attempt 1](https://github.com/Noveum/orbit/actions/runs/33421187930/attempts/1) timed out after 30 seconds while the PNG upload was still waiting on its presign request during long Next.js development cache compactions. The exact same source tree passed immediately before the merge, and [attempt 2](https://github.com/Noveum/orbit/actions/runs/33421187930) passed without a code change, so this is a narrow test-resilience fix rather than a product or Slack fix.

The separate PostgreSQL service-pull timeout in attempt 1 was external Docker Hub infrastructure and cleared on rerun. This change does not claim to address it.

## How you know it works

- `bun --env-file=../../.env --bun playwright test e2e/issue-attachments.spec.ts`: 2 passed on the final diff
- `bun --env-file=../../.env --bun playwright test e2e/issue-attachments.spec.ts --repeat-each=3`: 6 passed
- `bun --env-file=../../.env test tests/features/analytics --timeout 20000`: 152 passed
- Repository lint, comment policy, source-byte policy, Bun-import policy, dependency dedupe, and every type check passed
- [Exact-head GitHub CI](https://github.com/Noveum/orbit/actions/runs/33431280254) passed build, migrations, unit and integration tests, and the complete Playwright suite
- An independent review found no remaining correctness, security, performance, or maintainability issues after the timeout budget was raised to 300 seconds

## Checklist

- [x] `bun run verify` is green, all four checks
- [x] Tests added or updated, and the original test failed on main attempt 1
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions
- [x] External input parsing is not applicable to this E2E-only change
- [x] Authorization is not changed
- [x] Docs are not needed because product behavior and setup are unchanged
- [x] Database release and drift checks are not applicable because schema and migrations are unchanged

## Anything reviewers should know

On local macOS, Bun 1.3.14 traps at the same late `line-plot.test.tsx` suite boundary after all earlier web tests pass. The file passes 16 of 16 alone, the complete analytics directory passes 152 of 152, and exact-head GitHub CI passed the complete Linux unit and integration suite. The hosted run is the authoritative full-suite result for this PR.
