### PR TITLE
fix(web): stop the card controls test mock leaking into the issue card suite

### DIFF
--- a/apps/web/tests/features/issues/card-controls.test.tsx
+++ b/apps/web/tests/features/issues/card-controls.test.tsx
@@ -3,10 +3,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ToastProvider } from '@/components/ui/toast.tsx';
+import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import type { Issue, Member } from '@/lib/query/schemas.ts';
 import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
 
-await restoreModulesAfterThisFile(['@/lib/query/use-issues.ts']);
+await restoreModulesAfterThisFile([
+  '@/features/issues/workspace-provider.tsx',
+  '@/lib/query/use-issues.ts',
+]);
 
 const member: Member = {
   id: 'user_2',
@@ -17,8 +21,11 @@ const member: Member = {
   role: 'member',
 };
 
+const realUseWorkspace = workspaceProvider.useWorkspace;
+
 mock.module('@/features/issues/workspace-provider.tsx', () => ({
-  useWorkspace: () => ({ members: [member] }),
+  ...workspaceProvider,
+  useWorkspace: () => ({ ...realUseWorkspace(), members: [member], states: [] }),
 }));
 
 mock.module('@/lib/query/use-issues.ts', () => ({

--- a/apps/web/tests/features/issues/issue-card.test.tsx
+++ b/apps/web/tests/features/issues/issue-card.test.tsx
@@ -6,9 +6,20 @@ import { fireEvent, render as renderRaw, screen } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { ToastProvider } from '@/components/ui/toast.tsx';
 import { groupIssues } from '@/features/filters/grouping.ts';
+import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import type { Issue, Label, Member, WorkflowState } from '@/lib/query/schemas.ts';
 import { planDrop } from '../../../src/features/issues/board.tsx';
 import { IssueCard } from '../../../src/features/issues/issue-card.tsx';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
+
+const realUseWorkspace = workspaceProvider.useWorkspace;
+
+mock.module('@/features/issues/workspace-provider.tsx', () => ({
+  ...workspaceProvider,
+  useWorkspace: realUseWorkspace,
+}));
 
 function render(ui: ReactElement) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });


### PR DESCRIPTION
## What this changes

`apps/web/tests/features/issues/card-controls.test.tsx` mocked `workspace-provider` with a single `useWorkspace` export and never restored it. Bun keeps a module mock for the rest of the process, so whichever test file loaded the provider next lost `statesForTeam`, and the seven `IssueCard` tests failed with `states.filter` on undefined. Which file came next depended on directory order, which is why `main` (`3170e754`) and every open pull request went red on the same seven tests this week while nothing touched that code.

The mock now spreads the real module, carries an empty `states` list, and is restored after the file. `issue-card.test.tsx` mocks the provider itself with the real hook so it no longer depends on what ran before it.

## How you know it works

- `card-controls.test.tsx` followed by `issue-card.test.tsx` in one process reproduced the failure before the change and passes after it (18/18).
- `tests/features/issues` passes: 336 tests across 28 files. One 20s timeout on the reviewer cap dialog test under the full directory run passes on its own and is unrelated.
- Lint and comment policy clean.

## Checklist

- [x] Tests added or updated, and they fail without the change
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VF2UUVK1HnXDdyf64eDiE

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR isolates workspace-provider mocks in the issue test suites so test behavior does not depend on file execution order.
- Restores the workspace-provider module after each affected test file.
- Preserves the provider’s real exports while overriding only the workspace data needed by card-controls tests.
- Gives issue-card tests an explicit real useWorkspace implementation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The changed mocks preserve complete provider exports, supply the workspace fields used by the tests, and are isolated under the repository’s pinned test runtime.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/tests/features/issues/card-controls.test.tsx | Preserves the real workspace-provider exports, supplies stable members and states, and restores mocked modules after the suite. |
| apps/web/tests/features/issues/issue-card.test.tsx | Explicitly installs and restores the real workspace hook so the suite remains isolated from neighboring module mocks. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): stop the card controls test mo..."](https://github.com/noveum/orbit/commit/a2944b1b484bc2eacf68bd219cff1adf49dbf8a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60751278)</sub>

<!-- /greptile_comment -->