### PR TITLE
chore(mcp): publish Orbit to the official MCP Registry

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,6 +1,12 @@
 name: Publish MCP Registry
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - server.json
+      - .github/workflows/publish-mcp-registry.yml
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,44 @@
+name: Publish MCP Registry
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: publish-mcp-registry
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish Orbit MCP metadata
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout current main
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+
+      - name: Install verified MCP publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.1
+          MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
+        run: |
+          set -euo pipefail
+          ARCHIVE="mcp-publisher_linux_amd64.tar.gz"
+          curl --fail --location --silent --show-error \
+            --output "$ARCHIVE" \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/${ARCHIVE}"
+          echo "${MCP_PUBLISHER_SHA256}  ${ARCHIVE}" | sha256sum --check --strict
+          tar -xzf "$ARCHIVE" mcp-publisher
+          ./mcp-publisher --help >/dev/null
+
+      - name: Authenticate with GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish Orbit
+        run: ./mcp-publisher publish

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,6 +1,10 @@
 name: Publish MCP Registry
 
 on:
+  pull_request:
+    paths:
+      - server.json
+      - .github/workflows/publish-mcp-registry.yml
   push:
     branches:
       - main
@@ -10,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: publish-mcp-registry
+  group: publish-mcp-registry-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -18,13 +22,12 @@ permissions:
   id-token: write
 
 jobs:
-  publish:
-    name: Publish Orbit MCP metadata
-    if: github.ref == 'refs/heads/main'
+  validate-and-publish:
+    name: Validate and publish Orbit MCP metadata
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout current main
+      - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           persist-credentials: false
@@ -47,7 +50,9 @@ jobs:
         run: ./mcp-publisher validate
 
       - name: Authenticate with GitHub OIDC
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         run: ./mcp-publisher login github-oidc
 
       - name: Publish Orbit
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         run: ./mcp-publisher publish

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -37,6 +37,9 @@ jobs:
           tar -xzf "$ARCHIVE" mcp-publisher
           ./mcp-publisher --help >/dev/null
 
+      - name: Validate registry manifest
+        run: ./mcp-publisher validate
+
       - name: Authenticate with GitHub OIDC
         run: ./mcp-publisher login github-oidc
 

--- a/server.json
+++ b/server.json
@@ -14,9 +14,7 @@
     {
       "src": "https://raw.githubusercontent.com/Noveum/orbit/main/apps/web/public/logo.png",
       "mimeType": "image/png",
-      "sizes": [
-        "512x512"
-      ]
+      "sizes": ["512x512"]
     }
   ],
   "version": "0.1.0",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Noveum/orbit",
+  "title": "Orbit",
+  "description": "Task management for people and AI agents, with scoped OAuth access to issues, projects, and docs.",
+  "repository": {
+    "url": "https://github.com/Noveum/orbit",
+    "source": "github"
+  },
+  "websiteUrl": "https://orbit.noveum.ai",
+  "version": "0.1.0",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://orbit.noveum.ai/mcp"
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -5,14 +5,56 @@
   "description": "Task management for people and AI agents, with scoped OAuth access to issues, projects, and docs.",
   "repository": {
     "url": "https://github.com/Noveum/orbit",
-    "source": "github"
+    "source": "github",
+    "id": "1308968229",
+    "subfolder": "packages/mcp-server"
   },
   "websiteUrl": "https://orbit.noveum.ai",
+  "icons": [
+    {
+      "src": "https://raw.githubusercontent.com/Noveum/orbit/main/apps/web/public/logo.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
   "version": "0.1.0",
   "remotes": [
     {
       "type": "streamable-http",
       "url": "https://orbit.noveum.ai/mcp"
     }
-  ]
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "publisher": "Noveum AI",
+      "documentation": "https://github.com/Noveum/orbit/blob/main/docs/mcp.md",
+      "support": "https://github.com/Noveum/orbit/discussions",
+      "keywords": [
+        "task-management",
+        "project-management",
+        "issues",
+        "sprints",
+        "docs",
+        "productivity",
+        "oauth",
+        "mcp"
+      ],
+      "examples": [
+        {
+          "name": "Plan and update work",
+          "description": "Create, assign, prioritize, and update issues across teams and sprints."
+        },
+        {
+          "name": "Summarize delivery",
+          "description": "Summarize completed work, blockers, sprint progress, and project status."
+        },
+        {
+          "name": "Work with project docs",
+          "description": "Read, create, update, comment on, and attach files to Orbit docs."
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## What changed

- adds a root `server.json` for `io.github.Noveum/orbit`
- publishes the hosted Streamable HTTP endpoint at `https://orbit.noveum.ai/mcp`
- includes the upstream repository identity, 512 px icon, website, documentation, support, keywords, and example workflows
- adds a manually triggered GitHub OIDC workflow for publishing from `main`
- pins `mcp-publisher` to v1.8.1 and verifies the official Linux binary checksum before execution

## Why

The official MCP Registry is the primary source of truth for public MCP servers and is consumed by downstream registries. Publishing Orbit there gives every compatible aggregator a canonical, verified record while keeping the remote server OAuth-only.

## Safety

- the workflow has read-only repository access plus the OIDC permission required by the Registry
- there is no stored registry token or PAT
- publishing is refused unless the workflow runs from `main`
- the Registry version starts at `0.1.0`; published versions are immutable, so future metadata changes require a version bump
- this does not change application runtime behavior

## Verification

- parsed `server.json` as valid JSON
- confirmed the description is within the Registry's 100-character limit
- confirmed the manifest fields against the current `2025-12-11` Registry schema and official remote-server documentation
- confirmed `io.github.<org>/*` organization namespaces and GitHub OIDC are supported
- confirmed the pinned publisher asset and SHA-256 digest from the official v1.8.1 release

After merge, run **Actions → Publish MCP Registry → Run workflow** from `main`, then verify `io.github.Noveum/orbit` through the Registry API and catalogue.

Tracks #385




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the manifest and release automation needed to publish Orbit's hosted MCP server to the official registry.
- Defines the registry identity, source repository, metadata, and Streamable HTTP endpoint in `server.json`.
- Adds checksum-verified installation of the pinned MCP publisher.
- Validates changes on pull requests and authenticates through GitHub OIDC before publishing from `main`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/publish-mcp-registry.yml | Adds checksum-verified manifest validation and OIDC-backed registry publication restricted to runs on `main`. |
| server.json | Defines Orbit's official registry metadata and points clients to the existing hosted Streamable HTTP endpoint. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Change[Manifest or workflow change] --> Validate[Validate server.json]
  Validate --> Branch{Main branch run?}
  Branch -->|No| Stop[Validation only]
  Branch -->|Yes| OIDC[Authenticate with GitHub OIDC]
  OIDC --> Publish[Publish Orbit metadata]
  Publish --> Registry[Official MCP Registry]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["ci(mcp): validate registry manifest on p..."](https://github.com/noveum/orbit/commit/6826e413346ee7549360c9e173537ba67000d1db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59884498)</sub>

<!-- /greptile_comment -->