### PR TITLE
perf(notifications): add opt-in concurrent history backfill

### DIFF
--- a/docs/database-releases.md
+++ b/docs/database-releases.md
@@ -51,6 +51,34 @@ Every production Vercel build checks the configured production database before t
 application build. Missing credentials, an unreachable database or required drift
 fails the deployment. This guard never applies migrations during a build.
 
+## Notification history backfill
+
+Keep `NOTIFICATION_PROVIDERS_PAUSED=true` and
+`NOTIFICATION_CONVERSATIONS_ENABLED=false` on the deployed application while
+backfilling historical notifications. Schema migration alone does not complete
+this rollout.
+
+With `DATABASE_URL` loaded securely for the intended database, run:
+
+```bash
+bun run notifications:conversations-backfill --all --batch-size=100 --source-concurrency=4
+bun run notifications:conversations-verify --all
+```
+
+Source concurrency defaults to one and accepts integers from one through eight.
+It bounds independent source resolution and classification work, not the number
+of organizations. Start conservatively and account for the database connection
+pool and live application traffic. Equivalence groups stay intact, overlapping
+groups are refused, and checkpoints advance only after every started operation
+in the batch settles successfully. The remaining phases keep their existing
+ordering.
+
+Run only one backfill process per organization. After an interrupted process has
+stopped, rerun the same command to resume saved progress; do not erase checkpoints
+or delivery history. Require the verifier to return `ok: true` with zero drift
+before enabling conversation reads and resuming provider delivery. Environment
+flag changes require a new deployment before they affect running functions.
+
 ## Rollback
 
 Do not rewrite or delete an applied migration. Roll application code back while

--- a/packages/services/src/notifications/conversation-backfill.ts
+++ b/packages/services/src/notifications/conversation-backfill.ts
@@ -161,6 +161,7 @@ export interface NotificationConversationBackfillOptions
   extends ResumableConversationBackfillOptions {
   readonly resolveLegacySource?: ResolveLegacyNotificationSource;
   readonly maxEquivalenceGroupRows?: number;
+  readonly sourceConcurrency?: number;
 }
 
 export interface ConversationBackfillOrganizationResult {
@@ -1381,12 +1382,31 @@ async function readSourceSeeds(
   `);
 }
 
+async function mapSourceWork<Input, Output>(
+  inputs: readonly Input[],
+  concurrency: number,
+  operation: (input: Input) => Promise<Output>,
+): Promise<Output[]> {
+  const outputs: Output[] = [];
+  for (let offset = 0; offset < inputs.length; offset += concurrency) {
+    const results = await Promise.allSettled(
+      inputs.slice(offset, offset + concurrency).map(operation),
+    );
+    for (const result of results) {
+      if (result.status === 'rejected') throw result.reason;
+      outputs.push(result.value);
+    }
+  }
+  return outputs;
+}
+
 async function resolveSourceGroups(
   database: Database,
   seeds: readonly SourceSeedRow[],
   resolver: ResolveLegacyNotificationSource,
   batchSize: number,
   maxEquivalenceGroupRows: number,
+  sourceConcurrency: number,
 ): Promise<{
   readonly groups: readonly SourceResolutionGroup[];
   readonly cursor: string | null;
@@ -1395,33 +1415,42 @@ async function resolveSourceGroups(
   let selectedRows = 0;
   let cursor: string | null = null;
 
-  for (const seed of seeds) {
-    const resolution = validateSourceResolution(
-      seed.id,
-      await resolver(database, notificationSourceInput(seed)),
-      maxEquivalenceGroupRows,
+  for (let offset = 0; offset < seeds.length; offset += sourceConcurrency) {
+    const resolved = await mapSourceWork(
+      seeds.slice(offset, offset + sourceConcurrency),
+      sourceConcurrency,
+      async (seed) => ({
+        seed,
+        resolution: validateSourceResolution(
+          seed.id,
+          await resolver(database, notificationSourceInput(seed)),
+          maxEquivalenceGroupRows,
+        ),
+      }),
     );
-    const existing = groups.get(resolution.sourceEventKey);
-    if (existing !== undefined) {
-      if (!sameSourceResolution(existing.resolution, resolution)) {
-        throw new Error(`Conflicting resolutions for ${resolution.sourceEventKey}.`);
+    for (const { seed, resolution } of resolved) {
+      const existing = groups.get(resolution.sourceEventKey);
+      if (existing !== undefined) {
+        if (!sameSourceResolution(existing.resolution, resolution)) {
+          throw new Error(`Conflicting resolutions for ${resolution.sourceEventKey}.`);
+        }
+        groups.set(resolution.sourceEventKey, {
+          resolution,
+          seedIds: [...existing.seedIds, seed.id],
+        });
+        cursor = seed.id;
+        continue;
       }
-      groups.set(resolution.sourceEventKey, {
-        resolution,
-        seedIds: [...existing.seedIds, seed.id],
-      });
+      if (
+        selectedRows > 0 &&
+        selectedRows + resolution.equivalentNotificationIds.length > batchSize
+      ) {
+        return { groups: [...groups.values()], cursor };
+      }
+      groups.set(resolution.sourceEventKey, { resolution, seedIds: [seed.id] });
+      selectedRows += resolution.equivalentNotificationIds.length;
       cursor = seed.id;
-      continue;
     }
-    if (
-      selectedRows > 0 &&
-      selectedRows + resolution.equivalentNotificationIds.length > batchSize
-    ) {
-      break;
-    }
-    groups.set(resolution.sourceEventKey, { resolution, seedIds: [seed.id] });
-    selectedRows += resolution.equivalentNotificationIds.length;
-    cursor = seed.id;
   }
   return { groups: [...groups.values()], cursor };
 }
@@ -1432,6 +1461,7 @@ async function processSourceBatch(
   highWaterMark: string | null,
   resolver: ResolveLegacyNotificationSource,
   maxEquivalenceGroupRows: number,
+  sourceConcurrency: number,
 ): Promise<ConversationBackfillBatchResult> {
   const actualHighWater =
     highWaterMark ?? (await notificationHighWaterMark(database, input.organizationId));
@@ -1456,21 +1486,23 @@ async function processSourceBatch(
     resolver,
     input.batchSize,
     maxEquivalenceGroupRows,
+    sourceConcurrency,
   );
   if (planned.groups.length === 0 || planned.cursor === null) {
     throw new Error('Source batch planning made no progress.');
   }
-  let processedRows = 0;
+  const notificationIds = new Set<string>();
   for (const group of planned.groups) {
-    processedRows += await applySourceResolutionGroup(
-      database,
-      input.organizationId,
-      group,
-      input.now,
-    );
+    for (const id of group.resolution.equivalentNotificationIds) {
+      if (notificationIds.has(id)) throw new Error('Source equivalence groups overlap.');
+      notificationIds.add(id);
+    }
   }
+  const counts = await mapSourceWork(planned.groups, sourceConcurrency, (group) =>
+    applySourceResolutionGroup(database, input.organizationId, group, input.now),
+  );
   return {
-    processedRows,
+    processedRows: counts.reduce((total, count) => total + count, 0),
     cursor: planned.cursor,
     highWaterMark: actualHighWater,
     done: false,
@@ -2157,6 +2189,7 @@ async function processTailBatch(
   maxEquivalenceGroupRows: number,
   passNumber: number,
   previousWatermark: string | null,
+  sourceConcurrency: number,
 ): Promise<ConversationBackfillBatchResult> {
   const before = JSON.stringify([
     await notificationHighWaterMark(database, input.organizationId),
@@ -2169,6 +2202,7 @@ async function processTailBatch(
     null,
     resolver,
     maxEquivalenceGroupRows,
+    sourceConcurrency,
   );
   if (!sources.done) {
     return {
@@ -2233,6 +2267,7 @@ class DatabaseConversationBackfillStore implements ConversationBackfillStore {
     private readonly database: Database,
     private readonly resolver: ResolveLegacyNotificationSource,
     private readonly maxEquivalenceGroupRows: number,
+    private readonly sourceConcurrency: number,
   ) {}
 
   async listOrganizationIds(): Promise<readonly string[]> {
@@ -2320,6 +2355,7 @@ class DatabaseConversationBackfillStore implements ConversationBackfillStore {
         highWaterMark,
         this.resolver,
         this.maxEquivalenceGroupRows,
+        this.sourceConcurrency,
       );
     }
     if (input.phase === 'recipients') {
@@ -2338,6 +2374,7 @@ class DatabaseConversationBackfillStore implements ConversationBackfillStore {
       this.maxEquivalenceGroupRows,
       progress?.passNumber ?? 1,
       progress?.highWaterMark ?? null,
+      this.sourceConcurrency,
     );
   }
 }
@@ -2347,6 +2384,10 @@ export async function runNotificationConversationBackfill(
   options: NotificationConversationBackfillOptions = {},
 ): Promise<ConversationBackfillRunResult> {
   const maxEquivalenceGroupRows = options.maxEquivalenceGroupRows ?? 10_000;
+  const sourceConcurrency = options.sourceConcurrency ?? 1;
+  if (!Number.isInteger(sourceConcurrency) || sourceConcurrency < 1 || sourceConcurrency > 8) {
+    throw new Error('Source concurrency must be an integer between 1 and 8.');
+  }
   if (!Number.isInteger(maxEquivalenceGroupRows) || maxEquivalenceGroupRows < 1) {
     throw new Error('Maximum source equivalence group size must be positive.');
   }
@@ -2354,6 +2395,7 @@ export async function runNotificationConversationBackfill(
     database,
     options.resolveLegacySource ?? defaultLegacySourceResolution,
     maxEquivalenceGroupRows,
+    sourceConcurrency,
   );
   return await runResumableConversationBackfill(store, options);
 }

--- a/packages/services/tests/notifications/conversation-backfill.test.ts
+++ b/packages/services/tests/notifications/conversation-backfill.test.ts
@@ -20,6 +20,7 @@ import {
   type ConversationBackfillProgress,
   type ConversationBackfillStore,
   classifyLegacyDeliveryGroup,
+  defaultLegacySourceResolution,
   foldLegacyRecipientGroup,
   type LegacyDeliveryCandidate,
   type LegacyRecipientCandidate,
@@ -74,6 +75,111 @@ function delivery(
 }
 
 describe('conversation backfill planning', () => {
+  it('bounds concurrent source work and verifies all historical rows after completion', async () => {
+    const suffix = randomUUIDv7();
+    const organizationId = `org_parallel_${suffix}`;
+    const userId = `usr_parallel_${suffix}`;
+    await db
+      .insert(organization)
+      .values({ id: organizationId, name: 'Parallel backfill', slug: `parallel-${suffix}` });
+    await db.insert(user).values({
+      id: userId,
+      name: 'Parallel user',
+      email: `parallel.${suffix}@orbit.local`,
+      handle: `parallel-${suffix}`,
+    });
+    try {
+      await db.insert(notification).values(
+        Array.from({ length: 5 }, (_, index) => ({
+          id: `ntf_parallel_${suffix}_${index}`,
+          organizationId,
+          userId,
+          type: 'comment_created',
+          reason: 'commented' as const,
+          actorId: userId,
+          actorName: 'Parallel user',
+          entityType: 'issue',
+          entityId: 'iss_parallel',
+          title: 'Historical comment',
+          body: '',
+          url: '/issues/iss_parallel',
+          deliveredChannels: ['inbox'],
+          createdAt: january,
+        })),
+      );
+      let active = 0;
+      let maximum = 0;
+      const options = {
+        organizationIds: [organizationId],
+        batchSize: 5,
+        sourceConcurrency: 3,
+        resolveLegacySource: async (
+          database: Parameters<typeof defaultLegacySourceResolution>[0],
+          input: Parameters<typeof defaultLegacySourceResolution>[1],
+        ) => {
+          active += 1;
+          maximum = Math.max(maximum, active);
+          try {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            return await defaultLegacySourceResolution(database, input);
+          } finally {
+            active -= 1;
+          }
+        },
+      };
+      const started: string[] = [];
+      await expect(
+        runNotificationConversationBackfill(db, {
+          ...options,
+          resolveLegacySource: async (database, input) => {
+            started.push(input.id);
+            active += 1;
+            try {
+              if (input.id.endsWith('_0')) throw new Error('Injected source failure');
+              await new Promise((resolve) => setTimeout(resolve, 20));
+              return await defaultLegacySourceResolution(database, input);
+            } finally {
+              active -= 1;
+            }
+          },
+        }),
+      ).rejects.toThrow('Injected source failure');
+      expect(active).toBe(0);
+      expect(started).toHaveLength(3);
+      const [failed] = await db
+        .select()
+        .from(notificationConversationBackfillProgress)
+        .where(eq(notificationConversationBackfillProgress.organizationId, organizationId));
+      expect(failed).toMatchObject({ status: 'failed', cursor: null, processedRows: 0 });
+      await runNotificationConversationBackfill(db, options);
+      expect(maximum).toBe(3);
+      expect(active).toBe(0);
+      expect(
+        (await verifyNotificationConversationBackfill(db, { organizationIds: [organizationId] }))
+          .ok,
+      ).toBe(true);
+      const rows = await db
+        .select()
+        .from(notification)
+        .where(eq(notification.organizationId, organizationId));
+      expect(rows).toHaveLength(5);
+      expect(rows.every((row) => row.conversationId !== null && row.sourceEventId !== null)).toBe(
+        true,
+      );
+    } finally {
+      await db.delete(organization).where(eq(organization.id, organizationId));
+      await db.delete(user).where(eq(user.id, userId));
+    }
+  });
+
+  it('rejects unsafe source concurrency before accessing the database', async () => {
+    for (const sourceConcurrency of [0, -1, 1.5, 9, Number.NaN]) {
+      await expect(runNotificationConversationBackfill(db, { sourceConcurrency })).rejects.toThrow(
+        'Source concurrency must be an integer between 1 and 8.',
+      );
+    }
+  });
+
   it('takes deterministic primary-key batches without splitting an equivalence group', () => {
     const rows = [
       { id: 'n_03', equivalenceKey: 'source-a' },

--- a/scripts/notification-conversation-backfill.ts
+++ b/scripts/notification-conversation-backfill.ts
@@ -12,6 +12,7 @@ const argumentNames = [
   'batch-size',
   'max-batches',
   'max-equivalence-group-rows',
+  'source-concurrency',
 ] as const;
 
 for (const value of args) {
@@ -65,12 +66,14 @@ async function main(): Promise<void> {
   const batchSize = positiveInteger('batch-size');
   const maxBatches = positiveInteger('max-batches');
   const maxEquivalenceGroupRows = positiveInteger('max-equivalence-group-rows');
+  const sourceConcurrency = positiveInteger('source-concurrency');
   const result = await runNotificationConversationBackfill(db, {
     ...(organizationIds.length === 0 ? {} : { organizationIds }),
     ...(requestedPhases === undefined ? {} : { phases: requestedPhases }),
     ...(batchSize === undefined ? {} : { batchSize }),
     ...(maxBatches === undefined ? {} : { maxBatches }),
     ...(maxEquivalenceGroupRows === undefined ? {} : { maxEquivalenceGroupRows }),
+    ...(sourceConcurrency === undefined ? {} : { sourceConcurrency }),
   });
   console.log(JSON.stringify(result, null, 2));
 }

--- a/tests/notification-conversation-cli.test.ts
+++ b/tests/notification-conversation-cli.test.ts
@@ -1,5 +1,27 @@
 import { expect, it } from 'bun:test';
 
+for (const value of ['0', '9', '1.5', 'invalid']) {
+  it(`backfill rejects unsafe source concurrency ${value}`, async () => {
+    const child = Bun.spawn(
+      [
+        'bun',
+        'scripts/notification-conversation-backfill.ts',
+        '--all',
+        `--source-concurrency=${value}`,
+      ],
+      {
+        cwd: `${import.meta.dir}/..`,
+        env: { ...process.env, DATABASE_URL: 'postgres://orbit:orbit@127.0.0.1:1/orbit_test' },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    );
+    const [code, error] = await Promise.all([child.exited, new Response(child.stderr).text()]);
+    expect(code).not.toBe(0);
+    expect(error).toMatch(/positive integer|between 1 and 8/);
+  });
+}
+
 for (const script of ['backfill', 'verify']) {
   for (const args of [[], ['--all', '--organization=example'], ['--organization=']]) {
     it(`${script} refuses unsafe organization scope ${JSON.stringify(args)}`, async () => {


### PR DESCRIPTION
## Summary
Add --source-concurrency=1..8 to the notification history backfill, defaulting to serial execution. Resolve and classify independent source groups in bounded windows. Drain started work before reporting failure, preserve cursor ordering and complete equivalence groups, and reject overlapping groups before classification. Other phases remain sequential. Document the restart and rollout procedure.

## Evidence
The production rollout was spending roughly half a second per database round trip. The serial source phase was the main bottleneck.

- Regression demonstrated maximum concurrency 1 before the fix and 3 after it.
- Failure regression confirms started work settles before a failed checkpoint, then the same run resumes to zero drift.
- Services suite: 846 passed, 5 optional storage tests skipped, no failures.
- CLI safeguards: 10 passed.
- Private pre-migration production backup restored locally, all 9 pending migrations applied, eight-worker backfill completed for all 10 organizations, and every verifier drift counter is zero.
- Full local verification is being rerun after restoring local database and Redis prerequisites. CI is required before merge.

## Rollout
PR #443 is already merged and deployed. The authorized production backfill has resumed from its saved checkpoint using the rehearsed eight-worker Node bundle. Provider delivery and grouped reads remain paused until production verification returns zero drift. No schema migration is introduced by this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds opt-in bounded concurrency to notification source resolution and classification while preserving serial execution by default.

- Adds and validates `sourceConcurrency` from the service API through the CLI.
- Resolves and applies independent source groups in bounded windows, draining started promises before propagating failures.
- Rejects overlapping equivalence groups before concurrent application.
- Adds concurrency, failure-recovery, and CLI validation coverage.
- Documents operational safeguards, restart behavior, verification, and rollout sequencing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security defects identified in the changed paths.

The bounded-window implementation validates concurrency, preserves seed-order cursor advancement, prevents overlapping groups from being applied concurrently, drains started operations on failure, and retains resumable checkpoint behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/services/src/notifications/conversation-backfill.ts | Adds validated bounded concurrency for source resolution and transactional group application while preserving ordered planning, overlap rejection, and checkpoint semantics. |
| packages/services/tests/notifications/conversation-backfill.test.ts | Adds integration coverage for maximum concurrency, draining work after failure, resumability, verification, and invalid concurrency values. |
| scripts/notification-conversation-backfill.ts | Exposes the source-concurrency option through the backfill CLI and delegates upper-bound validation to the service. |
| tests/notification-conversation-cli.test.ts | Verifies that zero, excessive, fractional, and nonnumeric concurrency arguments fail before useful execution. |
| docs/database-releases.md | Documents safe backfill rollout, concurrency limits, restart behavior, feature flags, and required drift verification. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Read ordered source seeds] --> B[Split into bounded windows]
  B --> C[Resolve every seed in window concurrently]
  C --> D{Any resolution failed?}
  D -- Yes --> E[Drain window and report failure]
  D -- No --> F[Build complete source groups in seed order]
  F --> G{Next group exceeds batch bound?}
  G -- Yes --> H[Defer group without advancing past it]
  G -- No --> I[Add or merge group and advance cursor]
  I --> F
  H --> J[Reject overlapping notification IDs]
  F --> J
  J --> K[Apply independent groups concurrently]
  K --> L{Every started transaction succeeded?}
  L -- No --> M[Drain work and preserve prior checkpoint]
  L -- Yes --> N[Persist ordered cursor and processed count]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(notifications): bound concurrent hi..."](https://github.com/noveum/orbit/commit/caef10385f1e2d5cdb424a894754d4daee9bd3ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61576103)</sub>

<!-- /greptile_comment -->