### PR TITLE
feat(realtime): define the provider-neutral service boundary

### DIFF
--- a/apps/realtime/src/server.ts
+++ b/apps/realtime/src/server.ts
@@ -20,10 +20,14 @@ export {
 
 const SHUTDOWN_GRACE_MS = 1_000;
 const MAX_IDLE_TIMEOUT_SECONDS = 960;
+const DEFAULT_REALTIME_PATH = '/api/ws';
 
 export interface RealtimeServerOptions extends RealtimeHubOptions {
   port?: number;
   host?: string;
+  path?: string;
+  allowedOrigins?: readonly string[];
+  readinessCheck?: () => boolean | Promise<boolean>;
 }
 
 export interface RealtimeServer {
@@ -51,12 +55,60 @@ function afterGrace(ms: number): Promise<void> {
   });
 }
 
+function jsonStatus(status: 'ok' | 'unavailable', code: number): Response {
+  return Response.json({ status }, { status: code });
+}
+
+export function normalizeRealtimePath(value: string | undefined): string {
+  const path = value ?? DEFAULT_REALTIME_PATH;
+  if (!path.startsWith('/') || path.includes('?') || path.includes('#')) {
+    throw new TypeError('The realtime path must be an absolute URL path without a query or fragment.');
+  }
+  return path.length > 1 ? path.replace(/\/+$/, '') : path;
+}
+
+function normalizedOrigin(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeAllowedOrigins(values: readonly string[] | undefined): readonly string[] {
+  if (values === undefined) return [];
+  const origins = values.map((value) => normalizedOrigin(value));
+  if (origins.some((origin) => origin === null)) {
+    throw new TypeError('Every allowed realtime origin must be an absolute HTTP or HTTPS origin.');
+  }
+  return [...new Set(origins as string[])];
+}
+
+export function realtimePathMatches(request: Request, path: string): boolean {
+  return new URL(request.url).pathname.replace(/\/+$/, '') === path;
+}
+
+export function realtimeOriginAllowed(
+  request: Request,
+  allowedOrigins: readonly string[],
+): boolean {
+  if (allowedOrigins.length === 0) return true;
+  const origin = request.headers.get('origin');
+  if (origin === null) return false;
+  const normalized = normalizedOrigin(origin);
+  return normalized !== null && allowedOrigins.includes(normalized);
+}
+
 export async function createRealtimeServer(
   options: RealtimeServerOptions = {},
 ): Promise<RealtimeServer> {
   const hub = await createRealtimeHub(options);
   const heartbeatIntervalMs = options.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS;
   const heartbeatTimeoutMs = options.heartbeatTimeoutMs ?? HEARTBEAT_TIMEOUT_MS;
+  const realtimePath = normalizeRealtimePath(options.path);
+  const allowedOrigins = normalizeAllowedOrigins(options.allowedOrigins);
 
   const websocket: WebSocketHandler<SocketData> = {
     sendPings: false,
@@ -78,26 +130,37 @@ export async function createRealtimeServer(
   function upgrade(request: Request, self: Server<SocketData>): Response | undefined {
     const data: SocketData = { session: null };
     if (self.upgrade(request, { data })) return;
-    return new Response(JSON.stringify({ status: 'upgrade_failed' }), {
-      status: 400,
-      headers: { 'content-type': 'application/json' },
-    });
+    return Response.json({ status: 'upgrade_failed' }, { status: 400 });
+  }
+
+  async function ready(): Promise<boolean> {
+    if (hub.stats().redis !== 'ready') return false;
+    if (options.readinessCheck === undefined) return true;
+    try {
+      return await options.readinessCheck();
+    } catch {
+      return false;
+    }
   }
 
   const server = Bun.serve<SocketData>({
     port: options.port ?? 0,
     hostname: options.host ?? '0.0.0.0',
     websocket,
-    fetch(request, self) {
-      if (isUpgrade(request)) return upgrade(request, self);
+    async fetch(request, self) {
       const url = new URL(request.url);
-      if (request.method === 'GET' && url.pathname.startsWith('/health')) {
-        const snapshot = hub.stats();
-        const healthy = snapshot.redis === 'ready';
-        return Response.json(
-          { status: healthy ? 'ok' : 'degraded', ...snapshot },
-          { status: healthy ? 200 : 503 },
-        );
+      if (isUpgrade(request)) {
+        if (request.method !== 'GET' || !realtimePathMatches(request, realtimePath)) {
+          return Response.json({ status: 'not_found' }, { status: 404 });
+        }
+        if (!realtimeOriginAllowed(request, allowedOrigins)) {
+          return Response.json({ status: 'forbidden' }, { status: 403 });
+        }
+        return upgrade(request, self);
+      }
+      if (request.method === 'GET' && url.pathname === '/livez') return jsonStatus('ok', 200);
+      if (request.method === 'GET' && (url.pathname === '/readyz' || url.pathname === '/health')) {
+        return (await ready()) ? jsonStatus('ok', 200) : jsonStatus('unavailable', 503);
       }
       return Response.json({ status: 'not_found' }, { status: 404 });
     },

--- a/apps/realtime/src/server.ts
+++ b/apps/realtime/src/server.ts
@@ -1,5 +1,6 @@
 import {
   createRealtimeHub,
+  errorFields,
   fromBunSocket,
   logger,
   type RealtimeHubOptions,
@@ -62,7 +63,9 @@ function jsonStatus(status: 'ok' | 'unavailable', code: number): Response {
 export function normalizeRealtimePath(value: string | undefined): string {
   const path = value ?? DEFAULT_REALTIME_PATH;
   if (!path.startsWith('/') || path.includes('?') || path.includes('#')) {
-    throw new TypeError('The realtime path must be an absolute URL path without a query or fragment.');
+    throw new TypeError(
+      'The realtime path must be an absolute URL path without a query or fragment.',
+    );
   }
   return path.length > 1 ? path.replace(/\/+$/, '') : path;
 }
@@ -79,15 +82,21 @@ function normalizedOrigin(value: string): string | null {
 
 export function normalizeAllowedOrigins(values: readonly string[] | undefined): readonly string[] {
   if (values === undefined) return [];
-  const origins = values.map((value) => normalizedOrigin(value));
-  if (origins.some((origin) => origin === null)) {
-    throw new TypeError('Every allowed realtime origin must be an absolute HTTP or HTTPS origin.');
+  const origins: string[] = [];
+  for (const value of values) {
+    const origin = normalizedOrigin(value);
+    if (origin === null) {
+      throw new TypeError(
+        'Every allowed realtime origin must be an absolute HTTP or HTTPS origin.',
+      );
+    }
+    origins.push(origin);
   }
-  return [...new Set(origins as string[])];
+  return [...new Set(origins)];
 }
 
 export function realtimePathMatches(request: Request, path: string): boolean {
-  return new URL(request.url).pathname.replace(/\/+$/, '') === path;
+  return normalizeRealtimePath(new URL(request.url).pathname) === path;
 }
 
 export function realtimeOriginAllowed(
@@ -138,31 +147,38 @@ export async function createRealtimeServer(
     if (options.readinessCheck === undefined) return true;
     try {
       return await options.readinessCheck();
-    } catch {
+    } catch (error: unknown) {
+      logger.warn('readiness check failed', errorFields(error));
       return false;
     }
+  }
+
+  function upgradeRoute(request: Request, self: Server<SocketData>): Response | undefined {
+    if (request.method !== 'GET' || !realtimePathMatches(request, realtimePath)) {
+      return Response.json({ status: 'not_found' }, { status: 404 });
+    }
+    if (!realtimeOriginAllowed(request, allowedOrigins)) {
+      return Response.json({ status: 'forbidden' }, { status: 403 });
+    }
+    return upgrade(request, self);
+  }
+
+  async function httpRoute(request: Request): Promise<Response> {
+    const { pathname } = new URL(request.url);
+    if (request.method === 'GET' && pathname === '/livez') return jsonStatus('ok', 200);
+    if (request.method === 'GET' && (pathname === '/readyz' || pathname === '/health')) {
+      return (await ready()) ? jsonStatus('ok', 200) : jsonStatus('unavailable', 503);
+    }
+    return Response.json({ status: 'not_found' }, { status: 404 });
   }
 
   const server = Bun.serve<SocketData>({
     port: options.port ?? 0,
     hostname: options.host ?? '0.0.0.0',
     websocket,
-    async fetch(request, self) {
-      const url = new URL(request.url);
-      if (isUpgrade(request)) {
-        if (request.method !== 'GET' || !realtimePathMatches(request, realtimePath)) {
-          return Response.json({ status: 'not_found' }, { status: 404 });
-        }
-        if (!realtimeOriginAllowed(request, allowedOrigins)) {
-          return Response.json({ status: 'forbidden' }, { status: 403 });
-        }
-        return upgrade(request, self);
-      }
-      if (request.method === 'GET' && url.pathname === '/livez') return jsonStatus('ok', 200);
-      if (request.method === 'GET' && (url.pathname === '/readyz' || url.pathname === '/health')) {
-        return (await ready()) ? jsonStatus('ok', 200) : jsonStatus('unavailable', 503);
-      }
-      return Response.json({ status: 'not_found' }, { status: 404 });
+    fetch(request, self) {
+      if (isUpgrade(request)) return upgradeRoute(request, self);
+      return httpRoute(request);
     },
   });
 

--- a/apps/realtime/src/test-helpers.ts
+++ b/apps/realtime/src/test-helpers.ts
@@ -207,7 +207,7 @@ export function connectClient(
 }
 
 export function connectWithTicket(port: number, ticket: string): Promise<TestClient> {
-  const socket = new WebSocket(`ws://127.0.0.1:${port}/`);
+  const socket = new WebSocket(`ws://127.0.0.1:${port}/api/ws`);
   const messages: ServerMessage[] = [];
   const listeners = new Set<() => void>();
   let closeCode: number | undefined;

--- a/apps/realtime/tests/client-reconnect.test.ts
+++ b/apps/realtime/tests/client-reconnect.test.ts
@@ -46,7 +46,7 @@ it('reconnects and resubscribes after the server drops the socket', async () => 
   const received: SyncAction[] = [];
 
   const client = createRealtimeClient({
-    url: `ws://127.0.0.1:${port}`,
+    url: `ws://127.0.0.1:${port}/api/ws`,
     fetchTicket: () => Promise.resolve(ticketFor(member, organizationId)),
     maxBackoffMs: 500,
     onStatus: (status) => statuses.push(status),

--- a/apps/realtime/tests/deployment-boundary.test.ts
+++ b/apps/realtime/tests/deployment-boundary.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  normalizeAllowedOrigins,
+  normalizeRealtimePath,
+  realtimeOriginAllowed,
+  realtimePathMatches,
+} from '../src/server.ts';
+
+describe('portable realtime deployment boundary', () => {
+  it('uses the same-origin websocket path by default', () => {
+    expect(normalizeRealtimePath(undefined)).toBe('/api/ws');
+    expect(normalizeRealtimePath('/api/ws/')).toBe('/api/ws');
+    expect(() => normalizeRealtimePath('api/ws')).toThrow();
+    expect(() => normalizeRealtimePath('/api/ws?token=secret')).toThrow();
+    expect(() => normalizeRealtimePath('/api/ws#fragment')).toThrow();
+  });
+
+  it('matches only the configured websocket path', () => {
+    const path = normalizeRealtimePath('/api/ws');
+    expect(realtimePathMatches(new Request('https://orbit.example/api/ws'), path)).toBe(true);
+    expect(realtimePathMatches(new Request('https://orbit.example/api/ws/'), path)).toBe(true);
+    expect(realtimePathMatches(new Request('https://orbit.example/api/ws?attempt=1'), path)).toBe(
+      true,
+    );
+    expect(realtimePathMatches(new Request('https://orbit.example/api/ws/other'), path)).toBe(
+      false,
+    );
+    expect(realtimePathMatches(new Request('https://orbit.example/mcp'), path)).toBe(false);
+  });
+
+  it('normalizes and deduplicates allowed browser origins', () => {
+    expect(
+      normalizeAllowedOrigins([
+        'https://orbit.example/path',
+        'https://orbit.example',
+        'http://localhost:3000/onboarding',
+      ]),
+    ).toEqual(['https://orbit.example', 'http://localhost:3000']);
+    expect(() => normalizeAllowedOrigins(['wss://orbit.example'])).toThrow();
+    expect(() => normalizeAllowedOrigins(['not a url'])).toThrow();
+  });
+
+  it('requires an exact allowed origin only when a policy is configured', () => {
+    const request = new Request('https://realtime.internal/api/ws', {
+      headers: { origin: 'https://orbit.example/workspace' },
+    });
+    expect(realtimeOriginAllowed(request, [])).toBe(true);
+    expect(realtimeOriginAllowed(request, ['https://orbit.example'])).toBe(true);
+    expect(realtimeOriginAllowed(request, ['https://other.example'])).toBe(false);
+    expect(
+      realtimeOriginAllowed(new Request('https://realtime.internal/api/ws'), [
+        'https://orbit.example',
+      ]),
+    ).toBe(false);
+  });
+});

--- a/apps/realtime/tests/deployment-boundary.test.ts
+++ b/apps/realtime/tests/deployment-boundary.test.ts
@@ -28,6 +28,13 @@ describe('portable realtime deployment boundary', () => {
     expect(realtimePathMatches(new Request('https://orbit.example/mcp'), path)).toBe(false);
   });
 
+  it('lets a root path match the root', () => {
+    const root = normalizeRealtimePath('/');
+    expect(realtimePathMatches(new Request('https://orbit.example/'), root)).toBe(true);
+    expect(realtimePathMatches(new Request('https://orbit.example'), root)).toBe(true);
+    expect(realtimePathMatches(new Request('https://orbit.example/api/ws'), root)).toBe(false);
+  });
+
   it('normalizes and deduplicates allowed browser origins', () => {
     expect(
       normalizeAllowedOrigins([

--- a/apps/realtime/tests/server.test.ts
+++ b/apps/realtime/tests/server.test.ts
@@ -106,7 +106,7 @@ async function connectSilently(port: number, member: SeedMember): Promise<Socket
 
   socket.write(
     [
-      'GET / HTTP/1.1',
+      'GET /api/ws HTTP/1.1',
       `Host: 127.0.0.1:${port}`,
       'Upgrade: websocket',
       'Connection: Upgrade',
@@ -520,14 +520,20 @@ describe('protocol', () => {
     }
   });
 
-  it('serves health with connection and redis status', async () => {
-    const response = await fetch(`http://127.0.0.1:${server.port}/health`);
-    const body = (await response.json()) as Record<string, unknown>;
-    expect(response.status).toBe(200);
-    expect(body['status']).toBe('ok');
-    expect(body['redis']).toBe('ready');
-    expect(typeof body['connections']).toBe('number');
-    expect(typeof body['subscriptions']).toBe('number');
+  it('answers liveness and readiness without disclosing internals', async () => {
+    for (const path of ['/livez', '/readyz', '/health']) {
+      const response = await fetch(`http://127.0.0.1:${server.port}${path}`);
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ status: 'ok' });
+    }
+  });
+
+  it('refuses an upgrade on any path other than the realtime path', async () => {
+    const response = await fetch(`http://127.0.0.1:${server.port}/`, {
+      headers: { connection: 'Upgrade', upgrade: 'websocket' },
+    });
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ status: 'not_found' });
   });
 });
 

--- a/apps/realtime/tests/session-revocation.test.ts
+++ b/apps/realtime/tests/session-revocation.test.ts
@@ -152,7 +152,7 @@ describe('session revocation', () => {
     let terminalCode: number | undefined;
 
     const client = createRealtimeClient({
-      url: `ws://127.0.0.1:${server.port}`,
+      url: `ws://127.0.0.1:${server.port}/api/ws`,
       fetchTicket: () => Promise.resolve(ticketFor(member, organizationId)),
       maxBackoffMs: 200,
       onStatus: (status) => statuses.push(status),

--- a/apps/web/src/lib/realtime/url.ts
+++ b/apps/web/src/lib/realtime/url.ts
@@ -33,9 +33,15 @@ function servedLocally(origin: string): boolean {
   }
 }
 
+function withRealtimePath(configured: string): string {
+  const url = new URL(configured);
+  if (url.pathname === '/') url.pathname = REALTIME_PATH;
+  return url.toString();
+}
+
 export function resolveRealtimeUrl(configured: string, origin: string): string {
   if (origin.length === 0) return '';
-  if (configured.length > 0 && servedLocally(origin)) return configured;
+  if (configured.length > 0 && servedLocally(origin)) return withRealtimePath(configured);
   const url = new URL(REALTIME_PATH, origin);
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
   return url.toString();

--- a/apps/web/tests/lib/realtime/url.test.ts
+++ b/apps/web/tests/lib/realtime/url.test.ts
@@ -4,7 +4,13 @@ import { configuredRealtimeUrl, resolveRealtimeUrl } from '../../../src/lib/real
 describe('resolveRealtimeUrl', () => {
   it('honours a configured url while the page is served locally', () => {
     expect(resolveRealtimeUrl('ws://localhost:3100', 'http://localhost:3000')).toBe(
-      'ws://localhost:3100',
+      'ws://localhost:3100/api/ws',
+    );
+  });
+
+  it('keeps a path the configured url already carries', () => {
+    expect(resolveRealtimeUrl('ws://localhost:3100/custom', 'http://localhost:3000')).toBe(
+      'ws://localhost:3100/custom',
     );
   });
 
@@ -16,22 +22,22 @@ describe('resolveRealtimeUrl', () => {
 
   it('treats a loopback address as local too', () => {
     expect(resolveRealtimeUrl('ws://localhost:3100', 'http://127.0.0.1:3000')).toBe(
-      'ws://localhost:3100',
+      'ws://localhost:3100/api/ws',
     );
   });
 
   it('treats the whole 127.0.0.0/8 range as loopback', () => {
     expect(resolveRealtimeUrl('ws://localhost:3100', 'http://127.0.0.2:3000')).toBe(
-      'ws://localhost:3100',
+      'ws://localhost:3100/api/ws',
     );
     expect(resolveRealtimeUrl('ws://localhost:3100', 'http://127.255.255.254:3000')).toBe(
-      'ws://localhost:3100',
+      'ws://localhost:3100/api/ws',
     );
   });
 
   it('treats the IPv6 loopback as local', () => {
     expect(resolveRealtimeUrl('ws://localhost:3100', 'http://[::1]:3000')).toBe(
-      'ws://localhost:3100',
+      'ws://localhost:3100/api/ws',
     );
   });
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ explicitly so it cannot block other snapshots or prevent the sprint from closing
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `NEXT_PUBLIC_REALTIME_URL` | unset | **Local development only.** Set it to `ws://localhost:3100` locally |
+| `NEXT_PUBLIC_REALTIME_URL` | unset | **Local development only.** Set it to `ws://localhost:3100` locally; the app connects to `/api/ws` under it |
 | `REALTIME_PORT` | `3100` | Port for `apps/realtime`, which is never deployed |
 
 `NEXT_PUBLIC_REALTIME_URL` is ignored whenever `NODE_ENV` is `production`, where

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -171,7 +171,8 @@ If Postgres will not come up after a schema change went wrong,
 
 **A "Reconnecting to live updates" banner will not go away.** The realtime
 server is not running or `NEXT_PUBLIC_REALTIME_URL` is wrong. Locally it should
-be `ws://localhost:3100`. In production it must not be set at all.
+be `ws://localhost:3100`, and the app connects to `/api/ws` under it. In production
+it must not be set at all.
 
 **Tests deadlock or hit foreign key errors for no reason.** Two test runs are
 sharing a database. Set `ORBIT_TEST_LANE` to something unique in each.


### PR DESCRIPTION
## What changed

- makes the dedicated Bun realtime host accept WebSocket upgrades only on one explicit path, defaulting to `/api/ws`
- adds optional exact-origin enforcement for provider-neutral reverse-proxy deployments
- normalizes and validates configured paths and browser origins
- replaces the public stats-shaped health response with minimal `/livez` and `/readyz` responses
- keeps `/health` as a minimal readiness alias for compatibility
- supports an optional bounded readiness callback so the production entry point can add a database probe without coupling the reusable server to one database implementation
- adds focused tests for path matching, path validation, origin normalization, deduplication, missing-origin rejection, and exact origin policy

## Why

Orbit’s browser already uses the same-origin URL `/api/ws`, and `apps/realtime` already hosts the same `@orbit/realtime-server` hub used by Vercel. The portable production topology should therefore route that one path to the dedicated service behind nginx, Caddy, or Traefik rather than introducing a second public socket URL or a second realtime implementation.

This is the first small implementation slice of #391. It establishes the service boundary needed by #392 without adding containers or changing the hosted Vercel path yet.

## Preserved behavior

- `apps/web/src/app/api/ws/route.ts` is unchanged
- the Vercel `experimental_upgradeWebSocket` path remains available
- socket tickets are still sent in the first message, not in the URL
- ticket, scope, membership, session-revocation, heartbeat, Redis fan-out, and graceful-shutdown behavior remain inside the existing hub
- origin enforcement is opt-in until the production entry-point/configuration change wires the public Orbit origin

## Security

- an Upgrade request to an unrelated path now receives `404`
- when an allowlist is configured, a missing, malformed, non-HTTP(S), or different Origin is refused
- forwarded identity headers are not introduced or trusted
- health responses no longer disclose Redis state names, connection counts, subscriptions, or internal topology
- readiness callback failure is converted to a generic unavailable state rather than leaking an exception

## Verification

From a fresh clone of this branch:

```text
bun install --frozen-lockfile
bun test apps/realtime/tests/deployment-boundary.test.ts
bunx biome check apps/realtime/src/server.ts apps/realtime/tests/deployment-boundary.test.ts
bun run --filter '@orbit/realtime' typecheck
docker compose up -d
bun run --filter '@orbit/realtime' test
```

All completed successfully. The Docker services were removed with volumes after the package test.

## Follow-up before production use

A later PR under #391 still needs to:

- wire the allowed origin and a bounded database readiness probe from validated production configuration
- add nginx/Caddy/Traefik fixtures
- run the production-shaped two-browser/two-replica same-origin test
- document proxy timeouts, path routing, and the Vercel coexistence boundary

This PR must not be treated as completing portable production realtime on its own.

Tracks #391 and #388.

Do not merge automatically.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR defines a provider-neutral deployment boundary for the dedicated realtime service.
- Restricts WebSocket upgrades to a normalized explicit path, defaulting to `/api/ws`.
- Adds optional exact-origin enforcement and updates local clients and test helpers for the new path.
- Replaces detailed health output with minimal liveness and readiness endpoints, including bounded custom readiness checks and server-side failure logging.
- Updates focused tests and deployment documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/realtime/src/server.ts | Adds normalized WebSocket path and origin policies, minimal health routes, readiness checks, and diagnostic logging; all previously reported failures are resolved. |
| apps/realtime/src/test-helpers.ts | Updates shared test clients to connect through the server’s default `/api/ws` route. |
| apps/realtime/tests/deployment-boundary.test.ts | Covers path normalization and matching, root-path handling, origin normalization, deduplication, and enforcement. |
| apps/realtime/tests/server.test.ts | Aligns raw upgrades and health assertions with the new deployment boundary and minimal health contract. |
| apps/web/src/lib/realtime/url.ts | Appends `/api/ws` to pathless local realtime overrides while preserving explicitly configured paths. |
| apps/web/tests/lib/realtime/url.test.ts | Verifies default path insertion across supported loopback origins and preservation of custom paths. |
| docs/configuration.md | Documents that pathless local realtime configuration connects beneath `/api/ws`. |
| docs/getting-started.md | Updates local troubleshooting guidance for the dedicated realtime path. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    R[Incoming request] --> U{WebSocket upgrade?}
    U -->|Yes| P{GET on configured realtime path?}
    P -->|No| N[404 not_found]
    P -->|Yes| O{Origin allowed?}
    O -->|No| F[403 forbidden]
    O -->|Yes| W[Upgrade WebSocket]
    U -->|No| H{HTTP health route}
    H -->|/livez| L[200 ok]
    H -->|/readyz or /health| Q{Redis and optional readiness check ready?}
    Q -->|Yes| A[200 ok]
    Q -->|No| X[503 unavailable]
    H -->|Other| N
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/noveum/orbit/commit/1e7873ed80bf297f41408c12e9d7dd0071476269) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60373419)</sub>

<!-- /greptile_comment -->