### PR TITLE
feat(backup): manifest schema, database dump, and atomic capture CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,11 +308,11 @@ jobs:
           docker run -d --name orbit-minio -p 9010:9000 \
             -e MINIO_ROOT_USER=orbitminio \
             -e MINIO_ROOT_PASSWORD=orbitminio \
-            minio/minio:latest server /data
+            quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e server /data
           for attempt in $(seq 1 60); do
             if curl -fsS http://localhost:9010/minio/health/live >/dev/null; then
               echo "minio is up after ${attempt} attempts"
-              docker run --rm --network host --entrypoint sh minio/mc:latest -c \
+              docker run --rm --network host --entrypoint sh quay.io/minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727 -c \
                 "mc alias set orbit http://localhost:9010 orbitminio orbitminio && mc mb --ignore-existing orbit/orbit-uploads"
               exit 0
             fi

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "orbit",
@@ -224,6 +223,7 @@
         "linkedom": "^0.18.13",
         "lowlight": "^3",
         "marked": "18.0.9",
+        "postgres": "^3.4.9",
         "resend": "6.18.1",
         "zod": "4.4.3",
       },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       retries: 20
 
   minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     container_name: orbit-minio
     restart: unless-stopped
     command: server /data --console-address ":9011"
@@ -54,7 +54,7 @@ services:
       retries: 20
 
   minio-bucket:
-    image: minio/mc:latest
+    image: quay.io/minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     container_name: orbit-minio-bucket
     depends_on:
       minio:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -271,12 +271,76 @@ labelled `breaking change` and follow the upgrade notes in the associated releas
 
 ### Backups
 
-Back up Postgres. That is where everything lives except uploaded files, which
-are in the bucket. Redis holds no durable state, so losing it costs you nothing
-except a reconnect.
+Back up Postgres and object storage together. Orbit ships a coordinated backup
+CLI (`bun run backup:create`) that exports a single repeatable-read PostgreSQL
+snapshot, runs `pg_dump` against it, and downloads all referenced attachment
+objects into an atomic backup archive.
 
-Supabase and Neon both take automatic backups. If you run your own Postgres,
-`pg_dump` on a schedule, and restore it somewhere once so you know it works.
+```bash
+# Capture a backup into ./backups
+bun run backup:create --destination ./backups
+
+# Pass a direct database connection explicitly
+DIRECT_URL="postgres://user:pass@host:5432/orbit" bun run backup:create -d ./backups
+
+# Machine-readable output for cron or orchestrators
+bun run backup:create --json --destination /var/backups/orbit
+```
+
+#### CLI flags and environment variables
+
+| Flag | Env variable | Default | Description |
+| --- | --- | --- | --- |
+| `--destination`, `-d` | `ORBIT_BACKUP_DESTINATION` | `./backups` | Target directory where the backup folder is published |
+| `--database-url` | `DIRECT_URL`, `DATABASE_URL` | none | Direct connection string to PostgreSQL |
+| `--pg-dump-path` | `PG_DUMP_PATH` | `pg_dump` | Path to the local `pg_dump` binary |
+| `--orbit-version` | `ORBIT_VERSION` | `0.1.0` | Orbit version string stamped into `manifest.json` |
+| `--source-revision` | `SOURCE_REVISION`, `VERCEL_GIT_COMMIT_SHA` | `unknown` | Git commit SHA stamped into `manifest.json` |
+| `--json` | none | `false` | Emit JSON status on stdout and stderr |
+
+#### Prerequisites
+
+1. **`pg_dump` installed locally:** The backup runner invokes `pg_dump` directly.
+   Its version must match or exceed the version of the PostgreSQL server being
+   backed up. Configure `PG_DUMP_PATH` or `--pg-dump-path` if `pg_dump` is not in
+   `PATH`.
+2. **Direct database connection:** `DIRECT_URL` must point directly to PostgreSQL,
+   not through a transaction-mode connection pooler such as PgBouncer or Supabase's
+   transaction pooler (port 6543). The coordinated snapshot requires
+   `pg_export_snapshot()`, which requires an open transaction session.
+3. **Object storage credentials:** Storage environment variables (`S3_BUCKET`,
+   `S3_ENDPOINT`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, etc.) must be
+   accessible to the command so it can download attachment files.
+
+#### Output structure and atomicity
+
+Each backup creates an isolated directory named `orbit-backup-<timestamp>-<hash>/`:
+
+```
+orbit-backup-2026-09-10T19-36-31-839Z-68a1dddb/
+├── manifest.json      # Schema ledger, checksums, counts, safe config allowlist
+├── database.dump      # pg_dump custom format (-Fc) archive
+└── objects/           # Captured attachments keyed by storage key
+    └── org_xxx/issue/att_yyy/file.png
+```
+
+Backups write to a temporary `.tmp` directory first. If `pg_dump`, preflight
+validation, or object capture fails, the working directory is renamed to
+`.incomplete` and the command exits with code 1. Only a fully verified backup
+is published to its final path.
+
+#### Backup limitations
+
+- **Unencrypted at rest:** Archive files and dumps are written with restricted
+  file modes (`0o600`), but payloads are unencrypted. Encrypt the backup
+  directory at the filesystem or bucket level if storing backups in cloud cold
+  storage.
+- **Online object capture:** The database snapshot guarantees consistent relational
+  state, and object storage capture fetches all attachments present when the
+  snapshot began. If external tooling deletes an object from storage while Orbit
+  is running, the backup fails rather than publishing a partial archive.
+- **Local scratch disk space:** The destination directory must have enough disk
+  capacity to hold the uncompressed PostgreSQL dump and all attachment objects.
 
 ### Scaling
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "check-deps": "bun scripts/check-dependency-dedupe.ts",
     "strip-comments": "bun scripts/strip-comments.ts",
     "verify": "bun run lint && bun run check-comments && bun run check-bytes && bun run check-bun-imports && bun run check-deps && bun run typecheck && bun run test",
+    "backup:create": "bun scripts/backup/create.ts",
     "db:generate": "bun run --filter '@orbit/db' generate",
     "db:migrate": "bun run --filter '@orbit/db' migrate",
     "db:release": "bun run --filter '@orbit/db' release",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./check-drift": "./src/check-drift.ts",
+    "./migration-release": "./src/migration-release.ts",
     "./schema": "./src/schema/index.ts",
     "./test-lane": "./src/test-lane.ts"
   },

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.ts",
     "./markdown": "./src/markdown/index.ts",
     "./storage": "./src/storage/index.ts",
+    "./backup": "./src/backup/index.ts",
     "./email": "./src/email/index.ts",
     "./github": "./src/github/index.ts",
     "./notifications": "./src/notifications/index.ts",
@@ -30,6 +31,7 @@
     "linkedom": "^0.18.13",
     "lowlight": "^3",
     "marked": "18.0.9",
+    "postgres": "^3.4.9",
     "resend": "6.18.1",
     "zod": "4.4.3"
   },

--- a/packages/services/src/backup/create.ts
+++ b/packages/services/src/backup/create.ts
@@ -11,6 +11,7 @@ import {
 import { createStorageDriver, storageDriver } from '../storage/index.ts';
 import { dumpDatabase } from './database.ts';
 import { verifyPreflight } from './preflight.ts';
+import { openCoordinatedSnapshot } from './snapshot.ts';
 import { captureStorageObjects } from './storage.ts';
 import type { BackupCreateOptions, BackupCreateResult } from './types.ts';
 
@@ -33,25 +34,33 @@ export async function createBackup(options: BackupCreateOptions): Promise<Backup
   const workingDir = join(destinationDir, `${backupId}.tmp`);
   const incompleteDir = join(destinationDir, `${backupId}.incomplete`);
 
-  await mkdir(workingDir, { recursive: true });
+  await mkdir(workingDir, { recursive: true, mode: 0o700 });
 
   try {
     const preflight = await verifyPreflight(databaseUrl, options.migrationsFolder);
 
-    const dumpResult = await dumpDatabase({
-      databaseUrl,
-      outputFile: join(workingDir, 'database.dump'),
-      databaseVersion: preflight.databaseVersion,
-      ledger: preflight.ledger,
-      pgDumpPath: options.pgDumpPath,
-    });
+    const snapshot = await openCoordinatedSnapshot(databaseUrl);
+    let dumpResult: Awaited<ReturnType<typeof dumpDatabase>>;
+    try {
+      dumpResult = await dumpDatabase({
+        databaseUrl,
+        outputFile: join(workingDir, 'database.dump'),
+        databaseVersion: preflight.databaseVersion,
+        ledger: preflight.ledger,
+        pgDumpPath: options.pgDumpPath,
+        snapshotId: snapshot.snapshotId,
+        counts: snapshot.counts,
+      });
+    } finally {
+      await snapshot.release();
+    }
 
     const driver =
       options.env === undefined
         ? storageDriver()
         : createStorageDriver(options.env as NodeJS.ProcessEnv);
     const storageResult = await captureStorageObjects({
-      databaseUrl,
+      records: snapshot.records,
       outputObjectsDir: join(workingDir, 'objects'),
       driver,
     });
@@ -87,13 +96,16 @@ export async function createBackup(options: BackupCreateOptions): Promise<Backup
       },
       metadata: {
         generator: 'orbit-backup-create',
-        boundedConsistencyModel: 'postgres-preflight-then-object-capture',
+        boundedConsistencyModel: 'postgres-snapshot-coordinated-object-capture',
         ...(options.customMetadata ?? {}),
       },
     };
 
     const manifest = backupManifestSchema.parse(rawManifest);
-    await writeFile(join(workingDir, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf8');
+    await writeFile(join(workingDir, 'manifest.json'), JSON.stringify(manifest, null, 2), {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
 
     await rename(workingDir, targetDir);
 

--- a/packages/services/src/backup/create.ts
+++ b/packages/services/src/backup/create.ts
@@ -7,6 +7,7 @@ import {
   CURRENT_BACKUP_FORMAT_VERSION,
   extractBackupConfiguration,
   validateConfigurationSafety,
+  validationFailed,
 } from '@orbit/shared';
 import { createStorageDriver, storageDriver } from '../storage/index.ts';
 import { dumpDatabase } from './database.ts';
@@ -20,12 +21,12 @@ export async function createBackup(options: BackupCreateOptions): Promise<Backup
   const databaseUrl = options.databaseUrl ?? env['DIRECT_URL'] ?? env['DATABASE_URL'];
 
   if (databaseUrl === undefined || databaseUrl.length === 0) {
-    throw new Error('DATABASE_URL or DIRECT_URL is required to create a backup.');
+    throw validationFailed('DATABASE_URL or DIRECT_URL is required to create a backup.');
   }
 
   const destinationDir = options.destinationDir;
   if (destinationDir.length === 0) {
-    throw new Error('Destination directory path must not be empty.');
+    throw validationFailed('Destination directory path must not be empty.');
   }
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
@@ -41,6 +42,7 @@ export async function createBackup(options: BackupCreateOptions): Promise<Backup
 
     const snapshot = await openCoordinatedSnapshot(databaseUrl);
     let dumpResult: Awaited<ReturnType<typeof dumpDatabase>>;
+    let storageResult: Awaited<ReturnType<typeof captureStorageObjects>>;
     try {
       dumpResult = await dumpDatabase({
         databaseUrl,
@@ -51,19 +53,19 @@ export async function createBackup(options: BackupCreateOptions): Promise<Backup
         snapshotId: snapshot.snapshotId,
         counts: snapshot.counts,
       });
+
+      const driver =
+        options.env === undefined
+          ? storageDriver()
+          : createStorageDriver(options.env as NodeJS.ProcessEnv);
+      storageResult = await captureStorageObjects({
+        records: snapshot.records,
+        outputObjectsDir: join(workingDir, 'objects'),
+        driver,
+      });
     } finally {
       await snapshot.release();
     }
-
-    const driver =
-      options.env === undefined
-        ? storageDriver()
-        : createStorageDriver(options.env as NodeJS.ProcessEnv);
-    const storageResult = await captureStorageObjects({
-      records: snapshot.records,
-      outputObjectsDir: join(workingDir, 'objects'),
-      driver,
-    });
 
     const configuration = extractBackupConfiguration(env);
     validateConfigurationSafety(configuration);

--- a/packages/services/src/backup/create.ts
+++ b/packages/services/src/backup/create.ts
@@ -55,9 +55,10 @@ export async function createBackup(options: BackupCreateOptions): Promise<Backup
       });
 
       const driver =
-        options.env === undefined
+        options.storageDriver ??
+        (options.env === undefined
           ? storageDriver()
-          : createStorageDriver(options.env as NodeJS.ProcessEnv);
+          : createStorageDriver(options.env as NodeJS.ProcessEnv));
       storageResult = await captureStorageObjects({
         records: snapshot.records,
         outputObjectsDir: join(workingDir, 'objects'),

--- a/packages/services/src/backup/create.ts
+++ b/packages/services/src/backup/create.ts
@@ -1,0 +1,113 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, rename, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  type BackupManifest,
+  backupManifestSchema,
+  CURRENT_BACKUP_FORMAT_VERSION,
+  extractBackupConfiguration,
+  validateConfigurationSafety,
+} from '@orbit/shared';
+import { createStorageDriver, storageDriver } from '../storage/index.ts';
+import { dumpDatabase } from './database.ts';
+import { verifyPreflight } from './preflight.ts';
+import { captureStorageObjects } from './storage.ts';
+import type { BackupCreateOptions, BackupCreateResult } from './types.ts';
+
+export async function createBackup(options: BackupCreateOptions): Promise<BackupCreateResult> {
+  const env = options.env ?? process.env;
+  const databaseUrl = options.databaseUrl ?? env['DIRECT_URL'] ?? env['DATABASE_URL'];
+
+  if (databaseUrl === undefined || databaseUrl.length === 0) {
+    throw new Error('DATABASE_URL or DIRECT_URL is required to create a backup.');
+  }
+
+  const destinationDir = options.destinationDir;
+  if (destinationDir.length === 0) {
+    throw new Error('Destination directory path must not be empty.');
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupId = `orbit-backup-${timestamp}-${randomUUID().slice(0, 8)}`;
+  const targetDir = join(destinationDir, backupId);
+  const workingDir = join(destinationDir, `${backupId}.tmp`);
+  const incompleteDir = join(destinationDir, `${backupId}.incomplete`);
+
+  await mkdir(workingDir, { recursive: true });
+
+  try {
+    const preflight = await verifyPreflight(databaseUrl, options.migrationsFolder);
+
+    const dumpResult = await dumpDatabase({
+      databaseUrl,
+      outputFile: join(workingDir, 'database.dump'),
+      databaseVersion: preflight.databaseVersion,
+      ledger: preflight.ledger,
+      pgDumpPath: options.pgDumpPath,
+    });
+
+    const driver =
+      options.env === undefined
+        ? storageDriver()
+        : createStorageDriver(options.env as NodeJS.ProcessEnv);
+    const storageResult = await captureStorageObjects({
+      databaseUrl,
+      outputObjectsDir: join(workingDir, 'objects'),
+      driver,
+    });
+
+    const configuration = extractBackupConfiguration(env);
+    validateConfigurationSafety(configuration);
+
+    const orbitVersion = options.orbitVersion ?? env['ORBIT_VERSION'] ?? '0.1.0';
+    const sourceRevision =
+      options.sourceRevision ?? env['SOURCE_REVISION'] ?? env['VERCEL_GIT_COMMIT_SHA'] ?? 'unknown';
+    const imageDigests = options.imageDigests ?? {};
+
+    const rawManifest: BackupManifest = {
+      formatVersion: CURRENT_BACKUP_FORMAT_VERSION,
+      orbitVersion,
+      sourceRevision,
+      imageDigests,
+      databaseVersion: dumpResult.databaseVersion,
+      createdAt: new Date().toISOString(),
+      migrationLedger: [...dumpResult.migrationLedger],
+      configuration,
+      checksums: {
+        databaseDump: {
+          file: dumpResult.file,
+          sha256: dumpResult.sha256,
+          bytes: dumpResult.bytes,
+        },
+        objects: [...storageResult.objects],
+      },
+      counts: dumpResult.counts,
+      encryption: {
+        enabled: false,
+      },
+      metadata: {
+        generator: 'orbit-backup-create',
+        boundedConsistencyModel: 'postgres-preflight-then-object-capture',
+        ...(options.customMetadata ?? {}),
+      },
+    };
+
+    const manifest = backupManifestSchema.parse(rawManifest);
+    await writeFile(join(workingDir, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf8');
+
+    await rename(workingDir, targetDir);
+
+    return {
+      backupId,
+      backupDir: targetDir,
+      manifest,
+    };
+  } catch (error) {
+    try {
+      await rename(workingDir, incompleteDir);
+    } catch {
+      await rm(workingDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+    throw error;
+  }
+}

--- a/packages/services/src/backup/create.ts
+++ b/packages/services/src/backup/create.ts
@@ -98,9 +98,9 @@ export async function createBackup(options: BackupCreateOptions): Promise<Backup
         enabled: false,
       },
       metadata: {
+        ...(options.customMetadata ?? {}),
         generator: 'orbit-backup-create',
         boundedConsistencyModel: 'postgres-snapshot-coordinated-object-capture',
-        ...(options.customMetadata ?? {}),
       },
     };
 

--- a/packages/services/src/backup/database.ts
+++ b/packages/services/src/backup/database.ts
@@ -95,37 +95,60 @@ export async function dumpDatabase(options: DumpDatabaseOptions): Promise<Databa
       hash.update(chunk);
     });
 
+    let settled = false;
+    let exitCode: number | null = null;
+    let streamFinished = false;
+
+    const settleReject = (err: unknown) => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    };
+
+    const settleResolve = (val: DatabaseDumpResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(val);
+    };
+
+    const checkComplete = () => {
+      if (settled || exitCode === null || !streamFinished) return;
+      if (exitCode === 0) {
+        settleResolve({
+          file: 'database.dump',
+          sha256: hash.digest('hex'),
+          bytes: byteCount,
+          databaseVersion,
+          migrationLedger: ledger,
+          counts,
+        });
+      } else {
+        settleReject(
+          internal(`pg_dump exited with nonzero status code ${exitCode}: ${stderrText.trim()}`),
+        );
+      }
+    };
+
+    fileStream.on('finish', () => {
+      streamFinished = true;
+      checkComplete();
+    });
+
     fileStream.on('error', (err) => {
       child.stdout?.unpipe(fileStream);
       child.stdout?.destroy();
       child.kill('SIGTERM');
-      reject(err);
+      settleReject(err);
     });
 
     child.on('error', (err) => {
       fileStream.destroy();
-      reject(internal(`Failed to spawn "${binary}": ${err.message}`, err));
+      settleReject(internal(`Failed to spawn "${binary}": ${err.message}`, err));
     });
 
     child.on('close', (code) => {
-      fileStream.end(() => {
-        if (code === 0) {
-          resolve({
-            file: 'database.dump',
-            sha256: hash.digest('hex'),
-            bytes: byteCount,
-            databaseVersion,
-            migrationLedger: ledger,
-            counts,
-          });
-        } else {
-          reject(
-            internal(
-              `pg_dump exited with nonzero status code ${code ?? 'unknown'}: ${stderrText.trim()}`,
-            ),
-          );
-        }
-      });
+      exitCode = code ?? -1;
+      checkComplete();
     });
 
     child.stdout.pipe(fileStream);

--- a/packages/services/src/backup/database.ts
+++ b/packages/services/src/backup/database.ts
@@ -1,0 +1,157 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import postgres from 'postgres';
+import type { DatabaseDumpResult } from './types.ts';
+
+export interface ParsedConnection {
+  readonly host: string;
+  readonly port: string;
+  readonly user: string;
+  readonly password?: string | undefined;
+  readonly database: string;
+}
+
+export function parseDatabaseConnection(connectionUrl: string): ParsedConnection {
+  const parsed = new URL(connectionUrl);
+  const host = parsed.hostname;
+  const port = parsed.port.length > 0 ? parsed.port : '5432';
+  const user = decodeURIComponent(parsed.username);
+  const password = parsed.password.length > 0 ? decodeURIComponent(parsed.password) : undefined;
+  const database = parsed.pathname.replace(/^\//, '');
+
+  if (host.length === 0 || user.length === 0 || database.length === 0) {
+    throw new Error('DATABASE_URL must include host, username, and database name.');
+  }
+
+  return { host, port, user, password, database };
+}
+
+export async function queryDatabaseCounts(url: string): Promise<{
+  readonly workspaces: number;
+  readonly users: number;
+  readonly attachments: number;
+  readonly issues: number;
+}> {
+  const sql = postgres(url, { max: 1, idle_timeout: 10, prepare: false });
+  try {
+    const [orgRow] = await sql<{ count: number }[]>`
+      select count(*)::int as count from organization
+    `;
+    const [userRow] = await sql<{ count: number }[]>`
+      select count(*)::int as count from "user"
+    `;
+    const [attRow] = await sql<{ count: number }[]>`
+      select count(*)::int as count from attachment
+    `;
+    const [issueRow] = await sql<{ count: number }[]>`
+      select count(*)::int as count from issue
+    `;
+
+    return {
+      workspaces: orgRow?.count ?? 0,
+      users: userRow?.count ?? 0,
+      attachments: attRow?.count ?? 0,
+      issues: issueRow?.count ?? 0,
+    };
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+export interface DumpDatabaseOptions {
+  readonly databaseUrl: string;
+  readonly outputFile: string;
+  readonly databaseVersion: string;
+  readonly ledger: readonly { readonly hash: string; readonly createdAt: string }[];
+  readonly pgDumpPath?: string | undefined;
+}
+
+export async function dumpDatabase(options: DumpDatabaseOptions): Promise<DatabaseDumpResult> {
+  const { databaseUrl, outputFile, databaseVersion, ledger, pgDumpPath } = options;
+  const connection = parseDatabaseConnection(databaseUrl);
+  const counts = await queryDatabaseCounts(databaseUrl);
+
+  await mkdir(dirname(outputFile), { recursive: true });
+
+  const binary = pgDumpPath ?? process.env['PG_DUMP_PATH'] ?? 'pg_dump';
+  const args = [
+    '-Fc',
+    '--no-owner',
+    '--no-acl',
+    '-h',
+    connection.host,
+    '-p',
+    connection.port,
+    '-U',
+    connection.user,
+    '-d',
+    connection.database,
+  ];
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...(connection.password === undefined ? {} : { PGPASSWORD: connection.password }),
+  };
+
+  const hash = createHash('sha256');
+  let byteCount = 0;
+
+  await new Promise<void>((resolve, reject) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(binary, args, { env, stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (error) {
+      reject(new Error(`Failed to spawn "${binary}": ${String(error)}`));
+      return;
+    }
+
+    const fileStream = createWriteStream(outputFile);
+    let stderrOutput = '';
+
+    child.on('error', (error) => {
+      reject(new Error(`pg_dump execution failed (${binary}): ${error.message}`));
+    });
+
+    if (child.stderr !== null) {
+      child.stderr.on('data', (chunk: Buffer | string) => {
+        stderrOutput += chunk.toString();
+      });
+    }
+
+    if (child.stdout !== null) {
+      child.stdout.on('data', (chunk: Buffer) => {
+        byteCount += chunk.length;
+        hash.update(chunk);
+      });
+      child.stdout.pipe(fileStream);
+    }
+
+    fileStream.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      fileStream.close(() => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(
+            new Error(`pg_dump exited with nonzero status code ${code}: ${stderrOutput.trim()}`),
+          );
+        }
+      });
+    });
+  });
+
+  return {
+    file: 'database.dump',
+    sha256: hash.digest('hex'),
+    bytes: byteCount,
+    databaseVersion,
+    migrationLedger: ledger,
+    counts,
+  };
+}

--- a/packages/services/src/backup/database.ts
+++ b/packages/services/src/backup/database.ts
@@ -4,7 +4,6 @@ import { createWriteStream } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { internal, validationFailed } from '@orbit/shared';
-import postgres from 'postgres';
 import type { DatabaseDumpResult } from './types.ts';
 
 export interface ParsedConnection {
@@ -30,63 +29,24 @@ export function parseDatabaseConnection(connectionUrl: string): ParsedConnection
   return { host, port, user, password, database };
 }
 
-export async function queryDatabaseCounts(url: string): Promise<{
-  readonly workspaces: number;
-  readonly users: number;
-  readonly attachments: number;
-  readonly issues: number;
-}> {
-  const sql = postgres(url, {
-    max: 1,
-    connect_timeout: 5,
-    idle_timeout: 10,
-    prepare: false,
-  });
-  try {
-    const [orgRow] = await sql<{ count: number }[]>`
-      select count(*)::int as count from organization
-    `;
-    const [userRow] = await sql<{ count: number }[]>`
-      select count(*)::int as count from "user"
-    `;
-    const [attRow] = await sql<{ count: number }[]>`
-      select count(*)::int as count from attachment
-    `;
-    const [issueRow] = await sql<{ count: number }[]>`
-      select count(*)::int as count from issue
-    `;
-
-    return {
-      workspaces: orgRow?.count ?? 0,
-      users: userRow?.count ?? 0,
-      attachments: attRow?.count ?? 0,
-      issues: issueRow?.count ?? 0,
-    };
-  } finally {
-    await sql.end({ timeout: 5 });
-  }
-}
-
 export interface DumpDatabaseOptions {
   readonly databaseUrl: string;
   readonly outputFile: string;
   readonly databaseVersion: string;
   readonly ledger: readonly { readonly hash: string; readonly createdAt: string }[];
   readonly pgDumpPath?: string | undefined;
-  readonly snapshotId?: string | undefined;
-  readonly counts?:
-    | {
-        readonly workspaces: number;
-        readonly users: number;
-        readonly attachments: number;
-        readonly issues: number;
-      }
-    | undefined;
+  readonly snapshotId: string;
+  readonly counts: {
+    readonly workspaces: number;
+    readonly users: number;
+    readonly attachments: number;
+    readonly issues: number;
+  };
 }
 
 export async function dumpDatabase(options: DumpDatabaseOptions): Promise<DatabaseDumpResult> {
-  const { databaseUrl, outputFile, databaseVersion, ledger, pgDumpPath, snapshotId } = options;
-  const counts = options.counts ?? (await queryDatabaseCounts(databaseUrl));
+  const { databaseUrl, outputFile, databaseVersion, ledger, pgDumpPath, snapshotId, counts } =
+    options;
 
   await mkdir(dirname(outputFile), { recursive: true, mode: 0o700 });
 
@@ -96,11 +56,7 @@ export async function dumpDatabase(options: DumpDatabaseOptions): Promise<Databa
   const sanitizedUrl = parsed.toString();
 
   const binary = pgDumpPath ?? process.env['PG_DUMP_PATH'] ?? 'pg_dump';
-  const args = ['-Fc', '--no-owner', '--no-acl', '-d', sanitizedUrl];
-
-  if (snapshotId !== undefined && snapshotId.length > 0) {
-    args.push(`--snapshot=${snapshotId}`);
-  }
+  const args = ['-Fc', '--no-owner', '--no-acl', '-d', sanitizedUrl, `--snapshot=${snapshotId}`];
 
   const env: NodeJS.ProcessEnv = {
     ...process.env,

--- a/packages/services/src/backup/database.ts
+++ b/packages/services/src/backup/database.ts
@@ -1,7 +1,5 @@
-import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { createWriteStream } from 'node:fs';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, open } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import postgres from 'postgres';
 import type { DatabaseDumpResult } from './types.ts';
@@ -35,7 +33,12 @@ export async function queryDatabaseCounts(url: string): Promise<{
   readonly attachments: number;
   readonly issues: number;
 }> {
-  const sql = postgres(url, { max: 1, idle_timeout: 10, prepare: false });
+  const sql = postgres(url, {
+    max: 1,
+    connect_timeout: 5,
+    idle_timeout: 10,
+    prepare: false,
+  });
   try {
     const [orgRow] = await sql<{ count: number }[]>`
       select count(*)::int as count from organization
@@ -67,84 +70,75 @@ export interface DumpDatabaseOptions {
   readonly databaseVersion: string;
   readonly ledger: readonly { readonly hash: string; readonly createdAt: string }[];
   readonly pgDumpPath?: string | undefined;
+  readonly snapshotId?: string | undefined;
+  readonly counts?:
+    | {
+        readonly workspaces: number;
+        readonly users: number;
+        readonly attachments: number;
+        readonly issues: number;
+      }
+    | undefined;
 }
 
 export async function dumpDatabase(options: DumpDatabaseOptions): Promise<DatabaseDumpResult> {
-  const { databaseUrl, outputFile, databaseVersion, ledger, pgDumpPath } = options;
-  const connection = parseDatabaseConnection(databaseUrl);
-  const counts = await queryDatabaseCounts(databaseUrl);
+  const { databaseUrl, outputFile, databaseVersion, ledger, pgDumpPath, snapshotId } = options;
+  const counts = options.counts ?? (await queryDatabaseCounts(databaseUrl));
 
-  await mkdir(dirname(outputFile), { recursive: true });
+  await mkdir(dirname(outputFile), { recursive: true, mode: 0o700 });
+
+  const parsed = new URL(databaseUrl);
+  const password = parsed.password.length > 0 ? decodeURIComponent(parsed.password) : undefined;
+  parsed.password = '';
+  const sanitizedUrl = parsed.toString();
 
   const binary = pgDumpPath ?? process.env['PG_DUMP_PATH'] ?? 'pg_dump';
-  const args = [
-    '-Fc',
-    '--no-owner',
-    '--no-acl',
-    '-h',
-    connection.host,
-    '-p',
-    connection.port,
-    '-U',
-    connection.user,
-    '-d',
-    connection.database,
-  ];
+  const args = ['-Fc', '--no-owner', '--no-acl', '-d', sanitizedUrl];
+
+  if (snapshotId !== undefined && snapshotId.length > 0) {
+    args.push(`--snapshot=${snapshotId}`);
+  }
 
   const env: NodeJS.ProcessEnv = {
     ...process.env,
-    ...(connection.password === undefined ? {} : { PGPASSWORD: connection.password }),
+    ...(password === undefined ? {} : { PGPASSWORD: password }),
   };
+
+  let proc: ReturnType<typeof Bun.spawn>;
+  try {
+    proc = Bun.spawn([binary, ...args], {
+      env,
+      stdin: 'ignore',
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+  } catch (error) {
+    throw new Error(`Failed to spawn "${binary}": ${String(error)}`);
+  }
 
   const hash = createHash('sha256');
   let byteCount = 0;
 
-  await new Promise<void>((resolve, reject) => {
-    let child: ReturnType<typeof spawn>;
-    try {
-      child = spawn(binary, args, { env, stdio: ['ignore', 'pipe', 'pipe'] });
-    } catch (error) {
-      reject(new Error(`Failed to spawn "${binary}": ${String(error)}`));
-      return;
+  const fileHandle = await open(outputFile, 'w', 0o600);
+  try {
+    const reader = proc.stdout.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      byteCount += value.byteLength;
+      hash.update(value);
+      await fileHandle.write(value);
     }
+  } finally {
+    await fileHandle.close();
+  }
 
-    const fileStream = createWriteStream(outputFile);
-    let stderrOutput = '';
+  const stderrText = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
 
-    child.on('error', (error) => {
-      reject(new Error(`pg_dump execution failed (${binary}): ${error.message}`));
-    });
-
-    if (child.stderr !== null) {
-      child.stderr.on('data', (chunk: Buffer | string) => {
-        stderrOutput += chunk.toString();
-      });
-    }
-
-    if (child.stdout !== null) {
-      child.stdout.on('data', (chunk: Buffer) => {
-        byteCount += chunk.length;
-        hash.update(chunk);
-      });
-      child.stdout.pipe(fileStream);
-    }
-
-    fileStream.on('error', (error) => {
-      reject(error);
-    });
-
-    child.on('close', (code) => {
-      fileStream.close(() => {
-        if (code === 0) {
-          resolve();
-        } else {
-          reject(
-            new Error(`pg_dump exited with nonzero status code ${code}: ${stderrOutput.trim()}`),
-          );
-        }
-      });
-    });
-  });
+  if (exitCode !== 0) {
+    throw new Error(`pg_dump exited with nonzero status code ${exitCode}: ${stderrText.trim()}`);
+  }
 
   return {
     file: 'database.dump',

--- a/packages/services/src/backup/database.ts
+++ b/packages/services/src/backup/database.ts
@@ -1,6 +1,9 @@
+import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdir, open } from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
+import { internal, validationFailed } from '@orbit/shared';
 import postgres from 'postgres';
 import type { DatabaseDumpResult } from './types.ts';
 
@@ -21,7 +24,7 @@ export function parseDatabaseConnection(connectionUrl: string): ParsedConnection
   const database = parsed.pathname.replace(/^\//, '');
 
   if (host.length === 0 || user.length === 0 || database.length === 0) {
-    throw new Error('DATABASE_URL must include host, username, and database name.');
+    throw validationFailed('DATABASE_URL must include host, username, and database name.');
   }
 
   return { host, port, user, password, database };
@@ -104,48 +107,71 @@ export async function dumpDatabase(options: DumpDatabaseOptions): Promise<Databa
     ...(password === undefined ? {} : { PGPASSWORD: password }),
   };
 
-  let proc: ReturnType<typeof Bun.spawn>;
-  try {
-    proc = Bun.spawn([binary, ...args], {
-      env,
-      stdin: 'ignore',
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-  } catch (error) {
-    throw new Error(`Failed to spawn "${binary}": ${String(error)}`);
-  }
-
-  const hash = createHash('sha256');
-  let byteCount = 0;
-
-  const fileHandle = await open(outputFile, 'w', 0o600);
-  try {
-    const reader = proc.stdout.getReader();
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      byteCount += value.byteLength;
-      hash.update(value);
-      await fileHandle.write(value);
+  return new Promise((resolve, reject) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(binary, args, { env, stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (error) {
+      reject(internal(`Failed to spawn "${binary}": ${String(error)}`, error));
+      return;
     }
-  } finally {
-    await fileHandle.close();
-  }
 
-  const stderrText = await new Response(proc.stderr).text();
-  const exitCode = await proc.exited;
+    if (child.stdout === null) {
+      reject(internal('pg_dump stdout stream is not available'));
+      return;
+    }
 
-  if (exitCode !== 0) {
-    throw new Error(`pg_dump exited with nonzero status code ${exitCode}: ${stderrText.trim()}`);
-  }
+    const hash = createHash('sha256');
+    let byteCount = 0;
 
-  return {
-    file: 'database.dump',
-    sha256: hash.digest('hex'),
-    bytes: byteCount,
-    databaseVersion,
-    migrationLedger: ledger,
-    counts,
-  };
+    const fileStream = createWriteStream(outputFile, { mode: 0o600 });
+    let stderrText = '';
+
+    if (child.stderr !== null) {
+      child.stderr.setEncoding('utf8');
+      child.stderr.on('data', (chunk: string) => {
+        stderrText += chunk;
+      });
+    }
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      byteCount += chunk.length;
+      hash.update(chunk);
+    });
+
+    fileStream.on('error', (err) => {
+      child.stdout?.unpipe(fileStream);
+      child.stdout?.destroy();
+      child.kill('SIGTERM');
+      reject(err);
+    });
+
+    child.on('error', (err) => {
+      fileStream.destroy();
+      reject(internal(`Failed to spawn "${binary}": ${err.message}`, err));
+    });
+
+    child.on('close', (code) => {
+      fileStream.end(() => {
+        if (code === 0) {
+          resolve({
+            file: 'database.dump',
+            sha256: hash.digest('hex'),
+            bytes: byteCount,
+            databaseVersion,
+            migrationLedger: ledger,
+            counts,
+          });
+        } else {
+          reject(
+            internal(
+              `pg_dump exited with nonzero status code ${code ?? 'unknown'}: ${stderrText.trim()}`,
+            ),
+          );
+        }
+      });
+    });
+
+    child.stdout.pipe(fileStream);
+  });
 }

--- a/packages/services/src/backup/database.ts
+++ b/packages/services/src/backup/database.ts
@@ -15,11 +15,25 @@ export interface ParsedConnection {
 }
 
 export function parseDatabaseConnection(connectionUrl: string): ParsedConnection {
-  const parsed = new URL(connectionUrl);
+  let parsed: URL;
+  try {
+    parsed = new URL(connectionUrl);
+  } catch (error) {
+    throw validationFailed('Invalid database connection URL.', { cause: error });
+  }
+
   const host = parsed.hostname;
   const port = parsed.port.length > 0 ? parsed.port : '5432';
-  const user = decodeURIComponent(parsed.username);
-  const password = parsed.password.length > 0 ? decodeURIComponent(parsed.password) : undefined;
+  let user: string;
+  let password: string | undefined;
+  try {
+    user = decodeURIComponent(parsed.username);
+    password = parsed.password.length > 0 ? decodeURIComponent(parsed.password) : undefined;
+  } catch (error) {
+    throw validationFailed('Database connection credentials could not be decoded.', {
+      cause: error,
+    });
+  }
   const database = parsed.pathname.replace(/^\//, '');
 
   if (host.length === 0 || user.length === 0 || database.length === 0) {
@@ -50,8 +64,20 @@ export async function dumpDatabase(options: DumpDatabaseOptions): Promise<Databa
 
   await mkdir(dirname(outputFile), { recursive: true, mode: 0o700 });
 
-  const parsed = new URL(databaseUrl);
-  const password = parsed.password.length > 0 ? decodeURIComponent(parsed.password) : undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(databaseUrl);
+  } catch (error) {
+    throw validationFailed('Invalid database connection URL.', { cause: error });
+  }
+  let password: string | undefined;
+  try {
+    password = parsed.password.length > 0 ? decodeURIComponent(parsed.password) : undefined;
+  } catch (error) {
+    throw validationFailed('Database connection credentials could not be decoded.', {
+      cause: error,
+    });
+  }
   parsed.password = '';
   const sanitizedUrl = parsed.toString();
 
@@ -88,11 +114,22 @@ export async function dumpDatabase(options: DumpDatabaseOptions): Promise<Databa
       child.stderr.on('data', (chunk: string) => {
         stderrText += chunk;
       });
+      child.stderr.on('error', (err) => {
+        fileStream.destroy();
+        child.kill('SIGTERM');
+        settleReject(internal(`pg_dump stderr stream error: ${err.message}`, err));
+      });
     }
 
     child.stdout.on('data', (chunk: Buffer) => {
       byteCount += chunk.length;
       hash.update(chunk);
+    });
+
+    child.stdout.on('error', (err) => {
+      fileStream.destroy();
+      child.kill('SIGTERM');
+      settleReject(internal(`pg_dump stdout stream error: ${err.message}`, err));
     });
 
     let settled = false;
@@ -138,7 +175,7 @@ export async function dumpDatabase(options: DumpDatabaseOptions): Promise<Databa
       child.stdout?.unpipe(fileStream);
       child.stdout?.destroy();
       child.kill('SIGTERM');
-      settleReject(err);
+      settleReject(internal(`Database dump write stream error: ${err.message}`, err));
     });
 
     child.on('error', (err) => {

--- a/packages/services/src/backup/index.ts
+++ b/packages/services/src/backup/index.ts
@@ -1,0 +1,5 @@
+export * from './create.ts';
+export * from './database.ts';
+export * from './preflight.ts';
+export * from './storage.ts';
+export * from './types.ts';

--- a/packages/services/src/backup/preflight.ts
+++ b/packages/services/src/backup/preflight.ts
@@ -13,7 +13,12 @@ export async function verifyPreflight(
   url: string,
   customMigrationsFolder?: string,
 ): Promise<PreflightCheckResult> {
-  const sql = postgres(url, { max: 1, idle_timeout: 10, prepare: false });
+  const sql = postgres(url, {
+    max: 1,
+    connect_timeout: 5,
+    idle_timeout: 10,
+    prepare: false,
+  });
   try {
     const [versionRow] = await sql<{ version: string }[]>`select version() as version`;
     if (versionRow === undefined) {

--- a/packages/services/src/backup/preflight.ts
+++ b/packages/services/src/backup/preflight.ts
@@ -1,0 +1,85 @@
+import { fileURLToPath } from 'node:url';
+import { schema } from '@orbit/db';
+import { catalogDriftBetween, expectedCatalog, isBehind, liveCatalog } from '@orbit/db/check-drift';
+import { readMigrationFiles } from 'drizzle-orm/migrator';
+import postgres from 'postgres';
+
+export interface PreflightCheckResult {
+  readonly databaseVersion: string;
+  readonly ledger: readonly { readonly hash: string; readonly createdAt: string }[];
+}
+
+export async function verifyPreflight(
+  url: string,
+  customMigrationsFolder?: string,
+): Promise<PreflightCheckResult> {
+  const sql = postgres(url, { max: 1, idle_timeout: 10, prepare: false });
+  try {
+    const [versionRow] = await sql<{ version: string }[]>`select version() as version`;
+    if (versionRow === undefined) {
+      throw new Error('Unable to determine PostgreSQL version.');
+    }
+
+    const [tableExistsRow] = await sql<{ exists: boolean }[]>`
+      select exists (
+        select 1 from information_schema.tables
+        where table_schema = 'drizzle' and table_name = '__drizzle_migrations'
+      ) as exists
+    `;
+    if (tableExistsRow?.exists !== true) {
+      throw new Error('Migration ledger table "drizzle.__drizzle_migrations" does not exist.');
+    }
+
+    const rows = await sql<{ hash: string; created_at: string }[]>`
+      select hash, created_at::text as created_at
+      from drizzle.__drizzle_migrations
+      order by created_at, id
+    `;
+    if (rows.length === 0) {
+      throw new Error('Migration ledger is empty. Apply database migrations before backing up.');
+    }
+
+    const migrationsFolder =
+      customMigrationsFolder ?? fileURLToPath(new URL('../../../db/drizzle', import.meta.url));
+    const committedMigrations = readMigrationFiles({ migrationsFolder });
+
+    if (rows.length > committedMigrations.length) {
+      throw new Error('Database migration ledger is ahead of this application release.');
+    }
+
+    for (const [index, row] of rows.entries()) {
+      const committed = committedMigrations[index];
+      if (committed === undefined || row.created_at !== String(committed.folderMillis)) {
+        throw new Error(
+          'Database migration ledger is not a contiguous prefix of committed migrations.',
+        );
+      }
+      if (row.hash !== committed.hash) {
+        throw new Error(
+          `Migration ${row.created_at} hash does not match committed migration file.`,
+        );
+      }
+    }
+
+    if (rows.length < committedMigrations.length) {
+      throw new Error(
+        `Database is missing ${committedMigrations.length - rows.length} pending migration(s). Run db:release before backing up.`,
+      );
+    }
+
+    const live = await liveCatalog(url);
+    const drift = catalogDriftBetween(expectedCatalog(schema), live);
+    if (isBehind(drift)) {
+      throw new Error(
+        'Database schema has unapplied or incompatible drift relative to application schema.',
+      );
+    }
+
+    return {
+      databaseVersion: versionRow.version,
+      ledger: rows.map((r) => ({ hash: r.hash, createdAt: r.created_at })),
+    };
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}

--- a/packages/services/src/backup/preflight.ts
+++ b/packages/services/src/backup/preflight.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from 'node:url';
-import { schema } from '@orbit/db';
 import { catalogDriftBetween, expectedCatalog, isBehind, liveCatalog } from '@orbit/db/check-drift';
+import * as schema from '@orbit/db/schema';
+import { internal, validationFailed } from '@orbit/shared';
 import { readMigrationFiles } from 'drizzle-orm/migrator';
 import postgres from 'postgres';
 
@@ -22,7 +23,7 @@ export async function verifyPreflight(
   try {
     const [versionRow] = await sql<{ version: string }[]>`select version() as version`;
     if (versionRow === undefined) {
-      throw new Error('Unable to determine PostgreSQL version.');
+      throw internal('Unable to determine PostgreSQL version.');
     }
 
     const [tableExistsRow] = await sql<{ exists: boolean }[]>`
@@ -32,7 +33,9 @@ export async function verifyPreflight(
       ) as exists
     `;
     if (tableExistsRow?.exists !== true) {
-      throw new Error('Migration ledger table "drizzle.__drizzle_migrations" does not exist.');
+      throw validationFailed(
+        'Migration ledger table "drizzle.__drizzle_migrations" does not exist.',
+      );
     }
 
     const rows = await sql<{ hash: string; created_at: string }[]>`
@@ -41,7 +44,9 @@ export async function verifyPreflight(
       order by created_at, id
     `;
     if (rows.length === 0) {
-      throw new Error('Migration ledger is empty. Apply database migrations before backing up.');
+      throw validationFailed(
+        'Migration ledger is empty. Apply database migrations before backing up.',
+      );
     }
 
     const migrationsFolder =
@@ -49,25 +54,25 @@ export async function verifyPreflight(
     const committedMigrations = readMigrationFiles({ migrationsFolder });
 
     if (rows.length > committedMigrations.length) {
-      throw new Error('Database migration ledger is ahead of this application release.');
+      throw validationFailed('Database migration ledger is ahead of this application release.');
     }
 
     for (const [index, row] of rows.entries()) {
       const committed = committedMigrations[index];
       if (committed === undefined || row.created_at !== String(committed.folderMillis)) {
-        throw new Error(
+        throw validationFailed(
           'Database migration ledger is not a contiguous prefix of committed migrations.',
         );
       }
       if (row.hash !== committed.hash) {
-        throw new Error(
+        throw validationFailed(
           `Migration ${row.created_at} hash does not match committed migration file.`,
         );
       }
     }
 
     if (rows.length < committedMigrations.length) {
-      throw new Error(
+      throw validationFailed(
         `Database is missing ${committedMigrations.length - rows.length} pending migration(s). Run db:release before backing up.`,
       );
     }
@@ -75,7 +80,7 @@ export async function verifyPreflight(
     const live = await liveCatalog(url);
     const drift = catalogDriftBetween(expectedCatalog(schema), live);
     if (isBehind(drift)) {
-      throw new Error(
+      throw validationFailed(
         'Database schema has unapplied or incompatible drift relative to application schema.',
       );
     }

--- a/packages/services/src/backup/snapshot.ts
+++ b/packages/services/src/backup/snapshot.ts
@@ -1,8 +1,9 @@
+import { internal } from '@orbit/shared';
 import postgres from 'postgres';
 import type { AttachmentRecord } from './types.ts';
 
 export interface DatabaseSnapshotSession {
-  readonly snapshotId?: string | undefined;
+  readonly snapshotId: string;
   readonly records: readonly AttachmentRecord[];
   readonly counts: {
     readonly workspaces: number;
@@ -35,14 +36,13 @@ export async function openCoordinatedSnapshot(url: string): Promise<DatabaseSnap
       .begin(async (tx) => {
         try {
           await tx.unsafe('set transaction isolation level repeatable read read only');
-          try {
-            const [snapRow] = await tx<{ snapshot: string }[]>`
-              select pg_export_snapshot() as snapshot
-            `;
-            snapshotId = snapRow?.snapshot;
-          } catch {
-            snapshotId = undefined;
+          const [snapRow] = await tx<{ snapshot: string }[]>`
+            select pg_export_snapshot() as snapshot
+          `;
+          if (snapRow?.snapshot === undefined || snapRow.snapshot.length === 0) {
+            throw internal('Failed to export PostgreSQL snapshot for backup coordination.');
           }
+          snapshotId = snapRow.snapshot;
 
           records = await tx<AttachmentRecord[]>`
             select id, storage_key, size, content_type
@@ -84,7 +84,23 @@ export async function openCoordinatedSnapshot(url: string): Promise<DatabaseSnap
       });
   });
 
-  await sessionReady;
+  try {
+    await sessionReady;
+  } catch (error) {
+    if (closeTransaction !== undefined) {
+      closeTransaction();
+    }
+    await sql.end({ timeout: 5 }).catch(() => undefined);
+    throw error;
+  }
+
+  if (snapshotId === undefined) {
+    if (closeTransaction !== undefined) {
+      closeTransaction();
+    }
+    await sql.end({ timeout: 5 }).catch(() => undefined);
+    throw internal('Failed to export PostgreSQL snapshot for backup coordination.');
+  }
 
   return {
     snapshotId,

--- a/packages/services/src/backup/snapshot.ts
+++ b/packages/services/src/backup/snapshot.ts
@@ -102,11 +102,14 @@ export async function openCoordinatedSnapshot(url: string): Promise<DatabaseSnap
     throw internal('Failed to export PostgreSQL snapshot for backup coordination.');
   }
 
+  let released = false;
   return {
     snapshotId,
     records,
     counts,
     async release() {
+      if (released) return;
+      released = true;
       if (closeTransaction !== undefined) {
         closeTransaction();
       }

--- a/packages/services/src/backup/snapshot.ts
+++ b/packages/services/src/backup/snapshot.ts
@@ -1,0 +1,100 @@
+import postgres from 'postgres';
+import type { AttachmentRecord } from './types.ts';
+
+export interface DatabaseSnapshotSession {
+  readonly snapshotId?: string | undefined;
+  readonly records: readonly AttachmentRecord[];
+  readonly counts: {
+    readonly workspaces: number;
+    readonly users: number;
+    readonly attachments: number;
+    readonly issues: number;
+  };
+  readonly release: () => Promise<void>;
+}
+
+export async function openCoordinatedSnapshot(url: string): Promise<DatabaseSnapshotSession> {
+  const sql = postgres(url, {
+    max: 1,
+    connect_timeout: 5,
+    idle_timeout: 10,
+    prepare: false,
+  });
+
+  let snapshotId: string | undefined;
+  let records: AttachmentRecord[] = [];
+  let counts = { workspaces: 0, users: 0, attachments: 0, issues: 0 };
+  let closeTransaction: (() => void) | undefined;
+
+  const transactionPromise = new Promise<void>((resolveTransaction) => {
+    closeTransaction = resolveTransaction;
+  });
+
+  const sessionReady = new Promise<void>((resolveSession, rejectSession) => {
+    sql
+      .begin(async (tx) => {
+        try {
+          await tx.unsafe('set transaction isolation level repeatable read read only');
+          try {
+            const [snapRow] = await tx<{ snapshot: string }[]>`
+              select pg_export_snapshot() as snapshot
+            `;
+            snapshotId = snapRow?.snapshot;
+          } catch {
+            snapshotId = undefined;
+          }
+
+          records = await tx<AttachmentRecord[]>`
+            select id, storage_key, size, content_type
+            from attachment
+            where status = 'ready'
+            order by id
+          `;
+
+          const [orgRow] = await tx<{ count: number }[]>`
+            select count(*)::int as count from organization
+          `;
+          const [userRow] = await tx<{ count: number }[]>`
+            select count(*)::int as count from "user"
+          `;
+          const [attRow] = await tx<{ count: number }[]>`
+            select count(*)::int as count from attachment
+          `;
+          const [issueRow] = await tx<{ count: number }[]>`
+            select count(*)::int as count from issue
+          `;
+
+          counts = {
+            workspaces: orgRow?.count ?? 0,
+            users: userRow?.count ?? 0,
+            attachments: attRow?.count ?? 0,
+            issues: issueRow?.count ?? 0,
+          };
+
+          resolveSession();
+        } catch (error) {
+          rejectSession(error);
+          return;
+        }
+
+        await transactionPromise;
+      })
+      .catch((error) => {
+        rejectSession(error);
+      });
+  });
+
+  await sessionReady;
+
+  return {
+    snapshotId,
+    records,
+    counts,
+    async release() {
+      if (closeTransaction !== undefined) {
+        closeTransaction();
+      }
+      await sql.end({ timeout: 5 }).catch(() => undefined);
+    },
+  };
+}

--- a/packages/services/src/backup/storage.ts
+++ b/packages/services/src/backup/storage.ts
@@ -2,14 +2,12 @@ import { createHash } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { internal } from '@orbit/shared';
-import postgres from 'postgres';
 import { assertSafeKey } from '../storage/key.ts';
 import type { StorageDriver } from '../storage/types.ts';
 import type { AttachmentRecord, StorageCaptureResult } from './types.ts';
 
 export interface CaptureStorageOptions {
-  readonly databaseUrl?: string | undefined;
-  readonly records?: readonly AttachmentRecord[] | undefined;
+  readonly records: readonly AttachmentRecord[];
   readonly outputObjectsDir: string;
   readonly driver: StorageDriver;
 }
@@ -17,31 +15,7 @@ export interface CaptureStorageOptions {
 export async function captureStorageObjects(
   options: CaptureStorageOptions,
 ): Promise<StorageCaptureResult> {
-  const { databaseUrl, records: passedRecords, outputObjectsDir, driver } = options;
-
-  let records: readonly AttachmentRecord[];
-  if (passedRecords !== undefined) {
-    records = passedRecords;
-  } else if (databaseUrl === undefined) {
-    records = [];
-  } else {
-    const sql = postgres(databaseUrl, {
-      max: 1,
-      connect_timeout: 5,
-      idle_timeout: 10,
-      prepare: false,
-    });
-    try {
-      records = await sql<AttachmentRecord[]>`
-        select id, storage_key, size, content_type
-        from attachment
-        where status = 'ready'
-        order by id
-      `;
-    } finally {
-      await sql.end({ timeout: 5 });
-    }
-  }
+  const { records, outputObjectsDir, driver } = options;
 
   const objects: {
     readonly key: string;

--- a/packages/services/src/backup/storage.ts
+++ b/packages/services/src/backup/storage.ts
@@ -1,0 +1,68 @@
+import { createHash } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import postgres from 'postgres';
+import type { StorageDriver } from '../storage/types.ts';
+import type { StorageCaptureResult } from './types.ts';
+
+interface AttachmentRecord {
+  readonly id: string;
+  readonly storage_key: string;
+  readonly size: number;
+  readonly content_type: string;
+}
+
+export interface CaptureStorageOptions {
+  readonly databaseUrl: string;
+  readonly outputObjectsDir: string;
+  readonly driver: StorageDriver;
+}
+
+export async function captureStorageObjects(
+  options: CaptureStorageOptions,
+): Promise<StorageCaptureResult> {
+  const { databaseUrl, outputObjectsDir, driver } = options;
+  const sql = postgres(databaseUrl, { max: 1, idle_timeout: 10, prepare: false });
+
+  let records: AttachmentRecord[] = [];
+  try {
+    records = await sql<AttachmentRecord[]>`
+      select id, storage_key, size, content_type
+      from attachment
+      where status = 'ready'
+      order by id
+    `;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+
+  const objects: {
+    readonly key: string;
+    readonly sha256: string;
+    readonly bytes: number;
+    readonly contentType: string;
+  }[] = [];
+
+  for (const record of records) {
+    const data = await driver.get(record.storage_key);
+    if (data === null) {
+      throw new Error(
+        `Referenced object "${record.storage_key}" for attachment "${record.id}" was not found in object storage.`,
+      );
+    }
+
+    const sha256 = createHash('sha256').update(data).digest('hex');
+    const destinationPath = join(outputObjectsDir, record.storage_key);
+    await mkdir(dirname(destinationPath), { recursive: true });
+    await writeFile(destinationPath, data);
+
+    objects.push({
+      key: record.storage_key,
+      sha256,
+      bytes: data.byteLength,
+      contentType: record.content_type,
+    });
+  }
+
+  return { objects };
+}

--- a/packages/services/src/backup/storage.ts
+++ b/packages/services/src/backup/storage.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { internal } from '@orbit/shared';
 import postgres from 'postgres';
 import { assertSafeKey } from '../storage/key.ts';
 import type { StorageDriver } from '../storage/types.ts';
@@ -53,7 +54,7 @@ export async function captureStorageObjects(
     const safeKey = assertSafeKey(record.storage_key);
     const data = await driver.get(safeKey);
     if (data === null) {
-      throw new Error(
+      throw internal(
         `Referenced object "${safeKey}" for attachment "${record.id}" was not found in object storage.`,
       );
     }

--- a/packages/services/src/backup/storage.ts
+++ b/packages/services/src/backup/storage.ts
@@ -2,18 +2,13 @@ import { createHash } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import postgres from 'postgres';
+import { assertSafeKey } from '../storage/key.ts';
 import type { StorageDriver } from '../storage/types.ts';
-import type { StorageCaptureResult } from './types.ts';
-
-interface AttachmentRecord {
-  readonly id: string;
-  readonly storage_key: string;
-  readonly size: number;
-  readonly content_type: string;
-}
+import type { AttachmentRecord, StorageCaptureResult } from './types.ts';
 
 export interface CaptureStorageOptions {
-  readonly databaseUrl: string;
+  readonly databaseUrl?: string | undefined;
+  readonly records?: readonly AttachmentRecord[] | undefined;
   readonly outputObjectsDir: string;
   readonly driver: StorageDriver;
 }
@@ -21,19 +16,30 @@ export interface CaptureStorageOptions {
 export async function captureStorageObjects(
   options: CaptureStorageOptions,
 ): Promise<StorageCaptureResult> {
-  const { databaseUrl, outputObjectsDir, driver } = options;
-  const sql = postgres(databaseUrl, { max: 1, idle_timeout: 10, prepare: false });
+  const { databaseUrl, records: passedRecords, outputObjectsDir, driver } = options;
 
-  let records: AttachmentRecord[] = [];
-  try {
-    records = await sql<AttachmentRecord[]>`
-      select id, storage_key, size, content_type
-      from attachment
-      where status = 'ready'
-      order by id
-    `;
-  } finally {
-    await sql.end({ timeout: 5 });
+  let records: readonly AttachmentRecord[];
+  if (passedRecords !== undefined) {
+    records = passedRecords;
+  } else if (databaseUrl === undefined) {
+    records = [];
+  } else {
+    const sql = postgres(databaseUrl, {
+      max: 1,
+      connect_timeout: 5,
+      idle_timeout: 10,
+      prepare: false,
+    });
+    try {
+      records = await sql<AttachmentRecord[]>`
+        select id, storage_key, size, content_type
+        from attachment
+        where status = 'ready'
+        order by id
+      `;
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
   }
 
   const objects: {
@@ -44,20 +50,21 @@ export async function captureStorageObjects(
   }[] = [];
 
   for (const record of records) {
-    const data = await driver.get(record.storage_key);
+    const safeKey = assertSafeKey(record.storage_key);
+    const data = await driver.get(safeKey);
     if (data === null) {
       throw new Error(
-        `Referenced object "${record.storage_key}" for attachment "${record.id}" was not found in object storage.`,
+        `Referenced object "${safeKey}" for attachment "${record.id}" was not found in object storage.`,
       );
     }
 
     const sha256 = createHash('sha256').update(data).digest('hex');
-    const destinationPath = join(outputObjectsDir, record.storage_key);
-    await mkdir(dirname(destinationPath), { recursive: true });
-    await writeFile(destinationPath, data);
+    const destinationPath = join(outputObjectsDir, safeKey);
+    await mkdir(dirname(destinationPath), { recursive: true, mode: 0o700 });
+    await writeFile(destinationPath, data, { mode: 0o600 });
 
     objects.push({
-      key: record.storage_key,
+      key: safeKey,
       sha256,
       bytes: data.byteLength,
       contentType: record.content_type,

--- a/packages/services/src/backup/types.ts
+++ b/packages/services/src/backup/types.ts
@@ -1,0 +1,42 @@
+import type { BackupManifest } from '@orbit/shared';
+
+export interface BackupCreateOptions {
+  readonly destinationDir: string;
+  readonly databaseUrl?: string | undefined;
+  readonly migrationsFolder?: string | undefined;
+  readonly orbitVersion?: string | undefined;
+  readonly sourceRevision?: string | undefined;
+  readonly imageDigests?: Record<string, string> | undefined;
+  readonly pgDumpPath?: string | undefined;
+  readonly customMetadata?: Record<string, string> | undefined;
+  readonly env?: Record<string, string | undefined> | undefined;
+}
+
+export interface BackupCreateResult {
+  readonly backupId: string;
+  readonly backupDir: string;
+  readonly manifest: BackupManifest;
+}
+
+export interface DatabaseDumpResult {
+  readonly file: string;
+  readonly sha256: string;
+  readonly bytes: number;
+  readonly databaseVersion: string;
+  readonly migrationLedger: readonly { readonly hash: string; readonly createdAt: string }[];
+  readonly counts: {
+    readonly workspaces: number;
+    readonly users: number;
+    readonly attachments: number;
+    readonly issues: number;
+  };
+}
+
+export interface StorageCaptureResult {
+  readonly objects: readonly {
+    readonly key: string;
+    readonly sha256: string;
+    readonly bytes: number;
+    readonly contentType: string;
+  }[];
+}

--- a/packages/services/src/backup/types.ts
+++ b/packages/services/src/backup/types.ts
@@ -40,3 +40,10 @@ export interface StorageCaptureResult {
     readonly contentType: string;
   }[];
 }
+
+export interface AttachmentRecord {
+  readonly id: string;
+  readonly storage_key: string;
+  readonly size: number;
+  readonly content_type: string;
+}

--- a/packages/services/src/backup/types.ts
+++ b/packages/services/src/backup/types.ts
@@ -1,4 +1,5 @@
 import type { BackupManifest } from '@orbit/shared';
+import type { StorageDriver } from '../storage/types.ts';
 
 export interface BackupCreateOptions {
   readonly destinationDir: string;
@@ -10,6 +11,7 @@ export interface BackupCreateOptions {
   readonly pgDumpPath?: string | undefined;
   readonly customMetadata?: Record<string, string> | undefined;
   readonly env?: Record<string, string | undefined> | undefined;
+  readonly storageDriver?: StorageDriver | undefined;
 }
 
 export interface BackupCreateResult {

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,4 +1,3 @@
-export * from './backup/index.ts';
 export * from './email/index.ts';
 export * from './github/index.ts';
 export * from './markdown/index.ts';

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,3 +1,4 @@
+export * from './backup/index.ts';
 export * from './email/index.ts';
 export * from './github/index.ts';
 export * from './markdown/index.ts';

--- a/packages/services/src/storage/parent.ts
+++ b/packages/services/src/storage/parent.ts
@@ -95,10 +95,10 @@ async function docAllowing(
   const allowed =
     level === 'read'
       ? canReadDoc(
-        principal,
-        row,
-        grants.map((grant) => grant.docId),
-      )
+          principal,
+          row,
+          grants.map((grant) => grant.docId),
+        )
       : canWriteDoc(principal, row, grants.length > 0);
   return allowed ? row : undefined;
 }

--- a/packages/services/src/storage/parent.ts
+++ b/packages/services/src/storage/parent.ts
@@ -95,10 +95,10 @@ async function docAllowing(
   const allowed =
     level === 'read'
       ? canReadDoc(
-          principal,
-          row,
-          grants.map((grant) => grant.docId),
-        )
+        principal,
+        row,
+        grants.map((grant) => grant.docId),
+      )
       : canWriteDoc(principal, row, grants.length > 0);
   return allowed ? row : undefined;
 }

--- a/packages/services/tests/backup/create.test.ts
+++ b/packages/services/tests/backup/create.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { releaseDatabase } from '@orbit/db/migration-release';
+import { resolveTestDatabaseUrl } from '../../../../scripts/test-env.ts';
 import { createBackup } from '../../src/backup/create.ts';
 
 const MIGRATIONS = fileURLToPath(new URL('../../../db/drizzle', import.meta.url));
@@ -28,8 +29,7 @@ describe('createBackup', () => {
   });
 
   it('marks incomplete backup atomically when pg_dump fails or is missing', async () => {
-    const databaseUrl = process.env['DATABASE_URL'];
-    if (databaseUrl === undefined) return;
+    const databaseUrl = process.env['DATABASE_URL'] ?? resolveTestDatabaseUrl('orbit_test_svc');
 
     await releaseDatabase(databaseUrl, MIGRATIONS);
 

--- a/packages/services/tests/backup/create.test.ts
+++ b/packages/services/tests/backup/create.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createBackup } from '../../src/backup/create.ts';
+
+describe('createBackup', () => {
+  it('throws when destination directory is empty', async () => {
+    await expect(
+      createBackup({
+        destinationDir: '',
+        databaseUrl: 'postgres://orbit:orbit@localhost:5434/orbit',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('throws when database url is missing', async () => {
+    await expect(
+      createBackup({
+        destinationDir: '/tmp/orbit-test',
+        databaseUrl: '',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('marks incomplete backup atomically when pg_dump fails or is missing', async () => {
+    const databaseUrl = process.env['DATABASE_URL'];
+    if (databaseUrl === undefined) return;
+
+    const tempDir = await mkdtemp(join(tmpdir(), 'orbit-create-test-'));
+    try {
+      let thrownError: Error | undefined;
+      try {
+        await createBackup({
+          destinationDir: tempDir,
+          databaseUrl,
+          pgDumpPath: 'non_existent_pg_dump_binary_xyz',
+        });
+      } catch (err) {
+        thrownError = err as Error;
+      }
+
+      expect(thrownError).toBeDefined();
+
+      const files = await readdir(tempDir);
+      const incomplete = files.filter((f) => f.endsWith('.incomplete'));
+      const successful = files.filter((f) => !(f.endsWith('.incomplete') || f.endsWith('.tmp')));
+
+      expect(incomplete.length).toBe(1);
+      expect(successful.length).toBe(0);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/services/tests/backup/create.test.ts
+++ b/packages/services/tests/backup/create.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'bun:test';
 import { mkdtemp, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { releaseDatabase } from '@orbit/db/migration-release';
 import { createBackup } from '../../src/backup/create.ts';
+
+const MIGRATIONS = fileURLToPath(new URL('../../../db/drizzle', import.meta.url));
 
 describe('createBackup', () => {
   it('throws when destination directory is empty', async () => {
@@ -26,6 +30,8 @@ describe('createBackup', () => {
   it('marks incomplete backup atomically when pg_dump fails or is missing', async () => {
     const databaseUrl = process.env['DATABASE_URL'];
     if (databaseUrl === undefined) return;
+
+    await releaseDatabase(databaseUrl, MIGRATIONS);
 
     const tempDir = await mkdtemp(join(tmpdir(), 'orbit-create-test-'));
     try {

--- a/packages/services/tests/backup/create.test.ts
+++ b/packages/services/tests/backup/create.test.ts
@@ -14,36 +14,80 @@ import type { StorageDriver, StoredObject, UploadTarget } from '../../src/storag
 const MIGRATIONS = fileURLToPath(new URL('../../../db/drizzle', import.meta.url));
 
 let resolvedPgDump: string | undefined;
+let discoveredContainerId: string | undefined;
 let temporaryShimDir: string | undefined;
 
-async function setupPgDump(): Promise<string | undefined> {
-  let hasHostPgDump = false;
+async function getServerMajorVersion(databaseUrl: string): Promise<number | undefined> {
+  try {
+    const sql = postgres(databaseUrl, { max: 1, idle_timeout: 5 });
+    try {
+      const [row] = await sql<{ major: number }[]>`
+        select current_setting('server_version_num')::int / 10000 as major
+      `;
+      return row?.major;
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+function getHostPgDumpMajor(): number | undefined {
   try {
     const probe = Bun.spawnSync(['pg_dump', '--version']);
-    hasHostPgDump = probe.exitCode === 0;
+    if (probe.exitCode !== 0) return undefined;
+    const match = probe.stdout.toString().match(/\b(\d+)\./);
+    return match ? Number.parseInt(match[1] ?? '0', 10) : undefined;
   } catch {
-    hasHostPgDump = false;
+    return undefined;
   }
-  if (hasHostPgDump) return undefined;
+}
 
-  let hasDockerPgDump = false;
+function findPostgresContainer(): string | undefined {
   try {
-    const dockerProbe = Bun.spawnSync(['docker', 'exec', 'orbit-postgres', 'pg_dump', '--version']);
-    hasDockerPgDump = dockerProbe.exitCode === 0;
+    const res = Bun.spawnSync(['docker', 'ps', '--format', '{{.ID}} {{.Image}} {{.Names}}']);
+    if (res.exitCode !== 0) return undefined;
+    for (const line of res.stdout.toString().split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      const parts = trimmed.split(/\s+/);
+      const id = parts[0];
+      const image = parts[1] ?? '';
+      const name = parts[2] ?? '';
+      if (id !== undefined && (image.includes('postgres') || name.includes('postgres'))) {
+        const probe = Bun.spawnSync(['docker', 'exec', id, 'pg_dump', '--version']);
+        if (probe.exitCode === 0) {
+          return id;
+        }
+      }
+    }
   } catch {
-    hasDockerPgDump = false;
+    return undefined;
+  }
+  return undefined;
+}
+
+async function setupPgDump(databaseUrl: string): Promise<string | undefined> {
+  const serverMajor = await getServerMajorVersion(databaseUrl);
+  const hostMajor = getHostPgDumpMajor();
+  if (hostMajor !== undefined && (serverMajor === undefined || hostMajor >= serverMajor)) {
+    return undefined;
   }
 
-  if (hasDockerPgDump) {
+  const containerId = findPostgresContainer();
+  if (containerId !== undefined) {
+    discoveredContainerId = containerId;
     const shimDir = await mkdtemp(join(tmpdir(), 'orbit-pg-dump-shim-'));
     temporaryShimDir = shimDir;
+    const isWindows = process.platform === 'win32';
+    const shimExe = join(shimDir, isWindows ? 'pg_dump.exe' : 'pg_dump');
     const shimSource = join(shimDir, 'shim.ts');
-    const shimExe = join(shimDir, 'pg_dump.exe');
     await writeFile(
       shimSource,
       `import { spawn } from 'node:child_process';
-const args = process.argv.slice(2).map((a) => a.replace(':5434', ':5432'));
-const child = spawn('docker', ['exec', '-i', '-e', \`PGPASSWORD=\${process.env['PGPASSWORD'] ?? ''}\`, 'orbit-postgres', 'pg_dump', ...args], {
+const args = process.argv.slice(2).map((a) => a.replace(/:543[34]\\b/g, ':5432'));
+const child = spawn('docker', ['exec', '-i', '-e', \`PGPASSWORD=\${process.env['PGPASSWORD'] ?? ''}\`, '${containerId}', 'pg_dump', ...args], {
   stdio: ['ignore', 'pipe', 'inherit'],
 });
 child.stdout.pipe(process.stdout);
@@ -78,11 +122,12 @@ async function inspectArchive(dumpPath: string): Promise<string> {
     return hostOutput;
   }
 
+  const containerTarget = discoveredContainerId ?? 'orbit-postgres';
   let dockerRestoreSuccess = false;
   let dockerOutput = '';
   try {
     const dockerRestore = Bun.spawnSync(
-      ['docker', 'exec', '-i', 'orbit-postgres', 'pg_restore', '-l'],
+      ['docker', 'exec', '-i', containerTarget, 'pg_restore', '-l'],
       { stdin: fileBytes },
     );
     if (dockerRestore.exitCode === 0) {
@@ -152,7 +197,8 @@ function createMockDriver(store: Map<string, Uint8Array>): StorageDriver {
 
 describe('createBackup', () => {
   beforeAll(async () => {
-    resolvedPgDump = await setupPgDump();
+    const databaseUrl = process.env['DATABASE_URL'] ?? resolveTestDatabaseUrl('orbit_test_svc');
+    resolvedPgDump = await setupPgDump(databaseUrl);
   });
 
   afterAll(async () => {

--- a/packages/services/tests/backup/create.test.ts
+++ b/packages/services/tests/backup/create.test.ts
@@ -1,15 +1,106 @@
-import { describe, expect, it } from 'bun:test';
-import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { releaseDatabase } from '@orbit/db/migration-release';
+import { backupManifestSchema } from '@orbit/shared';
+import postgres from 'postgres';
 import { resolveTestDatabaseUrl } from '../../../../scripts/test-env.ts';
 import { createBackup } from '../../src/backup/create.ts';
+import { storageDriver } from '../../src/storage/index.ts';
 
 const MIGRATIONS = fileURLToPath(new URL('../../../db/drizzle', import.meta.url));
 
+let resolvedPgDump: string | undefined;
+let temporaryShim: string | undefined;
+
+async function setupPgDump(): Promise<string | undefined> {
+  let hasHostPgDump = false;
+  try {
+    const probe = Bun.spawnSync(['pg_dump', '--version']);
+    hasHostPgDump = probe.exitCode === 0;
+  } catch {
+    hasHostPgDump = false;
+  }
+  if (hasHostPgDump) return undefined;
+
+  let hasDockerPgDump = false;
+  try {
+    const dockerProbe = Bun.spawnSync(['docker', 'exec', 'orbit-postgres', 'pg_dump', '--version']);
+    hasDockerPgDump = dockerProbe.exitCode === 0;
+  } catch {
+    hasDockerPgDump = false;
+  }
+
+  if (hasDockerPgDump) {
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const shimSource = join(tmpdir(), `orbit-pg-dump-shim-${stamp}.ts`);
+    const shimExe = join(tmpdir(), `orbit-pg-dump-shim-${stamp}.exe`);
+    await writeFile(
+      shimSource,
+      `import { spawn } from 'node:child_process';
+const args = process.argv.slice(2).map((a) => a.replace(':5434', ':5432'));
+const child = spawn('docker', ['exec', '-i', '-e', \`PGPASSWORD=\${process.env['PGPASSWORD'] ?? ''}\`, 'orbit-postgres', 'pg_dump', ...args], {
+  stdio: ['ignore', 'pipe', 'inherit'],
+});
+child.stdout.pipe(process.stdout);
+child.on('close', (code) => process.exit(code ?? 0));
+`,
+    );
+    Bun.spawnSync(['bun', 'build', '--compile', shimSource, '--outfile', shimExe]);
+    await rm(shimSource, { force: true }).catch(() => undefined);
+    temporaryShim = shimExe;
+    return shimExe;
+  }
+
+  return undefined;
+}
+
+async function inspectArchive(dumpPath: string): Promise<string> {
+  const fileBytes = await readFile(dumpPath);
+  let hostRestoreSuccess = false;
+  let hostOutput = '';
+  try {
+    const probe = Bun.spawnSync(['pg_restore', '--version']);
+    if (probe.exitCode === 0) {
+      const restore = Bun.spawnSync(['pg_restore', '-l', dumpPath]);
+      if (restore.exitCode === 0) {
+        hostRestoreSuccess = true;
+        hostOutput = restore.stdout.toString();
+      }
+    }
+  } catch {
+    hostRestoreSuccess = false;
+  }
+  if (hostRestoreSuccess) {
+    return hostOutput;
+  }
+
+  const dockerRestore = Bun.spawnSync(
+    ['docker', 'exec', '-i', 'orbit-postgres', 'pg_restore', '-l'],
+    { stdin: fileBytes },
+  );
+  if (dockerRestore.exitCode !== 0) {
+    throw new Error(
+      `docker pg_restore failed with exit code ${dockerRestore.exitCode}: ${dockerRestore.stderr.toString()}`,
+    );
+  }
+  return dockerRestore.stdout.toString();
+}
+
 describe('createBackup', () => {
+  beforeAll(async () => {
+    resolvedPgDump = await setupPgDump();
+  });
+
+  afterAll(async () => {
+    if (temporaryShim !== undefined) {
+      await rm(temporaryShim, { force: true }).catch(() => undefined);
+    }
+  });
+
   it('throws when destination directory is empty', async () => {
     await expect(
       createBackup({
@@ -56,6 +147,154 @@ describe('createBackup', () => {
       expect(successful.length).toBe(0);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('marks incomplete backup atomically when object capture fails', async () => {
+    const databaseUrl = process.env['DATABASE_URL'] ?? resolveTestDatabaseUrl('orbit_test_svc');
+    await releaseDatabase(databaseUrl, MIGRATIONS);
+
+    const stamp = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const orgId = `org_fail_${stamp}`;
+    const userId = `usr_fail_${stamp}`;
+    const attId = `att_fail_${stamp}`;
+    const missingKey = `test_missing_${stamp}/file.txt`;
+
+    const sql = postgres(databaseUrl, { max: 1, idle_timeout: 5 });
+    try {
+      await sql`insert into organization (id, name, slug) values (${orgId}, 'Fail Test Org', ${orgId})`;
+      await sql`insert into "user" (id, name, email, handle) values (${userId}, 'Fail User', ${`${userId}@orbit.test`}, ${userId})`;
+      await sql`
+        insert into attachment (id, organization_id, parent_type, parent_id, file_name, content_type, size, storage_key, status, uploaded_by_id)
+        values (${attId}, ${orgId}, 'issue', 'dummy-issue', 'file.txt', 'text/plain', 100, ${missingKey}, 'ready', ${userId})
+      `;
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+
+    const tempDir = await mkdtemp(join(tmpdir(), 'orbit-create-fail-test-'));
+    try {
+      let thrownError: Error | undefined;
+      try {
+        await createBackup({
+          destinationDir: tempDir,
+          databaseUrl,
+          ...(resolvedPgDump === undefined ? {} : { pgDumpPath: resolvedPgDump }),
+        });
+      } catch (err) {
+        thrownError = err as Error;
+      }
+
+      expect(thrownError).toBeDefined();
+
+      const files = await readdir(tempDir);
+      const incomplete = files.filter((f) => f.endsWith('.incomplete'));
+      const successful = files.filter((f) => !(f.endsWith('.incomplete') || f.endsWith('.tmp')));
+
+      expect(incomplete.length).toBe(1);
+      expect(successful.length).toBe(0);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+      const cleanupSql = postgres(databaseUrl, { max: 1, idle_timeout: 5 });
+      try {
+        await cleanupSql`delete from attachment where id = ${attId}`;
+        await cleanupSql`delete from "user" where id = ${userId}`;
+        await cleanupSql`delete from organization where id = ${orgId}`;
+      } finally {
+        await cleanupSql.end({ timeout: 5 });
+      }
+    }
+  });
+
+  it('exercises a complete successful backup with database dump and storage capture', async () => {
+    const databaseUrl = process.env['DATABASE_URL'] ?? resolveTestDatabaseUrl('orbit_test_svc');
+    await releaseDatabase(databaseUrl, MIGRATIONS);
+
+    const testBytes = new TextEncoder().encode('successful backup integration test payload');
+    const expectedSha256 = createHash('sha256').update(testBytes).digest('hex');
+
+    const stamp = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const orgId = `org_succ_${stamp}`;
+    const userId = `usr_succ_${stamp}`;
+    const attId = `att_succ_${stamp}`;
+    const storageKey = `test_success_${stamp}/payload.txt`;
+
+    const driver = storageDriver();
+    await driver.put(storageKey, testBytes, 'text/plain');
+
+    const sql = postgres(databaseUrl, { max: 1, idle_timeout: 5 });
+    try {
+      await sql`insert into organization (id, name, slug) values (${orgId}, 'Success Test Org', ${orgId})`;
+      await sql`insert into "user" (id, name, email, handle) values (${userId}, 'Success User', ${`${userId}@orbit.test`}, ${userId})`;
+      await sql`
+        insert into attachment (id, organization_id, parent_type, parent_id, file_name, content_type, size, storage_key, status, uploaded_by_id)
+        values (${attId}, ${orgId}, 'issue', 'dummy-issue', 'payload.txt', 'text/plain', ${testBytes.byteLength}, ${storageKey}, 'ready', ${userId})
+      `;
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+
+    const tempDir = await mkdtemp(join(tmpdir(), 'orbit-create-succ-test-'));
+    try {
+      const result = await createBackup({
+        destinationDir: tempDir,
+        databaseUrl,
+        storageDriver: driver,
+        ...(resolvedPgDump === undefined ? {} : { pgDumpPath: resolvedPgDump }),
+      });
+
+      expect(result.backupId).toBeDefined();
+      expect(result.backupDir).toBeDefined();
+
+      const files = await readdir(tempDir);
+      const incomplete = files.filter((f) => f.endsWith('.incomplete'));
+      const tmp = files.filter((f) => f.endsWith('.tmp'));
+      const successful = files.filter((f) => !(f.endsWith('.incomplete') || f.endsWith('.tmp')));
+
+      expect(incomplete.length).toBe(0);
+      expect(tmp.length).toBe(0);
+      expect(successful.length).toBe(1);
+      expect(successful[0]).toBe(result.backupId);
+
+      const manifestPath = join(result.backupDir, 'manifest.json');
+      const manifestRaw = await readFile(manifestPath, 'utf8');
+      const manifest = backupManifestSchema.parse(JSON.parse(manifestRaw));
+
+      expect(manifest.formatVersion).toBe('1.0.0');
+      expect(manifest.counts.workspaces).toBeGreaterThanOrEqual(1);
+      expect(manifest.counts.users).toBeGreaterThanOrEqual(1);
+      expect(manifest.counts.attachments).toBeGreaterThanOrEqual(1);
+
+      const dumpPath = join(result.backupDir, manifest.checksums.databaseDump.file);
+      const dumpBytes = await readFile(dumpPath);
+      const dumpSha = createHash('sha256').update(dumpBytes).digest('hex');
+      expect(dumpBytes.byteLength).toBe(manifest.checksums.databaseDump.bytes);
+      expect(dumpSha).toBe(manifest.checksums.databaseDump.sha256);
+
+      const objectEntry = manifest.checksums.objects.find((obj) => obj.key === storageKey);
+      expect(objectEntry).toBeDefined();
+      expect(objectEntry?.bytes).toBe(testBytes.byteLength);
+      expect(objectEntry?.sha256).toBe(expectedSha256);
+      expect(objectEntry?.contentType).toBe('text/plain');
+
+      const capturedObjectPath = join(result.backupDir, 'objects', storageKey);
+      const capturedBytes = await readFile(capturedObjectPath);
+      expect(new Uint8Array(capturedBytes)).toEqual(testBytes);
+
+      const toc = await inspectArchive(dumpPath);
+      expect(toc).toContain('TABLE DATA public organization');
+      expect(toc).toContain('TABLE DATA public attachment');
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+      await driver.delete(storageKey).catch(() => undefined);
+      const cleanupSql = postgres(databaseUrl, { max: 1, idle_timeout: 5 });
+      try {
+        await cleanupSql`delete from attachment where id = ${attId}`;
+        await cleanupSql`delete from "user" where id = ${userId}`;
+        await cleanupSql`delete from organization where id = ${orgId}`;
+      } finally {
+        await cleanupSql.end({ timeout: 5 });
+      }
     }
   });
 });

--- a/packages/services/tests/backup/create.test.ts
+++ b/packages/services/tests/backup/create.test.ts
@@ -9,7 +9,7 @@ import { backupManifestSchema } from '@orbit/shared';
 import postgres from 'postgres';
 import { resolveTestDatabaseUrl } from '../../../../scripts/test-env.ts';
 import { createBackup } from '../../src/backup/create.ts';
-import { storageDriver } from '../../src/storage/index.ts';
+import type { StorageDriver, StoredObject, UploadTarget } from '../../src/storage/types.ts';
 
 const MIGRATIONS = fileURLToPath(new URL('../../../db/drizzle', import.meta.url));
 
@@ -78,16 +78,76 @@ async function inspectArchive(dumpPath: string): Promise<string> {
     return hostOutput;
   }
 
-  const dockerRestore = Bun.spawnSync(
-    ['docker', 'exec', '-i', 'orbit-postgres', 'pg_restore', '-l'],
-    { stdin: fileBytes },
-  );
-  if (dockerRestore.exitCode !== 0) {
-    throw new Error(
-      `docker pg_restore failed with exit code ${dockerRestore.exitCode}: ${dockerRestore.stderr.toString()}`,
+  let dockerRestoreSuccess = false;
+  let dockerOutput = '';
+  try {
+    const dockerRestore = Bun.spawnSync(
+      ['docker', 'exec', '-i', 'orbit-postgres', 'pg_restore', '-l'],
+      { stdin: fileBytes },
     );
+    if (dockerRestore.exitCode === 0) {
+      dockerRestoreSuccess = true;
+      dockerOutput = dockerRestore.stdout.toString();
+    }
+  } catch {
+    dockerRestoreSuccess = false;
   }
-  return dockerRestore.stdout.toString();
+  if (dockerRestoreSuccess) {
+    return dockerOutput;
+  }
+
+  return fileBytes.toString('utf8');
+}
+
+function createMockDriver(store: Map<string, Uint8Array>): StorageDriver {
+  return {
+    name: 's3',
+    get(key: string): Promise<Uint8Array | null> {
+      return Promise.resolve(store.get(key) ?? null);
+    },
+    put(key: string, body: Uint8Array): Promise<void> {
+      store.set(key, body);
+      return Promise.resolve();
+    },
+    stat(key: string): Promise<StoredObject | null> {
+      const data = store.get(key);
+      if (data === undefined) return Promise.resolve(null);
+      return Promise.resolve({
+        key,
+        size: data.byteLength,
+        contentType: 'application/octet-stream',
+        updatedAt: new Date(),
+      });
+    },
+    delete(key: string): Promise<void> {
+      store.delete(key);
+      return Promise.resolve();
+    },
+    summarizePrefix(): Promise<{
+      objects: number;
+      bytes: number;
+      versions: number;
+      versionBytes: number;
+    }> {
+      return Promise.resolve({ objects: 0, bytes: 0, versions: 0, versionBytes: 0 });
+    },
+    deletePrefix(): Promise<void> {
+      return Promise.resolve();
+    },
+    getUrl(): Promise<string> {
+      return Promise.resolve('');
+    },
+    createUploadTarget(key: string, _contentType: string, maxBytes: number): Promise<UploadTarget> {
+      return Promise.resolve({
+        key,
+        url: 'http://localhost/upload',
+        method: 'PUT',
+        headers: {},
+        maxBytes,
+        expiresAt: new Date().toISOString(),
+      });
+    },
+  };
 }
 
 describe('createBackup', () => {
@@ -179,6 +239,7 @@ describe('createBackup', () => {
         await createBackup({
           destinationDir: tempDir,
           databaseUrl,
+          storageDriver: createMockDriver(new Map()),
           ...(resolvedPgDump === undefined ? {} : { pgDumpPath: resolvedPgDump }),
         });
       } catch (err) {
@@ -219,7 +280,8 @@ describe('createBackup', () => {
     const attId = `att_succ_${stamp}`;
     const storageKey = `test_success_${stamp}/payload.txt`;
 
-    const driver = storageDriver();
+    const store = new Map<string, Uint8Array>();
+    const driver = createMockDriver(store);
     await driver.put(storageKey, testBytes, 'text/plain');
 
     const sql = postgres(databaseUrl, { max: 1, idle_timeout: 5 });
@@ -240,6 +302,11 @@ describe('createBackup', () => {
         destinationDir: tempDir,
         databaseUrl,
         storageDriver: driver,
+        customMetadata: {
+          generator: 'custom-generator-attempt',
+          boundedConsistencyModel: 'custom-model-attempt',
+          extraLabel: 'production-daily',
+        },
         ...(resolvedPgDump === undefined ? {} : { pgDumpPath: resolvedPgDump }),
       });
 
@@ -264,6 +331,11 @@ describe('createBackup', () => {
       expect(manifest.counts.workspaces).toBeGreaterThanOrEqual(1);
       expect(manifest.counts.users).toBeGreaterThanOrEqual(1);
       expect(manifest.counts.attachments).toBeGreaterThanOrEqual(1);
+      expect(manifest.metadata['generator']).toBe('orbit-backup-create');
+      expect(manifest.metadata['boundedConsistencyModel']).toBe(
+        'postgres-snapshot-coordinated-object-capture',
+      );
+      expect(manifest.metadata['extraLabel']).toBe('production-daily');
 
       const dumpPath = join(result.backupDir, manifest.checksums.databaseDump.file);
       const dumpBytes = await readFile(dumpPath);

--- a/packages/services/tests/backup/create.test.ts
+++ b/packages/services/tests/backup/create.test.ts
@@ -14,7 +14,7 @@ import { storageDriver } from '../../src/storage/index.ts';
 const MIGRATIONS = fileURLToPath(new URL('../../../db/drizzle', import.meta.url));
 
 let resolvedPgDump: string | undefined;
-let temporaryShim: string | undefined;
+let temporaryShimDir: string | undefined;
 
 async function setupPgDump(): Promise<string | undefined> {
   let hasHostPgDump = false;
@@ -35,9 +35,10 @@ async function setupPgDump(): Promise<string | undefined> {
   }
 
   if (hasDockerPgDump) {
-    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const shimSource = join(tmpdir(), `orbit-pg-dump-shim-${stamp}.ts`);
-    const shimExe = join(tmpdir(), `orbit-pg-dump-shim-${stamp}.exe`);
+    const shimDir = await mkdtemp(join(tmpdir(), 'orbit-pg-dump-shim-'));
+    temporaryShimDir = shimDir;
+    const shimSource = join(shimDir, 'shim.ts');
+    const shimExe = join(shimDir, 'pg_dump.exe');
     await writeFile(
       shimSource,
       `import { spawn } from 'node:child_process';
@@ -51,7 +52,6 @@ child.on('close', (code) => process.exit(code ?? 0));
     );
     Bun.spawnSync(['bun', 'build', '--compile', shimSource, '--outfile', shimExe]);
     await rm(shimSource, { force: true }).catch(() => undefined);
-    temporaryShim = shimExe;
     return shimExe;
   }
 
@@ -96,8 +96,8 @@ describe('createBackup', () => {
   });
 
   afterAll(async () => {
-    if (temporaryShim !== undefined) {
-      await rm(temporaryShim, { force: true }).catch(() => undefined);
+    if (temporaryShimDir !== undefined) {
+      await rm(temporaryShimDir, { recursive: true, force: true }).catch(() => undefined);
     }
   });
 

--- a/packages/services/tests/backup/database.test.ts
+++ b/packages/services/tests/backup/database.test.ts
@@ -31,4 +31,21 @@ describe('parseDatabaseConnection', () => {
   it('throws on invalid connection url', () => {
     expect(() => parseDatabaseConnection('postgres:///empty_host')).toThrow();
   });
+
+  it('preserves TLS and libpq parameters when URL is sanitized', () => {
+    const rawUrl =
+      'postgres://orbit_user:secret_pass@db.example.com:5433/orbit_db?sslmode=verify-full&sslrootcert=%2Fpath%2Froot.crt';
+    const parsed = new URL(rawUrl);
+    const password = parsed.password.length > 0 ? decodeURIComponent(parsed.password) : undefined;
+    parsed.password = '';
+    const sanitizedUrl = parsed.toString();
+
+    expect(password).toBe('secret_pass');
+    expect(sanitizedUrl).toBe(
+      'postgres://orbit_user@db.example.com:5433/orbit_db?sslmode=verify-full&sslrootcert=%2Fpath%2Froot.crt',
+    );
+    expect(sanitizedUrl).toContain('sslmode=verify-full');
+    expect(sanitizedUrl).toContain('sslrootcert=');
+    expect(sanitizedUrl).not.toContain('secret_pass');
+  });
 });

--- a/packages/services/tests/backup/database.test.ts
+++ b/packages/services/tests/backup/database.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+import { parseDatabaseConnection } from '../../src/backup/database.ts';
+
+describe('parseDatabaseConnection', () => {
+  it('parses standard connection url', () => {
+    const parsed = parseDatabaseConnection(
+      'postgres://orbit_user:secret_pass@db.example.com:5433/orbit_db',
+    );
+    expect(parsed.host).toBe('db.example.com');
+    expect(parsed.port).toBe('5433');
+    expect(parsed.user).toBe('orbit_user');
+    expect(parsed.password).toBe('secret_pass');
+    expect(parsed.database).toBe('orbit_db');
+  });
+
+  it('defaults port to 5432 when omitted', () => {
+    const parsed = parseDatabaseConnection('postgres://orbit_user@localhost/orbit');
+    expect(parsed.port).toBe('5432');
+    expect(parsed.password).toBeUndefined();
+  });
+
+  it('handles percent-encoded credentials properly', () => {
+    const parsed = parseDatabaseConnection(
+      'postgres://user%40domain:p%40ss%23word@127.0.0.1:5432/my_db',
+    );
+    expect(parsed.user).toBe('user@domain');
+    expect(parsed.password).toBe('p@ss#word');
+    expect(parsed.database).toBe('my_db');
+  });
+
+  it('throws on invalid connection url', () => {
+    expect(() => parseDatabaseConnection('postgres:///empty_host')).toThrow();
+  });
+});

--- a/packages/services/tests/backup/database.test.ts
+++ b/packages/services/tests/backup/database.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
-import { parseDatabaseConnection } from '../../src/backup/database.ts';
+import { DomainError } from '@orbit/shared';
+import { dumpDatabase, parseDatabaseConnection } from '../../src/backup/database.ts';
 
 describe('parseDatabaseConnection', () => {
   it('parses standard connection url', () => {
@@ -32,6 +33,26 @@ describe('parseDatabaseConnection', () => {
     expect(() => parseDatabaseConnection('postgres:///empty_host')).toThrow();
   });
 
+  it('throws validationFailed on invalid connection url format', () => {
+    try {
+      parseDatabaseConnection('not-a-valid-url');
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('validation_failed');
+    }
+  });
+
+  it('throws validationFailed on malformed percent-encoded credentials', () => {
+    try {
+      parseDatabaseConnection('postgres://invalid%FFuser@localhost:5432/orbit');
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('validation_failed');
+    }
+  });
+
   it('preserves TLS and libpq parameters when URL is sanitized', () => {
     const rawUrl =
       'postgres://orbit_user:secret_pass@db.example.com:5433/orbit_db?sslmode=verify-full&sslrootcert=%2Fpath%2Froot.crt';
@@ -47,5 +68,38 @@ describe('parseDatabaseConnection', () => {
     expect(sanitizedUrl).toContain('sslmode=verify-full');
     expect(sanitizedUrl).toContain('sslrootcert=');
     expect(sanitizedUrl).not.toContain('secret_pass');
+  });
+});
+
+describe('dumpDatabase', () => {
+  it('throws validationFailed when databaseUrl is invalid', async () => {
+    await expect(
+      dumpDatabase({
+        databaseUrl: 'invalid-url',
+        outputFile: '/tmp/test.dump',
+        databaseVersion: 'PostgreSQL 16',
+        ledger: [],
+        snapshotId: 'test-snap',
+        counts: { workspaces: 0, users: 0, attachments: 0, issues: 0 },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects with internal error when binary cannot be spawned', async () => {
+    try {
+      await dumpDatabase({
+        databaseUrl: 'postgres://orbit:orbit@localhost:5432/orbit',
+        outputFile: '/tmp/test.dump',
+        databaseVersion: 'PostgreSQL 16',
+        ledger: [],
+        snapshotId: 'test-snap',
+        pgDumpPath: '/nonexistent/path/to/pg_dump_binary',
+        counts: { workspaces: 0, users: 0, attachments: 0, issues: 0 },
+      });
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('internal');
+    }
   });
 });

--- a/packages/services/tests/backup/preflight.test.ts
+++ b/packages/services/tests/backup/preflight.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import { verifyPreflight } from '../../src/backup/preflight.ts';
+
+describe('verifyPreflight', () => {
+  it('succeeds against compatible live database', async () => {
+    const databaseUrl = process.env['DATABASE_URL'];
+    if (databaseUrl === undefined) return;
+
+    const result = await verifyPreflight(databaseUrl);
+    expect(typeof result.databaseVersion).toBe('string');
+    expect(result.databaseVersion.length).toBeGreaterThan(0);
+    expect(Array.isArray(result.ledger)).toBe(true);
+    expect(result.ledger.length).toBeGreaterThan(0);
+  });
+
+  it('rejects invalid or unreachable database', async () => {
+    await expect(
+      verifyPreflight('postgres://orbit:orbit@localhost:59999/non_existent_db'),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/services/tests/backup/preflight.test.ts
+++ b/packages/services/tests/backup/preflight.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+import { releaseDatabase } from '@orbit/db/migration-release';
 import { verifyPreflight } from '../../src/backup/preflight.ts';
+
+const MIGRATIONS = fileURLToPath(new URL('../../../db/drizzle', import.meta.url));
 
 describe('verifyPreflight', () => {
   it('succeeds against compatible live database', async () => {
     const databaseUrl = process.env['DATABASE_URL'];
     if (databaseUrl === undefined) return;
 
-    const result = await verifyPreflight(databaseUrl);
+    await releaseDatabase(databaseUrl, MIGRATIONS);
+
+    const result = await verifyPreflight(databaseUrl, MIGRATIONS);
     expect(typeof result.databaseVersion).toBe('string');
     expect(result.databaseVersion.length).toBeGreaterThan(0);
     expect(Array.isArray(result.ledger)).toBe(true);
@@ -17,5 +23,5 @@ describe('verifyPreflight', () => {
     await expect(
       verifyPreflight('postgres://orbit:orbit@localhost:59999/non_existent_db'),
     ).rejects.toThrow();
-  });
+  }, 10_000);
 });

--- a/packages/services/tests/backup/preflight.test.ts
+++ b/packages/services/tests/backup/preflight.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from 'bun:test';
 import { fileURLToPath } from 'node:url';
 import { releaseDatabase } from '@orbit/db/migration-release';
+import { resolveTestDatabaseUrl } from '../../../../scripts/test-env.ts';
 import { verifyPreflight } from '../../src/backup/preflight.ts';
 
 const MIGRATIONS = fileURLToPath(new URL('../../../db/drizzle', import.meta.url));
 
 describe('verifyPreflight', () => {
   it('succeeds against compatible live database', async () => {
-    const databaseUrl = process.env['DATABASE_URL'];
-    if (databaseUrl === undefined) return;
+    const databaseUrl = process.env['DATABASE_URL'] ?? resolveTestDatabaseUrl('orbit_test_svc');
 
     await releaseDatabase(databaseUrl, MIGRATIONS);
 

--- a/packages/services/tests/backup/storage.test.ts
+++ b/packages/services/tests/backup/storage.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import postgres from 'postgres';
+import { captureStorageObjects } from '../../src/backup/storage.ts';
+import type { StorageDriver, StoredObject, UploadTarget } from '../../src/storage/types.ts';
+
+function createMockDriver(store: Map<string, Uint8Array>): StorageDriver {
+  return {
+    name: 's3',
+    get(key: string): Promise<Uint8Array | null> {
+      return Promise.resolve(store.get(key) ?? null);
+    },
+    put(key: string, body: Uint8Array): Promise<void> {
+      store.set(key, body);
+      return Promise.resolve();
+    },
+    stat(key: string): Promise<StoredObject | null> {
+      const data = store.get(key);
+      if (data === undefined) return Promise.resolve(null);
+      return Promise.resolve({
+        key,
+        size: data.byteLength,
+        contentType: 'application/octet-stream',
+        updatedAt: new Date(),
+      });
+    },
+    delete(key: string): Promise<void> {
+      store.delete(key);
+      return Promise.resolve();
+    },
+    summarizePrefix(): Promise<{
+      objects: number;
+      bytes: number;
+      versions: number;
+      versionBytes: number;
+    }> {
+      return Promise.resolve({ objects: 0, bytes: 0, versions: 0, versionBytes: 0 });
+    },
+    deletePrefix(): Promise<void> {
+      return Promise.resolve();
+    },
+    getUrl(): Promise<string> {
+      return Promise.resolve('');
+    },
+    createUploadTarget(key: string, _contentType: string, maxBytes: number): Promise<UploadTarget> {
+      return Promise.resolve({
+        key,
+        url: 'http://localhost/upload',
+        method: 'PUT',
+        headers: {},
+        maxBytes,
+        expiresAt: new Date().toISOString(),
+      });
+    },
+  };
+}
+
+describe('captureStorageObjects', () => {
+  it('captures referenced storage objects into destination directory', async () => {
+    const databaseUrl = process.env['DATABASE_URL'];
+    if (databaseUrl === undefined) return;
+
+    const tempDir = await mkdtemp(join(tmpdir(), 'orbit-storage-test-'));
+    try {
+      const store = new Map<string, Uint8Array>();
+      const driver = createMockDriver(store);
+      const result = await captureStorageObjects({
+        databaseUrl,
+        outputObjectsDir: tempDir,
+        driver,
+      });
+
+      expect(Array.isArray(result.objects)).toBe(true);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws descriptive error when referenced object is missing', async () => {
+    const databaseUrl = process.env['DATABASE_URL'];
+    if (databaseUrl === undefined) return;
+
+    const sql = postgres(databaseUrl, { max: 1, idle_timeout: 10, prepare: false });
+    const testKey = `test-missing-${Date.now()}`;
+    const testId = `att-test-${Date.now()}`;
+    const [userRow] = await sql<{ id: string }[]>`select id from "user" limit 1`;
+    const [orgRow] = await sql<{ id: string }[]>`select id from organization limit 1`;
+
+    if (userRow === undefined || orgRow === undefined) {
+      await sql.end({ timeout: 5 });
+      return;
+    }
+
+    await sql`
+      insert into attachment (id, organization_id, parent_type, parent_id, file_name, content_type, size, storage_key, status, uploaded_by_id)
+      values (${testId}, ${orgRow.id}, 'issue', 'issue-1', 'test.txt', 'text/plain', 10, ${testKey}, 'ready', ${userRow.id})
+    `;
+
+    const tempDir = await mkdtemp(join(tmpdir(), 'orbit-missing-test-'));
+    try {
+      const store = new Map<string, Uint8Array>();
+      const driver = createMockDriver(store);
+
+      let thrownError: Error | undefined;
+      try {
+        await captureStorageObjects({
+          databaseUrl,
+          outputObjectsDir: tempDir,
+          driver,
+        });
+      } catch (err) {
+        thrownError = err as Error;
+      }
+
+      expect(thrownError).toBeDefined();
+      expect(thrownError?.message).toContain(testKey);
+    } finally {
+      await sql`delete from attachment where id = ${testId}`;
+      await sql.end({ timeout: 5 });
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/services/tests/backup/storage.test.ts
+++ b/packages/services/tests/backup/storage.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'bun:test';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import postgres from 'postgres';
+import { DomainError } from '@orbit/shared';
 import { captureStorageObjects } from '../../src/backup/storage.ts';
 import type { StorageDriver, StoredObject, UploadTarget } from '../../src/storage/types.ts';
 
@@ -59,66 +60,69 @@ function createMockDriver(store: Map<string, Uint8Array>): StorageDriver {
 
 describe('captureStorageObjects', () => {
   it('captures referenced storage objects into destination directory', async () => {
-    const databaseUrl = process.env['DATABASE_URL'];
-    if (databaseUrl === undefined) return;
-
     const tempDir = await mkdtemp(join(tmpdir(), 'orbit-storage-test-'));
     try {
-      const store = new Map<string, Uint8Array>();
+      const testBytes = new TextEncoder().encode('hello world backup storage content');
+      const expectedSha256 = createHash('sha256').update(testBytes).digest('hex');
+      const testKey = 'org_test/issue/att_123/file.txt';
+
+      const store = new Map<string, Uint8Array>([[testKey, testBytes]]);
       const driver = createMockDriver(store);
       const result = await captureStorageObjects({
-        databaseUrl,
+        records: [
+          {
+            id: 'att-123',
+            storage_key: testKey,
+            size: testBytes.byteLength,
+            content_type: 'text/plain',
+          },
+        ],
         outputObjectsDir: tempDir,
         driver,
       });
 
       expect(Array.isArray(result.objects)).toBe(true);
+      expect(result.objects.length).toBe(1);
+      expect(result.objects[0]?.key).toBe(testKey);
+      expect(result.objects[0]?.sha256).toBe(expectedSha256);
+      expect(result.objects[0]?.bytes).toBe(testBytes.byteLength);
+      expect(result.objects[0]?.contentType).toBe('text/plain');
+
+      const written = await readFile(join(tempDir, testKey));
+      expect(new Uint8Array(written)).toEqual(testBytes);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
   });
 
   it('throws descriptive error when referenced object is missing', async () => {
-    const databaseUrl = process.env['DATABASE_URL'];
-    if (databaseUrl === undefined) return;
-
-    const sql = postgres(databaseUrl, { max: 1, idle_timeout: 10, prepare: false });
-    const testKey = `test-missing-${Date.now()}`;
-    const testId = `att-test-${Date.now()}`;
-    const [userRow] = await sql<{ id: string }[]>`select id from "user" limit 1`;
-    const [orgRow] = await sql<{ id: string }[]>`select id from organization limit 1`;
-
-    if (userRow === undefined || orgRow === undefined) {
-      await sql.end({ timeout: 5 });
-      return;
-    }
-
-    await sql`
-      insert into attachment (id, organization_id, parent_type, parent_id, file_name, content_type, size, storage_key, status, uploaded_by_id)
-      values (${testId}, ${orgRow.id}, 'issue', 'issue-1', 'test.txt', 'text/plain', 10, ${testKey}, 'ready', ${userRow.id})
-    `;
-
     const tempDir = await mkdtemp(join(tmpdir(), 'orbit-missing-test-'));
     try {
+      const testKey = `test-missing-${Date.now()}`;
       const store = new Map<string, Uint8Array>();
       const driver = createMockDriver(store);
 
-      let thrownError: Error | undefined;
+      let thrownError: unknown;
       try {
         await captureStorageObjects({
-          databaseUrl,
+          records: [
+            {
+              id: 'att-missing-1',
+              storage_key: testKey,
+              size: 10,
+              content_type: 'text/plain',
+            },
+          ],
           outputObjectsDir: tempDir,
           driver,
         });
       } catch (err) {
-        thrownError = err as Error;
+        thrownError = err;
       }
 
-      expect(thrownError).toBeDefined();
-      expect(thrownError?.message).toContain(testKey);
+      expect(thrownError).toBeInstanceOf(DomainError);
+      expect((thrownError as DomainError).message).toContain(testKey);
     } finally {
-      await sql`delete from attachment where id = ${testId}`;
-      await sql.end({ timeout: 5 });
       await rm(tempDir, { recursive: true, force: true });
     }
   });

--- a/packages/shared/src/validators/backup.ts
+++ b/packages/shared/src/validators/backup.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { validationFailed } from '../errors/index.ts';
 
 export const CURRENT_BACKUP_FORMAT_VERSION = '1.0.0';
 export const MIN_SUPPORTED_BACKUP_FORMAT_VERSION = '1.0.0';
@@ -73,7 +74,7 @@ export const backupEncryptionSchema = z.object({
 export type BackupEncryption = z.infer<typeof backupEncryptionSchema>;
 
 export const backupManifestSchema = z.object({
-  formatVersion: z.string().regex(/^1\.\d+\.\d+$/),
+  formatVersion: z.literal(CURRENT_BACKUP_FORMAT_VERSION),
   orbitVersion: z.string().min(1),
   sourceRevision: z.string().min(1),
   imageDigests: z.record(z.string(), z.string()).default({}),
@@ -117,7 +118,7 @@ export function extractBackupConfiguration(
 export function validateConfigurationSafety(config: Record<string, string>): void {
   for (const key of Object.keys(config)) {
     if (!isAllowedBackupConfigKey(key)) {
-      throw new Error(`Configuration key "${key}" is not permitted in backup manifest.`);
+      throw validationFailed(`Configuration key "${key}" is not permitted in backup manifest.`);
     }
   }
 }

--- a/packages/shared/src/validators/backup.ts
+++ b/packages/shared/src/validators/backup.ts
@@ -1,0 +1,123 @@
+import { z } from 'zod';
+
+export const CURRENT_BACKUP_FORMAT_VERSION = '1.0.0';
+export const MIN_SUPPORTED_BACKUP_FORMAT_VERSION = '1.0.0';
+export const MAX_SUPPORTED_BACKUP_FORMAT_VERSION = '1.0.0';
+
+export const ALLOWED_BACKUP_CONFIG_KEYS = [
+  'ALLOWED_EMAIL_DOMAINS',
+  'BETTER_AUTH_URL',
+  'DATABASE_PREPARED_STATEMENTS',
+  'EMAIL_FROM',
+  'NEXT_PUBLIC_APP_URL',
+  'S3_BUCKET',
+  'S3_REGION',
+] as const;
+
+export type AllowedBackupConfigKey = (typeof ALLOWED_BACKUP_CONFIG_KEYS)[number];
+
+const FORBIDDEN_SECRET_PATTERNS = [
+  /secret/i,
+  /password/i,
+  /token/i,
+  /key/i,
+  /credential/i,
+  /private/i,
+] as const;
+
+export const backupMigrationLedgerRowSchema = z.object({
+  hash: z.string().min(1),
+  createdAt: z.string().min(1),
+});
+
+export type BackupMigrationLedgerRow = z.infer<typeof backupMigrationLedgerRowSchema>;
+
+export const backupDatabaseDumpSchema = z.object({
+  file: z.string().min(1),
+  sha256: z
+    .string()
+    .length(64)
+    .regex(/^[0-9a-f]{64}$/i),
+  bytes: z.number().int().nonnegative(),
+});
+
+export type BackupDatabaseDump = z.infer<typeof backupDatabaseDumpSchema>;
+
+export const backupObjectEntrySchema = z.object({
+  key: z.string().min(1),
+  sha256: z
+    .string()
+    .length(64)
+    .regex(/^[0-9a-f]{64}$/i),
+  bytes: z.number().int().nonnegative(),
+  contentType: z.string().min(1),
+});
+
+export type BackupObjectEntry = z.infer<typeof backupObjectEntrySchema>;
+
+export const backupCountsSchema = z.object({
+  workspaces: z.number().int().nonnegative(),
+  users: z.number().int().nonnegative(),
+  attachments: z.number().int().nonnegative(),
+  issues: z.number().int().nonnegative(),
+});
+
+export type BackupCounts = z.infer<typeof backupCountsSchema>;
+
+export const backupEncryptionSchema = z.object({
+  enabled: z.boolean(),
+  algorithm: z.enum(['aes-256-gcm']).optional(),
+  keyId: z.string().optional(),
+});
+
+export type BackupEncryption = z.infer<typeof backupEncryptionSchema>;
+
+export const backupManifestSchema = z.object({
+  formatVersion: z.string().regex(/^1\.\d+\.\d+$/),
+  orbitVersion: z.string().min(1),
+  sourceRevision: z.string().min(1),
+  imageDigests: z.record(z.string(), z.string()).default({}),
+  databaseVersion: z.string().min(1),
+  createdAt: z.string().datetime(),
+  migrationLedger: z.array(backupMigrationLedgerRowSchema),
+  configuration: z.record(z.string(), z.string()).default({}),
+  checksums: z.object({
+    databaseDump: backupDatabaseDumpSchema,
+    objects: z.array(backupObjectEntrySchema),
+  }),
+  counts: backupCountsSchema,
+  encryption: backupEncryptionSchema,
+  metadata: z.record(z.string(), z.string()).default({}),
+});
+
+export type BackupManifest = z.infer<typeof backupManifestSchema>;
+
+export function isAllowedBackupConfigKey(key: string): key is AllowedBackupConfigKey {
+  return (ALLOWED_BACKUP_CONFIG_KEYS as readonly string[]).includes(key);
+}
+
+export function isForbiddenBackupConfigKey(key: string): boolean {
+  if (isAllowedBackupConfigKey(key)) return false;
+  return FORBIDDEN_SECRET_PATTERNS.some((pattern) => pattern.test(key));
+}
+
+export function extractBackupConfiguration(
+  env: Record<string, string | undefined>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const key of ALLOWED_BACKUP_CONFIG_KEYS) {
+    const value = env[key]?.trim();
+    if (value !== undefined && value.length > 0) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+export function validateConfigurationSafety(config: Record<string, string>): void {
+  for (const key of Object.keys(config)) {
+    if (!isAllowedBackupConfigKey(key)) {
+      throw new Error(`Configuration key "${key}" is not permitted in backup manifest.`);
+    }
+  }
+}

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1,6 +1,7 @@
 export * from './analytics.ts';
 export * from './auth.ts';
 export * from './avatar.ts';
+export * from './backup.ts';
 export * from './bootstrap.ts';
 export * from './comment.ts';
 export * from './common.ts';

--- a/packages/shared/tests/validators/backup.test.ts
+++ b/packages/shared/tests/validators/backup.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { DomainError } from '../../src/errors/index.ts';
 import {
   type BackupManifest,
   backupManifestSchema,
@@ -65,7 +66,27 @@ describe('backupManifestSchema', () => {
     expect(parsed.counts.workspaces).toBe(1);
   });
 
-  it('rejects an invalid format version', () => {
+  it('accepts supported format version 1.0.0 and rejects out of range versions', () => {
+    const accepted = backupManifestSchema.parse({
+      ...validManifest,
+      formatVersion: '1.0.0',
+    });
+    expect(accepted.formatVersion).toBe('1.0.0');
+
+    expect(() =>
+      backupManifestSchema.parse({
+        ...validManifest,
+        formatVersion: '1.0.1',
+      }),
+    ).toThrow();
+
+    expect(() =>
+      backupManifestSchema.parse({
+        ...validManifest,
+        formatVersion: '1.1.0',
+      }),
+    ).toThrow();
+
     expect(() =>
       backupManifestSchema.parse({
         ...validManifest,
@@ -141,6 +162,6 @@ describe('configuration safety and extraction', () => {
       validateConfigurationSafety({
         BETTER_AUTH_SECRET: 'secret',
       }),
-    ).toThrow();
+    ).toThrow(DomainError);
   });
 });

--- a/packages/shared/tests/validators/backup.test.ts
+++ b/packages/shared/tests/validators/backup.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  type BackupManifest,
+  backupManifestSchema,
+  CURRENT_BACKUP_FORMAT_VERSION,
+  extractBackupConfiguration,
+  isAllowedBackupConfigKey,
+  isForbiddenBackupConfigKey,
+  validateConfigurationSafety,
+} from '../../src/validators/backup.ts';
+
+describe('backupManifestSchema', () => {
+  const validManifest: BackupManifest = {
+    formatVersion: CURRENT_BACKUP_FORMAT_VERSION,
+    orbitVersion: '0.1.0',
+    sourceRevision: 'abc123def456',
+    imageDigests: {
+      web: 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    },
+    databaseVersion: 'PostgreSQL 18.6 on x86_64-pc-linux-gnu',
+    createdAt: '2026-09-08T12:00:00.000Z',
+    migrationLedger: [
+      {
+        hash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+        createdAt: '1786217938315',
+      },
+    ],
+    configuration: {
+      NEXT_PUBLIC_APP_URL: 'https://orbit.example.com',
+      EMAIL_FROM: 'Orbit <orbit@example.com>',
+    },
+    checksums: {
+      databaseDump: {
+        file: 'database.dump',
+        sha256: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+        bytes: 1024,
+      },
+      objects: [
+        {
+          key: 'org_123/issue/att_456/file.png',
+          sha256: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+          bytes: 2048,
+          contentType: 'image/png',
+        },
+      ],
+    },
+    counts: {
+      workspaces: 1,
+      users: 5,
+      attachments: 1,
+      issues: 10,
+    },
+    encryption: {
+      enabled: false,
+    },
+    metadata: {
+      generator: 'orbit-backup-create',
+    },
+  };
+
+  it('validates a complete valid manifest', () => {
+    const parsed = backupManifestSchema.parse(validManifest);
+    expect(parsed.formatVersion).toBe(CURRENT_BACKUP_FORMAT_VERSION);
+    expect(parsed.checksums.objects.length).toBe(1);
+    expect(parsed.counts.workspaces).toBe(1);
+  });
+
+  it('rejects an invalid format version', () => {
+    expect(() =>
+      backupManifestSchema.parse({
+        ...validManifest,
+        formatVersion: '2.0',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects non-hex sha256 checksums', () => {
+    expect(() =>
+      backupManifestSchema.parse({
+        ...validManifest,
+        checksums: {
+          ...validManifest.checksums,
+          databaseDump: {
+            ...validManifest.checksums.databaseDump,
+            sha256: 'not-a-valid-sha256-hash',
+          },
+        },
+      }),
+    ).toThrow();
+  });
+
+  it('rejects negative counts', () => {
+    expect(() =>
+      backupManifestSchema.parse({
+        ...validManifest,
+        counts: {
+          ...validManifest.counts,
+          workspaces: -1,
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+describe('configuration safety and extraction', () => {
+  it('correctly classifies allowed and forbidden keys', () => {
+    expect(isAllowedBackupConfigKey('NEXT_PUBLIC_APP_URL')).toBe(true);
+    expect(isAllowedBackupConfigKey('EMAIL_FROM')).toBe(true);
+    expect(isAllowedBackupConfigKey('BETTER_AUTH_SECRET')).toBe(false);
+
+    expect(isForbiddenBackupConfigKey('BETTER_AUTH_SECRET')).toBe(true);
+    expect(isForbiddenBackupConfigKey('DATABASE_PASSWORD')).toBe(true);
+    expect(isForbiddenBackupConfigKey('S3_SECRET_ACCESS_KEY')).toBe(true);
+    expect(isForbiddenBackupConfigKey('GITHUB_APP_PRIVATE_KEY')).toBe(true);
+    expect(isForbiddenBackupConfigKey('NEXT_PUBLIC_APP_URL')).toBe(false);
+  });
+
+  it('extracts only allowed non-empty configuration keys', () => {
+    const env = {
+      NEXT_PUBLIC_APP_URL: 'https://orbit.example.com',
+      EMAIL_FROM: 'orbit@example.com',
+      BETTER_AUTH_SECRET: 'super-secret-value-12345',
+      DATABASE_URL: 'postgres://orbit:pass@localhost:5432/orbit',
+      S3_BUCKET: 'orbit-uploads',
+      ALLOWED_EMAIL_DOMAINS: '',
+      UNKNOWN_VAR: 'value',
+    };
+    const extracted = extractBackupConfiguration(env);
+    expect(extracted).toEqual({
+      NEXT_PUBLIC_APP_URL: 'https://orbit.example.com',
+      EMAIL_FROM: 'orbit@example.com',
+      S3_BUCKET: 'orbit-uploads',
+    });
+    expect(extracted['BETTER_AUTH_SECRET']).toBeUndefined();
+    expect(extracted['DATABASE_URL']).toBeUndefined();
+    expect(extracted['UNKNOWN_VAR']).toBeUndefined();
+  });
+
+  it('throws when forbidden keys are passed to validateConfigurationSafety', () => {
+    expect(() =>
+      validateConfigurationSafety({
+        BETTER_AUTH_SECRET: 'secret',
+      }),
+    ).toThrow();
+  });
+});

--- a/scripts/backup-create.test.ts
+++ b/scripts/backup-create.test.ts
@@ -42,4 +42,22 @@ describe('backup create CLI args', () => {
     expect(args.orbitVersion).toBe('1.2.3');
     expect(args.sourceRevision).toBe('git-sha-xyz');
   });
+
+  it('emits json error and exits nonzero when database url is missing and --json is passed', () => {
+    const env = {
+      ...process.env,
+      DATABASE_URL: '',
+      DIRECT_URL: '',
+    };
+    const proc = Bun.spawnSync(['bun', 'scripts/backup/create.ts', '--json'], {
+      env,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(proc.exitCode).toBe(1);
+    const stderrText = proc.stderr.toString();
+    const parsed = JSON.parse(stderrText) as { status: string; error: string };
+    expect(parsed.status).toBe('error');
+    expect(parsed.error).toContain('DATABASE_URL or DIRECT_URL is required');
+  });
 });

--- a/scripts/backup-create.test.ts
+++ b/scripts/backup-create.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test';
+import { parseArgs } from './backup/create.ts';
+
+describe('backup create CLI args', () => {
+  it('parses default arguments', () => {
+    const args = parseArgs(['bun', 'scripts/backup/create.ts']);
+    expect(typeof args.destination).toBe('string');
+    expect(args.json).toBe(false);
+  });
+
+  it('parses explicit destination flag', () => {
+    const args = parseArgs([
+      'bun',
+      'scripts/backup/create.ts',
+      '--destination',
+      '/var/backups/orbit',
+    ]);
+    expect(args.destination).toContain('orbit');
+  });
+
+  it('parses json flag and custom database url', () => {
+    const args = parseArgs([
+      'bun',
+      'scripts/backup/create.ts',
+      '--json',
+      '--database-url',
+      'postgres://user:pass@localhost:5432/testdb',
+    ]);
+    expect(args.json).toBe(true);
+    expect(args.databaseUrl).toBe('postgres://user:pass@localhost:5432/testdb');
+  });
+
+  it('parses version and revision flags', () => {
+    const args = parseArgs([
+      'bun',
+      'scripts/backup/create.ts',
+      '--orbit-version',
+      '1.2.3',
+      '--source-revision',
+      'git-sha-xyz',
+    ]);
+    expect(args.orbitVersion).toBe('1.2.3');
+    expect(args.sourceRevision).toBe('git-sha-xyz');
+  });
+});

--- a/scripts/backup/create.ts
+++ b/scripts/backup/create.ts
@@ -1,0 +1,126 @@
+import { resolve } from 'node:path';
+import { createBackup } from '../../packages/services/src/backup/index.ts';
+
+export interface ParsedArgs {
+  readonly destination: string;
+  readonly databaseUrl?: string | undefined;
+  readonly json: boolean;
+  readonly pgDumpPath?: string | undefined;
+  readonly orbitVersion?: string | undefined;
+  readonly sourceRevision?: string | undefined;
+}
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const flags = new Map<string, string>();
+  let json = false;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const item = argv[index];
+    if (item === undefined) continue;
+    if (item === '--json') {
+      json = true;
+      continue;
+    }
+    const eqIdx = item.indexOf('=');
+    if (eqIdx !== -1) {
+      flags.set(item.slice(0, eqIdx), item.slice(eqIdx + 1));
+      continue;
+    }
+    const next = argv[index + 1];
+    if (next !== undefined && !next.startsWith('-')) {
+      flags.set(item, next);
+      index += 1;
+    }
+  }
+
+  const destination = resolve(
+    flags.get('--destination') ??
+      flags.get('-d') ??
+      process.env['ORBIT_BACKUP_DESTINATION'] ??
+      './backups',
+  );
+  const databaseUrl =
+    flags.get('--database-url') ?? process.env['DIRECT_URL'] ?? process.env['DATABASE_URL'];
+  const pgDumpPath = flags.get('--pg-dump-path') ?? process.env['PG_DUMP_PATH'];
+  const orbitVersion = flags.get('--orbit-version') ?? process.env['ORBIT_VERSION'];
+  const sourceRevision =
+    flags.get('--source-revision') ??
+    process.env['SOURCE_REVISION'] ??
+    process.env['VERCEL_GIT_COMMIT_SHA'];
+
+  return {
+    destination,
+    databaseUrl,
+    json,
+    pgDumpPath,
+    orbitVersion,
+    sourceRevision,
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+
+  if (args.databaseUrl === undefined || args.databaseUrl.length === 0) {
+    process.stderr.write('Error: DATABASE_URL or DIRECT_URL is required to create a backup.\n');
+    process.exit(1);
+  }
+
+  try {
+    const result = await createBackup({
+      destinationDir: args.destination,
+      databaseUrl: args.databaseUrl,
+      pgDumpPath: args.pgDumpPath,
+      orbitVersion: args.orbitVersion,
+      sourceRevision: args.sourceRevision,
+    });
+
+    if (args.json) {
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            status: 'ok',
+            backupId: result.backupId,
+            backupDir: result.backupDir,
+            manifest: result.manifest,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } else {
+      process.stdout.write(`Backup successfully created.\n`);
+      process.stdout.write(`ID: ${result.backupId}\n`);
+      process.stdout.write(`Directory: ${result.backupDir}\n`);
+      process.stdout.write(`Database version: ${result.manifest.databaseVersion}\n`);
+      process.stdout.write(
+        `Postgres dump: ${result.manifest.checksums.databaseDump.bytes} bytes\n`,
+      );
+      process.stdout.write(`Objects captured: ${result.manifest.checksums.objects.length}\n`);
+      process.stdout.write(
+        `Counts: ${result.manifest.counts.workspaces} workspace(s), ${result.manifest.counts.users} user(s), ${result.manifest.counts.attachments} attachment(s), ${result.manifest.counts.issues} issue(s)\n`,
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (args.json) {
+      process.stderr.write(
+        `${JSON.stringify(
+          {
+            status: 'error',
+            error: message,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } else {
+      process.stderr.write(`Backup creation failed: ${message}\n`);
+    }
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/backup/create.ts
+++ b/scripts/backup/create.ts
@@ -1,5 +1,4 @@
 import { resolve } from 'node:path';
-import { createBackup } from '../../packages/services/src/backup/index.ts';
 
 export interface ParsedArgs {
   readonly destination: string;
@@ -62,11 +61,25 @@ async function main(): Promise<void> {
   const args = parseArgs(process.argv);
 
   if (args.databaseUrl === undefined || args.databaseUrl.length === 0) {
-    process.stderr.write('Error: DATABASE_URL or DIRECT_URL is required to create a backup.\n');
+    if (args.json) {
+      process.stderr.write(
+        `${JSON.stringify(
+          {
+            status: 'error',
+            error: 'DATABASE_URL or DIRECT_URL is required to create a backup.',
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } else {
+      process.stderr.write('Error: DATABASE_URL or DIRECT_URL is required to create a backup.\n');
+    }
     process.exit(1);
   }
 
   try {
+    const { createBackup } = await import('../../packages/services/src/backup/index.ts');
     const result = await createBackup({
       destinationDir: args.destination,
       databaseUrl: args.databaseUrl,


### PR DESCRIPTION

## What this changes

Adds the versioned backup manifest schema in `@orbit/shared`, preflight migration and catalog drift verification, PostgreSQL custom dump capture, referenced S3 object capture, and the atomic `bun run backup:create` CLI command.

## Why

Part of #394. Self-hosted Orbit lacked an upstream, atomic backup command that records a versioned manifest with SHA-256 checksums and pairs database state with referenced object storage assets.

## How you know it works

Added 22 unit and integration tests across 6 test files covering schema validation, configuration secret filtering, connection parsing, missing object failure handling, live preflight verification, atomic `.incomplete` failure handling, and CLI parsing:

```bash
bun test packages/shared/tests/validators/backup.test.ts \
         packages/services/tests/backup/database.test.ts \
         packages/services/tests/backup/storage.test.ts \
         packages/services/tests/backup/preflight.test.ts \
         packages/services/tests/backup/create.test.ts \
         scripts/backup-create.test.ts
```

All repository policy checks pass:
- `bun run check-comments`: 0 disallowed comments.
- `bun run check-bytes`: 0 control bytes in tracked source files.
- `bun run check-bun-imports`: 0 Bun built-ins imported at runtime in shipped server code.
- `bun run check-deps`: all overridden packages resolve to a single version.
- `bunx @biomejs/biome check`: clean, 0 errors.

## Checklist

- [x] `bun run verify` checks pass (lint, comments, bytes, bun-imports, deps, tests)
- [x] Tests added or updated, and they fail without the change
- [x] No comments added to code, and no em-dash characters anywhere
- [x] No `any`, no non-null assertions
- [x] External input is parsed with a Zod schema from `@orbit/shared`
- [x] Authorization is enforced on the server through `packages/shared/src/policy`, not only in the UI
- [ ] Docs updated if behaviour, configuration or setup changed (operator runbooks planned for PR 4)
- [x] `bun run db:release` and `bun run db:check-drift` passed against the target database before this ships

## Anything reviewers should know

- This is **PR 1 of 4** for issue #394, covering backup capture and manifest serialization. PR 2 will introduce the guarded restore engine and application-aware validator.
- Runtime secrets (`BETTER_AUTH_SECRET`, database passwords, S3 secret access keys, Resend API keys) are strictly excluded from the manifest; only allowlisted non-secret topology variables are saved.
- Database passwords are piped to `pg_dump` via child process environment variables (`PGPASSWORD`) to prevent exposure in process arguments or logs.
- Captures fail atomically: if database dump or storage object capture fails, the output directory is renamed with a `.incomplete` suffix and the CLI exits with a nonzero status code.








<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces a versioned backup manifest and an atomic backup CLI that verifies migration/catalog state, captures a coordinated PostgreSQL dump, copies referenced storage objects, and records checksums.
- Adds shared backup schemas and configuration filtering.
- Adds preflight migration and catalog verification.
- Coordinates database and attachment inventory through an exported PostgreSQL snapshot.
- Writes completed backups atomically and retains failed captures with an `.incomplete` suffix.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/services/src/backup/create.ts | Orchestrates preflight verification, coordinated capture, manifest creation, and atomic completion or failure handling. |
| packages/services/src/backup/database.ts | Captures a custom-format PostgreSQL dump while preserving connection parameters and excluding the password from process arguments. |
| packages/services/src/backup/snapshot.ts | Holds an exported repeatable-read snapshot open across database and object capture. |
| packages/services/src/backup/preflight.ts | Fails backup creation when migration history or the live catalog is incompatible. |
| packages/services/src/backup/storage.ts | Copies snapshot-referenced objects and records their content metadata and SHA-256 checksums. |
| packages/shared/src/validators/backup.ts | Defines the versioned manifest contract and allowlisted non-secret configuration extraction. |
| scripts/backup/create.ts | Exposes argument parsing, structured output, and exit handling for the operator backup command. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant CLI as backup:create CLI
  participant Preflight as Preflight verifier
  participant Snapshot as PostgreSQL snapshot
  participant Dump as pg_dump
  participant Storage as Object storage
  participant Disk as Backup directory
  CLI->>Preflight: Verify ledger and live catalog
  CLI->>Snapshot: Begin repeatable-read transaction
  Snapshot-->>CLI: Snapshot ID, attachment records, counts
  CLI->>Dump: Capture database with snapshot ID
  Dump-->>Disk: database.dump
  CLI->>Storage: Fetch snapshot-referenced objects
  Storage-->>Disk: Object files
  CLI->>Disk: Write checksummed manifest
  CLI->>Snapshot: Release transaction
  CLI->>Disk: Rename temporary directory atomically
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(backup): require valid postgres snap..."](https://github.com/noveum/orbit/commit/1b593e84a7d8efce5f71a5c5390f1de93b5fa1be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61579533)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/noveum/orbit/blob/main/CLAUDE.md))
- Knowledge Base — [Data model and database operations](https://app.greptile.com/noveum-ai/-/custom-context/knowledge-base/noveum/orbit/-/docs/data-model-and-database-operations.md)

<!-- /greptile_comment -->