### PR TITLE
test(web): restore the workspace provider mock in every file that replaces it

### DIFF
--- a/apps/web/tests/features/docs/doc-surface-access.test.tsx
+++ b/apps/web/tests/features/docs/doc-surface-access.test.tsx
@@ -7,6 +7,9 @@ import { TooltipProvider } from '@/components/ui/tooltip.tsx';
 import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import { createQueryClient } from '@/lib/query/provider.tsx';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 const push = mock();
 

--- a/apps/web/tests/features/docs/doc-surface-return.test.tsx
+++ b/apps/web/tests/features/docs/doc-surface-return.test.tsx
@@ -8,6 +8,9 @@ import { TooltipProvider } from '@/components/ui/tooltip.tsx';
 import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import { createQueryClient } from '@/lib/query/provider.tsx';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 mock.module('@orbit/realtime-client/react', () => ({
   useScopeSubscription: () => undefined,

--- a/apps/web/tests/features/filters/filter-bar.test.tsx
+++ b/apps/web/tests/features/filters/filter-bar.test.tsx
@@ -13,6 +13,9 @@ import { createQueryClient } from '@/lib/query/provider.tsx';
 import { FilterBar } from '../../../src/features/filters/filter-bar.tsx';
 import { defaultViewConfig, type ViewConfig } from '../../../src/features/filters/view-config.ts';
 import type { ViewControls } from '../../../src/features/filters/view-controls.tsx';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 const workspace: WorkspaceData = {
   ready: true,

--- a/apps/web/tests/features/inbox/inbox-issue.test.tsx
+++ b/apps/web/tests/features/inbox/inbox-issue.test.tsx
@@ -9,6 +9,9 @@ import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import { HotkeyProvider } from '@/lib/keyboard/index.ts';
 import type { Member, WorkflowState } from '@/lib/query/schemas.ts';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 const realtimeReact = { ...(await import('@orbit/realtime-client/react')) };
 mock.module('@orbit/realtime-client/react', () => ({

--- a/apps/web/tests/features/issues/board.test.tsx
+++ b/apps/web/tests/features/issues/board.test.tsx
@@ -21,6 +21,9 @@ import { boardSearch } from '@/lib/query/issue-search.ts';
 import { queryKeys } from '@/lib/query/keys.ts';
 import type { BoardPage, Issue, WorkflowState } from '@/lib/query/schemas.ts';
 import { seedBoardColumns } from '@/lib/query/use-issues.ts';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 const push = mock();
 const nativeFetch = globalThis.fetch;

--- a/apps/web/tests/features/issues/copy-branch-name.test.tsx
+++ b/apps/web/tests/features/issues/copy-branch-name.test.tsx
@@ -5,6 +5,9 @@ import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu
 import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import type { Issue, Member } from '@/lib/query/schemas.ts';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 const toast = mock();
 

--- a/apps/web/tests/features/issues/issue-copy-actions.test.tsx
+++ b/apps/web/tests/features/issues/issue-copy-actions.test.tsx
@@ -5,6 +5,9 @@ import { TooltipProvider } from '@/components/ui/tooltip.tsx';
 import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import type { Issue } from '@/lib/query/schemas.ts';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 const toast = mock();
 

--- a/apps/web/tests/features/issues/issue-deletion.test.tsx
+++ b/apps/web/tests/features/issues/issue-deletion.test.tsx
@@ -11,6 +11,9 @@ import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import { dangerAction, dangerMenuAction } from '@/lib/interaction.ts';
 import { HotkeyProvider } from '@/lib/keyboard/index.ts';
 import type { Issue, WorkflowState } from '@/lib/query/schemas.ts';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 mock.module('next/navigation', () => ({
   useRouter: () => ({ push: mock(), replace: mock(), refresh: mock(), prefetch: mock() }),

--- a/apps/web/tests/features/issues/issue-detail-delete.test.tsx
+++ b/apps/web/tests/features/issues/issue-detail-delete.test.tsx
@@ -10,6 +10,9 @@ import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import { HotkeyProvider } from '@/lib/keyboard/index.ts';
 import { queryKeys } from '@/lib/query/keys.ts';
 import type { Issue, IssueDetail, WorkflowState } from '@/lib/query/schemas.ts';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 const pushed: string[] = [];
 const replaced: string[] = [];

--- a/apps/web/tests/features/issues/issue-list.test.tsx
+++ b/apps/web/tests/features/issues/issue-list.test.tsx
@@ -13,7 +13,10 @@ import type { WorkspaceData } from '../../../src/features/issues/workspace-provi
 import * as workspaceProvider from '../../../src/features/issues/workspace-provider.tsx';
 import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
 
-await restoreModulesAfterThisFile(['@/lib/query/use-issues.ts']);
+await restoreModulesAfterThisFile([
+  '@/features/issues/workspace-provider.tsx',
+  '@/lib/query/use-issues.ts',
+]);
 
 mock.module('next/navigation', () => ({
   useRouter: () => ({ push: mock(), replace: mock(), refresh: mock() }),

--- a/apps/web/tests/features/issues/issue-properties.test.tsx
+++ b/apps/web/tests/features/issues/issue-properties.test.tsx
@@ -14,7 +14,10 @@ import { createQueryClient } from '@/lib/query/provider.tsx';
 import type { Issue, Member, Milestone } from '@/lib/query/schemas.ts';
 import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
 
-await restoreModulesAfterThisFile(['@/lib/query/use-issues.ts']);
+await restoreModulesAfterThisFile([
+  '@/features/issues/workspace-provider.tsx',
+  '@/lib/query/use-issues.ts',
+]);
 
 const patches: Record<string, unknown>[] = [];
 

--- a/apps/web/tests/features/issues/my-issues-view.test.tsx
+++ b/apps/web/tests/features/issues/my-issues-view.test.tsx
@@ -10,6 +10,9 @@ import type { Issue, WorkflowState } from '@/lib/query/schemas.ts';
 import { assignedSearch, DEFAULT_ISSUE_QUERY } from '@/lib/query/use-issues.ts';
 import type { WorkspaceData } from '../../../src/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '../../../src/features/issues/workspace-provider.tsx';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 mock.module('next/navigation', () => ({
   useRouter: () => ({ push: mock(), replace: mock() }),

--- a/apps/web/tests/features/issues/quick-create.test.tsx
+++ b/apps/web/tests/features/issues/quick-create.test.tsx
@@ -8,6 +8,7 @@ import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
 
 await restoreModulesAfterThisFile([
+  '@/features/issues/workspace-provider.tsx',
   '@/lib/query/use-issues.ts',
   '@/lib/query/use-duplicate-issues.ts',
 ]);

--- a/apps/web/tests/features/standup/standup-board.test.tsx
+++ b/apps/web/tests/features/standup/standup-board.test.tsx
@@ -8,6 +8,9 @@ import type { Issue, Member, WorkflowState } from '@/lib/query/schemas.ts';
 import { emptyFacets } from '@/lib/query/schemas.ts';
 import type { WorkspaceData } from '../../../src/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '../../../src/features/issues/workspace-provider.tsx';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 let search = '';
 

--- a/apps/web/tests/features/views/create-view-dialog.test.tsx
+++ b/apps/web/tests/features/views/create-view-dialog.test.tsx
@@ -8,6 +8,9 @@ import { ToastProvider } from '@/components/ui/toast.tsx';
 import type { WorkspaceData } from '@/features/issues/workspace-provider.tsx';
 import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import { HotkeyProvider } from '@/lib/keyboard/index.ts';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 mock.module('next/navigation', () => ({
   useRouter: () => ({ push: mock(), replace: mock(), refresh: mock() }),

--- a/apps/web/tests/features/views/saved-view-page.test.tsx
+++ b/apps/web/tests/features/views/saved-view-page.test.tsx
@@ -9,6 +9,9 @@ import { HotkeyProvider } from '@/lib/keyboard/index.ts';
 import { queryKeys } from '@/lib/query/keys.ts';
 import type { Issue, View, WorkflowState } from '@/lib/query/schemas.ts';
 import { emptyFacets } from '@/lib/query/schemas.ts';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 mock.module('next/navigation', () => ({
   useRouter: () => ({ push: mock(), replace: mock(), refresh: mock() }),

--- a/apps/web/tests/features/views/unresolvable-scope.test.tsx
+++ b/apps/web/tests/features/views/unresolvable-scope.test.tsx
@@ -11,7 +11,9 @@ import { HotkeyProvider } from '@/lib/keyboard/index.ts';
 import { queryKeys } from '@/lib/query/keys.ts';
 import type { View } from '@/lib/query/schemas.ts';
 import { bootstrapSchema, viewListSchema } from '@/lib/query/schemas.ts';
-import { mockSession } from '../../../tests-support.ts';
+import { mockSession, restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 const ORIGIN = 'http://localhost:3000';
 

--- a/apps/web/tests/features/views/views-page.test.tsx
+++ b/apps/web/tests/features/views/views-page.test.tsx
@@ -9,6 +9,9 @@ import * as workspaceProvider from '@/features/issues/workspace-provider.tsx';
 import { HotkeyProvider } from '@/lib/keyboard/index.ts';
 import { queryKeys } from '@/lib/query/keys.ts';
 import type { View } from '@/lib/query/schemas.ts';
+import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
+
+await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
 mock.module('next/navigation', () => ({
   useRouter: () => ({ push: mock(), replace: mock(), refresh: mock() }),

--- a/apps/web/tests/lib/auth/mock-isolation.test.ts
+++ b/apps/web/tests/lib/auth/mock-isolation.test.ts
@@ -9,7 +9,11 @@ const PACKAGE_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
 
 const GUARDED = [SESSION_MODULE, PRINCIPAL_MODULE] as const;
 
-const MUST_BE_RESTORED = ['@/lib/query/use-issue-search.ts', '@/lib/query/use-issues.ts'] as const;
+const MUST_BE_RESTORED = [
+  '@/features/issues/workspace-provider.tsx',
+  '@/lib/query/use-issue-search.ts',
+  '@/lib/query/use-issues.ts',
+] as const;
 
 interface Candidate {
   readonly label: string;
@@ -37,6 +41,10 @@ function stubs(source: string, specifier: string): boolean {
   return new RegExp(`mock\\.module\\(\\s*['"\`]${asPattern(specifier)}['"\`]`).test(source);
 }
 
+function packageAlias(specifier: string): string {
+  return specifier.replace(/^(?:\.\.\/)+src\//, '@/');
+}
+
 function stringConstantsIn(source: string): Map<string, string> {
   return new Map(
     [...source.matchAll(/(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*['"`]([^'"`]+)['"`]/g)].map(
@@ -53,7 +61,7 @@ function timesStubbed(source: string, specifier: string): number {
   )) {
     const named = call[2];
     const reached = call[1] ?? (named === undefined ? undefined : constants.get(named));
-    if (reached === specifier) seen += 1;
+    if (reached !== undefined && packageAlias(reached) === specifier) seen += 1;
   }
   return seen;
 }
@@ -61,7 +69,9 @@ function timesStubbed(source: string, specifier: string): number {
 function specifiersHandedToTheHelper(source: string): Set<string> {
   return new Set(
     [...source.matchAll(/restoreModulesAfterThisFile\(\s*\[([^\]]*)\]/g)].flatMap((call) =>
-      [...(call[1] ?? '').matchAll(/['"`]([^'"`]+)['"`]/g)].map((entry) => entry[1] ?? ''),
+      [...(call[1] ?? '').matchAll(/['"`]([^'"`]+)['"`]/g)].map((entry) =>
+        packageAlias(entry[1] ?? ''),
+      ),
     ),
   );
 }


### PR DESCRIPTION
## What this changes

Every web test file that replaces `@/features/issues/workspace-provider.tsx` now hands that
specifier to `restoreModulesAfterThisFile` from `tests-support.ts`, so the mock dies with the file
that installed it. `mock-isolation.test.ts` now guards the module too, which is what stops the
next one from slipping through.

## Why

`bun test` keeps a `mock.module` for the rest of the run, so a file that mocks the workspace
provider and never restores it changes what the next file sees. None of the current assertions
happen to depend on a leaked fixture, so the suite is green today by luck of file order rather
than by isolation.

Closes #415

## How you know it works

**The leak, before and after.** Two throwaway files in `tests/features/issues/`: the first mocks
the provider with `useWorkspace: () => 'LEAKED'`, the second asserts the real hook is in place.
Without the restore call, the second file sees the first file's fixture:

```
error: expect(received).toContain(expected)
Expected to contain: "useContext"
Received: "() => \"LEAKED\""
(fail) sees the real hook after the previous file restored it
```

With `restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx'])` in the first
file, both pass. Worth recording for anyone chasing this later: on bun 1.3.14 the mock reached
the next file in the same directory but not a file in a sibling directory, which is part of why
it has stayed invisible.

**The guard fails without the change.** Revert only the eighteen test files and
`mock-isolation.test.ts` names every one of them:

```
board, copy-branch-name, create-view-dialog, doc-surface-access, doc-surface-return,
filter-bar, inbox-issue, issue-copy-actions, issue-deletion, issue-detail-delete,
issue-list, issue-properties, my-issues-view, quick-create, saved-view-page,
standup-board, unresolvable-scope, views-page
```

**The suite is otherwise unchanged.** `bun test tests` in `apps/web`, before and after:
2222 pass, 306 fail, 2528 tests across 304 files both times, and the sorted list of failing test
names is byte for byte identical. Every one of those failures is a database backed test that
cannot reach Postgres on this machine.

## Checklist

- [ ] `bun run verify` is green, all four checks (see the last note: no database here)
- [x] Tests added or updated, and they fail without the change
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions
- [ ] External input parsed with a Zod schema (not applicable)
- [ ] Authorization enforced through `packages/shared/src/policy` (not applicable)
- [ ] Docs updated (not applicable)
- [ ] `bun run db:release` and `bun run db:check-drift` (not applicable, no schema change)

## Anything reviewers should know

**Three files beyond the fifteen named in the issue.** `issue-list`, `my-issues-view` and
`standup-board` carry the same defect. Leaving them out would mean file order still matters in
`tests/features/issues` and `tests/features/standup`, so the issue's own acceptance line would
not hold.

**The guard only recognised one spelling.** Those same three reach the module through
`../../../src/features/issues/workspace-provider.tsx` rather than the `@/` alias, and
`timesStubbed` compared specifier strings literally. Adding the module to `MUST_BE_RESTORED`
without also normalising the relative form would have produced a passing guard while three files
still leaked, so `packageAlias` folds `../../src/x` into `@/x` on both sides of the comparison.
That blind spot applied to the two entries already in the list as well. Happy to split this into
its own pull request if you would rather review it separately.

**What I could not run.** No Docker or Postgres on this machine, so the database backed suites
fail locally for want of a connection, identically before and after. Green here: `biome check`,
`check-comments`, `check-bytes`, `tsc --noEmit`, and every web test that does not need a database.
Rebased on `main` at 6482e9b, which merged cleanly apart from `quick-create.test.tsx`, where the
restore list now carries the workspace provider alongside the two entries #379 added.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR registers the workspace provider with the shared module-restoration helper in every affected web test and extends the isolation guard to recognize that module and normalize existing relative source paths.
- Adds per-file workspace-provider restoration across eighteen test files.
- Extends `MUST_BE_RESTORED` and normalizes `../../../src/...` spellings in the isolation guard.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking import-style inconsistency across the newly edited tests.

The module-restoration registrations and guard changes cover the current literal mock forms, while the accepted feedback concerns repository import conventions rather than test behavior.

**Files Needing Attention:** apps/web/tests/features/docs/doc-surface-access.test.tsx and the other test files adding ../../../tests-support.ts imports

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/tests/lib/auth/mock-isolation.test.ts | Extends the guarded module set and canonicalizes existing relative src specifiers for static mock-restoration checks. |
| apps/web/tests/features/issues/issue-list.test.tsx | Adds the workspace provider to the file’s existing restoration list. |
| apps/web/tests/features/issues/quick-create.test.tsx | Adds workspace-provider restoration alongside the two query modules already restored. |
| apps/web/tests/features/standup/standup-board.test.tsx | Registers restoration for a workspace-provider mock that uses the repository’s relative source spelling. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20noveum%2Forbit%20PR%20%23438%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=noveum%2Forbit&pr=438&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fweb%2Ftests%2Ffeatures%2Fdocs%2Fdoc-surface-access.test.tsx%3A10%0A**Relative%20imports%20violate%20web%20convention**%0A%0AThis%20newly%20added%20%60..%2F..%2F..%2Ftests-support.ts%60%20import%2C%20repeated%20across%20sixteen%20changed%20test%20files%2C%20violates%20the%20repository%20requirement%20to%20use%20%60%40%2F%60%20imports%20inside%20%60apps%2Fweb%60%2C%20expanding%20inconsistent%20path%20usage%20and%20making%20refactors%20and%20automated%20path%20checks%20more%20brittle.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=noveum%2Forbit&pr=438&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/tests/features/docs/doc-surface-access.test.tsx:10
**Relative imports violate web convention**

This newly added `../../../tests-support.ts` import, repeated across sixteen changed test files, violates the repository requirement to use `@/` imports inside `apps/web`, expanding inconsistent path usage and making refactors and automated path checks more brittle.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(web): guard the workspace provider ..."](https://github.com/noveum/orbit/commit/d247f499447cb40e9f586c23202d58e5cfa0a573) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61146439)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/noveum/orbit/blob/main/CLAUDE.md))

<!-- /greptile_comment -->