### PR TITLE
feat(slack): sync every workspace member

### DIFF
--- a/apps/web/src/app/api/integrations/slack/route.ts
+++ b/apps/web/src/app/api/integrations/slack/route.ts
@@ -2,13 +2,15 @@ import { and, db, eq, schema } from '@orbit/db';
 import {
   connectCanonicalSlackChannel,
   disconnectSlackChannel,
+  isSlackReauthorizationError,
   listSlackConversations,
+  SlackApiError,
+  syncSlackUserMappings,
 } from '@orbit/services';
 import { hasSlackBotToken } from '@orbit/services/slack/credentials';
-import { validationFailed } from '@orbit/shared/errors';
+import { conflict, rateLimited, validationFailed } from '@orbit/shared/errors';
 import { assertCan } from '@orbit/shared/policy';
-import { slackConnectChannelSchema, slackDisconnectChannelSchema } from '@orbit/shared/validators';
-import { z } from 'zod';
+import { slackIntegrationActionSchema } from '@orbit/shared/validators';
 import { apiContext, handleRoute, readJson } from '@/lib/api/handler.ts';
 import {
   slackIntegrationEnabledForOrganization,
@@ -16,11 +18,6 @@ import {
   slackRolloutConfigured,
 } from '@/lib/integrations/slack-capability.ts';
 import { assertTeamInWorkspace } from '@/lib/workspace.ts';
-
-const requestSchema = z.discriminatedUnion('action', [
-  slackConnectChannelSchema.extend({ action: z.literal('connect') }),
-  slackDisconnectChannelSchema.extend({ action: z.literal('disconnect') }),
-]);
 
 export async function GET(): Promise<Response> {
   if (!slackRolloutConfigured()) return slackIntegrationUnavailable();
@@ -72,7 +69,11 @@ export async function POST(request: Request): Promise<Response> {
     if (!slackIntegrationEnabledForOrganization(principal.organizationId))
       return slackIntegrationUnavailable();
     assertCan(principal, 'integration:manage');
-    const input = requestSchema.parse(await readJson(request));
+    const input = slackIntegrationActionSchema.parse(await readJson(request));
+
+    if (input.action === 'sync_members') {
+      return await syncSlackMembers(principal.organizationId, principal.userId);
+    }
 
     if (input.action === 'connect') {
       if (input.teamId !== null) await assertTeamInWorkspace(principal, input.teamId);
@@ -89,6 +90,28 @@ export async function POST(request: Request): Promise<Response> {
     const removed = await disconnectSlackChannel(db, { integrationId, channelId: input.channelId });
     return { removed };
   });
+}
+
+async function syncSlackMembers(
+  organizationId: string,
+  userId: string,
+): Promise<{ readonly eligible: number; readonly mapped: number }> {
+  let result: Awaited<ReturnType<typeof syncSlackUserMappings>>;
+  try {
+    result = await syncSlackUserMappings(db, { organizationId, userId });
+  } catch (error) {
+    if (error instanceof SlackApiError && error.code === 'ratelimited') {
+      throw rateLimited('Slack is busy. Try syncing members again shortly.');
+    }
+    if (isSlackReauthorizationError(error)) {
+      throw validationFailed('Reconnect Slack before syncing members.');
+    }
+    throw error;
+  }
+  if (result.status === 'stale') {
+    throw conflict('Slack changed while members were syncing. Try again.');
+  }
+  return { eligible: result.eligibleMembers, mapped: result.mappedMembers };
 }
 
 async function slackIntegrationId(organizationId: string): Promise<string> {

--- a/apps/web/src/features/settings/integrations-connect.ts
+++ b/apps/web/src/features/settings/integrations-connect.ts
@@ -1,11 +1,8 @@
-import { and, db, eq } from '@orbit/db';
-import { integration, slackUserMapping, user } from '@orbit/db/schema';
-import { SlackClient } from '@orbit/services/slack';
+import { db } from '@orbit/db';
 import {
   assertSlackIntegrationManager,
   ensureSlackIntegrationWithVersion,
-  slackCredentialVersionExpression,
-  upsertSlackUserMapping,
+  syncSlackUserMappings,
 } from '@orbit/services/slack/dispatch';
 import { internal } from '@orbit/shared/errors';
 import { z } from 'zod';
@@ -68,7 +65,7 @@ export async function completeSlackInstall(input: {
     .split(',')
     .map((scope) => scope.trim())
     .filter((scope) => scope.length > 0);
-  const connected = await db.transaction(async (tx) => {
+  await db.transaction(async (tx) => {
     return await ensureSlackIntegrationWithVersion(tx, {
       organizationId: input.organizationId,
       connectedById: input.userId,
@@ -77,87 +74,8 @@ export async function completeSlackInstall(input: {
       scopes: grantedScopes,
     });
   });
-  const integrationId = connected.id;
-
-  const [orbitUser] = await db
-    .select({ email: user.email })
-    .from(user)
-    .where(eq(user.id, input.userId))
-    .limit(1);
-  if (orbitUser === undefined) return;
-
-  let slackUser: Awaited<ReturnType<SlackClient['lookupUserByEmail']>>;
-  try {
-    slackUser = await new SlackClient({ token: accessToken }).lookupUserByEmail(
-      orbitUser.email.trim().toLowerCase(),
-    );
-  } catch (error) {
-    await reconcileSlackUserMapping({
-      organizationId: input.organizationId,
-      integrationId,
-      integrationVersion: connected.integrationVersion,
-      userId: input.userId,
-      slackTeamId,
-      slackUser: null,
-    });
-    console.error('Could not map the Slack user after installation.', error);
-    return;
-  }
-  await reconcileSlackUserMapping({
+  await syncSlackUserMappings(db, {
     organizationId: input.organizationId,
-    integrationId,
-    integrationVersion: connected.integrationVersion,
     userId: input.userId,
-    slackTeamId,
-    slackUser,
-  });
-}
-
-async function reconcileSlackUserMapping(input: {
-  readonly organizationId: string;
-  readonly integrationId: string;
-  readonly integrationVersion: string;
-  readonly userId: string;
-  readonly slackTeamId: string;
-  readonly slackUser: Awaited<ReturnType<SlackClient['lookupUserByEmail']>>;
-}): Promise<void> {
-  await db.transaction(async (tx) => {
-    const [current] = await tx
-      .select({
-        config: integration.config,
-        integrationVersion: slackCredentialVersionExpression(),
-      })
-      .from(integration)
-      .where(
-        and(
-          eq(integration.id, input.integrationId),
-          eq(integration.organizationId, input.organizationId),
-          eq(integration.provider, 'slack'),
-        ),
-      )
-      .limit(1)
-      .for('update');
-    if (current === undefined) return;
-    if (current.integrationVersion !== input.integrationVersion) return;
-    if (current.config['slackTeamId'] !== input.slackTeamId) return;
-    if (input.slackUser === null) {
-      await tx
-        .delete(slackUserMapping)
-        .where(
-          and(
-            eq(slackUserMapping.organizationId, input.organizationId),
-            eq(slackUserMapping.integrationId, input.integrationId),
-            eq(slackUserMapping.userId, input.userId),
-          ),
-        );
-      return;
-    }
-    await upsertSlackUserMapping(tx, {
-      organizationId: input.organizationId,
-      integrationId: input.integrationId,
-      userId: input.userId,
-      slackUserId: input.slackUser.id,
-      slackDisplayName: input.slackUser.displayName,
-    });
   });
 }

--- a/apps/web/src/features/settings/integrations-data.ts
+++ b/apps/web/src/features/settings/integrations-data.ts
@@ -1,6 +1,6 @@
 import { and, count, db, desc, eq, schema } from '@orbit/db';
 import { hasSlackBotToken } from '@orbit/services/slack/credentials';
-import { resolveSlackContext, type SlackContext } from '@orbit/services/slack/dispatch';
+import { resolveSlackContext, slackUserMappingSyncReady } from '@orbit/services/slack/dispatch';
 import { can, type Principal } from '@orbit/shared/policy';
 import { slackConnectReady } from '@/lib/env.ts';
 import { slackIntegrationEnabledForOrganization } from '@/lib/integrations/slack-capability.ts';
@@ -106,30 +106,13 @@ export async function loadIntegrationSettings(principal: Principal): Promise<Int
       teams,
       memberSync: {
         ...memberSync,
-        ready: slackMemberSyncReady(slackRow, slackContext),
+        ready: slackUserMappingSyncReady({
+          context: slackContext,
+          slackTeamId: slackRow?.config['slackTeamId'],
+        }),
       },
     },
   };
-}
-
-function slackMemberSyncReady(
-  row:
-    | {
-        readonly credentials: unknown;
-        readonly config: Record<string, unknown>;
-      }
-    | undefined,
-  context: SlackContext | null,
-): boolean {
-  if (row === undefined || context === null || context.token === null) return false;
-  const slackTeamId = row.config['slackTeamId'];
-  return (
-    !context.reauthorize &&
-    typeof slackTeamId === 'string' &&
-    slackTeamId.length > 0 &&
-    context.scopes.includes('users:read') &&
-    context.scopes.includes('users:read.email')
-  );
 }
 
 async function loadSlackMemberSync(

--- a/apps/web/src/features/settings/integrations-data.ts
+++ b/apps/web/src/features/settings/integrations-data.ts
@@ -1,5 +1,6 @@
-import { and, db, desc, eq, schema } from '@orbit/db';
+import { and, count, db, desc, eq, schema } from '@orbit/db';
 import { hasSlackBotToken } from '@orbit/services/slack/credentials';
+import { resolveSlackContext, type SlackContext } from '@orbit/services/slack/dispatch';
 import { can, type Principal } from '@orbit/shared/policy';
 import { slackConnectReady } from '@/lib/env.ts';
 import { slackIntegrationEnabledForOrganization } from '@/lib/integrations/slack-capability.ts';
@@ -26,6 +27,11 @@ export interface SlackIntegrationSettings {
   readonly slackConnectEnabled: boolean;
   readonly channels: ConnectedChannel[];
   readonly teams: IntegrationTeam[];
+  readonly memberSync: {
+    readonly eligible: number;
+    readonly mapped: number;
+    readonly ready: boolean;
+  };
 }
 
 export interface IntegrationSettings {
@@ -50,11 +56,12 @@ export async function loadIntegrationSettings(principal: Principal): Promise<Int
   const github = await loadGithubSettings(principal);
   if (!slackIntegrationEnabledForOrganization(principal.organizationId)) return { github };
 
-  const [slackRows, teams] = await Promise.all([
+  const [slackRows, teams, slackContext] = await Promise.all([
     db
       .select({
         id: schema.integration.id,
         credentials: schema.integration.credentials,
+        config: schema.integration.config,
       })
       .from(schema.integration)
       .where(
@@ -66,13 +73,14 @@ export async function loadIntegrationSettings(principal: Principal): Promise<Int
       )
       .limit(1),
     listTeamsForPrincipal(principal),
+    resolveSlackContext(db, principal.organizationId, 'default'),
   ]);
 
   const slackRow = slackRows[0];
-  const channels =
+  const [channels, memberSync] = await Promise.all([
     slackRow === undefined
-      ? []
-      : await db
+      ? Promise.resolve([])
+      : db
           .select({
             channelId: schema.slackChannelSync.channelId,
             channelName: schema.slackChannelSync.channelName,
@@ -85,7 +93,9 @@ export async function loadIntegrationSettings(principal: Principal): Promise<Int
               eq(schema.slackChannelSync.organizationId, principal.organizationId),
               eq(schema.slackChannelSync.integrationId, slackRow.id),
             ),
-          );
+          ),
+    loadSlackMemberSync(principal.organizationId, slackRow?.id),
+  ]);
   return {
     github,
     slack: {
@@ -94,8 +104,61 @@ export async function loadIntegrationSettings(principal: Principal): Promise<Int
       slackConnectEnabled: slackConnectReady(),
       channels,
       teams,
+      memberSync: {
+        ...memberSync,
+        ready: slackMemberSyncReady(slackRow, slackContext),
+      },
     },
   };
+}
+
+function slackMemberSyncReady(
+  row:
+    | {
+        readonly credentials: unknown;
+        readonly config: Record<string, unknown>;
+      }
+    | undefined,
+  context: SlackContext | null,
+): boolean {
+  if (row === undefined || context === null || context.token === null) return false;
+  const slackTeamId = row.config['slackTeamId'];
+  return (
+    !context.reauthorize &&
+    typeof slackTeamId === 'string' &&
+    slackTeamId.length > 0 &&
+    context.scopes.includes('users:read') &&
+    context.scopes.includes('users:read.email')
+  );
+}
+
+async function loadSlackMemberSync(
+  organizationId: string,
+  integrationId: string | undefined,
+): Promise<{ readonly eligible: number; readonly mapped: number }> {
+  if (integrationId === undefined) {
+    const [summary] = await db
+      .select({ eligible: count(schema.member.userId) })
+      .from(schema.member)
+      .where(eq(schema.member.organizationId, organizationId));
+    return { eligible: summary?.eligible ?? 0, mapped: 0 };
+  }
+  const [summary] = await db
+    .select({
+      eligible: count(schema.member.userId),
+      mapped: count(schema.slackUserMapping.id),
+    })
+    .from(schema.member)
+    .leftJoin(
+      schema.slackUserMapping,
+      and(
+        eq(schema.slackUserMapping.organizationId, organizationId),
+        eq(schema.slackUserMapping.integrationId, integrationId),
+        eq(schema.slackUserMapping.userId, schema.member.userId),
+      ),
+    )
+    .where(eq(schema.member.organizationId, organizationId));
+  return { eligible: summary?.eligible ?? 0, mapped: summary?.mapped ?? 0 };
 }
 
 export interface GithubDeliveryView {

--- a/apps/web/src/features/settings/integrations-panel.tsx
+++ b/apps/web/src/features/settings/integrations-panel.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import { slackMemberSyncResultSchema } from '@orbit/shared/validators';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
-import { z } from 'zod';
 import { Badge } from '@/components/ui/badge.tsx';
 import { Button } from '@/components/ui/button.tsx';
 import { apiRequest, messageOf } from '@/lib/api/client.ts';
@@ -107,11 +107,6 @@ type CallFn = (
   method: string,
   body: Record<string, unknown>,
 ) => Promise<unknown | null>;
-
-const slackMemberSyncResultSchema = z.object({
-  eligible: z.number().int().nonnegative(),
-  mapped: z.number().int().nonnegative(),
-});
 
 function ConnectionBadge({ connected }: { connected: boolean }) {
   return connected ? (
@@ -325,7 +320,7 @@ function SlackSection({
                 Connect a channel
               </Button>
               {settings.memberSync.ready ? (
-                <Button variant="secondary" size="sm" disabled={syncing} onClick={syncMembers}>
+                <Button variant="secondary" size="sm" aria-disabled={syncing} onClick={syncMembers}>
                   {syncing ? 'Syncing Slack members' : 'Sync Slack members'}
                 </Button>
               ) : null}

--- a/apps/web/src/features/settings/integrations-panel.tsx
+++ b/apps/web/src/features/settings/integrations-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { z } from 'zod';
 import { Badge } from '@/components/ui/badge.tsx';
 import { Button } from '@/components/ui/button.tsx';
 import { apiRequest, messageOf } from '@/lib/api/client.ts';
@@ -38,13 +39,19 @@ export function IntegrationsPanel({
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
 
-  async function call(path: string, method: string, body: Record<string, unknown>): Promise<void> {
+  async function call(
+    path: string,
+    method: string,
+    body: Record<string, unknown>,
+  ): Promise<unknown | null> {
     setError(null);
     try {
-      await apiRequest(path, { method, body });
+      const payload = await apiRequest<unknown>(path, { method, body });
       router.refresh();
+      return payload;
     } catch (caught) {
       setError(messageOf(caught));
+      return null;
     }
   }
 
@@ -66,7 +73,13 @@ export function IntegrationsPanel({
             <GithubPanel settings={settings.github} canManage={canManage} onError={setError} />
           </IntegrationCard>
           {settings.slack === undefined ? null : (
-            <SlackSection settings={settings.slack} canManage={canManage} onCall={call} />
+            <SlackSection
+              settings={settings.slack}
+              canManage={canManage}
+              onCall={call}
+              onError={setError}
+              onSyncSuccess={() => router.replace('/settings/integrations', { scroll: false })}
+            />
           )}
         </>
       ) : (
@@ -80,16 +93,25 @@ export function IntegrationsPanel({
 function WorkspaceIntegrationsWithheld() {
   return (
     <section className="flex flex-col gap-1.5 rounded-xl border border-border bg-surface p-4 sm:p-5">
-      <h3 className="font-medium text-dense text-text">GitHub</h3>
+      <h3 className="font-medium text-dense text-text">Workspace integrations</h3>
       <p className="text-muted text-xs" data-testid="integrations-withheld">
-        Only workspace admins can see which repositories this workspace is connected to. Your own
-        MCP client connections are below.
+        Only workspace admins can see and manage connected providers. Your own MCP client
+        connections are below.
       </p>
     </section>
   );
 }
 
-type CallFn = (path: string, method: string, body: Record<string, unknown>) => Promise<void>;
+type CallFn = (
+  path: string,
+  method: string,
+  body: Record<string, unknown>,
+) => Promise<unknown | null>;
+
+const slackMemberSyncResultSchema = z.object({
+  eligible: z.number().int().nonnegative(),
+  mapped: z.number().int().nonnegative(),
+});
 
 function ConnectionBadge({ connected }: { connected: boolean }) {
   return connected ? (
@@ -230,12 +252,37 @@ function SlackSection({
   settings,
   canManage,
   onCall,
+  onError,
+  onSyncSuccess,
 }: {
   settings: SlackIntegrationSettings;
   canManage: boolean;
   onCall: CallFn;
+  onError: (message: string | null) => void;
+  onSyncSuccess: () => void;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [syncStatus, setSyncStatus] = useState<string | null>(null);
+
+  async function syncMembers(): Promise<void> {
+    setSyncing(true);
+    setSyncStatus(null);
+    const payload = await onCall('/api/integrations/slack', 'POST', {
+      action: 'sync_members',
+    });
+    setSyncing(false);
+    if (payload === null) return;
+    const parsed = slackMemberSyncResultSchema.safeParse(payload);
+    if (!parsed.success) {
+      onError('Slack returned an unexpected member sync response.');
+      return;
+    }
+    setSyncStatus(
+      `Slack member sync completed: ${parsed.data.mapped} of ${parsed.data.eligible} matched.`,
+    );
+    onSyncSuccess();
+  }
 
   return (
     <IntegrationCard
@@ -245,6 +292,18 @@ function SlackSection({
     >
       {settings.slackHasToken ? (
         <div className="flex flex-col gap-2.5">
+          <p className="text-faint text-xs">
+            {settings.memberSync.mapped} of {settings.memberSync.eligible} workspace members matched
+            by email.
+          </p>
+          {settings.memberSync.ready ? null : (
+            <p className="text-faint text-xs">Reconnect Slack to enable workspace member sync.</p>
+          )}
+          {syncStatus === null ? null : (
+            <p role="status" className="text-success text-xs">
+              {syncStatus}
+            </p>
+          )}
           <ul className="flex flex-col overflow-hidden rounded-lg border border-border">
             {settings.channels.length === 0 ? (
               <li className="px-3 py-2.5 text-faint text-xs">No channels connected yet.</li>
@@ -265,6 +324,11 @@ function SlackSection({
               <Button variant="primary" size="sm" onClick={() => setPickerOpen(true)}>
                 Connect a channel
               </Button>
+              {settings.memberSync.ready ? (
+                <Button variant="secondary" size="sm" disabled={syncing} onClick={syncMembers}>
+                  {syncing ? 'Syncing Slack members' : 'Sync Slack members'}
+                </Button>
+              ) : null}
               <ConnectLink
                 href="/api/integrations/slack/start"
                 label="Reconnect Slack"

--- a/apps/web/src/features/settings/slack-connect-notice.tsx
+++ b/apps/web/src/features/settings/slack-connect-notice.tsx
@@ -8,7 +8,8 @@ export function slackConnectStatusOf(value: unknown): SlackConnectStatus | null 
 
 const MESSAGES: Record<SlackConnectStatus, string> = {
   connected: 'Slack is connected. Invite the Orbit bot to a channel, then map it below.',
-  error: 'Orbit could not finish connecting to Slack. Start the connection again.',
+  error:
+    'Orbit could not finish Slack setup. If Slack appears connected below, sync its members; otherwise reconnect it.',
   denied: 'You no longer have permission to connect Slack to this workspace.',
   claimed:
     'That Slack workspace is already connected to another Orbit workspace. Disconnect it there first, or connect a different Slack workspace.',

--- a/apps/web/tests/app/api/integrations/slack/route.test.ts
+++ b/apps/web/tests/app/api/integrations/slack/route.test.ts
@@ -61,6 +61,7 @@ beforeAll(async () => {
     connectedById: workspace.adminUser.id,
     botToken: 'xoxb-workspace-secret',
     externalId: 'T-WORKSPACE',
+    scopes: ['chat:write', 'im:write', 'users:read', 'users:read.email'],
   });
   await connectSlackChannel(db, {
     organizationId: workspace.organizationId,
@@ -118,6 +119,241 @@ describe('GET /api/integrations/slack', () => {
       .from(schema.integration)
       .where(eq(schema.integration.organizationId, workspace.organizationId));
     expect(JSON.stringify(saved?.credentials)).not.toContain('xoxb-raw-token');
+  });
+
+  it('syncs every matching member through the existing Slack connection', async () => {
+    const teammate = await addMember(workspace, 'member', { name: 'Slack Teammate' });
+    const realFetch = globalThis.fetch;
+    const requests: { authorization: string | null; url: string }[] = [];
+    globalThis.fetch = Object.assign(
+      (...args: Parameters<typeof globalThis.fetch>) => {
+        const request = new Request(...args);
+        requests.push({ authorization: request.headers.get('authorization'), url: request.url });
+        return Promise.resolve(
+          Response.json({
+            ok: true,
+            members: [
+              {
+                id: 'U-ADMIN-SYNC',
+                deleted: false,
+                is_bot: false,
+                is_app_user: false,
+                real_name: workspace.adminUser.name,
+                profile: { email: workspace.adminUser.email, display_name: 'Admin' },
+              },
+              {
+                id: 'U-TEAMMATE-SYNC',
+                deleted: false,
+                is_bot: false,
+                is_app_user: false,
+                real_name: teammate.user.name,
+                profile: { email: teammate.user.email, display_name: 'Teammate' },
+              },
+            ],
+            response_metadata: { next_cursor: '' },
+          }),
+        );
+      },
+      { preconnect: realFetch.preconnect },
+    );
+
+    try {
+      const response = await POST(
+        new Request('https://orbit.test/api/integrations/slack', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ action: 'sync_members' }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ eligible: 2, mapped: 2 });
+      expect(requests).toEqual([
+        {
+          authorization: 'Bearer xoxb-workspace-secret',
+          url: 'https://slack.com/api/users.list?limit=200',
+        },
+      ]);
+      const mappings = await db
+        .select({
+          userId: schema.slackUserMapping.userId,
+          slackUserId: schema.slackUserMapping.slackUserId,
+        })
+        .from(schema.slackUserMapping)
+        .where(eq(schema.slackUserMapping.organizationId, workspace.organizationId));
+      expect(mappings.sort((left, right) => left.userId.localeCompare(right.userId))).toEqual(
+        [
+          { userId: workspace.adminUser.id, slackUserId: 'U-ADMIN-SYNC' },
+          { userId: teammate.user.id, slackUserId: 'U-TEAMMATE-SYNC' },
+        ].sort((left, right) => left.userId.localeCompare(right.userId)),
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it('rejects member synchronization before provider access when the viewer cannot manage it', async () => {
+    const viewer = await addMember(workspace, 'member', { name: 'Slack Viewer' });
+    signIn(viewer.user);
+    const realFetch = globalThis.fetch;
+    let providerCalls = 0;
+    globalThis.fetch = Object.assign(
+      () => {
+        providerCalls += 1;
+        return Promise.resolve(Response.json({ ok: false, error: 'must_not_call' }));
+      },
+      { preconnect: realFetch.preconnect },
+    );
+
+    try {
+      const response = await POST(
+        new Request('https://orbit.test/api/integrations/slack', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ action: 'sync_members' }),
+        }),
+      );
+
+      expect(response.status).toBe(403);
+      expect(providerCalls).toBe(0);
+    } finally {
+      globalThis.fetch = realFetch;
+      signIn(workspace.adminUser);
+    }
+  });
+
+  it('requires a reconnect before syncing a token without directory scopes', async () => {
+    const [current] = await db
+      .select({ id: schema.integration.id, config: schema.integration.config })
+      .from(schema.integration)
+      .where(
+        and(
+          eq(schema.integration.organizationId, workspace.organizationId),
+          eq(schema.integration.provider, 'slack'),
+          eq(schema.integration.externalId, 'default'),
+        ),
+      );
+    if (current === undefined) throw new Error('Expected the canonical Slack integration.');
+    await db
+      .update(schema.integration)
+      .set({ config: { ...current.config, scopes: ['chat:write'] } })
+      .where(eq(schema.integration.id, current.id));
+    const realFetch = globalThis.fetch;
+    let providerCalls = 0;
+    globalThis.fetch = Object.assign(
+      () => {
+        providerCalls += 1;
+        return Promise.resolve(Response.json({ ok: false, error: 'must_not_call' }));
+      },
+      { preconnect: realFetch.preconnect },
+    );
+
+    try {
+      const response = await POST(
+        new Request('https://orbit.test/api/integrations/slack', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ action: 'sync_members' }),
+        }),
+      );
+
+      expect(response.status).toBe(422);
+      expect(await response.json()).toEqual({
+        error: {
+          code: 'validation_failed',
+          message: 'Reconnect Slack before syncing members.',
+        },
+      });
+      expect(providerCalls).toBe(0);
+    } finally {
+      globalThis.fetch = realFetch;
+      await db
+        .update(schema.integration)
+        .set({ config: current.config })
+        .where(eq(schema.integration.id, current.id));
+    }
+  });
+
+  it('returns a retryable response when Slack rate limits member synchronization', async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = Object.assign(
+      () =>
+        Promise.resolve(
+          Response.json(
+            { ok: false, error: 'ratelimited' },
+            { status: 429, headers: { 'retry-after': '30' } },
+          ),
+        ),
+      { preconnect: realFetch.preconnect },
+    );
+
+    try {
+      const response = await POST(
+        new Request('https://orbit.test/api/integrations/slack', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ action: 'sync_members' }),
+        }),
+      );
+
+      expect(response.status).toBe(429);
+      expect(await response.json()).toEqual({
+        error: {
+          code: 'rate_limited',
+          message: 'Slack is busy. Try syncing members again shortly.',
+        },
+      });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it('requires a reconnect and records reauthorization when the stored token expires', async () => {
+    const [current] = await db
+      .select({ id: schema.integration.id, config: schema.integration.config })
+      .from(schema.integration)
+      .where(
+        and(
+          eq(schema.integration.organizationId, workspace.organizationId),
+          eq(schema.integration.provider, 'slack'),
+          eq(schema.integration.externalId, 'default'),
+        ),
+      );
+    if (current === undefined) throw new Error('Expected the canonical Slack integration.');
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = Object.assign(
+      () => Promise.resolve(Response.json({ ok: false, error: 'token_expired' })),
+      { preconnect: realFetch.preconnect },
+    );
+
+    try {
+      const response = await POST(
+        new Request('https://orbit.test/api/integrations/slack', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ action: 'sync_members' }),
+        }),
+      );
+
+      expect(response.status).toBe(422);
+      expect(await response.json()).toEqual({
+        error: {
+          code: 'validation_failed',
+          message: 'Reconnect Slack before syncing members.',
+        },
+      });
+      const [stored] = await db
+        .select({ config: schema.integration.config })
+        .from(schema.integration)
+        .where(eq(schema.integration.id, current.id));
+      expect(stored?.config['slackReauthorize']).toBe(true);
+    } finally {
+      globalThis.fetch = realFetch;
+      await db
+        .update(schema.integration)
+        .set({ config: current.config })
+        .where(eq(schema.integration.id, current.id));
+    }
   });
 
   it('offers only joined channels through the legacy channel listing', async () => {

--- a/apps/web/tests/features/settings/integrations-connect-slack.test.ts
+++ b/apps/web/tests/features/settings/integrations-connect-slack.test.ts
@@ -23,7 +23,9 @@ function deferred(): { readonly promise: Promise<void>; readonly resolve: () => 
   return { promise, resolve: () => settle?.() };
 }
 
-function oauthFetch(scope = 'chat:write,im:write,users:read.email'): typeof globalThis.fetch {
+function oauthFetch(
+  scope = 'chat:write,im:write,users:read,users:read.email',
+): typeof globalThis.fetch {
   return (async () =>
     new Response(
       JSON.stringify({
@@ -66,11 +68,17 @@ async function mapConnectingUser(): Promise<void> {
     new Response(
       JSON.stringify({
         ok: true,
-        user: {
-          id: 'U0123',
-          real_name: 'Ada Admin',
-          profile: { email: workspace.adminUser.email, display_name: 'Ada' },
-        },
+        members: [
+          {
+            id: 'U0123',
+            deleted: false,
+            is_bot: false,
+            is_app_user: false,
+            real_name: 'Ada Admin',
+            profile: { email: workspace.adminUser.email, display_name: 'Ada' },
+          },
+        ],
+        response_metadata: { next_cursor: '' },
       }),
       { status: 200 },
     )) as unknown as typeof globalThis.fetch;
@@ -93,16 +101,31 @@ describe.serial('completeSlackInstall', () => {
     else process.env['SLACK_ENABLED'] = originalSlackEnabled;
   });
 
-  it('persists the granted scopes and maps the connecting user', async () => {
+  it('persists the granted scopes and maps every current workspace member', async () => {
+    const teammate = await addMember(workspace, 'member', { name: 'Grace Member' });
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
           ok: true,
-          user: {
-            id: 'U0123',
-            real_name: 'Ada Admin',
-            profile: { email: workspace.adminUser.email, display_name: 'Ada' },
-          },
+          members: [
+            {
+              id: 'U0123',
+              deleted: false,
+              is_bot: false,
+              is_app_user: false,
+              real_name: 'Ada Admin',
+              profile: { email: workspace.adminUser.email, display_name: 'Ada' },
+            },
+            {
+              id: 'U0456',
+              deleted: false,
+              is_bot: false,
+              is_app_user: false,
+              real_name: 'Grace Member',
+              profile: { email: teammate.user.email, display_name: 'Grace' },
+            },
+          ],
+          response_metadata: { next_cursor: '' },
         }),
         { status: 200 },
       )) as unknown as typeof globalThis.fetch;
@@ -113,14 +136,17 @@ describe.serial('completeSlackInstall', () => {
       .select()
       .from(schema.integration)
       .where(eq(schema.integration.organizationId, workspace.organizationId));
-    const [mapping] = await db
+    const mappings = await db
       .select()
       .from(schema.slackUserMapping)
       .where(eq(schema.slackUserMapping.organizationId, workspace.organizationId));
 
     expect(savedIntegration).toMatchObject({
       externalId: 'default',
-      config: { scopes: ['chat:write', 'im:write', 'users:read.email'], slackTeamId: 'T0123' },
+      config: {
+        scopes: ['chat:write', 'im:write', 'users:read', 'users:read.email'],
+        slackTeamId: 'T0123',
+      },
     });
     expect(hasSlackBotToken(savedIntegration?.credentials)).toBe(true);
     expect(JSON.stringify(savedIntegration?.credentials)).not.toContain('xoxb-test');
@@ -130,20 +156,25 @@ describe.serial('completeSlackInstall', () => {
         integrationId: savedIntegration?.id ?? '',
       }),
     ).toBe('xoxb-test');
-    expect(mapping).toMatchObject({
-      integrationId: savedIntegration?.id,
-      userId: workspace.adminUser.id,
-      slackUserId: 'U0123',
-    });
+    expect(
+      mappings
+        .map((mapping) => ({ userId: mapping.userId, slackUserId: mapping.slackUserId }))
+        .sort((left, right) => left.userId.localeCompare(right.userId)),
+    ).toEqual(
+      [
+        { userId: workspace.adminUser.id, slackUserId: 'U0123' },
+        { userId: teammate.user.id, slackUserId: 'U0456' },
+      ].sort((left, right) => left.userId.localeCompare(right.userId)),
+    );
   });
 
-  it('keeps the installation connected when Slack cannot find the user', async () => {
+  it('surfaces a directory sync failure while keeping the installation connected', async () => {
     globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ ok: false, error: 'users_not_found' }), {
+      new Response(JSON.stringify({ ok: false, error: 'internal_error' }), {
         status: 200,
       })) as unknown as typeof globalThis.fetch;
 
-    await expect(complete()).resolves.toBeUndefined();
+    await expect(complete()).rejects.toThrow(/internal_error/);
 
     const integrations = await db
       .select()
@@ -157,11 +188,13 @@ describe.serial('completeSlackInstall', () => {
     expect(mappings).toHaveLength(0);
   });
 
-  it('clears a stale installer mapping when Slack no longer finds the user', async () => {
+  it('clears stale mappings after a complete directory has no match', async () => {
     await mapConnectingUser();
     globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ ok: false, error: 'users_not_found' }), {
-        status: 200,
+      Response.json({
+        ok: true,
+        members: [],
+        response_metadata: { next_cursor: '' },
       })) as unknown as typeof globalThis.fetch;
 
     await complete();
@@ -176,24 +209,26 @@ describe.serial('completeSlackInstall', () => {
     );
   });
 
-  it('clears a stale installer mapping when Slack lookup fails', async () => {
+  it('retains the previous mapping snapshot when the Slack directory request fails', async () => {
     await mapConnectingUser();
     globalThis.fetch = Object.assign(
       (..._args: Parameters<typeof globalThis.fetch>) =>
-        Promise.reject(new Error('Slack lookup unavailable')),
+        Promise.reject(new Error('Slack directory unavailable')),
       { preconnect: globalThis.fetch.preconnect },
     ) satisfies typeof globalThis.fetch;
 
-    await expect(complete()).resolves.toBeUndefined();
+    await expect(complete()).rejects.toThrow('Slack directory unavailable');
 
     const mappings = await db
       .select()
       .from(schema.slackUserMapping)
       .where(eq(schema.slackUserMapping.organizationId, workspace.organizationId));
-    expect(mappings).toEqual([]);
-    expect(await slackDmAvailable(db, workspace.organizationId, workspace.adminUser.id)).toBe(
-      false,
-    );
+    expect(mappings).toHaveLength(1);
+    expect(mappings[0]).toMatchObject({
+      userId: workspace.adminUser.id,
+      slackUserId: 'U0123',
+    });
+    expect(await slackDmAvailable(db, workspace.organizationId, workspace.adminUser.id)).toBe(true);
   });
 
   it('rejects an OAuth response without a team before changing the installation', async () => {
@@ -245,6 +280,12 @@ describe.serial('completeSlackInstall', () => {
         config: { scopes: ['chat:write'], slackTeamId: 'T0123' },
       })
       .returning();
+    globalThis.fetch = (async () =>
+      Response.json({
+        ok: true,
+        members: [],
+        response_metadata: { next_cursor: '' },
+      })) as unknown as typeof globalThis.fetch;
 
     await complete();
 
@@ -256,7 +297,10 @@ describe.serial('completeSlackInstall', () => {
     expect(integrations[0]).toMatchObject({
       id: legacy?.id,
       externalId: 'default',
-      config: { scopes: ['chat:write', 'im:write', 'users:read.email'], slackTeamId: 'T0123' },
+      config: {
+        scopes: ['chat:write', 'im:write', 'users:read', 'users:read.email'],
+        slackTeamId: 'T0123',
+      },
     });
     expect(JSON.stringify(integrations[0]?.credentials)).not.toContain('xoxb-test');
     expect(
@@ -267,7 +311,7 @@ describe.serial('completeSlackInstall', () => {
     ).toBe('xoxb-test');
   });
 
-  it('does not persist a stale team mapping from a concurrent OAuth install', async () => {
+  it('does not persist a stale mapping from an older same-team OAuth install', async () => {
     const newerAdmin = await addMember(workspace, 'admin', { name: 'Grace Admin' });
     const oldLookupStarted = deferred();
     const releaseOldLookup = deferred();
@@ -278,20 +322,32 @@ describe.serial('completeSlackInstall', () => {
         await releaseOldLookup.promise;
         return Response.json({
           ok: true,
-          user: {
-            id: 'U-old-team',
-            real_name: 'Ada Admin',
-            profile: { email: workspace.adminUser.email, display_name: 'Ada' },
-          },
+          members: [
+            {
+              id: 'U-old-team',
+              deleted: false,
+              is_bot: false,
+              is_app_user: false,
+              real_name: 'Ada Admin',
+              profile: { email: workspace.adminUser.email, display_name: 'Ada' },
+            },
+          ],
+          response_metadata: { next_cursor: '' },
         });
       }
       return Response.json({
         ok: true,
-        user: {
-          id: 'U-new-team',
-          real_name: 'Grace Admin',
-          profile: { email: newerAdmin.user.email, display_name: 'Grace' },
-        },
+        members: [
+          {
+            id: 'U-new-team',
+            deleted: false,
+            is_bot: false,
+            is_app_user: false,
+            real_name: 'Grace Admin',
+            profile: { email: newerAdmin.user.email, display_name: 'Grace' },
+          },
+        ],
+        response_metadata: { next_cursor: '' },
       });
     }) as unknown as typeof globalThis.fetch;
 
@@ -302,7 +358,7 @@ describe.serial('completeSlackInstall', () => {
       redirectUri: 'https://orbit.test/api/integrations/slack/callback',
       clientId: 'client-id',
       clientSecret: 'client-secret',
-      fetch: teamOAuthFetch('T-old', 'xoxb-old-team'),
+      fetch: teamOAuthFetch('T-same', 'xoxb-old-team'),
     });
     await oldLookupStarted.promise;
     await completeSlackInstall({
@@ -312,7 +368,7 @@ describe.serial('completeSlackInstall', () => {
       redirectUri: 'https://orbit.test/api/integrations/slack/callback',
       clientId: 'client-id',
       clientSecret: 'client-secret',
-      fetch: teamOAuthFetch('T-new', 'xoxb-new-team'),
+      fetch: teamOAuthFetch('T-same', 'xoxb-new-team'),
     });
     releaseOldLookup.resolve();
     await olderInstall;
@@ -329,7 +385,7 @@ describe.serial('completeSlackInstall', () => {
     expect(integrations[0]).toMatchObject({
       externalId: 'default',
       connectedById: newerAdmin.user.id,
-      config: { slackTeamId: 'T-new' },
+      config: { slackTeamId: 'T-same' },
     });
     expect(
       decryptSlackBotToken(integrations[0]?.credentials, {
@@ -424,7 +480,11 @@ describe.serial('completeSlackInstall', () => {
   it('rejects a Slack team claimed by another Orbit workspace', async () => {
     const other = await createWorkspace('slack-team-owner');
     globalThis.fetch = (async () =>
-      Response.json({ ok: false, error: 'users_not_found' })) as unknown as typeof globalThis.fetch;
+      Response.json({
+        ok: true,
+        members: [],
+        response_metadata: { next_cursor: '' },
+      })) as unknown as typeof globalThis.fetch;
     await completeSlackInstall({
       organizationId: other.organizationId,
       userId: other.adminUser.id,

--- a/apps/web/tests/features/settings/integrations-data.test.ts
+++ b/apps/web/tests/features/settings/integrations-data.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@orbit/core/test-support';
 import { db, eq, schema } from '@orbit/db';
 import { bindGithubInstallation, replaceGithubRepositories } from '@orbit/services';
+import { encryptSlackBotToken } from '@orbit/services/slack/credentials';
 import type { OrgRole } from '@orbit/shared/constants';
 import type { Principal } from '@orbit/shared/policy';
 import { randomUUIDv7 } from '@orbit/shared/utils';
@@ -90,6 +91,9 @@ describe('loadIntegrationSettings', () => {
   it('loads only the canonical Slack integration and its channels when enabled', async () => {
     const canonicalIntegrationId = `int_${randomUUIDv7()}`;
     const legacyIntegrationId = `int_${randomUUIDv7()}`;
+    const teammate = await addMember(workspace, 'member', { name: 'Current Slack Member' });
+    const former = await addMember(workspace, 'member', { name: 'Former Slack Member' });
+    await db.delete(schema.member).where(eq(schema.member.userId, former.user.id));
     await db.insert(schema.integration).values([
       {
         id: canonicalIntegrationId,
@@ -98,12 +102,16 @@ describe('loadIntegrationSettings', () => {
         externalId: 'default',
         connectedById: workspace.adminUser.id,
         credentials: {
-          botToken: {
-            version: 1,
-            iv: 'AAAAAAAAAAAAAAAA',
-            ciphertext: 'AA',
-            tag: 'AAAAAAAAAAAAAAAAAAAAAA',
-          },
+          botToken: encryptSlackBotToken({
+            organizationId: workspace.organizationId,
+            integrationId: canonicalIntegrationId,
+            token: 'xoxb-current',
+          }),
+        },
+        config: {
+          credentialVersion: 'current-version',
+          slackTeamId: 'T-CANONICAL',
+          scopes: ['users:read', 'users:read.email'],
         },
         createdAt: new Date('2026-01-01T00:00:00Z'),
       },
@@ -135,6 +143,32 @@ describe('loadIntegrationSettings', () => {
         channelName: 'legacy-private',
       },
     ]);
+    await db.insert(schema.slackUserMapping).values([
+      {
+        id: `sum_${randomUUIDv7()}`,
+        organizationId: workspace.organizationId,
+        integrationId: canonicalIntegrationId,
+        userId: workspace.adminUser.id,
+        slackUserId: 'U-CANONICAL-ADMIN',
+        slackDisplayName: 'Admin',
+      },
+      {
+        id: `sum_${randomUUIDv7()}`,
+        organizationId: workspace.organizationId,
+        integrationId: canonicalIntegrationId,
+        userId: former.user.id,
+        slackUserId: 'U-CANONICAL-FORMER',
+        slackDisplayName: 'Former',
+      },
+      {
+        id: `sum_${randomUUIDv7()}`,
+        organizationId: workspace.organizationId,
+        integrationId: legacyIntegrationId,
+        userId: teammate.user.id,
+        slackUserId: 'U-LEGACY-TEAMMATE',
+        slackDisplayName: 'Legacy',
+      },
+    ]);
 
     process.env['SLACK_ENABLED'] = 'true';
 
@@ -142,8 +176,120 @@ describe('loadIntegrationSettings', () => {
 
     expect(settings.slack?.slackConnected).toBe(true);
     expect(settings.slack?.slackHasToken).toBe(true);
+    expect(settings.slack?.memberSync.ready).toBe(true);
     expect(settings.slack?.channels.map((channel) => channel.channelId)).toEqual(['C-CANONICAL']);
+    expect(settings.slack?.memberSync).toEqual({ eligible: 2, mapped: 1, ready: true });
   });
+
+  it('requires reconnecting before a scope-deficient Slack connection can sync members', async () => {
+    const scopeIntegrationId = `int_${randomUUIDv7()}`;
+    await db.insert(schema.integration).values({
+      id: scopeIntegrationId,
+      organizationId: workspace.organizationId,
+      provider: 'slack',
+      externalId: 'default',
+      connectedById: workspace.adminUser.id,
+      credentials: {
+        botToken: encryptSlackBotToken({
+          organizationId: workspace.organizationId,
+          integrationId: scopeIntegrationId,
+          token: 'xoxb-legacy',
+        }),
+      },
+      config: {
+        credentialVersion: 'legacy-version',
+        slackTeamId: 'T-LEGACY',
+        scopes: ['chat:write'],
+      },
+    });
+    process.env['SLACK_ENABLED'] = 'true';
+
+    const settings = await loadIntegrationSettings(workspace.admin);
+
+    expect(settings.slack?.memberSync.ready).toBe(false);
+  });
+
+  it('requires reconnecting when the stored Slack token cannot be decrypted', async () => {
+    const integrationId = `int_${randomUUIDv7()}`;
+    const activeSecret = process.env['BETTER_AUTH_SECRET'];
+    if (activeSecret === undefined) throw new Error('Expected an active auth secret.');
+    process.env['BETTER_AUTH_SECRET'] = 'retired-slack-integrations-data-secret';
+    const retiredToken = encryptSlackBotToken({
+      organizationId: workspace.organizationId,
+      integrationId,
+      token: 'xoxb-retired',
+    });
+    process.env['BETTER_AUTH_SECRET'] = activeSecret;
+    await db.insert(schema.integration).values({
+      id: integrationId,
+      organizationId: workspace.organizationId,
+      provider: 'slack',
+      externalId: 'default',
+      connectedById: workspace.adminUser.id,
+      credentials: { botToken: retiredToken },
+      config: {
+        credentialVersion: 'retired-version',
+        slackTeamId: 'T-RETIRED',
+        scopes: ['users:read', 'users:read.email'],
+      },
+    });
+    process.env['SLACK_ENABLED'] = 'true';
+
+    const settings = await loadIntegrationSettings(workspace.admin);
+
+    expect(settings.slack?.memberSync.ready).toBe(false);
+  });
+
+  for (const readinessCase of [
+    {
+      name: 'requires reconnecting when Slack explicitly marks the connection for reauthorization',
+      config: {
+        credentialVersion: 'reauthorize-version',
+        slackTeamId: 'T-REAUTHORIZE',
+        scopes: ['users:read', 'users:read.email'],
+        slackReauthorize: true,
+      },
+    },
+    {
+      name: 'keeps member sync unavailable when the Slack team id is missing',
+      config: {
+        credentialVersion: 'missing-team-version',
+        scopes: ['users:read', 'users:read.email'],
+      },
+    },
+    {
+      name: 'keeps member sync unavailable when the Slack team id is empty',
+      config: {
+        credentialVersion: 'empty-team-version',
+        slackTeamId: '',
+        scopes: ['users:read', 'users:read.email'],
+      },
+    },
+  ] as const) {
+    it(readinessCase.name, async () => {
+      const integrationId = `int_${randomUUIDv7()}`;
+      await db.insert(schema.integration).values({
+        id: integrationId,
+        organizationId: workspace.organizationId,
+        provider: 'slack',
+        externalId: 'default',
+        connectedById: workspace.adminUser.id,
+        credentials: {
+          botToken: encryptSlackBotToken({
+            organizationId: workspace.organizationId,
+            integrationId,
+            token: 'xoxb-readiness',
+          }),
+        },
+        config: readinessCase.config,
+      });
+      process.env['SLACK_ENABLED'] = 'true';
+
+      const settings = await loadIntegrationSettings(workspace.admin);
+
+      expect(settings.slack?.memberSync.ready).toBe(false);
+    });
+  }
 
   for (const role of ['guest', 'contributor', 'member'] as const) {
     it(`hands a ${role} no repository name at all`, async () => {

--- a/apps/web/tests/features/settings/integrations-data.test.ts
+++ b/apps/web/tests/features/settings/integrations-data.test.ts
@@ -213,13 +213,18 @@ describe('loadIntegrationSettings', () => {
     const integrationId = `int_${randomUUIDv7()}`;
     const activeSecret = process.env['BETTER_AUTH_SECRET'];
     if (activeSecret === undefined) throw new Error('Expected an active auth secret.');
-    process.env['BETTER_AUTH_SECRET'] = 'retired-slack-integrations-data-secret';
-    const retiredToken = encryptSlackBotToken({
-      organizationId: workspace.organizationId,
-      integrationId,
-      token: 'xoxb-retired',
-    });
-    process.env['BETTER_AUTH_SECRET'] = activeSecret;
+    const retiredToken = (() => {
+      process.env['BETTER_AUTH_SECRET'] = 'retired-slack-integrations-data-secret';
+      try {
+        return encryptSlackBotToken({
+          organizationId: workspace.organizationId,
+          integrationId,
+          token: 'xoxb-retired',
+        });
+      } finally {
+        process.env['BETTER_AUTH_SECRET'] = activeSecret;
+      }
+    })();
     await db.insert(schema.integration).values({
       id: integrationId,
       organizationId: workspace.organizationId,

--- a/apps/web/tests/features/settings/integrations-panel.test.tsx
+++ b/apps/web/tests/features/settings/integrations-panel.test.tsx
@@ -208,7 +208,7 @@ describe('IntegrationsPanel', () => {
     expect(replace).toHaveBeenCalledWith('/settings/integrations', { scroll: false });
   });
 
-  it('disables the member sync control while Slack is still responding', async () => {
+  it('marks the member sync control aria-disabled while Slack is still responding', async () => {
     let finish: (() => void) | undefined;
     globalThis.fetch = mock(
       () =>
@@ -221,7 +221,10 @@ describe('IntegrationsPanel', () => {
 
     await user.click(screen.getByRole('button', { name: 'Sync Slack members' }));
 
-    expect(screen.getByRole('button', { name: 'Syncing Slack members' })).toBeDisabled();
+    const pendingSync = screen.getByRole('button', { name: 'Syncing Slack members' });
+    expect(pendingSync).toHaveAttribute('aria-disabled', 'true');
+    expect(pendingSync).not.toBeDisabled();
+    expect(pendingSync).toHaveFocus();
     finish?.();
     await screen.findByText('Slack member sync completed: 2 of 2 matched.');
   });

--- a/apps/web/tests/features/settings/integrations-panel.test.tsx
+++ b/apps/web/tests/features/settings/integrations-panel.test.tsx
@@ -8,9 +8,10 @@ import { IntegrationsPanel } from '@/features/settings/integrations-panel.tsx';
 import type { McpConnection } from '@/features/settings/mcp-panel.tsx';
 
 const refresh = mock();
+const replace = mock();
 
 mock.module('next/navigation', () => ({
-  useRouter: () => ({ refresh }),
+  useRouter: () => ({ refresh, replace }),
 }));
 
 const MCP_URL = 'https://orbit.example.com/mcp';
@@ -59,6 +60,7 @@ const CONNECTED_WITH_SLACK: IntegrationSettings = {
     slackConnectEnabled: true,
     channels: [],
     teams: [],
+    memberSync: { eligible: 3, mapped: 0, ready: false },
   },
 };
 
@@ -70,6 +72,7 @@ const CONNECTED_WITH_SLACK_TOKEN: IntegrationSettings = {
     slackConnectEnabled: true,
     channels: [],
     teams: [{ id: 'team-engineering', name: 'Engineering', key: 'ENG' }],
+    memberSync: { eligible: 2, mapped: 1, ready: true },
   },
 };
 
@@ -116,19 +119,24 @@ let lastRequest: { url: string; method: string; body: unknown } | null = null;
 
 beforeEach(() => {
   refresh.mockClear();
+  replace.mockClear();
   lastRequest = null;
   globalThis.fetch = mock((url: string, init?: { method?: string; body?: string }) => {
+    const body = init?.body === undefined ? undefined : JSON.parse(init.body);
     lastRequest = {
       url,
       method: init?.method ?? 'GET',
-      body: init?.body === undefined ? undefined : JSON.parse(init.body),
+      body,
     };
-    const payload = url.startsWith('/api/integrations/slack/channels')
-      ? {
-          channels: [{ channelId: 'C-CANONICAL', channelName: 'canonical-name' }],
-          nextCursor: null,
-        }
-      : {};
+    let payload: unknown = {};
+    if (url.startsWith('/api/integrations/slack/channels')) {
+      payload = {
+        channels: [{ channelId: 'C-CANONICAL', channelName: 'canonical-name' }],
+        nextCursor: null,
+      };
+    } else if (body?.action === 'sync_members') {
+      payload = { eligible: 2, mapped: 2 };
+    }
     return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(payload) });
   }) as unknown as typeof fetch;
 });
@@ -146,6 +154,7 @@ describe('IntegrationsPanel', () => {
       'href',
       '/api/integrations/slack/start',
     );
+    expect(screen.queryByRole('button', { name: 'Sync Slack members' })).toBeNull();
   });
 
   it('does not render Slack when the server withholds Slack settings', () => {
@@ -176,6 +185,85 @@ describe('IntegrationsPanel', () => {
         teamId: 'team-engineering',
       },
     });
+  });
+
+  it('shows member coverage and synchronizes the existing Slack connection', async () => {
+    const user = userEvent.setup();
+    renderPanel(CONNECTED_WITH_SLACK_TOKEN, true);
+
+    expect(screen.getByText('1 of 2 workspace members matched by email.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Sync Slack members' }));
+
+    await waitFor(() => {
+      expect(lastRequest).toEqual({
+        url: '/api/integrations/slack',
+        method: 'POST',
+        body: { action: 'sync_members' },
+      });
+    });
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'Slack member sync completed: 2 of 2 matched.',
+    );
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(replace).toHaveBeenCalledWith('/settings/integrations', { scroll: false });
+  });
+
+  it('disables the member sync control while Slack is still responding', async () => {
+    let finish: (() => void) | undefined;
+    globalThis.fetch = mock(
+      () =>
+        new Promise((resolve) => {
+          finish = () => resolve(Response.json({ eligible: 2, mapped: 2 }));
+        }),
+    ) as unknown as typeof fetch;
+    const user = userEvent.setup();
+    renderPanel(CONNECTED_WITH_SLACK_TOKEN, true);
+
+    await user.click(screen.getByRole('button', { name: 'Sync Slack members' }));
+
+    expect(screen.getByRole('button', { name: 'Syncing Slack members' })).toBeDisabled();
+    finish?.();
+    await screen.findByText('Slack member sync completed: 2 of 2 matched.');
+  });
+
+  it('re-enables member sync and reports a provider failure without refreshing', async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        Response.json(
+          { error: { code: 'internal', message: 'Slack directory unavailable.' } },
+          { status: 500 },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+    const user = userEvent.setup();
+    renderPanel(CONNECTED_WITH_SLACK_TOKEN, true);
+
+    await user.click(screen.getByRole('button', { name: 'Sync Slack members' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Slack directory unavailable.');
+    expect(screen.getByRole('button', { name: 'Sync Slack members' })).toBeEnabled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('asks for reconnection instead of offering a member sync that cannot succeed', () => {
+    const slackSettings = CONNECTED_WITH_SLACK_TOKEN.slack;
+    if (slackSettings === undefined) throw new Error('Expected Slack settings.');
+    renderPanel(
+      {
+        ...CONNECTED_WITH_SLACK_TOKEN,
+        slack: {
+          ...slackSettings,
+          memberSync: { eligible: 2, mapped: 1, ready: false },
+        },
+      },
+      true,
+    );
+
+    expect(
+      screen.getByText('Reconnect Slack to enable workspace member sync.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sync Slack members' })).toBeNull();
+    expect(screen.getByRole('link', { name: 'Reconnect Slack' })).toBeInTheDocument();
   });
 
   it('offers GitHub connect as the primary path when nothing is connected', () => {
@@ -214,9 +302,12 @@ describe('IntegrationsPanel', () => {
   });
 
   it('hides management affordances when the viewer cannot manage integrations', () => {
-    renderPanel(CONNECTED, false);
+    renderPanel(CONNECTED_WITH_SLACK_TOKEN, false);
     expect(screen.queryByRole('link', { name: 'Connect another organisation' })).toBeNull();
     expect(screen.queryByRole('button', { name: /^Remove the/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Sync Slack members' })).toBeNull();
+    expect(screen.queryByText('1 of 2 workspace members matched by email.')).toBeNull();
+    expect(screen.getByText('Workspace integrations')).toBeInTheDocument();
     expect(screen.getByTestId('mcp-url')).toBeInTheDocument();
   });
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -219,14 +219,16 @@ Slack integration behavior:
   replacement claim becomes authoritative, and a late worker cannot finalize
   the superseded attempt. The scheduled worker runs every minute, takes small
   concurrent batches, and stops claiming new work before its runtime deadline.
-- **Current mapping behavior.** OAuth maps only the Orbit user who completes
-  **Connect**, by matching their Orbit email with Slack. Other workspace members
-  remain unmapped, so they keep their other enabled notification channels and
-  cannot enable Slack DMs.
-- **Known mapping gap.** There is currently no administrator mapping screen,
-  workspace-wide backfill, or per-user fallback linking flow. Those are separate
-  follow-up work and are not prerequisites for delivery to users who are
-  already mapped.
+- **Member mapping.** OAuth loads the complete Slack user directory before it
+  maps every current Orbit workspace member whose normalized email has exactly
+  one matching active human Slack user. Ambiguous emails remain unmapped so a
+  private notification cannot be routed to an arbitrary account.
+- **Member resynchronization.** Workspace admins can use **Sync Slack members**
+  in integration settings to refresh a healthy connection without repeating
+  OAuth. Connections with missing directory scopes, unusable credentials, or a
+  reauthorization requirement must reconnect first. Orbit replaces the mapping
+  snapshot atomically only after every Slack directory page succeeds. The
+  settings panel reports how many current workspace members are matched.
 
 ### Note on GitHub sign-in
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -225,10 +225,12 @@ Slack integration behavior:
   private notification cannot be routed to an arbitrary account.
 - **Member resynchronization.** Workspace admins can use **Sync Slack members**
   in integration settings to refresh a healthy connection without repeating
-  OAuth. Connections with missing directory scopes, unusable credentials, or a
-  reauthorization requirement must reconnect first. Orbit replaces the mapping
-  snapshot atomically only after every Slack directory page succeeds. The
-  settings panel reports how many current workspace members are matched.
+  OAuth. Newly joined Orbit members remain unmapped until a workspace admin
+  runs **Sync Slack members** again. Connections with missing directory scopes,
+  unusable credentials, or a reauthorization requirement must reconnect first.
+  Orbit replaces the mapping snapshot atomically only after every Slack
+  directory page succeeds. The settings panel reports how many current
+  workspace members are matched.
 
 ### Note on GitHub sign-in
 

--- a/packages/core/src/notifications/notify.ts
+++ b/packages/core/src/notifications/notify.ts
@@ -9,7 +9,11 @@ import {
   notifyMany,
 } from '@orbit/services/notifications';
 import { escapeSlackText, SlackApiError } from '@orbit/services/slack';
-import { dispatchSlackDmResult, SlackDmDispatchError } from '@orbit/services/slack/dispatch';
+import {
+  dispatchSlackDmResult,
+  isSlackReauthorizationError,
+  SlackDmDispatchError,
+} from '@orbit/services/slack/dispatch';
 import type { SyncAction } from '@orbit/shared/events';
 import type { Executor } from '../internal.ts';
 
@@ -206,15 +210,7 @@ async function finalizeSlackDmFailure(
   let code = '';
   if (error instanceof SlackDmDispatchError) code = error.slackCode ?? '';
   else if (cause instanceof SlackApiError) code = cause.code;
-  if (
-    [
-      'invalid_auth',
-      'account_inactive',
-      'credential_unavailable',
-      'missing_scope',
-      'token_revoked',
-    ].includes(code)
-  ) {
+  if (code === 'credential_unavailable' || isSlackReauthorizationError(cause)) {
     const reauthorizationMarked = await markSlackReauthorizationRequired(
       database,
       organizationId,

--- a/packages/core/src/org/member-service.ts
+++ b/packages/core/src/org/member-service.ts
@@ -304,6 +304,14 @@ export async function removeMember(
         ),
       );
 
+    await tx
+      .delete(schema.slackUserMapping)
+      .where(
+        and(
+          eq(schema.slackUserMapping.organizationId, principal.organizationId),
+          eq(schema.slackUserMapping.userId, current.userId),
+        ),
+      );
     await tx.delete(schema.member).where(eq(schema.member.id, memberId));
     await tx.delete(schema.session).where(eq(schema.session.userId, current.userId));
 

--- a/packages/core/tests/notifications/notify.test.ts
+++ b/packages/core/tests/notifications/notify.test.ts
@@ -1,10 +1,14 @@
 import { afterAll, beforeEach, describe, expect, it } from 'bun:test';
-import { db, eq, schema } from '@orbit/db';
+import { and, db, eq, schema } from '@orbit/db';
 import type { NotificationEvent } from '@orbit/services/notifications';
 import { claimSlackDmDeliveries } from '@orbit/services/notifications';
 import { SlackApiError } from '@orbit/services/slack';
 import { encryptSlackBotToken } from '@orbit/services/slack/credentials';
-import type { dispatchSlackDmResult } from '@orbit/services/slack/dispatch';
+import {
+  type dispatchSlackDmResult,
+  resolveSlackContext,
+  SlackDmDispatchError,
+} from '@orbit/services/slack/dispatch';
 import { randomUUIDv7 } from '@orbit/shared/utils';
 import { deliverPendingSlackDms, notifyRecipients } from '../../src/notifications/notify.ts';
 import { resetDatabase } from '../../src/test-support.ts';
@@ -53,6 +57,12 @@ async function seedPendingSlackDm(): Promise<Fixture> {
     name: 'Ada',
     email: `ada.${suffix}@orbit.local`,
     handle: `ada-${suffix.toLowerCase()}`,
+  });
+  await db.insert(schema.member).values({
+    id: `mem_${suffix}`,
+    organizationId,
+    userId,
+    role: 'member',
   });
   await db.insert(schema.integration).values({
     id: integrationId,
@@ -185,6 +195,30 @@ describe('notifyRecipients global Slack rollout', () => {
 });
 
 describe('deliverPendingSlackDms', () => {
+  it('skips a queued private message after the recipient leaves the workspace', async () => {
+    const fixture = await seedPendingSlackDm();
+    await db
+      .delete(schema.member)
+      .where(
+        and(
+          eq(schema.member.organizationId, fixture.organizationId),
+          eq(schema.member.userId, fixture.userId),
+        ),
+      );
+    let providerCalls = 0;
+    const fetch = (() => {
+      providerCalls += 1;
+      return Promise.resolve(Response.json({ ok: true }));
+    }) as unknown as typeof globalThis.fetch;
+
+    expect(await deliverPendingSlackDms(db, 1, fetch)).toBe(0);
+    expect(providerCalls).toBe(0);
+    const [delivery] = await db
+      .select({ status: schema.notificationDelivery.status })
+      .from(schema.notificationDelivery);
+    expect(delivery?.status).toBe('skipped');
+  });
+
   it('delivers pending messages across every organization without a filter', async () => {
     const first = await seedPendingSlackDm();
     const second = await seedPendingSlackDm();
@@ -596,15 +630,12 @@ describe('deliverPendingSlackDms', () => {
 
   it('retries a permanent failure after a concurrent token refresh', async () => {
     const fixture = await seedPendingSlackDm();
-    let calls = 0;
-    const authorization: string[] = [];
-    const fetch = (async (_input: URL | RequestInfo, init?: RequestInit) => {
-      calls += 1;
-      authorization.push(String(new Headers(init?.headers).get('authorization')));
-      if (calls === 1) {
-        return new Response(JSON.stringify({ ok: true, channel: { id: 'D123' } }));
-      }
-      if (calls === 2) {
+    const staleContext = await resolveSlackContext(db, fixture.organizationId, 'default');
+    if (staleContext === null) throw new Error('Expected the Slack integration context.');
+    let dispatchCalls = 0;
+    const dispatch: typeof dispatchSlackDmResult = async () => {
+      dispatchCalls += 1;
+      if (dispatchCalls === 1) {
         await db
           .update(schema.integration)
           .set({
@@ -613,12 +644,15 @@ describe('deliverPendingSlackDms', () => {
             updatedAt: new Date(Date.now() + 1_000),
           })
           .where(eq(schema.integration.id, fixture.integrationId));
-        return new Response(JSON.stringify({ ok: false, error: 'invalid_auth' }));
+        throw new SlackDmDispatchError(
+          staleContext,
+          new SlackApiError('chat.postMessage', 'invalid_auth'),
+        );
       }
-      return new Response(JSON.stringify({ ok: true, channel: 'D123', ts: '123.456' }));
-    }) as unknown as typeof globalThis.fetch;
+      return { delivered: 1, channel: 'D123', ts: '123.456' };
+    };
 
-    expect(await deliverPendingSlackDms(db, 10, fetch)).toBe(0);
+    expect(await deliverPendingSlackDms(db, 10, globalThis.fetch, dispatch)).toBe(0);
 
     const [storedIntegration] = await db
       .select({ config: schema.integration.config, credentials: schema.integration.credentials })
@@ -636,18 +670,17 @@ describe('deliverPendingSlackDms', () => {
       .set({ availableAt: new Date(0) })
       .where(eq(schema.notificationDelivery.id, failedDelivery.id));
 
-    expect(await deliverPendingSlackDms(db, 10, fetch)).toBe(1);
-    expect(authorization).toEqual(['Bearer xoxb-old', 'Bearer xoxb-old', 'Bearer xoxb-refreshed']);
+    expect(await deliverPendingSlackDms(db, 10, globalThis.fetch, dispatch)).toBe(1);
+    expect(dispatchCalls).toBe(2);
+    const refreshedContext = await resolveSlackContext(db, fixture.organizationId, 'default');
+    expect(refreshedContext?.token).toBe('xoxb-refreshed');
   });
 
   it('does not mark a same-token refreshed Slack integration for reauthorization', async () => {
     const fixture = await seedPendingSlackDm();
-    let calls = 0;
-    const fetch = (async () => {
-      calls += 1;
-      if (calls === 1) {
-        return new Response(JSON.stringify({ ok: true, channel: { id: 'D123' } }));
-      }
+    const staleContext = await resolveSlackContext(db, fixture.organizationId, 'default');
+    if (staleContext === null) throw new Error('Expected the Slack integration context.');
+    const dispatch: typeof dispatchSlackDmResult = async () => {
       await db
         .update(schema.integration)
         .set({
@@ -655,10 +688,13 @@ describe('deliverPendingSlackDms', () => {
           updatedAt: new Date(Date.now() + 1_000),
         })
         .where(eq(schema.integration.id, fixture.integrationId));
-      return new Response(JSON.stringify({ ok: false, error: 'invalid_auth' }));
-    }) as unknown as typeof globalThis.fetch;
+      throw new SlackDmDispatchError(
+        staleContext,
+        new SlackApiError('chat.postMessage', 'invalid_auth'),
+      );
+    };
 
-    expect(await deliverPendingSlackDms(db, 10, fetch)).toBe(0);
+    expect(await deliverPendingSlackDms(db, 10, globalThis.fetch, dispatch)).toBe(0);
 
     const [storedIntegration] = await db
       .select({ config: schema.integration.config })

--- a/packages/core/tests/org/member-service.test.ts
+++ b/packages/core/tests/org/member-service.test.ts
@@ -128,6 +128,63 @@ describe('updateMemberRole', () => {
 });
 
 describe('removeMember', () => {
+  it('removes the Slack identity bound to the workspace membership', async () => {
+    const { user } = await addMember(workspace, 'member');
+    const localMemberId = await memberIdFor(user.id);
+    const integrationId = newId();
+    await db.insert(schema.integration).values({
+      id: integrationId,
+      organizationId: workspace.organizationId,
+      provider: 'slack',
+      externalId: 'default',
+      connectedById: workspace.admin.userId,
+      credentials: { botToken: 'xoxb-member-removal' },
+      config: { scopes: ['chat:write', 'im:write'] },
+    });
+    await db.insert(schema.slackUserMapping).values({
+      id: newId(),
+      organizationId: workspace.organizationId,
+      integrationId,
+      userId: user.id,
+      slackUserId: 'U-REMOVED',
+      slackDisplayName: 'Removed member',
+    });
+    const other = await createWorkspace('Other');
+    await db.insert(schema.member).values({
+      id: newId(),
+      organizationId: other.organizationId,
+      userId: user.id,
+      role: 'member',
+    });
+    const otherIntegrationId = newId();
+    await db.insert(schema.integration).values({
+      id: otherIntegrationId,
+      organizationId: other.organizationId,
+      provider: 'slack',
+      externalId: 'default',
+      connectedById: other.admin.userId,
+      credentials: { botToken: 'xoxb-other-member' },
+      config: { scopes: ['chat:write', 'im:write'] },
+    });
+    await db.insert(schema.slackUserMapping).values({
+      id: newId(),
+      organizationId: other.organizationId,
+      integrationId: otherIntegrationId,
+      userId: user.id,
+      slackUserId: 'U-OTHER',
+      slackDisplayName: 'Other workspace member',
+    });
+
+    await removeMember(workspace.admin, localMemberId);
+
+    expect(
+      await db
+        .select({ organizationId: schema.slackUserMapping.organizationId })
+        .from(schema.slackUserMapping)
+        .where(eq(schema.slackUserMapping.userId, user.id)),
+    ).toEqual([{ organizationId: other.organizationId }]);
+  });
+
   it('unassigns their open issues and drops team memberships', async () => {
     const { user } = await addMember(workspace, 'member');
     const { issue } = await createIssue(workspace.admin, {

--- a/packages/services/src/slack/dispatch.ts
+++ b/packages/services/src/slack/dispatch.ts
@@ -313,6 +313,23 @@ interface SlackMemberIdentity {
   readonly email: string;
 }
 
+export function slackUserMappingSyncReady(input: {
+  readonly context: SlackContext | null;
+  readonly slackTeamId: unknown;
+}): input is {
+  readonly context: SlackContext & { readonly token: string };
+  readonly slackTeamId: string;
+} {
+  return (
+    input.context !== null &&
+    input.context.token !== null &&
+    !input.context.reauthorize &&
+    typeof input.slackTeamId === 'string' &&
+    input.slackTeamId.length > 0 &&
+    slackDirectoryScopesPresent(input.context.scopes)
+  );
+}
+
 export async function syncSlackUserMappings(
   database: SlackDatabase,
   input: {
@@ -392,22 +409,15 @@ async function slackUserMappingSyncContext(
   if (row === undefined) throw validationFailed('Reconnect Slack before syncing members.');
   const context = slackContextFromRow(row, organizationId);
   const slackTeamId = row.config['slackTeamId'];
-  const hasDirectoryScopes =
-    context.scopes.includes('users:read') && context.scopes.includes('users:read.email');
-  if (
-    context.token === null ||
-    context.reauthorize ||
-    typeof slackTeamId !== 'string' ||
-    slackTeamId.length === 0 ||
-    !hasDirectoryScopes
-  ) {
+  const readiness = { context, slackTeamId };
+  if (!slackUserMappingSyncReady(readiness)) {
     throw validationFailed('Reconnect Slack before syncing members.');
   }
   return {
-    integrationId: context.integrationId,
-    integrationVersion: context.integrationVersion,
-    slackTeamId,
-    token: context.token,
+    integrationId: readiness.context.integrationId,
+    integrationVersion: readiness.context.integrationVersion,
+    slackTeamId: readiness.slackTeamId,
+    token: readiness.context.token,
   };
 }
 

--- a/packages/services/src/slack/dispatch.ts
+++ b/packages/services/src/slack/dispatch.ts
@@ -13,7 +13,7 @@ import {
 import { conflict, type Priority, parseIssueIdentifier, validationFailed } from '@orbit/shared';
 import { ORG_ROLES, type OrgRole } from '@orbit/shared/constants';
 import { assertCan } from '@orbit/shared/policy';
-import { randomUUIDv7 } from '@orbit/shared/utils';
+import { chunk, randomUUIDv7 } from '@orbit/shared/utils';
 import { and, eq, inArray, isNull, ne, or, type SQL, sql } from 'drizzle-orm';
 import {
   decryptSlackBotToken,
@@ -29,6 +29,7 @@ import {
   type SlackIssue,
   type SlackMessageRef,
   type SlackUnfurl,
+  type SlackUser,
 } from './index.ts';
 
 export type SlackDatabase = Database | Transaction;
@@ -36,6 +37,15 @@ export type SlackDatabase = Database | Transaction;
 const SLACK_TEAM_CLAIMED = 'That Slack workspace is already connected to another Orbit workspace.';
 const SLACK_CHANNEL_UNAVAILABLE = 'Invite Orbit to the Slack channel before mapping it.';
 const SLACK_CHANNEL_ACCESS_ERRORS = new Set(['channel_not_found', 'not_in_channel']);
+const SLACK_REAUTHORIZATION_ERRORS = new Set([
+  'account_inactive',
+  'invalid_auth',
+  'missing_scope',
+  'not_authed',
+  'token_expired',
+  'token_revoked',
+]);
+const SLACK_USER_MAPPING_INSERT_BATCH_SIZE = 500;
 
 export function slackCredentialVersionExpression(): SQL<string> {
   return sql<string>`coalesce(${integration.config} ->> 'credentialVersion', extract(epoch from ${integration.updatedAt})::text)`;
@@ -281,6 +291,260 @@ export async function upsertSlackUserMapping(
         updatedAt: new Date(),
       },
     });
+}
+
+export type SlackUserMappingSyncResult =
+  | {
+      readonly status: 'applied';
+      readonly eligibleMembers: number;
+      readonly mappedMembers: number;
+    }
+  | { readonly status: 'stale' };
+
+interface SlackUserMappingSyncContext {
+  readonly integrationId: string;
+  readonly integrationVersion: string;
+  readonly slackTeamId: string;
+  readonly token: string;
+}
+
+interface SlackMemberIdentity {
+  readonly userId: string;
+  readonly email: string;
+}
+
+export async function syncSlackUserMappings(
+  database: SlackDatabase,
+  input: {
+    readonly organizationId: string;
+    readonly userId: string;
+    readonly fetch?: typeof globalThis.fetch;
+  },
+): Promise<SlackUserMappingSyncResult> {
+  await assertSlackIntegrationManager(database, input);
+  const context = await slackUserMappingSyncContext(database, input.organizationId);
+  let slackUsers: SlackUser[];
+  try {
+    slackUsers = await new SlackClient({
+      token: context.token,
+      ...(input.fetch === undefined ? {} : { fetch: input.fetch }),
+    }).listUsers();
+  } catch (error) {
+    if (isSlackReauthorizationError(error)) {
+      await markSlackSyncReauthorizationRequired(database, input.organizationId, context);
+    }
+    throw error;
+  }
+  const reconcile = async (tx: Transaction): Promise<SlackUserMappingSyncResult> => {
+    return await reconcileSlackUserMappings(tx, input, context, slackUsers);
+  };
+  if ('transaction' in database) return await database.transaction(reconcile);
+  return await reconcile(database);
+}
+
+export function isSlackReauthorizationError(error: unknown): error is SlackApiError {
+  return error instanceof SlackApiError && SLACK_REAUTHORIZATION_ERRORS.has(error.code);
+}
+
+async function markSlackSyncReauthorizationRequired(
+  database: SlackDatabase,
+  organizationId: string,
+  context: SlackUserMappingSyncContext,
+): Promise<void> {
+  await database
+    .update(integration)
+    .set({
+      config: sql`jsonb_set(${integration.config}, '{slackReauthorize}', 'true'::jsonb)`,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(integration.id, context.integrationId),
+        eq(integration.organizationId, organizationId),
+        eq(integration.provider, 'slack'),
+        eq(integration.externalId, 'default'),
+        sql`${slackCredentialVersionExpression()} = ${context.integrationVersion}`,
+      ),
+    );
+}
+
+async function slackUserMappingSyncContext(
+  database: SlackDatabase,
+  organizationId: string,
+): Promise<SlackUserMappingSyncContext> {
+  const [row] = await database
+    .select({
+      id: integration.id,
+      credentials: integration.credentials,
+      config: integration.config,
+      updatedAt: integration.updatedAt,
+      integrationVersion: slackCredentialVersionExpression(),
+    })
+    .from(integration)
+    .where(
+      and(
+        eq(integration.organizationId, organizationId),
+        eq(integration.provider, 'slack'),
+        eq(integration.externalId, 'default'),
+      ),
+    )
+    .limit(1);
+  if (row === undefined) throw validationFailed('Reconnect Slack before syncing members.');
+  const context = slackContextFromRow(row, organizationId);
+  const slackTeamId = row.config['slackTeamId'];
+  const hasDirectoryScopes =
+    context.scopes.includes('users:read') && context.scopes.includes('users:read.email');
+  if (
+    context.token === null ||
+    context.reauthorize ||
+    typeof slackTeamId !== 'string' ||
+    slackTeamId.length === 0 ||
+    !hasDirectoryScopes
+  ) {
+    throw validationFailed('Reconnect Slack before syncing members.');
+  }
+  return {
+    integrationId: context.integrationId,
+    integrationVersion: context.integrationVersion,
+    slackTeamId,
+    token: context.token,
+  };
+}
+
+async function reconcileSlackUserMappings(
+  database: Transaction,
+  input: { readonly organizationId: string; readonly userId: string },
+  observed: SlackUserMappingSyncContext,
+  slackUsers: readonly SlackUser[],
+): Promise<SlackUserMappingSyncResult> {
+  await assertSlackIntegrationManagerForUpdate(database, input);
+  const [current] = await database
+    .select({
+      config: integration.config,
+      integrationVersion: slackCredentialVersionExpression(),
+    })
+    .from(integration)
+    .where(
+      and(
+        eq(integration.id, observed.integrationId),
+        eq(integration.organizationId, input.organizationId),
+        eq(integration.provider, 'slack'),
+        eq(integration.externalId, 'default'),
+      ),
+    )
+    .limit(1)
+    .for('update');
+  if (
+    current === undefined ||
+    current.integrationVersion !== observed.integrationVersion ||
+    current.config['slackTeamId'] !== observed.slackTeamId ||
+    current.config['slackReauthorize'] === true ||
+    !slackDirectoryScopesPresent(current.config['scopes'])
+  ) {
+    return { status: 'stale' };
+  }
+
+  const memberships = await database
+    .select({ userId: member.userId, email: user.email })
+    .from(member)
+    .innerJoin(user, eq(user.id, member.userId))
+    .where(eq(member.organizationId, input.organizationId))
+    .for('share', { of: member });
+  const existingMappings = await database
+    .select({
+      id: slackUserMapping.id,
+      userId: slackUserMapping.userId,
+      slackUserId: slackUserMapping.slackUserId,
+      slackChannelId: slackUserMapping.slackChannelId,
+      createdAt: slackUserMapping.createdAt,
+    })
+    .from(slackUserMapping)
+    .where(
+      and(
+        eq(slackUserMapping.organizationId, input.organizationId),
+        eq(slackUserMapping.integrationId, observed.integrationId),
+      ),
+    )
+    .for('update');
+  const eligibleMembers = memberships.map((membership) => ({
+    userId: membership.userId,
+    email: membership.email.trim().toLowerCase(),
+  }));
+  const matches = unambiguousSlackUserMatches(eligibleMembers, slackUsers);
+  const existingByUserId = new Map(existingMappings.map((mapping) => [mapping.userId, mapping]));
+  const now = new Date();
+
+  await database
+    .delete(slackUserMapping)
+    .where(
+      and(
+        eq(slackUserMapping.organizationId, input.organizationId),
+        eq(slackUserMapping.integrationId, observed.integrationId),
+      ),
+    );
+  if (matches.length > 0) {
+    const mappingValues = matches.map(({ orbitUser, slackUser }) => {
+      const existing = existingByUserId.get(orbitUser.userId);
+      const sameIdentity = existing?.slackUserId === slackUser.id;
+      return {
+        id: sameIdentity ? existing.id : randomUUIDv7(),
+        organizationId: input.organizationId,
+        integrationId: observed.integrationId,
+        userId: orbitUser.userId,
+        slackUserId: slackUser.id,
+        slackDisplayName: slackUser.displayName,
+        slackChannelId: sameIdentity ? existing.slackChannelId : null,
+        createdAt: sameIdentity ? existing.createdAt : now,
+        updatedAt: now,
+      };
+    });
+    for (const mappingBatch of chunk(mappingValues, SLACK_USER_MAPPING_INSERT_BATCH_SIZE)) {
+      await database.insert(slackUserMapping).values(mappingBatch);
+    }
+  }
+  return {
+    status: 'applied',
+    eligibleMembers: eligibleMembers.length,
+    mappedMembers: matches.length,
+  };
+}
+
+function slackDirectoryScopesPresent(value: unknown): boolean {
+  return Array.isArray(value) && value.includes('users:read') && value.includes('users:read.email');
+}
+
+function unambiguousSlackUserMatches(
+  orbitUsers: readonly SlackMemberIdentity[],
+  slackUsers: readonly SlackUser[],
+): { readonly orbitUser: SlackMemberIdentity; readonly slackUser: SlackUser }[] {
+  const orbitByEmail = uniqueByNormalizedEmail(orbitUsers, (entry) => entry.email);
+  const slackByEmail = uniqueByNormalizedEmail(
+    slackUsers.filter(
+      (entry): entry is SlackUser & { readonly email: string } => entry.email !== null,
+    ),
+    (entry) => entry.email,
+  );
+  const matches: { orbitUser: SlackMemberIdentity; slackUser: SlackUser }[] = [];
+  for (const [email, orbitUser] of orbitByEmail) {
+    if (orbitUser === null) continue;
+    const slackUser = slackByEmail.get(email);
+    if (slackUser === undefined || slackUser === null) continue;
+    matches.push({ orbitUser, slackUser });
+  }
+  return matches.sort((left, right) => left.orbitUser.userId.localeCompare(right.orbitUser.userId));
+}
+
+function uniqueByNormalizedEmail<T>(
+  entries: readonly T[],
+  emailOf: (entry: T) => string,
+): Map<string, T | null> {
+  const byEmail = new Map<string, T | null>();
+  for (const entry of entries) {
+    const email = emailOf(entry).trim().toLowerCase();
+    if (email.length === 0) continue;
+    byEmail.set(email, byEmail.has(email) ? null : entry);
+  }
+  return byEmail;
 }
 
 export async function ensureSlackIntegration(
@@ -677,6 +941,7 @@ async function resolveSlackDmTargetWithContext(
   organizationId: string,
   userId: string,
   context: SlackContext | null,
+  lockMapping = false,
 ): ReturnType<typeof resolveSlackDmTarget> {
   if (
     context === null ||
@@ -685,13 +950,20 @@ async function resolveSlackDmTargetWithContext(
     !context.hasDirectMessageScope
   )
     return null;
-  const [mapping] = await database
+  const query = database
     .select({
       id: slackUserMapping.id,
       slackChannelId: slackUserMapping.slackChannelId,
       slackUserId: slackUserMapping.slackUserId,
     })
     .from(slackUserMapping)
+    .innerJoin(
+      member,
+      and(
+        eq(member.organizationId, slackUserMapping.organizationId),
+        eq(member.userId, slackUserMapping.userId),
+      ),
+    )
     .where(
       and(
         eq(slackUserMapping.integrationId, context.integrationId),
@@ -700,6 +972,7 @@ async function resolveSlackDmTargetWithContext(
       ),
     )
     .limit(1);
+  const [mapping] = lockMapping ? await query.for('update', { of: slackUserMapping }) : await query;
   return mapping === undefined
     ? null
     : {
@@ -737,7 +1010,47 @@ export async function dispatchSlackDmResult(
   database: SlackDatabase,
   input: DispatchSlackDmInput,
 ): Promise<SlackDmDispatchResult> {
-  const observedContext = await resolveSlackContext(database, input.organizationId, 'default');
+  const dispatch = async (tx: Transaction): Promise<SlackDmDispatchResult> => {
+    return await dispatchSlackDmResultLocked(tx, input);
+  };
+  if ('transaction' in database) {
+    const outcome = await database.transaction(async (tx) => {
+      try {
+        return { status: 'delivered' as const, result: await dispatch(tx) };
+      } catch (error) {
+        return { status: 'failed' as const, error };
+      }
+    });
+    if (outcome.status === 'failed') throw outcome.error;
+    return outcome.result;
+  }
+  return await dispatch(database);
+}
+
+async function dispatchSlackDmResultLocked(
+  database: Transaction,
+  input: DispatchSlackDmInput,
+): Promise<SlackDmDispatchResult> {
+  const [contextRow] = await database
+    .select({
+      id: integration.id,
+      credentials: integration.credentials,
+      config: integration.config,
+      updatedAt: integration.updatedAt,
+      integrationVersion: slackCredentialVersionExpression(),
+    })
+    .from(integration)
+    .where(
+      and(
+        eq(integration.organizationId, input.organizationId),
+        eq(integration.provider, 'slack'),
+        eq(integration.externalId, 'default'),
+      ),
+    )
+    .limit(1)
+    .for('share');
+  const observedContext =
+    contextRow === undefined ? null : slackContextFromRow(contextRow, input.organizationId);
   if (observedContext?.credentialUnavailable === true) {
     throw new SlackDmDispatchError(observedContext, new SlackCredentialUnavailableError());
   }
@@ -746,6 +1059,7 @@ export async function dispatchSlackDmResult(
     input.organizationId,
     input.userId,
     observedContext,
+    true,
   );
   if (target === null) return { delivered: 0, channel: null, ts: null };
   const { context: targetContext } = target;

--- a/packages/services/src/slack/index.ts
+++ b/packages/services/src/slack/index.ts
@@ -5,6 +5,8 @@ import { z } from 'zod';
 export const SLACK_REPLAY_WINDOW_SECONDS = 300;
 export const SLACK_API_BASE = 'https://slack.com/api';
 export const SLACK_REQUEST_TIMEOUT_MS = 10_000;
+const SLACK_USER_DIRECTORY_MAX_PAGES = 5_000;
+const SLACK_USER_DIRECTORY_MAX_DURATION_MS = 30_000;
 
 export function verifySlackSignature(
   rawBody: string,
@@ -202,18 +204,30 @@ const conversationResponseSchema = z.discriminatedUnion('ok', [
   }),
 ]);
 
-const userResponseSchema = slackResponseSchema.extend({
-  user: z
+const usersResponseSchema = z.discriminatedUnion('ok', [
+  z.object({
+    ok: z.literal(true),
+    members: z.array(z.unknown()),
+    response_metadata: z.object({ next_cursor: z.string() }),
+  }),
+  z.object({
+    ok: z.literal(false),
+    error: z.string().optional(),
+  }),
+]);
+
+const directoryMemberSchema = z.object({
+  id: z.string().min(1),
+  deleted: z.boolean().optional(),
+  is_bot: z.boolean().optional(),
+  is_app_user: z.boolean().optional(),
+  real_name: z.string().nullable().optional(),
+  profile: z
     .object({
-      id: z.string(),
-      real_name: z.string().default(''),
-      profile: z
-        .object({
-          email: z.string().email().optional(),
-          display_name: z.string().default(''),
-        })
-        .default({ display_name: '' }),
+      email: z.string().nullable().optional(),
+      display_name: z.string().nullable().optional(),
     })
+    .nullable()
     .optional(),
 });
 
@@ -262,10 +276,78 @@ export interface SlackUser {
   readonly displayName: string;
 }
 
+function slackUserFromDirectoryMember(value: unknown): SlackUser | null {
+  const parsedMember = directoryMemberSchema.safeParse(value);
+  if (!parsedMember.success) return null;
+  const member = parsedMember.data;
+  if (member.deleted === true || member.is_bot !== false || member.is_app_user === true)
+    return null;
+  const parsedEmail = z.email().safeParse(member.profile?.email?.trim().toLowerCase());
+  if (!parsedEmail.success) return null;
+  return {
+    id: member.id,
+    email: parsedEmail.data,
+    displayName: member.profile?.display_name || member.real_name || '',
+  };
+}
+
+function nextSlackDirectoryCursor(nextCursor: string, seenCursors: Set<string>): string | null {
+  if (nextCursor.length === 0) return null;
+  if (seenCursors.has(nextCursor)) {
+    throw internal('Slack users.list returned a repeated cursor.');
+  }
+  seenCursors.add(nextCursor);
+  return nextCursor;
+}
+
+function assertSlackDirectoryWithinLimits(
+  pageCount: number,
+  startedAt: number,
+  pageLimit: number,
+): void {
+  if (pageCount >= pageLimit) {
+    throw internal('Slack users.list exceeded the safe page limit.');
+  }
+  if (Date.now() - startedAt >= SLACK_USER_DIRECTORY_MAX_DURATION_MS) {
+    throw internal('Slack users.list exceeded the safe duration limit.');
+  }
+}
+
+function slackDirectoryRetryAfter(error: unknown, startedAt: number): number | null {
+  if (!(error instanceof SlackApiError) || error.code !== 'ratelimited') return null;
+  if (error.retryAfterMs === undefined) return null;
+  const elapsedMs = Math.max(0, Date.now() - startedAt);
+  const remainingMs = SLACK_USER_DIRECTORY_MAX_DURATION_MS - elapsedMs - SLACK_REQUEST_TIMEOUT_MS;
+  return error.retryAfterMs < remainingMs ? error.retryAfterMs : null;
+}
+
+function waitForSlackDirectoryRetry(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+type SlackUserDirectoryPage = SuccessfulSlackResponse<typeof usersResponseSchema>;
+
+async function requestSlackDirectoryPage(
+  request: () => Promise<SlackUserDirectoryPage>,
+  startedAt: number,
+  retryAvailable: boolean,
+): Promise<{ readonly body: SlackUserDirectoryPage; readonly retried: boolean }> {
+  try {
+    return { body: await request(), retried: false };
+  } catch (error) {
+    const retryAfterMs = slackDirectoryRetryAfter(error, startedAt);
+    if (!retryAvailable || retryAfterMs === null) throw error;
+    await waitForSlackDirectoryRetry(retryAfterMs);
+    if (Date.now() - startedAt >= SLACK_USER_DIRECTORY_MAX_DURATION_MS) throw error;
+    return { body: await request(), retried: true };
+  }
+}
+
 export interface SlackClientOptions {
   readonly token: string;
   readonly baseUrl?: string;
   readonly fetch?: typeof globalThis.fetch;
+  readonly userDirectoryPageLimit?: number;
 }
 
 export interface PostMessageInput {
@@ -288,12 +370,18 @@ export class SlackClient {
   private readonly token: string;
   private readonly baseUrl: string;
   private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly userDirectoryPageLimit: number;
 
   constructor(options: SlackClientOptions) {
     if (options.token.length === 0) throw unauthorized('A Slack token is required.');
+    const userDirectoryPageLimit = options.userDirectoryPageLimit ?? SLACK_USER_DIRECTORY_MAX_PAGES;
+    if (!Number.isSafeInteger(userDirectoryPageLimit) || userDirectoryPageLimit < 1) {
+      throw internal('The Slack user directory page limit must be a positive integer.');
+    }
     this.token = options.token;
     this.baseUrl = options.baseUrl ?? SLACK_API_BASE;
     this.fetchImpl = options.fetch ?? globalThis.fetch;
+    this.userDirectoryPageLimit = Math.min(userDirectoryPageLimit, SLACK_USER_DIRECTORY_MAX_PAGES);
   }
 
   async postMessage(input: PostMessageInput): Promise<SlackMessageRef> {
@@ -383,21 +471,33 @@ export class SlackClient {
     };
   }
 
-  async lookupUserByEmail(email: string): Promise<SlackUser | null> {
-    let body: z.infer<typeof userResponseSchema>;
-    try {
-      body = await this.call('users.lookupByEmail', userResponseSchema, { email });
-    } catch (error) {
-      if (error instanceof SlackApiError && error.code === 'users_not_found') return null;
-      throw error;
-    }
-    const user = body.user;
-    if (user === undefined) return null;
-    return {
-      id: user.id,
-      email: user.profile.email ?? null,
-      displayName: user.profile.display_name || user.real_name,
-    };
+  async listUsers(): Promise<SlackUser[]> {
+    const users: SlackUser[] = [];
+    const seenCursors = new Set<string>();
+    const startedAt = Date.now();
+    let pageCount = 0;
+    let cursor: string | null = null;
+    let rateLimitRetryUsed = false;
+    do {
+      assertSlackDirectoryWithinLimits(pageCount, startedAt, this.userDirectoryPageLimit);
+      pageCount += 1;
+      const page = await requestSlackDirectoryPage(
+        () =>
+          this.callQuery('users.list', usersResponseSchema, {
+            limit: '200',
+            ...(cursor === null ? {} : { cursor }),
+          }),
+        startedAt,
+        !rateLimitRetryUsed,
+      );
+      rateLimitRetryUsed ||= page.retried;
+      for (const memberValue of page.body.members) {
+        const user = slackUserFromDirectoryMember(memberValue);
+        if (user !== null) users.push(user);
+      }
+      cursor = nextSlackDirectoryCursor(page.body.response_metadata.next_cursor, seenCursors);
+    } while (cursor !== null);
+    return users;
   }
 
   private call<T extends z.ZodTypeAny>(
@@ -438,7 +538,11 @@ export class SlackClient {
   ): Promise<SuccessfulSlackResponse<T>> {
     const response = await this.fetchImpl(input, init);
     if (response.status === 429) {
-      const retryAfterSeconds = Number(response.headers.get('retry-after'));
+      const retryAfterHeader = response.headers.get('retry-after');
+      const retryAfterSeconds =
+        retryAfterHeader === null || retryAfterHeader.trim().length === 0
+          ? Number.NaN
+          : Number(retryAfterHeader);
       const retryAfterMs =
         Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0
           ? Math.ceil(retryAfterSeconds * 1000)

--- a/packages/services/tests/slack/dispatch.test.ts
+++ b/packages/services/tests/slack/dispatch.test.ts
@@ -11,7 +11,7 @@ import {
   workflowState,
 } from '@orbit/db/schema';
 import { randomUUIDv7 } from '@orbit/shared/utils';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { markSlackReauthorizationRequired } from '../../src/notifications/index.ts';
 import { decryptSlackBotToken, encryptSlackBotToken } from '../../src/slack/credentials.ts';
 import {
@@ -27,9 +27,10 @@ import {
   resolveSlackTargets,
   sendSlackUnfurls,
   slackDmAvailable,
+  syncSlackUserMappings,
   upsertSlackUserMapping,
 } from '../../src/slack/dispatch.ts';
-import { type TestTransaction, withRollback } from '../../src/test-database.ts';
+import { type TestTransaction, testDb, withRollback } from '../../src/test-database.ts';
 
 const originalAuthSecret = process.env['BETTER_AUTH_SECRET'];
 process.env['BETTER_AUTH_SECRET'] ??= 'slack-dispatch-test-secret';
@@ -562,6 +563,857 @@ describe('resolveSlackContext stays inside the workspace it was asked about', ()
         reauthorize: false,
         updatedAt: expect.any(Date),
       });
+    });
+  });
+});
+
+describe('syncSlackUserMappings', () => {
+  it('waits for member removal before replacing the mapping snapshot', async () => {
+    const fixture = await testDb.transaction(async (tx) => await seed(tx));
+    const teammateId = `usr_${randomUUIDv7()}`;
+    const teammateMemberId = `mem_${randomUUIDv7()}`;
+    let releaseRemoval: () => void = () => undefined;
+    const removalRelease = new Promise<void>((resolve) => {
+      releaseRemoval = resolve;
+    });
+    let announceRemoval: () => void = () => undefined;
+    const removalReady = new Promise<void>((resolve) => {
+      announceRemoval = resolve;
+    });
+    let removal: Promise<void> | undefined;
+    let sync: ReturnType<typeof syncSlackUserMappings> | undefined;
+    try {
+      await testDb
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'member-removal-version',
+            slackTeamId: 'T-WORKSPACE',
+            scopes: ['users:read', 'users:read.email'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      const teammateEmail = `teammate.${randomUUIDv7()}@orbit.local`;
+      await testDb.insert(user).values({
+        id: teammateId,
+        name: 'Teammate',
+        email: teammateEmail,
+        handle: `teammate-${randomUUIDv7().toLowerCase()}`,
+      });
+      await testDb.insert(member).values({
+        id: teammateMemberId,
+        organizationId: fixture.organizationId,
+        userId: teammateId,
+        role: 'member',
+      });
+      await upsertSlackUserMapping(testDb, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        userId: teammateId,
+        slackUserId: 'U-TEAMMATE',
+        slackDisplayName: 'Teammate',
+      });
+      removal = testDb.transaction(async (tx) => {
+        await tx
+          .select({ id: member.id })
+          .from(member)
+          .where(eq(member.id, teammateMemberId))
+          .for('update');
+        announceRemoval();
+        await removalRelease;
+        await tx
+          .delete(slackUserMapping)
+          .where(
+            and(
+              eq(slackUserMapping.organizationId, fixture.organizationId),
+              eq(slackUserMapping.userId, teammateId),
+            ),
+          );
+        await tx.delete(member).where(eq(member.id, teammateMemberId));
+      });
+      await removalReady;
+      const fetch = (() =>
+        Promise.resolve(
+          Response.json({
+            ok: true,
+            members: [
+              {
+                id: 'U-TEAMMATE',
+                deleted: false,
+                is_bot: false,
+                is_app_user: false,
+                real_name: 'Teammate',
+                profile: { email: teammateEmail, display_name: 'Teammate' },
+              },
+            ],
+            response_metadata: { next_cursor: '' },
+          }),
+        )) as unknown as typeof globalThis.fetch;
+      sync = syncSlackUserMappings(testDb, {
+        organizationId: fixture.organizationId,
+        userId: fixture.userId,
+        fetch,
+      });
+      expect(
+        await Promise.race([
+          sync.then(
+            () => 'settled' as const,
+            () => 'settled' as const,
+          ),
+          new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 500)),
+        ]),
+      ).toBe('blocked');
+
+      releaseRemoval();
+      await removal;
+      await expect(sync).resolves.toEqual({
+        status: 'applied',
+        eligibleMembers: 1,
+        mappedMembers: 0,
+      });
+      expect(
+        await testDb
+          .select({ id: slackUserMapping.id })
+          .from(slackUserMapping)
+          .where(eq(slackUserMapping.userId, teammateId)),
+      ).toEqual([]);
+    } finally {
+      releaseRemoval();
+      await removal?.catch(() => undefined);
+      await sync?.catch(() => undefined);
+      await testDb.delete(organization).where(eq(organization.id, fixture.organizationId));
+      await testDb.delete(user).where(eq(user.id, fixture.userId));
+      await testDb.delete(user).where(eq(user.id, teammateId));
+    }
+  });
+
+  it('maps every current workspace member and removes mappings for former members', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await tx
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'sync-version',
+            slackTeamId: 'T-WORKSPACE',
+            scopes: ['users:read', 'users:read.email'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      const [admin] = await tx
+        .select({ email: user.email })
+        .from(user)
+        .where(eq(user.id, fixture.userId));
+      if (admin === undefined) throw new Error('Expected the workspace administrator.');
+      const teammateId = `usr_${randomUUIDv7()}`;
+      await tx.insert(user).values({
+        id: teammateId,
+        name: 'Grace',
+        email: `grace.${randomUUIDv7()}@orbit.local`,
+        handle: `grace-${randomUUIDv7().toLowerCase()}`,
+      });
+      await tx.insert(member).values({
+        id: `mem_${randomUUIDv7()}`,
+        organizationId: fixture.organizationId,
+        userId: teammateId,
+        role: 'member',
+      });
+      const [teammate] = await tx
+        .select({ email: user.email })
+        .from(user)
+        .where(eq(user.id, teammateId));
+      if (teammate === undefined) throw new Error('Expected the workspace teammate.');
+      const formerUserId = `usr_${randomUUIDv7()}`;
+      await tx.insert(user).values({
+        id: formerUserId,
+        name: 'Former',
+        email: `former.${randomUUIDv7()}@orbit.local`,
+        handle: `former-${randomUUIDv7().toLowerCase()}`,
+      });
+      const adminMappingId = `sum_${randomUUIDv7()}`;
+      const teammateMappingId = `sum_${randomUUIDv7()}`;
+      await tx.insert(slackUserMapping).values([
+        {
+          id: adminMappingId,
+          organizationId: fixture.organizationId,
+          integrationId: fixture.integrationId,
+          userId: fixture.userId,
+          slackUserId: 'U-ADMIN',
+          slackDisplayName: 'Ada',
+          slackChannelId: 'D-ADMIN',
+        },
+        {
+          id: teammateMappingId,
+          organizationId: fixture.organizationId,
+          integrationId: fixture.integrationId,
+          userId: teammateId,
+          slackUserId: 'U-GRACE-OLD',
+          slackDisplayName: 'Grace Old',
+          slackChannelId: 'D-GRACE-OLD',
+        },
+        {
+          id: `sum_${randomUUIDv7()}`,
+          organizationId: fixture.organizationId,
+          integrationId: fixture.integrationId,
+          userId: formerUserId,
+          slackUserId: 'U-FORMER',
+          slackDisplayName: 'Former',
+        },
+      ]);
+      const fetch = (() =>
+        Promise.resolve(
+          Response.json({
+            ok: true,
+            members: [
+              {
+                id: 'U-ADMIN',
+                deleted: false,
+                is_bot: false,
+                is_app_user: false,
+                real_name: 'Ada',
+                profile: { email: admin.email.toUpperCase(), display_name: 'Ada' },
+              },
+              {
+                id: 'U-GRACE',
+                deleted: false,
+                is_bot: false,
+                is_app_user: false,
+                real_name: 'Grace',
+                profile: { email: teammate.email, display_name: 'Grace' },
+              },
+            ],
+            response_metadata: { next_cursor: '' },
+          }),
+        )) as unknown as typeof globalThis.fetch;
+
+      await expect(
+        syncSlackUserMappings(tx, {
+          organizationId: fixture.organizationId,
+          userId: fixture.userId,
+          fetch,
+        }),
+      ).resolves.toEqual({ status: 'applied', eligibleMembers: 2, mappedMembers: 2 });
+      const mappings = await tx
+        .select({
+          id: slackUserMapping.id,
+          userId: slackUserMapping.userId,
+          slackUserId: slackUserMapping.slackUserId,
+          slackChannelId: slackUserMapping.slackChannelId,
+        })
+        .from(slackUserMapping)
+        .where(eq(slackUserMapping.integrationId, fixture.integrationId));
+      expect(mappings.sort((left, right) => left.userId.localeCompare(right.userId))).toEqual(
+        [
+          {
+            id: adminMappingId,
+            userId: fixture.userId,
+            slackUserId: 'U-ADMIN',
+            slackChannelId: 'D-ADMIN',
+          },
+          {
+            id: expect.not.stringContaining(teammateMappingId),
+            userId: teammateId,
+            slackUserId: 'U-GRACE',
+            slackChannelId: null,
+          },
+        ].sort((left, right) => left.userId.localeCompare(right.userId)),
+      );
+    });
+  });
+
+  it('maps a directory that crosses the database insert batch boundary', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await tx
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'batch-version',
+            slackTeamId: 'T-WORKSPACE',
+            scopes: ['users:read', 'users:read.email'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      const teammates = Array.from({ length: 7300 }, (_, index) => {
+        const suffix = randomUUIDv7();
+        return {
+          id: `usr_${suffix}`,
+          name: `Member ${index}`,
+          email: `batch.${index}.${suffix}@orbit.local`,
+          handle: `batch-${index}-${suffix.toLowerCase()}`,
+        };
+      });
+      await tx.insert(user).values(teammates);
+      await tx.insert(member).values(
+        teammates.map((teammate) => ({
+          id: `mem_${randomUUIDv7()}`,
+          organizationId: fixture.organizationId,
+          userId: teammate.id,
+          role: 'member' as const,
+        })),
+      );
+      const [admin] = await tx
+        .select({ email: user.email })
+        .from(user)
+        .where(eq(user.id, fixture.userId));
+      if (admin === undefined) throw new Error('Expected the workspace administrator.');
+      const directory = [
+        { id: 'U-BATCH-ADMIN', email: admin.email, displayName: 'Admin' },
+        ...teammates.map((teammate, index) => ({
+          id: `U-BATCH-${index}`,
+          email: teammate.email,
+          displayName: teammate.name,
+        })),
+      ];
+      const fetch = (() =>
+        Promise.resolve(
+          Response.json({
+            ok: true,
+            members: directory.map((entry) => ({
+              id: entry.id,
+              deleted: false,
+              is_bot: false,
+              is_app_user: false,
+              real_name: entry.displayName,
+              profile: { email: entry.email, display_name: entry.displayName },
+            })),
+            response_metadata: { next_cursor: '' },
+          }),
+        )) as unknown as typeof globalThis.fetch;
+
+      await expect(
+        syncSlackUserMappings(tx, {
+          organizationId: fixture.organizationId,
+          userId: fixture.userId,
+          fetch,
+        }),
+      ).resolves.toEqual({ status: 'applied', eligibleMembers: 7301, mappedMembers: 7301 });
+      const mappings = await tx
+        .select({ id: slackUserMapping.id })
+        .from(slackUserMapping)
+        .where(eq(slackUserMapping.integrationId, fixture.integrationId));
+      expect(mappings).toHaveLength(7301);
+    });
+  });
+
+  it('rolls back the old mapping snapshot when a replacement insert fails', async () => {
+    const fixture = await testDb.transaction(async (tx) => await seed(tx));
+    try {
+      await testDb
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'rollback-version',
+            slackTeamId: 'T-WORKSPACE',
+            scopes: ['users:read', 'users:read.email'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      const teammateId = `usr_${randomUUIDv7()}`;
+      const teammateEmail = `rollback.${randomUUIDv7()}@orbit.local`;
+      await testDb.insert(user).values({
+        id: teammateId,
+        name: 'Rollback Member',
+        email: teammateEmail,
+        handle: `rollback-${randomUUIDv7().toLowerCase()}`,
+      });
+      await testDb.insert(member).values({
+        id: `mem_${randomUUIDv7()}`,
+        organizationId: fixture.organizationId,
+        userId: teammateId,
+        role: 'member',
+      });
+      const [admin] = await testDb
+        .select({ email: user.email })
+        .from(user)
+        .where(eq(user.id, fixture.userId));
+      if (admin === undefined) throw new Error('Expected the workspace administrator.');
+      const oldMappingId = `sum_${randomUUIDv7()}`;
+      await testDb.insert(slackUserMapping).values({
+        id: oldMappingId,
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        userId: fixture.userId,
+        slackUserId: 'U-OLD',
+        slackDisplayName: 'Old',
+        slackChannelId: 'D-OLD',
+      });
+      const fetch = (() =>
+        Promise.resolve(
+          Response.json({
+            ok: true,
+            members: [admin.email, teammateEmail].map((email) => ({
+              id: 'U-DUPLICATE',
+              deleted: false,
+              is_bot: false,
+              is_app_user: false,
+              real_name: 'Duplicate',
+              profile: { email, display_name: 'Duplicate' },
+            })),
+            response_metadata: { next_cursor: '' },
+          }),
+        )) as unknown as typeof globalThis.fetch;
+
+      await expect(
+        syncSlackUserMappings(testDb, {
+          organizationId: fixture.organizationId,
+          userId: fixture.userId,
+          fetch,
+        }),
+      ).rejects.toThrow('insert into "slack_user_mapping"');
+      expect(
+        await testDb
+          .select({
+            id: slackUserMapping.id,
+            slackUserId: slackUserMapping.slackUserId,
+            slackChannelId: slackUserMapping.slackChannelId,
+          })
+          .from(slackUserMapping)
+          .where(eq(slackUserMapping.integrationId, fixture.integrationId)),
+      ).toEqual([{ id: oldMappingId, slackUserId: 'U-OLD', slackChannelId: 'D-OLD' }]);
+    } finally {
+      await testDb.delete(organization).where(eq(organization.id, fixture.organizationId));
+    }
+  });
+
+  it('keeps every prior mapping when a later Slack directory page is incomplete', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await tx
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'stable-version',
+            slackTeamId: 'T-WORKSPACE',
+            scopes: ['users:read', 'users:read.email'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      await upsertSlackUserMapping(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        userId: fixture.userId,
+        slackUserId: 'U-STABLE',
+        slackDisplayName: 'Stable',
+      });
+      await tx
+        .update(slackUserMapping)
+        .set({ slackChannelId: 'D-STABLE' })
+        .where(eq(slackUserMapping.integrationId, fixture.integrationId));
+      const [admin] = await tx
+        .select({ email: user.email })
+        .from(user)
+        .where(eq(user.id, fixture.userId));
+      if (admin === undefined) throw new Error('Expected the workspace administrator.');
+      let calls = 0;
+      const fetch = (() => {
+        calls += 1;
+        if (calls === 1) {
+          return Promise.resolve(
+            Response.json({
+              ok: true,
+              members: [
+                {
+                  id: 'U-REPLACEMENT',
+                  deleted: false,
+                  is_bot: false,
+                  is_app_user: false,
+                  real_name: 'Replacement',
+                  profile: { email: admin.email, display_name: 'Replacement' },
+                },
+              ],
+              response_metadata: { next_cursor: 'page-two' },
+            }),
+          );
+        }
+        return Promise.resolve(Response.json({ ok: true, members: [] }));
+      }) as unknown as typeof globalThis.fetch;
+
+      await expect(
+        syncSlackUserMappings(tx, {
+          organizationId: fixture.organizationId,
+          userId: fixture.userId,
+          fetch,
+        }),
+      ).rejects.toThrow('unexpected payload');
+      expect(
+        await tx
+          .select({
+            userId: slackUserMapping.userId,
+            slackUserId: slackUserMapping.slackUserId,
+            slackChannelId: slackUserMapping.slackChannelId,
+          })
+          .from(slackUserMapping)
+          .where(eq(slackUserMapping.integrationId, fixture.integrationId)),
+      ).toEqual([{ userId: fixture.userId, slackUserId: 'U-STABLE', slackChannelId: 'D-STABLE' }]);
+    });
+  });
+
+  it('marks the observed integration for reauthorization when its token expires', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await tx
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'expired-version',
+            slackTeamId: 'T-WORKSPACE',
+            scopes: ['users:read', 'users:read.email'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      const fetch = (() =>
+        Promise.resolve(
+          Response.json({ ok: false, error: 'token_expired' }),
+        )) as unknown as typeof globalThis.fetch;
+
+      await expect(
+        syncSlackUserMappings(tx, {
+          organizationId: fixture.organizationId,
+          userId: fixture.userId,
+          fetch,
+        }),
+      ).rejects.toMatchObject({ code: 'token_expired' });
+      const [stored] = await tx
+        .select({ config: integration.config })
+        .from(integration)
+        .where(eq(integration.id, fixture.integrationId));
+      expect(stored?.config['slackReauthorize']).toBe(true);
+    });
+  });
+
+  it('does not mark replacement credentials for an error from the previous token', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await tx
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'previous-version',
+            slackTeamId: 'T-WORKSPACE',
+            scopes: ['users:read', 'users:read.email'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      const fetch = (async () => {
+        await tx
+          .update(integration)
+          .set({
+            config: {
+              credentialVersion: 'replacement-version',
+              slackTeamId: 'T-WORKSPACE',
+              scopes: ['users:read', 'users:read.email'],
+            },
+          })
+          .where(eq(integration.id, fixture.integrationId));
+        return Response.json({ ok: false, error: 'invalid_auth' });
+      }) as unknown as typeof globalThis.fetch;
+
+      await expect(
+        syncSlackUserMappings(tx, {
+          organizationId: fixture.organizationId,
+          userId: fixture.userId,
+          fetch,
+        }),
+      ).rejects.toMatchObject({ code: 'invalid_auth' });
+      const [stored] = await tx
+        .select({ config: integration.config })
+        .from(integration)
+        .where(eq(integration.id, fixture.integrationId));
+      expect(stored?.config).toMatchObject({ credentialVersion: 'replacement-version' });
+      expect(stored?.config['slackReauthorize']).toBeUndefined();
+    });
+  });
+
+  it('retains prior mappings when reauthorization is marked during directory loading', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await tx
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'reauthorize-version',
+            slackTeamId: 'T-WORKSPACE',
+            scopes: ['users:read', 'users:read.email'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      await upsertSlackUserMapping(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        userId: fixture.userId,
+        slackUserId: 'U-STABLE',
+        slackDisplayName: 'Stable',
+      });
+      const fetch = (async () => {
+        await markSlackReauthorizationRequired(
+          tx,
+          fixture.organizationId,
+          fixture.integrationId,
+          'reauthorize-version',
+        );
+        return Response.json({
+          ok: true,
+          members: [],
+          response_metadata: { next_cursor: '' },
+        });
+      }) as unknown as typeof globalThis.fetch;
+
+      await expect(
+        syncSlackUserMappings(tx, {
+          organizationId: fixture.organizationId,
+          userId: fixture.userId,
+          fetch,
+        }),
+      ).resolves.toEqual({ status: 'stale' });
+      expect(
+        await tx
+          .select({ slackUserId: slackUserMapping.slackUserId })
+          .from(slackUserMapping)
+          .where(eq(slackUserMapping.integrationId, fixture.integrationId)),
+      ).toEqual([{ slackUserId: 'U-STABLE' }]);
+    });
+  });
+
+  it('rechecks manager authority after loading the Slack directory', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await tx
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'authority-version',
+            slackTeamId: 'T-WORKSPACE',
+            scopes: ['users:read', 'users:read.email'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      await upsertSlackUserMapping(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        userId: fixture.userId,
+        slackUserId: 'U-STABLE',
+        slackDisplayName: 'Stable',
+      });
+      const fetch = (async () => {
+        await tx.update(member).set({ role: 'member' }).where(eq(member.userId, fixture.userId));
+        return Response.json({
+          ok: true,
+          members: [],
+          response_metadata: { next_cursor: '' },
+        });
+      }) as unknown as typeof globalThis.fetch;
+
+      await expect(
+        syncSlackUserMappings(tx, {
+          organizationId: fixture.organizationId,
+          userId: fixture.userId,
+          fetch,
+        }),
+      ).rejects.toMatchObject({ code: 'forbidden' });
+      expect(
+        await tx
+          .select({ slackUserId: slackUserMapping.slackUserId })
+          .from(slackUserMapping)
+          .where(eq(slackUserMapping.integrationId, fixture.integrationId)),
+      ).toEqual([{ slackUserId: 'U-STABLE' }]);
+    });
+  });
+
+  it('does not apply a directory fetched with an older same-team credential version', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await tx
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'old-version',
+            slackTeamId: 'T-OLD',
+            scopes: ['users:read', 'users:read.email'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      await upsertSlackUserMapping(tx, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        userId: fixture.userId,
+        slackUserId: 'U-OLD',
+        slackDisplayName: 'Old',
+      });
+      const fetch = (async () => {
+        await tx
+          .update(integration)
+          .set({
+            config: {
+              credentialVersion: 'new-version',
+              slackTeamId: 'T-OLD',
+              scopes: ['users:read', 'users:read.email'],
+            },
+          })
+          .where(eq(integration.id, fixture.integrationId));
+        return Response.json({
+          ok: true,
+          members: [],
+          response_metadata: { next_cursor: '' },
+        });
+      }) as unknown as typeof globalThis.fetch;
+
+      await expect(
+        syncSlackUserMappings(tx, {
+          organizationId: fixture.organizationId,
+          userId: fixture.userId,
+          fetch,
+        }),
+      ).resolves.toEqual({ status: 'stale' });
+      expect(
+        await tx
+          .select({ slackUserId: slackUserMapping.slackUserId })
+          .from(slackUserMapping)
+          .where(eq(slackUserMapping.integrationId, fixture.integrationId)),
+      ).toEqual([{ slackUserId: 'U-OLD' }]);
+    });
+  });
+
+  it('leaves an ambiguous Orbit email unmapped without changing another workspace', async () => {
+    await withRollback(async (tx) => {
+      const target = await seed(tx);
+      const neighbour = await seedWorkspace(tx, {
+        name: 'Neighbour',
+        slackTeamId: 'default',
+        botToken: 'xoxb-neighbour',
+      });
+      await tx
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'target-version',
+            slackTeamId: 'T-TARGET',
+            scopes: ['users:read', 'users:read.email'],
+          },
+        })
+        .where(eq(integration.id, target.integrationId));
+      const [admin] = await tx
+        .select({ email: user.email })
+        .from(user)
+        .where(eq(user.id, target.userId));
+      if (admin === undefined) throw new Error('Expected the target administrator.');
+      const collidingUserId = 'usr_000_case_collision';
+      await tx.insert(user).values({
+        id: collidingUserId,
+        name: 'Case Collision',
+        email: admin.email.toUpperCase(),
+        handle: `case-collision-${randomUUIDv7().toLowerCase()}`,
+      });
+      await tx.insert(member).values({
+        id: `mem_${randomUUIDv7()}`,
+        organizationId: target.organizationId,
+        userId: collidingUserId,
+        role: 'member',
+      });
+      await upsertSlackUserMapping(tx, {
+        organizationId: neighbour.organizationId,
+        integrationId: neighbour.integrationId,
+        userId: neighbour.userId,
+        slackUserId: 'U-NEIGHBOUR',
+        slackDisplayName: 'Neighbour',
+      });
+      const fetch = (() =>
+        Promise.resolve(
+          Response.json({
+            ok: true,
+            members: [
+              {
+                id: 'U-A',
+                deleted: false,
+                is_bot: false,
+                is_app_user: false,
+                real_name: 'Earlier Identity',
+                profile: { email: admin.email.toUpperCase(), display_name: 'Earlier' },
+              },
+            ],
+            response_metadata: { next_cursor: '' },
+          }),
+        )) as unknown as typeof globalThis.fetch;
+
+      await expect(
+        syncSlackUserMappings(tx, {
+          organizationId: target.organizationId,
+          userId: target.userId,
+          fetch,
+        }),
+      ).resolves.toEqual({ status: 'applied', eligibleMembers: 2, mappedMembers: 0 });
+      expect(
+        await tx
+          .select({ userId: slackUserMapping.userId, slackUserId: slackUserMapping.slackUserId })
+          .from(slackUserMapping)
+          .where(eq(slackUserMapping.integrationId, target.integrationId)),
+      ).toEqual([]);
+      expect(
+        await tx
+          .select({ slackUserId: slackUserMapping.slackUserId })
+          .from(slackUserMapping)
+          .where(eq(slackUserMapping.integrationId, neighbour.integrationId)),
+      ).toEqual([{ slackUserId: 'U-NEIGHBOUR' }]);
+    });
+  });
+
+  it('leaves an ambiguous Slack email unmapped', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await tx
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'slack-collision-version',
+            slackTeamId: 'T-WORKSPACE',
+            scopes: ['users:read', 'users:read.email'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      const [admin] = await tx
+        .select({ email: user.email })
+        .from(user)
+        .where(eq(user.id, fixture.userId));
+      if (admin === undefined) throw new Error('Expected the workspace administrator.');
+      const fetch = (() =>
+        Promise.resolve(
+          Response.json({
+            ok: true,
+            members: [
+              {
+                id: 'U-A',
+                deleted: false,
+                is_bot: false,
+                is_app_user: false,
+                real_name: 'First Identity',
+                profile: { email: admin.email, display_name: 'First' },
+              },
+              {
+                id: 'U-B',
+                deleted: false,
+                is_bot: false,
+                is_app_user: false,
+                real_name: 'Second Identity',
+                profile: { email: admin.email.toUpperCase(), display_name: 'Second' },
+              },
+            ],
+            response_metadata: { next_cursor: '' },
+          }),
+        )) as unknown as typeof globalThis.fetch;
+
+      await expect(
+        syncSlackUserMappings(tx, {
+          organizationId: fixture.organizationId,
+          userId: fixture.userId,
+          fetch,
+        }),
+      ).resolves.toEqual({ status: 'applied', eligibleMembers: 1, mappedMembers: 0 });
+      expect(
+        await tx
+          .select({ id: slackUserMapping.id })
+          .from(slackUserMapping)
+          .where(eq(slackUserMapping.integrationId, fixture.integrationId)),
+      ).toEqual([]);
     });
   });
 });
@@ -1217,6 +2069,377 @@ describe('sendSlackUnfurls', () => {
 });
 
 describe('dispatchSlackDm', () => {
+  it('keeps one credential snapshot for an in-flight private send', async () => {
+    const fixture = await testDb.transaction(async (tx) => await seed(tx));
+    let releaseConversation: () => void = () => undefined;
+    const conversationRelease = new Promise<void>((resolve) => {
+      releaseConversation = resolve;
+    });
+    let announceConversation: () => void = () => undefined;
+    const conversationReady = new Promise<void>((resolve) => {
+      announceConversation = resolve;
+    });
+    const fetch = (async (url: string) => {
+      if (url.endsWith('conversations.open')) {
+        announceConversation();
+        await conversationRelease;
+        return Response.json({ ok: true, channel: { id: 'D-SNAPSHOT' } });
+      }
+      return Response.json({ ok: true, channel: 'D-SNAPSHOT', ts: '1.0' });
+    }) as unknown as typeof globalThis.fetch;
+    let dispatch: Promise<number> | undefined;
+    let rotation: Promise<void> | undefined;
+    try {
+      await testDb
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'snapshot-before',
+            slackTeamId: 'T-WORKSPACE',
+            scopes: ['chat:write', 'im:write'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      await upsertSlackUserMapping(testDb, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        userId: fixture.userId,
+        slackUserId: 'U-SNAPSHOT',
+        slackDisplayName: 'Snapshot identity',
+      });
+
+      dispatch = dispatchSlackDm(testDb, {
+        organizationId: fixture.organizationId,
+        userId: fixture.userId,
+        text: 'Private notification',
+        fetch,
+      });
+      await Promise.race([conversationReady, dispatch.then(() => undefined)]);
+      rotation = testDb.transaction(async (tx) => {
+        await tx
+          .update(integration)
+          .set({
+            credentials: { botToken: 'xoxb-snapshot-after' },
+            config: {
+              credentialVersion: 'snapshot-after',
+              slackTeamId: 'T-WORKSPACE',
+              scopes: ['chat:write', 'im:write'],
+            },
+          })
+          .where(eq(integration.id, fixture.integrationId));
+      });
+      expect(
+        await Promise.race([
+          rotation.then(
+            () => 'settled' as const,
+            () => 'settled' as const,
+          ),
+          new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 500)),
+        ]),
+      ).toBe('blocked');
+
+      releaseConversation();
+      await expect(dispatch).resolves.toBe(1);
+      await rotation;
+      const [current] = await testDb
+        .select({ config: integration.config })
+        .from(integration)
+        .where(eq(integration.id, fixture.integrationId));
+      expect(current?.config['credentialVersion']).toBe('snapshot-after');
+    } finally {
+      releaseConversation();
+      await dispatch?.catch(() => undefined);
+      await rotation?.catch(() => undefined);
+      await testDb.delete(organization).where(eq(organization.id, fixture.organizationId));
+      await testDb.delete(user).where(eq(user.id, fixture.userId));
+    }
+  });
+
+  it('serializes concurrent private sends for the same member mapping', async () => {
+    const fixture = await testDb.transaction(async (tx) => await seed(tx));
+    let releaseConversation: () => void = () => undefined;
+    const conversationRelease = new Promise<void>((resolve) => {
+      releaseConversation = resolve;
+    });
+    let announceConversation: () => void = () => undefined;
+    const conversationReady = new Promise<void>((resolve) => {
+      announceConversation = resolve;
+    });
+    const providerCalls: string[] = [];
+    const fetch = (async (url: string) => {
+      providerCalls.push(url);
+      if (url.endsWith('conversations.open')) {
+        announceConversation();
+        await conversationRelease;
+        return Response.json({ ok: true, channel: { id: 'D-SERIAL' } });
+      }
+      return Response.json({ ok: true, channel: 'D-SERIAL', ts: '1.0' });
+    }) as unknown as typeof globalThis.fetch;
+    let first: Promise<number> | undefined;
+    let second: Promise<number> | undefined;
+    try {
+      await testDb
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'concurrent-dm-version',
+            slackTeamId: 'T-WORKSPACE',
+            scopes: ['chat:write', 'im:write'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      await upsertSlackUserMapping(testDb, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        userId: fixture.userId,
+        slackUserId: 'U-SERIAL',
+        slackDisplayName: 'Serial identity',
+      });
+
+      first = dispatchSlackDm(testDb, {
+        organizationId: fixture.organizationId,
+        userId: fixture.userId,
+        text: 'First private notification',
+        fetch,
+      });
+      await Promise.race([conversationReady, first.then(() => undefined)]);
+      second = dispatchSlackDm(testDb, {
+        organizationId: fixture.organizationId,
+        userId: fixture.userId,
+        text: 'Second private notification',
+        fetch,
+      });
+      expect(
+        await Promise.race([
+          second.then(
+            () => 'settled' as const,
+            () => 'settled' as const,
+          ),
+          new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 500)),
+        ]),
+      ).toBe('blocked');
+      expect(providerCalls.filter((url) => url.endsWith('conversations.open'))).toHaveLength(1);
+
+      releaseConversation();
+      await expect(Promise.all([first, second])).resolves.toEqual([1, 1]);
+      expect(providerCalls.filter((url) => url.endsWith('conversations.open'))).toHaveLength(1);
+      expect(providerCalls.filter((url) => url.endsWith('chat.postMessage'))).toHaveLength(2);
+    } finally {
+      releaseConversation();
+      await first?.catch(() => undefined);
+      await second?.catch(() => undefined);
+      await testDb.delete(organization).where(eq(organization.id, fixture.organizationId));
+      await testDb.delete(user).where(eq(user.id, fixture.userId));
+    }
+  });
+
+  it('uses one replacement snapshot when reconnect wins the lock', async () => {
+    const fixture = await testDb.transaction(async (tx) => await seed(tx));
+    let releaseReplacement: () => void = () => undefined;
+    const replacementRelease = new Promise<void>((resolve) => {
+      releaseReplacement = resolve;
+    });
+    let announceReplacement: () => void = () => undefined;
+    const replacementReady = new Promise<void>((resolve) => {
+      announceReplacement = resolve;
+    });
+    let replacement: Promise<void> | undefined;
+    try {
+      await testDb
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'previous-dm-version',
+            slackTeamId: 'T-PREVIOUS',
+            scopes: ['chat:write', 'im:write'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      await upsertSlackUserMapping(testDb, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        userId: fixture.userId,
+        slackUserId: 'U-PREVIOUS',
+        slackDisplayName: 'Previous identity',
+      });
+      replacement = testDb.transaction(async (tx) => {
+        await tx
+          .update(integration)
+          .set({
+            credentials: { botToken: 'xoxb-replacement' },
+            config: {
+              credentialVersion: 'replacement-dm-version',
+              slackTeamId: 'T-REPLACEMENT',
+              scopes: ['chat:write', 'im:write'],
+            },
+          })
+          .where(eq(integration.id, fixture.integrationId));
+        await tx
+          .delete(slackUserMapping)
+          .where(eq(slackUserMapping.integrationId, fixture.integrationId));
+        await tx.insert(slackUserMapping).values({
+          id: `sum_${randomUUIDv7()}`,
+          organizationId: fixture.organizationId,
+          integrationId: fixture.integrationId,
+          userId: fixture.userId,
+          slackUserId: 'U-REPLACEMENT',
+          slackDisplayName: 'Replacement identity',
+        });
+        announceReplacement();
+        await replacementRelease;
+      });
+      await replacementReady;
+      const providerCalls: { authorization: string; body: Record<string, unknown> }[] = [];
+      const fetch = ((url: string, init?: RequestInit) => {
+        const headers = init?.headers as Record<string, string>;
+        const body = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+        providerCalls.push({ authorization: headers['authorization'] ?? '', body });
+        const response = url.endsWith('conversations.open')
+          ? { ok: true, channel: { id: 'D-REPLACEMENT' } }
+          : { ok: true, channel: 'D-REPLACEMENT', ts: '1.0' };
+        return Promise.resolve(Response.json(response));
+      }) as unknown as typeof globalThis.fetch;
+      const delivery = dispatchSlackDm(testDb, {
+        organizationId: fixture.organizationId,
+        userId: fixture.userId,
+        text: 'Private notification',
+        fetch,
+      });
+      expect(
+        await Promise.race([
+          delivery.then(
+            () => 'settled' as const,
+            () => 'settled' as const,
+          ),
+          new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 500)),
+        ]),
+      ).toBe('blocked');
+
+      releaseReplacement();
+      await replacement;
+      await expect(delivery).resolves.toBe(1);
+      expect(providerCalls).toEqual([
+        {
+          authorization: 'Bearer xoxb-replacement',
+          body: { users: 'U-REPLACEMENT' },
+        },
+        {
+          authorization: 'Bearer xoxb-replacement',
+          body: { channel: 'D-REPLACEMENT', text: 'Private notification' },
+        },
+      ]);
+    } finally {
+      releaseReplacement();
+      await replacement?.catch(() => undefined);
+      await testDb.delete(organization).where(eq(organization.id, fixture.organizationId));
+      await testDb.delete(user).where(eq(user.id, fixture.userId));
+    }
+  });
+
+  it('serializes a private send against member remapping', async () => {
+    const fixture = await testDb.transaction(async (tx) => await seed(tx));
+    let releaseConversation: () => void = () => undefined;
+    const conversationRelease = new Promise<void>((resolve) => {
+      releaseConversation = resolve;
+    });
+    let announceConversation: () => void = () => undefined;
+    const conversationReady = new Promise<void>((resolve) => {
+      announceConversation = resolve;
+    });
+    let dispatch: Promise<number> | undefined;
+    let sync: ReturnType<typeof syncSlackUserMappings> | undefined;
+    try {
+      await testDb
+        .update(integration)
+        .set({
+          config: {
+            credentialVersion: 'dm-race-version',
+            slackTeamId: 'T-WORKSPACE',
+            scopes: ['chat:write', 'im:write', 'users:read', 'users:read.email'],
+          },
+        })
+        .where(eq(integration.id, fixture.integrationId));
+      await upsertSlackUserMapping(testDb, {
+        organizationId: fixture.organizationId,
+        integrationId: fixture.integrationId,
+        userId: fixture.userId,
+        slackUserId: 'U-OLD',
+        slackDisplayName: 'Old identity',
+      });
+      const [admin] = await testDb
+        .select({ email: user.email })
+        .from(user)
+        .where(eq(user.id, fixture.userId));
+      if (admin === undefined) throw new Error('Expected the workspace administrator.');
+      const dmFetch = (async (url: string) => {
+        if (url.endsWith('conversations.open')) {
+          announceConversation();
+          await conversationRelease;
+          return Response.json({ ok: true, channel: { id: 'D-OLD' } });
+        }
+        return Response.json({ ok: true, channel: 'D-OLD', ts: '1.0' });
+      }) as unknown as typeof globalThis.fetch;
+      const directoryFetch = (() =>
+        Promise.resolve(
+          Response.json({
+            ok: true,
+            members: [
+              {
+                id: 'U-NEW',
+                deleted: false,
+                is_bot: false,
+                is_app_user: false,
+                real_name: 'New identity',
+                profile: { email: admin.email, display_name: 'New identity' },
+              },
+            ],
+            response_metadata: { next_cursor: '' },
+          }),
+        )) as unknown as typeof globalThis.fetch;
+
+      dispatch = dispatchSlackDm(testDb, {
+        organizationId: fixture.organizationId,
+        userId: fixture.userId,
+        text: 'Private notification',
+        fetch: dmFetch,
+      });
+      await Promise.race([conversationReady, dispatch.then(() => undefined)]);
+      sync = syncSlackUserMappings(testDb, {
+        organizationId: fixture.organizationId,
+        userId: fixture.userId,
+        fetch: directoryFetch,
+      });
+      expect(
+        await Promise.race([
+          sync.then(
+            () => 'settled' as const,
+            () => 'settled' as const,
+          ),
+          new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 500)),
+        ]),
+      ).toBe('blocked');
+
+      releaseConversation();
+      await expect(dispatch).resolves.toBe(1);
+      await expect(sync).resolves.toEqual({
+        status: 'applied',
+        eligibleMembers: 1,
+        mappedMembers: 1,
+      });
+      const [mapping] = await testDb
+        .select({ slackUserId: slackUserMapping.slackUserId })
+        .from(slackUserMapping)
+        .where(eq(slackUserMapping.integrationId, fixture.integrationId));
+      expect(mapping?.slackUserId).toBe('U-NEW');
+    } finally {
+      releaseConversation();
+      await dispatch?.catch(() => undefined);
+      await sync?.catch(() => undefined);
+      await testDb.delete(organization).where(eq(organization.id, fixture.organizationId));
+      await testDb.delete(user).where(eq(user.id, fixture.userId));
+    }
+  });
+
   it('uses the canonical integration when a legacy Slack row also exists', async () => {
     await withRollback(async (tx) => {
       const fixture = await seedWorkspace(tx, {

--- a/packages/services/tests/slack/dispatch.test.ts
+++ b/packages/services/tests/slack/dispatch.test.ts
@@ -27,6 +27,7 @@ import {
   resolveSlackTargets,
   sendSlackUnfurls,
   slackDmAvailable,
+  slackUserMappingSyncReady,
   syncSlackUserMappings,
   upsertSlackUserMapping,
 } from '../../src/slack/dispatch.ts';
@@ -154,6 +155,59 @@ describe('resolveSlackContext', () => {
       });
     }
   });
+});
+
+describe('slackUserMappingSyncReady', () => {
+  const readyContext = {
+    integrationId: 'int-ready',
+    integrationVersion: 'version-ready',
+    token: 'xoxb-ready',
+    scopes: ['users:read', 'users:read.email'],
+    hasDirectMessageScope: false,
+    reauthorize: false,
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+
+  it('accepts a usable Slack directory context', () => {
+    expect(slackUserMappingSyncReady({ context: readyContext, slackTeamId: 'T-WORKSPACE' })).toBe(
+      true,
+    );
+  });
+
+  for (const readinessCase of [
+    { name: 'missing context', context: null, slackTeamId: 'T-WORKSPACE' },
+    {
+      name: 'missing token',
+      context: { ...readyContext, token: null },
+      slackTeamId: 'T-WORKSPACE',
+    },
+    {
+      name: 'reauthorization required',
+      context: { ...readyContext, reauthorize: true },
+      slackTeamId: 'T-WORKSPACE',
+    },
+    { name: 'missing team id', context: readyContext, slackTeamId: undefined },
+    { name: 'empty team id', context: readyContext, slackTeamId: '' },
+    {
+      name: 'missing users read scope',
+      context: { ...readyContext, scopes: ['users:read.email'] },
+      slackTeamId: 'T-WORKSPACE',
+    },
+    {
+      name: 'missing users email scope',
+      context: { ...readyContext, scopes: ['users:read'] },
+      slackTeamId: 'T-WORKSPACE',
+    },
+  ]) {
+    it(`rejects ${readinessCase.name}`, () => {
+      expect(
+        slackUserMappingSyncReady({
+          context: readinessCase.context,
+          slackTeamId: readinessCase.slackTeamId,
+        }),
+      ).toBe(false);
+    });
+  }
 });
 
 describe('ensureSlackIntegration', () => {
@@ -821,7 +875,7 @@ describe('syncSlackUserMappings', () => {
     });
   });
 
-  it('maps a directory that crosses the database insert batch boundary', async () => {
+  it('maps a directory larger than PostgreSQL can bind in one insert', async () => {
     await withRollback(async (tx) => {
       const fixture = await seed(tx);
       await tx

--- a/packages/services/tests/slack/slack.test.ts
+++ b/packages/services/tests/slack/slack.test.ts
@@ -348,36 +348,394 @@ describe('SlackClient', () => {
     }
   });
 
-  it('looks up a Slack user by email', async () => {
-    const { impl, calls } = stubFetch(200, {
-      ok: true,
-      user: {
-        id: 'U1',
-        real_name: 'Ada Lovelace',
-        profile: { email: 'ADA@example.com', display_name: 'ada' },
-      },
+  it('lists every active human Slack user across pages', async () => {
+    const calls: { url: string; init: FetchInit }[] = [];
+    const impl = asFetchImpl((input, init) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url.endsWith('cursor=next-page')) {
+        return Promise.resolve(
+          Response.json({
+            ok: true,
+            members: [
+              {
+                id: 'U2',
+                deleted: false,
+                is_bot: false,
+                real_name: 'Grace Hopper',
+                profile: { email: ' GRACE@EXAMPLE.COM ', display_name: '' },
+              },
+              {
+                id: 'U-DELETED',
+                deleted: true,
+                is_bot: false,
+                is_app_user: false,
+                real_name: 'Former User',
+                profile: { email: 'former@example.com', display_name: 'Former' },
+              },
+              {
+                id: 'U-APP',
+                deleted: false,
+                is_bot: false,
+                is_app_user: true,
+                real_name: 'App User',
+                profile: { email: 'app@example.com', display_name: 'App' },
+              },
+            ],
+            response_metadata: { next_cursor: '' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        Response.json({
+          ok: true,
+          members: [
+            {
+              id: 'U1',
+              deleted: false,
+              is_bot: false,
+              is_app_user: false,
+              real_name: 'Ada Lovelace',
+              profile: { email: 'ADA@example.com', display_name: 'ada' },
+            },
+            {
+              id: 'U-BOT',
+              deleted: false,
+              is_bot: true,
+              is_app_user: false,
+              real_name: 'Build Bot',
+              profile: { email: 'bot@example.com', display_name: 'Build' },
+            },
+            {
+              id: 'U-GUEST',
+              deleted: false,
+              is_bot: false,
+              is_app_user: false,
+              is_restricted: true,
+              real_name: 'Workspace Guest',
+              profile: { email: 'guest@example.com', display_name: 'Guest' },
+            },
+            {
+              id: 'U-NO-EMAIL',
+              deleted: false,
+              is_bot: false,
+              is_app_user: false,
+              real_name: 'No Email',
+              profile: { display_name: 'Mystery' },
+            },
+            {
+              id: 'U-NULL-EMAIL',
+              deleted: false,
+              is_bot: false,
+              is_app_user: false,
+              real_name: 'Null Email',
+              profile: { email: null, display_name: 'Null' },
+            },
+            {
+              id: 'U-BAD-EMAIL',
+              deleted: false,
+              is_bot: false,
+              is_app_user: false,
+              real_name: 'Bad Email',
+              profile: { email: 'not-an-email', display_name: 'Bad' },
+            },
+            {
+              id: 'U-SPARSE',
+              is_bot: false,
+              real_name: 'Sparse User',
+              profile: { email: 'sparse@example.com', display_name: 'Sparse' },
+            },
+            {
+              id: 'U-UNCLASSIFIED',
+              deleted: false,
+              real_name: 'Unclassified User',
+              profile: { email: 'unclassified@example.com', display_name: 'Unclassified' },
+            },
+            {
+              id: 'U-NULL-PROFILE',
+              deleted: false,
+              is_bot: false,
+              profile: null,
+            },
+          ],
+          response_metadata: { next_cursor: 'next-page' },
+        }),
+      );
     });
     const client = new SlackClient({ token: 'xoxb-test', fetch: impl });
 
-    await expect(client.lookupUserByEmail('ADA@example.com')).resolves.toEqual({
-      id: 'U1',
-      email: 'ADA@example.com',
-      displayName: 'ada',
-    });
-    expect(calls[0]?.url).toBe('https://slack.com/api/users.lookupByEmail');
-    expect(calls[0]?.init?.body).toContain('ADA@example.com');
+    await expect(client.listUsers()).resolves.toEqual([
+      { id: 'U1', email: 'ada@example.com', displayName: 'ada' },
+      { id: 'U-GUEST', email: 'guest@example.com', displayName: 'Guest' },
+      { id: 'U-SPARSE', email: 'sparse@example.com', displayName: 'Sparse' },
+      { id: 'U2', email: 'grace@example.com', displayName: 'Grace Hopper' },
+    ]);
+    expect(calls.map((call) => call.url)).toEqual([
+      'https://slack.com/api/users.list?limit=200',
+      'https://slack.com/api/users.list?limit=200&cursor=next-page',
+    ]);
+    expect(calls.every((call) => call.init?.method === 'GET')).toBe(true);
+    expect(calls.every((call) => call.init?.body === undefined)).toBe(true);
   });
 
-  it('treats an unmapped Slack email as unavailable', async () => {
-    const { impl } = stubFetch(200, { ok: false, error: 'users_not_found' });
+  it('skips structurally malformed Slack members while retaining valid members', async () => {
+    const { impl } = stubFetch(200, {
+      ok: true,
+      members: [
+        {
+          id: 'U1',
+          deleted: false,
+          is_bot: false,
+          profile: { email: 'ada@example.com', display_name: 'Ada' },
+        },
+        null,
+        {
+          id: 42,
+          deleted: false,
+          is_bot: false,
+          profile: { email: 'wrong-id@example.com', display_name: 'Wrong Id' },
+        },
+        {
+          id: 'U-BROKEN-PROFILE',
+          deleted: false,
+          is_bot: false,
+          profile: 'not-an-object',
+        },
+        {
+          id: 'U2',
+          deleted: false,
+          is_bot: false,
+          profile: { email: 'grace@example.com', display_name: 'Grace' },
+        },
+      ],
+      response_metadata: { next_cursor: '' },
+    });
     const client = new SlackClient({ token: 'xoxb-test', fetch: impl });
-    await expect(client.lookupUserByEmail('missing@example.com')).resolves.toBeNull();
+
+    await expect(client.listUsers()).resolves.toEqual([
+      { id: 'U1', email: 'ada@example.com', displayName: 'Ada' },
+      { id: 'U2', email: 'grace@example.com', displayName: 'Grace' },
+    ]);
   });
 
   it('returns a null cursor when slack sends an empty one', async () => {
     const { impl } = stubFetch(200, { ok: true, channels: [], response_metadata: {} });
     const client = new SlackClient({ token: 'xoxb-test', fetch: impl });
     expect((await client.listConversations()).nextCursor).toBeNull();
+  });
+
+  it('rejects a repeated Slack user cursor instead of looping', async () => {
+    let calls = 0;
+    const impl = asFetchImpl(() => {
+      calls += 1;
+      return Promise.resolve(
+        Response.json({
+          ok: true,
+          members: [],
+          response_metadata: { next_cursor: 'repeat-me' },
+        }),
+      );
+    });
+    const client = new SlackClient({ token: 'xoxb-test', fetch: impl });
+
+    await expect(client.listUsers()).rejects.toThrow('repeated cursor');
+    expect(calls).toBe(2);
+  });
+
+  it('bounds a Slack directory with endlessly unique cursors by elapsed time', async () => {
+    let calls = 0;
+    let now = 0;
+    const realDateNow = Date.now;
+    Date.now = () => now;
+    const impl = asFetchImpl(() => {
+      calls += 1;
+      now += 15_001;
+      return Promise.resolve(
+        Response.json({
+          ok: true,
+          members: [],
+          response_metadata: { next_cursor: `cursor-${calls}` },
+        }),
+      );
+    });
+    const client = new SlackClient({ token: 'xoxb-test', fetch: impl });
+
+    try {
+      await expect(client.listUsers()).rejects.toThrow('safe duration limit');
+      expect(calls).toBe(2);
+    } finally {
+      Date.now = realDateNow;
+    }
+  });
+
+  it('stops before requesting a page beyond the configured directory page limit', async () => {
+    let calls = 0;
+    const impl = asFetchImpl(() => {
+      calls += 1;
+      return Promise.resolve(
+        Response.json({
+          ok: true,
+          members: [],
+          response_metadata: { next_cursor: calls < 3 ? `cursor-${calls}` : '' },
+        }),
+      );
+    });
+    const client = new SlackClient({
+      token: 'xoxb-test',
+      fetch: impl,
+      userDirectoryPageLimit: 2,
+    });
+
+    await expect(client.listUsers()).rejects.toThrow('safe page limit');
+    expect(calls).toBe(2);
+  });
+
+  it('retries one rate-limited page in the middle of a Slack directory', async () => {
+    const urls: string[] = [];
+    let calls = 0;
+    const impl = asFetchImpl((input) => {
+      calls += 1;
+      urls.push(String(input));
+      if (calls === 1) {
+        return Promise.resolve(
+          Response.json({
+            ok: true,
+            members: [
+              {
+                id: 'U1',
+                deleted: false,
+                is_bot: false,
+                profile: { email: 'ada@example.com', display_name: 'Ada' },
+              },
+            ],
+            response_metadata: { next_cursor: 'next-page' },
+          }),
+        );
+      }
+      if (calls === 2) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ ok: false, error: 'ratelimited' }), {
+            status: 429,
+            headers: { 'content-type': 'application/json', 'retry-after': '0' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        Response.json({
+          ok: true,
+          members: [
+            {
+              id: 'U2',
+              deleted: false,
+              is_bot: false,
+              profile: { email: 'grace@example.com', display_name: 'Grace' },
+            },
+          ],
+          response_metadata: { next_cursor: '' },
+        }),
+      );
+    });
+    const client = new SlackClient({ token: 'xoxb-test', fetch: impl });
+
+    await expect(client.listUsers()).resolves.toEqual([
+      { id: 'U1', email: 'ada@example.com', displayName: 'Ada' },
+      { id: 'U2', email: 'grace@example.com', displayName: 'Grace' },
+    ]);
+    expect(urls).toEqual([
+      'https://slack.com/api/users.list?limit=200',
+      'https://slack.com/api/users.list?limit=200&cursor=next-page',
+      'https://slack.com/api/users.list?limit=200&cursor=next-page',
+    ]);
+  });
+
+  it('allows only one rate-limit retry for an entire Slack directory', async () => {
+    let calls = 0;
+    const impl = asFetchImpl(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve(
+          Response.json({
+            ok: true,
+            members: [],
+            response_metadata: { next_cursor: 'next-page' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: false, error: 'ratelimited' }), {
+          status: 429,
+          headers: { 'content-type': 'application/json', 'retry-after': '0' },
+        }),
+      );
+    });
+    const client = new SlackClient({ token: 'xoxb-test', fetch: impl });
+
+    await expect(client.listUsers()).rejects.toMatchObject({ code: 'ratelimited' });
+    expect(calls).toBe(3);
+  });
+
+  it('does not retry a rate limit beyond the Slack directory time budget', async () => {
+    let calls = 0;
+    const impl = asFetchImpl(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve(
+          Response.json({
+            ok: true,
+            members: [],
+            response_metadata: { next_cursor: 'next-page' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: false, error: 'ratelimited' }), {
+          status: 429,
+          headers: { 'content-type': 'application/json', 'retry-after': '31' },
+        }),
+      );
+    });
+    const client = new SlackClient({ token: 'xoxb-test', fetch: impl });
+
+    await expect(client.listUsers()).rejects.toMatchObject({ code: 'ratelimited' });
+    expect(calls).toBe(2);
+  });
+
+  it('does not retry a rate limit without Retry-After guidance', async () => {
+    let calls = 0;
+    const impl = asFetchImpl(() => {
+      calls += 1;
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: false, error: 'ratelimited' }), {
+          status: 429,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    });
+    const client = new SlackClient({ token: 'xoxb-test', fetch: impl });
+
+    await expect(client.listUsers()).rejects.toMatchObject({
+      code: 'ratelimited',
+      retryAfterMs: undefined,
+    });
+    expect(calls).toBe(1);
+  });
+
+  it('rejects incomplete successful Slack directory pages', async () => {
+    const payloads = [{ ok: true }, { ok: true, members: [] }];
+
+    for (const payload of payloads) {
+      const client = new SlackClient({ token: 'xoxb-test', fetch: stubFetch(200, payload).impl });
+      await expect(client.listUsers()).rejects.toThrow('unexpected payload');
+    }
+  });
+
+  it('keeps Slack directory errors distinguishable from incomplete successes', async () => {
+    const client = new SlackClient({
+      token: 'xoxb-test',
+      fetch: stubFetch(200, { ok: false, error: 'invalid_auth' }).impl,
+    });
+
+    await expect(client.listUsers()).rejects.toMatchObject({ code: 'invalid_auth' });
   });
 
   it('throws on a slack level error', async () => {

--- a/packages/shared/src/validators/integration.ts
+++ b/packages/shared/src/validators/integration.ts
@@ -62,6 +62,11 @@ export const slackIntegrationActionSchema = z.discriminatedUnion('action', [
   z.object({ action: z.literal('sync_members') }),
 ]);
 
+export const slackMemberSyncResultSchema = z.object({
+  eligible: z.number().int().nonnegative(),
+  mapped: z.number().int().nonnegative(),
+});
+
 export const slackCallbackSchema = z.object({
   code: z.string().trim().min(1).max(255),
   state: z.string().trim().min(1).max(2048),

--- a/packages/shared/src/validators/integration.ts
+++ b/packages/shared/src/validators/integration.ts
@@ -56,6 +56,12 @@ export const slackDisconnectChannelSchema = z.object({
   channelId: z.string().trim().min(1).max(64),
 });
 
+export const slackIntegrationActionSchema = z.discriminatedUnion('action', [
+  slackConnectChannelSchema.extend({ action: z.literal('connect') }),
+  slackDisconnectChannelSchema.extend({ action: z.literal('disconnect') }),
+  z.object({ action: z.literal('sync_members') }),
+]);
+
 export const slackCallbackSchema = z.object({
   code: z.string().trim().min(1).max(255),
   state: z.string().trim().min(1).max(2048),

--- a/packages/shared/tests/validators/integration.test.ts
+++ b/packages/shared/tests/validators/integration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import {
   slackCallbackSchema,
   slackIntegrationActionSchema,
+  slackMemberSyncResultSchema,
 } from '../../src/validators/integration.ts';
 
 describe('Slack callback validator', () => {
@@ -33,5 +34,20 @@ describe('Slack integration action validator', () => {
     expect(slackIntegrationActionSchema.safeParse({ action: 'sync-users' }).success).toBe(false);
     expect(slackIntegrationActionSchema.safeParse({ action: 'connect' }).success).toBe(false);
     expect(slackIntegrationActionSchema.safeParse({ action: 'disconnect' }).success).toBe(false);
+  });
+});
+
+describe('Slack member sync result validator', () => {
+  it('accepts nonnegative integer member counts', () => {
+    expect(slackMemberSyncResultSchema.parse({ eligible: 3, mapped: 2 })).toEqual({
+      eligible: 3,
+      mapped: 2,
+    });
+  });
+
+  it('rejects missing, negative, and fractional member counts', () => {
+    expect(slackMemberSyncResultSchema.safeParse({ mapped: 2 }).success).toBe(false);
+    expect(slackMemberSyncResultSchema.safeParse({ eligible: -1, mapped: 0 }).success).toBe(false);
+    expect(slackMemberSyncResultSchema.safeParse({ eligible: 1, mapped: 0.5 }).success).toBe(false);
   });
 });

--- a/packages/shared/tests/validators/integration.test.ts
+++ b/packages/shared/tests/validators/integration.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { slackCallbackSchema } from '../../src/validators/integration.ts';
+import {
+  slackCallbackSchema,
+  slackIntegrationActionSchema,
+} from '../../src/validators/integration.ts';
 
 describe('Slack callback validator', () => {
   it('accepts bounded non-empty OAuth code and state values', () => {
@@ -16,5 +19,19 @@ describe('Slack callback validator', () => {
     expect(
       slackCallbackSchema.safeParse({ code: 'oauth-code', state: 'x'.repeat(2049) }).success,
     ).toBe(false);
+  });
+});
+
+describe('Slack integration action validator', () => {
+  it('accepts member synchronization without client-controlled identifiers', () => {
+    expect(slackIntegrationActionSchema.parse({ action: 'sync_members' })).toEqual({
+      action: 'sync_members',
+    });
+  });
+
+  it('rejects unknown actions and incomplete channel actions', () => {
+    expect(slackIntegrationActionSchema.safeParse({ action: 'sync-users' }).success).toBe(false);
+    expect(slackIntegrationActionSchema.safeParse({ action: 'connect' }).success).toBe(false);
+    expect(slackIntegrationActionSchema.safeParse({ action: 'disconnect' }).success).toBe(false);
   });
 });


### PR DESCRIPTION
## What this changes

Slack now maps every current Orbit workspace member with one unambiguous matching Slack email, both after OAuth and through an admin-triggered resync. The sync is atomic, paginated, rate-limit aware, concurrency safe, and removes stale mappings when members leave.

The integration settings page shows mapping readiness and counts, and lets an admin sync members without reconnecting a healthy installation.

## Why

The global `SLACK_ENABLED` gate already exposes Slack to every organization, but OAuth previously mapped only the admin who installed it. Other members could enable Slack preferences without having a deliverable DM target.

## How you know it works

- `bun run lint`, comment policy, source-byte policy, Bun import policy, dependency dedupe, and root typecheck pass.
- Full services suite: 680 pass, 0 fail.
- Full core suite: 1035 pass, 0 fail.
- All 302 web test files pass across four isolated shards, including the new settings and API coverage.
- The official `bun run verify` reaches the web suite after every earlier stage passes, then the local Bun 1.3.14 macOS aggregate runner exits with `SIGTRAP` at `line-plot.test.tsx`. That exact file passes 16 of 16 directly. CI remains the authoritative Linux aggregate run.
- Added failure-first coverage for pagination, malformed directory entries, ambiguous emails, stale OAuth races, rate limiting, authorization rechecks, 7,301-member batching, membership removal, cross-workspace isolation, token rotation, concurrent DMs, reconnect races, and queued delivery after removal.

## Screenshots

Not included. The added settings states and controls are covered by component tests.

## Checklist

- [ ] `bun run verify` is green, all four checks. Local aggregate runner issue described above; all files pass in shards.
- [x] Tests added or updated, and they fail without the change
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions
- [x] External input is parsed with a Zod schema from `@orbit/shared`
- [x] Authorization is enforced on the server through `packages/shared/src/policy`, not only in the UI
- [x] Docs updated if behaviour, configuration or setup changed
- [x] No database schema changed, so database release and drift commands are not required

## Anything reviewers should know

Directory sync has a 30-second budget, a 5,000-page ceiling, and one bounded `Retry-After` retry. A failed or incomplete directory read preserves the prior mapping snapshot. New workspace members need an admin to run **Sync Slack members** until an event-driven or scheduled sync is added later.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Slack member synchronization now maps current Orbit workspace members from Slack's paginated user directory after OAuth or an administrator-triggered resync.
- Adds atomic mapping reconciliation with rate-limit, credential-version, authorization, membership-removal, and concurrent-delivery handling.
- Adds mapping readiness, coverage counts, and a manual synchronization control to integration settings.
- Updates Slack direct-message delivery, validation contracts, documentation, and coverage across web, core, services, and shared packages.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the scope of this follow-up review.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/services/src/slack/dispatch.ts | Adds workspace-wide Slack identity reconciliation, readiness checks, stale-install protection, membership-aware DM targeting, and synchronization with concurrent dispatch. |
| packages/services/src/slack/index.ts | Replaces individual email lookup with bounded, paginated Slack directory loading and one rate-limit retry. |
| apps/web/src/app/api/integrations/slack/route.ts | Adds the authorized member-sync action and maps provider failures to typed API responses. |
| apps/web/src/features/settings/integrations-panel.tsx | Displays mapping coverage and readiness and adds the administrator-triggered synchronization flow. |
| apps/web/src/features/settings/integrations-connect.ts | Runs full workspace member synchronization after persisting a successful Slack OAuth installation. |
| packages/core/src/org/member-service.ts | Removes Slack identity mappings transactionally when a workspace member is removed. |
| packages/core/src/notifications/notify.ts | Consolidates Slack reauthorization classification for direct-message delivery failures. |
| packages/shared/src/validators/integration.ts | Defines shared request and response schemas for Slack member synchronization. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Admin
  participant Web as Integration settings API
  participant Slack
  participant DB
  Admin->>Web: Sync Slack members
  Web->>DB: Verify manager and read integration version
  Web->>Slack: Read paginated user directory
  Slack-->>Web: Active human users
  Web->>DB: Lock current integration and memberships
  Web->>DB: Atomically replace unambiguous email mappings
  DB-->>Web: Eligible and mapped counts
  Web-->>Admin: Refresh mapping readiness and coverage
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(slack): address member sync review"](https://github.com/noveum/orbit/commit/b864d66707274ce3c0bbda85a20d351dbe4df83d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58915399)</sub>

**Context used:**

- Knowledge Base — [Integrations and automation](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/docs/integrations-and-automation.md)
- Knowledge Base — [Notifications and delivery](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/docs/notifications-and-delivery.md)

<!-- /greptile_comment -->