### PR TITLE
feat(comments): let members and admins delete anyone's comment

### DIFF
--- a/apps/web/src/features/comments/comment-permissions.ts
+++ b/apps/web/src/features/comments/comment-permissions.ts
@@ -1,0 +1,6 @@
+import type { OrgRole } from '@orbit/shared/constants';
+import { permissionsFor } from '@orbit/shared/policy';
+
+export function canModerateComments(role: OrgRole): boolean {
+  return permissionsFor(role).includes('comment:delete:any');
+}

--- a/apps/web/src/features/comments/comment-thread.tsx
+++ b/apps/web/src/features/comments/comment-thread.tsx
@@ -16,6 +16,7 @@ import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import { proseOverflowClassName, taskListClassName } from '@/features/docs/doc-body.tsx';
 import { useHashScroll } from '@/features/docs/use-hash-scroll.ts';
 import { ActivityEntry } from '@/features/issues/activity-feed.tsx';
+import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
 import { cn } from '@/lib/cn.ts';
 import { revealOnHover } from '@/lib/interaction.ts';
 import { queryKeys } from '@/lib/query/keys.ts';
@@ -29,6 +30,7 @@ import {
 } from '@/lib/query/use-comments.ts';
 import { useCurrentUserId } from '@/lib/realtime/session.tsx';
 import { CommentComposer } from './comment-composer.tsx';
+import { canModerateComments } from './comment-permissions.ts';
 import { usePendingCommentFiles } from './comment-uploads.ts';
 
 const QUICK_EMOJI = ['👍', '🎉', '🚀', '👀', '❤️'] as const;
@@ -257,6 +259,7 @@ function CommentItem({
   isReply = false,
 }: CommentItemProps) {
   const currentUserId = useCurrentUserId();
+  const workspace = useWorkspace();
   const react = useToggleReaction(issueId);
   const update = useUpdateComment(issueId);
   const remove = useDeleteComment(issueId);
@@ -265,6 +268,7 @@ function CommentItem({
   const [editing, setEditing] = useState(false);
 
   const mine = entry.comment.authorId === currentUserId;
+  const removable = mine || canModerateComments(workspace.role);
   const summary = summarizeReactions(entry.reactions, currentUserId);
 
   return (
@@ -362,14 +366,14 @@ function CommentItem({
               </Button>
             )}
             {mine ? (
-              <>
-                <Button size="sm" variant="ghost" onClick={() => setEditing(true)}>
-                  Edit
-                </Button>
-                <Button size="sm" variant="ghost" onClick={() => remove.mutate(entry.comment.id)}>
-                  Delete
-                </Button>
-              </>
+              <Button size="sm" variant="ghost" onClick={() => setEditing(true)}>
+                Edit
+              </Button>
+            ) : null}
+            {removable ? (
+              <Button size="sm" variant="ghost" onClick={() => remove.mutate(entry.comment.id)}>
+                Delete
+              </Button>
             ) : null}
           </span>
         </div>

--- a/apps/web/src/features/docs/doc-comments.tsx
+++ b/apps/web/src/features/docs/doc-comments.tsx
@@ -8,7 +8,9 @@ import { Avatar } from '@/components/ui/avatar.tsx';
 import { Button } from '@/components/ui/button.tsx';
 import { RelativeTime } from '@/components/ui/relative-time.tsx';
 import { CommentComposer } from '@/features/comments/comment-composer.tsx';
+import { canModerateComments } from '@/features/comments/comment-permissions.ts';
 import { CommentBody } from '@/features/comments/comment-thread.tsx';
+import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
 import { cn } from '@/lib/cn.ts';
 import { revealOnHover } from '@/lib/interaction.ts';
 import type { DocComment, Member } from '@/lib/query/schemas.ts';
@@ -163,6 +165,7 @@ function DocCommentItem({
   isReply = false,
 }: DocCommentItemProps) {
   const currentUserId = useCurrentUserId();
+  const workspace = useWorkspace();
   const update = useUpdateDocComment(docId);
   const remove = useDeleteDocComment(docId);
   const createReply = useCreateDocComment(docId);
@@ -171,6 +174,7 @@ function DocCommentItem({
   const article = useRef<HTMLElement>(null);
 
   const mine = entry.comment.authorId === currentUserId;
+  const removable = mine || canModerateComments(workspace.role);
   const anchor = entry.comment.anchor;
   const state = anchorState(anchor, anchorText);
 
@@ -233,14 +237,14 @@ function DocCommentItem({
             </Button>
           )}
           {mine ? (
-            <>
-              <Button size="sm" variant="ghost" onClick={() => setEditing(true)}>
-                Edit
-              </Button>
-              <Button size="sm" variant="ghost" onClick={() => remove.mutate(entry.comment.id)}>
-                Delete
-              </Button>
-            </>
+            <Button size="sm" variant="ghost" onClick={() => setEditing(true)}>
+              Edit
+            </Button>
+          ) : null}
+          {removable ? (
+            <Button size="sm" variant="ghost" onClick={() => remove.mutate(entry.comment.id)}>
+              Delete
+            </Button>
           ) : null}
         </div>
 

--- a/apps/web/tests/features/comments/comment-moderation.test.tsx
+++ b/apps/web/tests/features/comments/comment-moderation.test.tsx
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import type { OrgRole } from '@orbit/shared/constants';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { ToastProvider } from '@/components/ui/toast.tsx';
+import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
+import type { Comment, Member } from '@/lib/query/schemas.ts';
+import { SessionProvider } from '@/lib/realtime/session.tsx';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile([
+  '@/features/issues/workspace-provider.tsx',
+  '@/features/docs/editor/rich-text-editor.tsx',
+]);
+
+const realUseWorkspace = workspaceProvider.useWorkspace;
+let role: OrgRole = 'guest';
+
+mock.module('@/features/issues/workspace-provider.tsx', () => ({
+  ...workspaceProvider,
+  useWorkspace: () => ({ ...realUseWorkspace(), role }),
+}));
+mock.module('@/features/docs/editor/rich-text-editor.tsx', () => ({
+  RichTextEditor: ({ testId }: { testId?: string }) => <div data-testid={testId} />,
+}));
+
+const { CommentThread } = await import('@/features/comments/comment-thread.tsx');
+
+const members: readonly Member[] = [
+  {
+    id: 'user_1',
+    name: 'Ada Admin',
+    email: 'ada@orbit.test',
+    image: null,
+    handle: 'ada',
+    role: 'admin',
+  },
+  {
+    id: 'user_2',
+    name: 'Aditi Rao',
+    email: 'aditi@orbit.test',
+    image: null,
+    handle: 'aditi',
+    role: 'member',
+  },
+];
+
+function comment(id: string, authorId: string): Comment {
+  return {
+    comment: {
+      id,
+      issueId: 'issue_1',
+      authorId,
+      parentId: null,
+      body: 'A note',
+      editedAt: null,
+      createdAt: '2026-01-02T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      deletedAt: null,
+      syncId: 2,
+    },
+    bodyHtml: '<p>A note</p>',
+    reactions: [],
+  };
+}
+
+function show(entry: Comment) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <SessionProvider userId="user_1">
+          <CommentThread
+            issueId="issue_1"
+            comments={[entry]}
+            activity={[]}
+            members={members}
+            focusCommentId={null}
+          />
+        </SessionProvider>
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+  return within(screen.getByTestId(`comment-${entry.comment.id}`));
+}
+
+afterEach(() => {
+  cleanup();
+  role = 'guest';
+});
+
+describe('deleting a comment somebody else wrote', () => {
+  it('is offered to a member, without the edit that stays with the author', () => {
+    role = 'member';
+    const item = show(comment('c_1', 'user_2'));
+    expect(item.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(item.queryByRole('button', { name: 'Edit' })).toBeNull();
+  });
+
+  it('is offered to an admin', () => {
+    role = 'admin';
+    const item = show(comment('c_1', 'user_2'));
+    expect(item.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(item.queryByRole('button', { name: 'Edit' })).toBeNull();
+  });
+
+  it('is withheld from a guest and a contributor', () => {
+    role = 'contributor';
+    const item = show(comment('c_1', 'user_2'));
+    expect(item.queryByRole('button', { name: 'Delete' })).toBeNull();
+    expect(item.queryByRole('button', { name: 'Edit' })).toBeNull();
+  });
+
+  it('never takes edit and delete away from the author, whatever the role', () => {
+    role = 'guest';
+    const item = show(comment('c_1', 'user_1'));
+    expect(item.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(item.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/features/comments/comment-moderation.test.tsx
+++ b/apps/web/tests/features/comments/comment-moderation.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test';
 import type { OrgRole } from '@orbit/shared/constants';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ToastProvider } from '@/components/ui/toast.tsx';
 import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import type { Comment, Member } from '@/lib/query/schemas.ts';
@@ -84,9 +85,12 @@ function show(entry: Comment) {
   return within(screen.getByTestId(`comment-${entry.comment.id}`));
 }
 
+const originalFetch = globalThis.fetch;
+
 afterEach(() => {
   cleanup();
   role = 'guest';
+  globalThis.fetch = originalFetch;
 });
 
 describe('deleting a comment somebody else wrote', () => {
@@ -116,5 +120,28 @@ describe('deleting a comment somebody else wrote', () => {
     const item = show(comment('c_1', 'user_1'));
     expect(item.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
     expect(item.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('sends the delete of somebody else comment to the server', async () => {
+    role = 'admin';
+    const requests: { url: string; method: string }[] = [];
+    globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(input), method: init?.method ?? 'GET' });
+      return Promise.resolve(
+        new Response(JSON.stringify({ deleted: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as unknown as typeof fetch;
+    const item = show(comment('c_1', 'user_2'));
+
+    await userEvent
+      .setup({ pointerEventsCheck: 0 })
+      .click(item.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() =>
+      expect(requests).toContainEqual({ url: '/api/comments/c_1', method: 'DELETE' }),
+    );
   });
 });

--- a/apps/web/tests/features/docs/doc-comments.test.tsx
+++ b/apps/web/tests/features/docs/doc-comments.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { OrgRole } from '@orbit/shared/constants';
 import { buildDocAnchor } from '@orbit/shared/utils';
 import type { DocCommentAnchor } from '@orbit/shared/validators';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -6,9 +7,22 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { ToastProvider } from '@/components/ui/toast.tsx';
+import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import type { Member } from '@/lib/query/schemas.ts';
 import { SessionProvider } from '@/lib/realtime/session.tsx';
-import { DocComments } from '../../../src/features/docs/doc-comments.tsx';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
+
+const realUseWorkspace = workspaceProvider.useWorkspace;
+let role: OrgRole = 'guest';
+
+mock.module('@/features/issues/workspace-provider.tsx', () => ({
+  ...workspaceProvider,
+  useWorkspace: () => ({ ...realUseWorkspace(), role }),
+}));
+
+const { DocComments } = await import('../../../src/features/docs/doc-comments.tsx');
 
 const members: readonly Member[] = [
   { id: 'user_1', name: 'Ada', email: 'ada@orbit.test', image: null, handle: 'ada', role: 'admin' },
@@ -27,15 +41,16 @@ interface WireComment {
   readonly body: string;
   readonly parentId: string | null;
   readonly anchor: DocCommentAnchor | null;
+  readonly authorId?: string;
 }
 
-function wireComment({ id, body, parentId, anchor }: WireComment) {
+function wireComment({ id, body, parentId, anchor, authorId = 'user_1' }: WireComment) {
   const at = '2026-01-01T00:00:00.000Z';
   return {
     comment: {
       id,
       docId: 'doc_1',
-      authorId: 'user_1',
+      authorId,
       parentId,
       body,
       anchor,
@@ -127,6 +142,39 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  role = 'guest';
+});
+
+describe('deleting a doc comment somebody else wrote', () => {
+  const theirs = wireComment({
+    id: 'c_theirs',
+    body: 'Not mine',
+    parentId: null,
+    anchor: null,
+    authorId: 'user_2',
+  });
+
+  it('is offered to a member, without the edit that stays with the author', async () => {
+    role = 'member';
+    await show([theirs]);
+    const item = within(screen.getByTestId('doc-comment-c_theirs'));
+    expect(item.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(item.queryByRole('button', { name: 'Edit' })).toBeNull();
+  });
+
+  it('is withheld from a guest', async () => {
+    await show([theirs]);
+    const item = within(screen.getByTestId('doc-comment-c_theirs'));
+    expect(item.queryByRole('button', { name: 'Delete' })).toBeNull();
+    expect(item.queryByRole('button', { name: 'Edit' })).toBeNull();
+  });
+
+  it('keeps edit and delete on the author own comment', async () => {
+    await show([comment('c_mine', 'Mine')]);
+    const item = within(screen.getByTestId('doc-comment-c_mine'));
+    expect(item.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(item.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
 });
 
 describe('DocComments', () => {

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -24,7 +24,7 @@ each role can do everything the one below it can.
 | --- | --- |
 | **Guest** | Read issues, projects and docs. Comment, react |
 | **Contributor** | Everything a guest can, plus create and update issues, upload attachments, manage their own views |
-| **Member** | Everything a contributor can, plus delete issues, manage projects, cycles, milestones, labels, workflows, and write and publish docs |
+| **Member** | Everything a contributor can, plus delete issues, delete anyone's comments, manage projects, cycles, milestones, labels, workflows, and write and publish docs |
 | **Admin** | Everything, plus invite and manage members, manage integrations and manage the workspace |
 
 Every authorization decision goes through `packages/shared/src/policy`, which is


### PR DESCRIPTION
## What this changes

An admin could not delete a comment written by somebody else, on an issue or on a document. The policy (`comment:delete:any`, held by members and admins) and both comment services already allowed it, and the MCP `delete_comment` and `delete_doc_comment` tools already worked. The two comment threads in the app were the only gate left: they rendered Delete only when the reader wrote the comment.

- `apps/web/src/features/comments/comment-permissions.ts`: one helper, `canModerateComments(role)`, reading the policy the same way `canDeleteIssues` does.
- `comment-thread.tsx` and `doc-comments.tsx`: Delete follows `mine || canModerateComments(role)`; Edit stays with the author.
- `docs/concepts.md`: the member row of the roles table now says "delete anyone's comments".

No server change. The role comes from the same `WorkspaceProvider` the issue deletion button uses, so the UI hides what the server would refuse, and the server stays the real gate.

## Why

Moderating a thread is a normal admin job, and issue deletion already works this way. Without this an admin's only route was the MCP tool.

## How you know it works

- New `apps/web/tests/features/comments/comment-moderation.test.tsx`: a member and an admin see Delete but not Edit on somebody else's comment, a contributor sees neither, and the author keeps both regardless of role.
- New cases in `apps/web/tests/features/docs/doc-comments.test.tsx` covering the same three situations for document comments.
- The server side is already covered by `lets an admin delete a comment written by someone else` in both `comment-service.test.ts` and `doc-comment-service.test.ts`.
- Lint, comment policy and the web typecheck are clean; the three comment test files pass together (22 tests).

## Checklist

- [x] Tests added or updated, and they fail without the change
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions
- [x] Authorization is enforced on the server through `packages/shared/src/policy`, not only in the UI
- [x] Docs updated

## Anything reviewers should know

Members hold `comment:delete:any` today, not only admins, matching `issue:delete`. This PR follows the policy as it stands rather than narrowing it. Deleting somebody else's comment has no confirmation step, the same as deleting your own; happy to add one if we want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VF2UUVK1HnXDdyf64eDiE



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns issue and document comment controls with the shared deletion policy so members and admins can remove comments written by others while editing remains author-only.
- Adds a shared comment-moderation capability helper.
- Updates issue and document comment threads to expose Delete according to the active workspace role.
- Adds role-based moderation tests and documents the member capability.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/features/comments/comment-permissions.ts | Adds a capability helper backed by the same shared policy used by server authorization. |
| apps/web/src/features/comments/comment-thread.tsx | Separates author-only editing from policy-based comment deletion in issue threads. |
| apps/web/src/features/docs/doc-comments.tsx | Applies the same moderation control to document comments. |
| apps/web/tests/features/comments/comment-moderation.test.tsx | Covers role-based issue-comment action visibility and the delete request. |
| apps/web/tests/features/docs/doc-comments.test.tsx | Covers role-based document-comment action visibility. |
| docs/concepts.md | Documents that members may delete comments written by anyone. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(comments): prove a moderator delete..."](https://github.com/noveum/orbit/commit/4e6dd76f35fa964e9f0d647893983eb72242141b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60851689)</sub>

<!-- /greptile_comment -->