### PR TITLE
fix(slack): use query request for channel lookup

### DIFF
--- a/packages/services/src/slack/index.ts
+++ b/packages/services/src/slack/index.ts
@@ -371,7 +371,7 @@ export class SlackClient {
   }
 
   async conversation(channelId: string): Promise<SlackChannel> {
-    const body = await this.call('conversations.info', conversationResponseSchema, {
+    const body = await this.callQuery('conversations.info', conversationResponseSchema, {
       channel: channelId,
     });
     return {
@@ -400,12 +400,12 @@ export class SlackClient {
     };
   }
 
-  private async call<T extends z.ZodTypeAny>(
+  private call<T extends z.ZodTypeAny>(
     method: string,
     schema: T,
     payload: Record<string, unknown>,
   ): Promise<SuccessfulSlackResponse<T>> {
-    const response = await this.fetchImpl(`${this.baseUrl}/${method}`, {
+    return this.request(method, schema, `${this.baseUrl}/${method}`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${this.token}`,
@@ -414,6 +414,29 @@ export class SlackClient {
       body: JSON.stringify(payload),
       signal: AbortSignal.timeout(SLACK_REQUEST_TIMEOUT_MS),
     });
+  }
+
+  private callQuery<T extends z.ZodTypeAny>(
+    method: string,
+    schema: T,
+    payload: Record<string, string>,
+  ): Promise<SuccessfulSlackResponse<T>> {
+    const url = new URL(`${this.baseUrl}/${method}`);
+    for (const [key, value] of Object.entries(payload)) url.searchParams.set(key, value);
+    return this.request(method, schema, url, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${this.token}` },
+      signal: AbortSignal.timeout(SLACK_REQUEST_TIMEOUT_MS),
+    });
+  }
+
+  private async request<T extends z.ZodTypeAny>(
+    method: string,
+    schema: T,
+    input: string | URL,
+    init: RequestInit,
+  ): Promise<SuccessfulSlackResponse<T>> {
+    const response = await this.fetchImpl(input, init);
     if (response.status === 429) {
       const retryAfterSeconds = Number(response.headers.get('retry-after'));
       const retryAfterMs =

--- a/packages/services/tests/slack/slack.test.ts
+++ b/packages/services/tests/slack/slack.test.ts
@@ -320,8 +320,9 @@ describe('SlackClient', () => {
       isArchived: false,
       isMember: true,
     });
-    expect(calls[0]?.url).toBe('https://slack.com/api/conversations.info');
-    expect(calls[0]?.init?.body).toBe(JSON.stringify({ channel: 'C-REQUESTED' }));
+    expect(calls[0]?.url).toBe('https://slack.com/api/conversations.info?channel=C-REQUESTED');
+    expect(calls[0]?.init?.method).toBe('GET');
+    expect(calls[0]?.init?.body).toBeUndefined();
   });
 
   it('rejects incomplete canonical channel metadata', async () => {


### PR DESCRIPTION
## What this changes

Uses Slack's documented GET query transport for `conversations.info` while preserving the existing shared response, rate-limit, and error handling.

## Why

Slack returned `invalid_arguments` for the POST JSON request in production, which prevented administrators from connecting a joined Slack channel.

## How you know it works

- The transport regression test failed against the previous implementation and passes with the fix.
- The complete services suite passes: 655 tests, 0 failures.
- The Slack integration route tests pass: 16 tests, 0 failures.
- Lint, comment policy, source byte, Bun import, dependency, and monorepo type checks pass.
- The aggregate test process reached the web suite with no assertion failures before Bun 1.3.14 exited with SIGTRAP. The file active at the crash passes 16 tests in isolation.

## Checklist

- [ ] `bun run verify` is green, all four checks
- [x] Tests added or updated, and they fail without the change
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions
- [x] External input remains parsed by the existing Zod response schema
- [x] Authorization behavior is unchanged
- [x] No documentation change is required for this provider transport fix
- [ ] Database release and drift checks are not applicable because this changes no schema or data

## Anything reviewers should know

CI is the final full-suite gate because the local aggregate Bun process crashed without a test assertion failure. The affected package, route tests, and crash-point file all pass independently.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes Slack `conversations.info` channel lookup from a POST JSON request to Slack's GET query transport while retaining shared parsing and error handling.
- Adds a query-based request helper and extracts common response handling.
- Updates the channel metadata test to verify GET transport, query encoding, and the absence of a request body.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The channel lookup now uses the intended GET query transport, while existing response validation, rate-limit handling, and Slack error propagation remain intact and are covered by the updated regression test.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/services/src/slack/index.ts | Routes channel lookup through a GET query request and preserves the existing shared Slack response, rate-limit, and error handling. |
| packages/services/tests/slack/slack.test.ts | Updates the channel lookup regression test to assert the documented GET query transport. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(slack): use query request for channe..."](https://github.com/noveum/orbit/commit/d07205e12d40e91c42067909dd14bc2e7004996b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58764537)</sub>

<!-- /greptile_comment -->