### PR TITLE
test(web): isolate issue failure surfaces

### DIFF
--- a/apps/web/e2e/issues.spec.ts
+++ b/apps/web/e2e/issues.spec.ts
@@ -5,10 +5,14 @@ const SHOTS = process.env['ORBIT_E2E_SHOTS'] ?? 'test-results';
 
 async function signIn(context: BrowserContext, email: string): Promise<Page> {
   const page = await context.newPage();
+  await signInPage(page, email);
+  return page;
+}
+
+async function signInPage(page: Page, email: string): Promise<void> {
   await page.goto(`${BASE}/login`);
   await page.getByTestId(`dev-sign-in-${email}`).click();
   await page.waitForURL(`${BASE}/my-issues`);
-  return page;
 }
 
 // biome-ignore lint/suspicious/noSkippedTests: board drag and drop reorder is flaky under synthetic mouse events; realtime comment and reaction propagation stays covered by same-user-tabs and second-workspace-realtime
@@ -86,58 +90,53 @@ test.fixme('two viewers see issue, board and comment changes without reloading',
   await second.close();
 });
 
-test('every issue surface says a failed request failed rather than looking empty', async ({
-  browser,
-}) => {
-  test.setTimeout(180_000);
-  const context = await browser.newContext({ viewport: { width: 1400, height: 800 } });
-  const page = await context.newPage();
-  await page.goto(`${BASE}/login`);
-  await page.getByTestId('dev-sign-in-alex@orbit.example').click();
-  await page.waitForURL(`${BASE}/my-issues`);
+test.use({ viewport: { width: 1400, height: 800 } });
 
-  for (const [path, testId] of [
-    ['/my-issues', 'retry-my-issues'],
-    ['/team/eng/issues', 'retry-team-issues'],
-    ['/sprints', 'retry-sprint-issues'],
-    ['/standup', 'retry-standup'],
-  ] as const) {
-    const surface = await context.newPage();
-    await surface.route('**/api/issues**', (route) =>
+for (const [path, testId] of [
+  ['/my-issues', 'retry-my-issues'],
+  ['/team/eng/issues', 'retry-team-issues'],
+  ['/sprints', 'retry-sprint-issues'],
+  ['/standup', 'retry-standup'],
+] as const) {
+  test(`failed request is visible on ${path}`, async ({ page }) => {
+    test.setTimeout(180_000);
+    await signInPage(page, 'alex@orbit.example');
+    await page.route('**/api/issues**', (route) =>
       route.fulfill({ status: 500, body: '{"error":"boom"}' }),
     );
-    await surface.goto(`${BASE}${path}`);
-    await expect(surface.getByTestId(testId)).toBeVisible({ timeout: 30_000 });
-    await surface.close();
-  }
+    await page.goto(`${BASE}${path}`);
+    await expect(page.getByTestId(testId)).toBeVisible({ timeout: 30_000 });
+  });
+}
 
-  const project = await context.newPage();
-  await project.goto(`${BASE}/projects`);
-  const projectHref = await project
+test('failed request is visible on project issues', async ({ page }) => {
+  test.setTimeout(180_000);
+  await signInPage(page, 'alex@orbit.example');
+  await page.goto(`${BASE}/projects`);
+  const projectHref = await page
     .locator('a[href^="/projects/"]')
     .filter({ hasNotText: /^$/ })
     .first()
     .getAttribute('href');
   if (projectHref !== null && projectHref !== '/projects') {
-    await project.route('**/api/issues**', (route) =>
+    await page.route('**/api/issues**', (route) =>
       route.fulfill({ status: 500, body: '{"error":"boom"}' }),
     );
-    await project.goto(`${BASE}${projectHref}/issues`);
-    await expect(project.getByTestId('retry-project-issues')).toBeVisible({ timeout: 30_000 });
+    await page.goto(`${BASE}${projectHref}/issues`);
+    await expect(page.getByTestId('retry-project-issues')).toBeVisible({ timeout: 30_000 });
   }
-  await project.close();
+});
 
-  const view = await context.newPage();
-  await view.goto(`${BASE}/views`);
-  const viewHref = await view.locator('a[href^="/views/"]').first().getAttribute('href');
+test('failed request is visible on a saved view', async ({ page }) => {
+  test.setTimeout(180_000);
+  await signInPage(page, 'alex@orbit.example');
+  await page.goto(`${BASE}/views`);
+  const viewHref = await page.locator('a[href^="/views/"]').first().getAttribute('href');
   if (viewHref !== null) {
-    await view.route('**/api/issues**', (route) =>
+    await page.route('**/api/issues**', (route) =>
       route.fulfill({ status: 500, body: '{"error":"boom"}' }),
     );
-    await view.goto(`${BASE}${viewHref}`);
-    await expect(view.getByTestId('retry-saved-view')).toBeVisible({ timeout: 30_000 });
+    await page.goto(`${BASE}${viewHref}`);
+    await expect(page.getByTestId('retry-saved-view')).toBeVisible({ timeout: 30_000 });
   }
-  await view.close();
-
-  await context.close();
 });


### PR DESCRIPTION
Closes #416.

Splits the combined issue-surface failure scenario into isolated Playwright tests while preserving each retry-state assertion and viewport.

Validation: Biome, comment policy, source-byte check, web typecheck, and Playwright test discovery pass. Full E2E execution is deferred to CI because Docker is unavailable locally.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Splits the combined issue-surface failure scenario into isolated Playwright tests while preserving the 1400×800 viewport and 180-second timeout.
- Extracts page-based sign-in into a reusable helper.
- Creates independent retry-state tests for four issue routes, project issues, and saved views.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable regressions identified.

The isolated tests retain fresh browser contexts, the required viewport and timeout, and route interception before each target navigation while preserving all existing retry-state checks.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/e2e/issues.spec.ts | The combined issue-surface test is safely separated into fixture-isolated tests with the existing viewport, timeout, request interception, and assertions preserved. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(web): isolate issue failure surface..."](https://github.com/noveum/orbit/commit/1ff19f591fdb36f43160cbca440041490b73d3e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60965094)</sub>

**Context used:**

- Knowledge Base — [Restore the issues E2E test timeout](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/reverts/rollback_360-20260827-e2e-timeout-65b8814.md)

<!-- /greptile_comment -->