### PR TITLE
chore(mcp): add static directory discovery metadata

### DIFF
--- a/apps/web/public/.well-known/mcp/server-card.json
+++ b/apps/web/public/.well-known/mcp/server-card.json
@@ -1,0 +1,10 @@
+{
+  "serverInfo": {
+    "name": "Orbit",
+    "version": "0.1.0"
+  },
+  "authentication": {
+    "required": true,
+    "schemes": ["oauth2"]
+  }
+}


### PR DESCRIPTION
## What changed

- adds `/.well-known/mcp/server-card.json` through the Next.js public directory
- identifies Orbit and its registry version
- declares that authentication is required through OAuth 2.0

## Why

Smithery documents this well-known server card as the fallback for authenticated remote MCP servers when automated capability scanning cannot pass the OAuth wall. Orbit remains discoverable through the normal MCP endpoint and OAuth discovery; this card only provides public, non-secret metadata.

## Verification

- JSON is valid
- all fields use Smithery's documented static server-card structure
- no tools are duplicated into a manually maintained list; Smithery can obtain the live capability list after authorization
- the deployed URL will be `https://orbit.noveum.ai/.well-known/mcp/server-card.json`

Tracks #385


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a public MCP server card so authenticated Orbit deployments remain discoverable without duplicating the live capability list.
- Publishes Orbit’s registry identity and version at `/.well-known/mcp/server-card.json`.
- Declares OAuth 2.0 authentication as required.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The new file contains valid static JSON, maps to the intended public discovery path, and accurately declares that OAuth authentication is required.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/public/.well-known/mcp/server-card.json | Adds valid, non-secret static discovery metadata under the Next.js public directory with no concrete correctness or security issue identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(mcp): add Smithery server card"](https://github.com/noveum/orbit/commit/8bf0189efb38b89b334b24c502696d6ec6f83bce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60078153)</sub>

<!-- /greptile_comment -->