### PR TITLE
fix(github): accept provider timestamp offsets

### DIFF
--- a/packages/services/src/github/index.ts
+++ b/packages/services/src/github/index.ts
@@ -371,7 +371,12 @@ export interface NormalizedGithubEvent {
 
 const githubCommitShaSchema = z.string().regex(/^[0-9a-f]{40}$/i);
 const githubProviderObjectIdSchema = z.number().int().positive();
-const nullableProviderTimestampSchema = z.string().datetime().nullable().optional();
+const nullableProviderTimestampSchema = z
+  .string()
+  .datetime({ offset: true })
+  .transform((value) => new Date(value).toISOString())
+  .nullable()
+  .optional();
 const checkRunNormalizationEnvelopeSchema = z.object({
   check_run: z.object({
     id: githubProviderObjectIdSchema,

--- a/packages/services/tests/github/github.test.ts
+++ b/packages/services/tests/github/github.test.ts
@@ -280,6 +280,40 @@ describe('parseGithubEvent', () => {
 });
 
 describe('normalizeGithubCheckEvent', () => {
+  it('accepts provider timestamp offsets and normalizes the same instant to UTC', () => {
+    for (const updatedAt of [
+      '2026-09-08T11:17:42+00:00',
+      '2026-09-08T16:47:42+05:30',
+      '2026-09-08T07:17:42-04:00',
+    ]) {
+      const result = normalizeGithubCheckEvent('status', {
+        id: 21,
+        sha: STATUS_SHA,
+        state: 'success',
+        context: 'Deploy',
+        updated_at: updatedAt,
+      });
+      expect(result).toMatchObject({
+        status: 'normalized',
+        value: { providerUpdatedAt: '2026-09-08T11:17:42.000Z' },
+      });
+    }
+  });
+
+  it('rejects malformed and timezone-free provider timestamps', () => {
+    for (const updatedAt of ['invalid', '2026-09-08T11:17:42', '2026-09-08T11:17:42+25:00']) {
+      expect(
+        normalizeGithubCheckEvent('status', {
+          id: 21,
+          sha: STATUS_SHA,
+          state: 'success',
+          context: 'Deploy',
+          updated_at: updatedAt,
+        }),
+      ).toEqual({ status: 'invalid', failure: { code: 'invalid_payload', path: 'updated_at' } });
+    }
+  });
+
   it('extracts the exact checked commit from every supported event shape', () => {
     const cases = [
       ['check_run', checkRunPayload()],


### PR DESCRIPTION
## Summary
Production verification after #383 found GitHub status deliveries using RFC3339 timestamps ending in +00:00. The new check-event parser rejected those valid timestamps and quarantined their deliveries.

Accept explicit timezone offsets and normalize them to UTC before downstream ordering. Preserve rejection of malformed and timezone-free values.

## Verification
- Added a regression test and observed it fail before the fix.
- Targeted GitHub parser suite: 27 passing tests.
- Full isolated verification in progress; services suite passed 849 tests.

## Deployment
No database migration is required. Deploy this fix before completing the notification rollout. Existing quarantined deliveries remain preserved; recovery still needs verification.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR allows GitHub check-event timestamps with explicit RFC3339 offsets and normalizes accepted values to canonical UTC strings.
- Enables offset-aware validation for nullable provider timestamps.
- Preserves rejection of malformed and timezone-free timestamps.
- Adds regression coverage for equivalent UTC, positive-offset, and negative-offset instants.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The offset-aware schema remains strict about calendar and timezone validity, while UTC normalization matches downstream parsing and ordering expectations and is covered by focused regression tests.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/services/src/github/index.ts | Broadens provider timestamp validation to explicit offsets and canonicalizes valid timestamps to UTC without exposing an identified failure. |
| packages/services/tests/github/github.test.ts | Adds focused coverage for valid timezone offsets, malformed values, timezone-free values, and invalid offset ranges. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(github): normalize provider timestam..."](https://github.com/noveum/orbit/commit/22d4900b495eed163b09738e186f5ac890892839) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61560725)</sub>

<!-- /greptile_comment -->