### PR TITLE
docs(analytics): define lead and cycle time

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -152,6 +152,27 @@ What a sprint gives you:
 - **Burndown** of remaining work against time.
 - **Carryover**, meaning what did not finish when you complete the sprint.
 
+### Lead time and cycle time
+
+The sprint analytics flow-time card summarizes completed issues associated with
+the selected sprint. It shows the median (`p50`) and the 85th percentile (`p85`)
+in calendar days. Unfinished and canceled issues do not contribute a duration.
+
+- **Lead time** runs from the issue's creation time to its durable completion
+  time. It starts at creation even when the issue joined the sprint later.
+- **Cycle time** runs from the issue's `startedAt` time to its durable completion
+  time. Orbit omits an issue from this calculation when it has no start time.
+
+Orbit also omits either duration when its end is earlier than its start. If no
+valid durations remain, the corresponding metric is unavailable.
+
+Lead time uses the creation timestamp from the current issue row. Cycle time
+uses the current mutable `startedAt` column. For an active sprint, Orbit labels
+that cycle-time coverage `current-column`. For a completed sprint, it labels the
+coverage `reconstructed-current-column` because close outcomes preserve the
+completion time but not the first start time. Editing `startedAt` later can
+therefore change a completed sprint's historical cycle-time distribution.
+
 Completing a sprint asks what to do with unfinished issues: move them to the
 next sprint, or back to the backlog.
 


### PR DESCRIPTION
Closes #183

## Summary

- define lead time and cycle time for sprint analytics
- explain the completed-issue cohort, p50 and p85 summaries, and invalid-duration handling
- document why completed sprint cycle time is reconstructed from the current `startedAt` column

## Validation

- pre-push lint and typecheck passed
- `bun run docs:build` completed and rendered the updated Concepts page; VitePress also emitted an SSR diagnostic from the untouched `VERCEL_BUILD_GATE.md` page
- `ORBIT_TEST_LANE=parallel01a183 bun run verify` passed static checks, typechecks, and sprint analytics tests; the overall run was stopped by unrelated Slack delivery assertions and a later `SIGTRAP` in the web test suite


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR documents how sprint analytics calculate lead time and cycle time.

- Defines the completed-issue cohort and p50/p85 calendar-day summaries.
- Explains handling for missing starts, invalid durations, and unavailable metrics.
- Clarifies timestamp ownership and why completed-sprint cycle time is reconstructed from the current `startedAt` value.

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge.

The documented cohort, percentile calculations, invalid-duration handling, timestamp sources, and coverage labels align with the sprint analytics implementation, and no actionable defect remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/concepts.md | Adds an accurate explanation of sprint flow-time calculations, exclusions, coverage labels, and historical reconstruction behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(analytics): define lead and cycle t..."](https://github.com/noveum/orbit/commit/f141ba272637898ce1276ae311763dcee76756a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60932829)</sub>

<!-- /greptile_comment -->