### PR TITLE
fix(notifications): bound verifier checks and preserve comment access

### DIFF
--- a/packages/core/tests/notifications/conversation-service.test.ts
+++ b/packages/core/tests/notifications/conversation-service.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { and, db, eq, schema } from '@orbit/db';
-import { notifyMany } from '@orbit/services/notifications';
+import { notifyMany, runNotificationConversationBackfill } from '@orbit/services/notifications';
+import { randomUUIDv7 } from '@orbit/shared/utils';
+import { createComment } from '../../src/content/comment-service.ts';
 import { createDocComment } from '../../src/content/doc-comment-service.ts';
 import { createDoc, setDocAccess, updateDoc } from '../../src/content/doc-service.ts';
 import {
@@ -18,6 +20,7 @@ import {
   resetDatabase,
   type Workspace,
 } from '../../src/test-support.ts';
+import { createIssue } from '../../src/work/issue-service.ts';
 
 let workspace: Workspace;
 
@@ -62,6 +65,53 @@ async function emit(
 }
 
 describe('conversation inbox', () => {
+  it('opens historical issue comments and denies history after team access is revoked', async () => {
+    const recipient = await addMember(workspace, 'member', { name: 'Reader' });
+    const { issue } = await createIssue(workspace.admin, {
+      teamId: workspace.teamId,
+      title: 'Historical discussion',
+    });
+    const { comment } = await createComment(workspace.admin, issue.id, { body: 'Old comment' });
+    const notificationId = randomUUIDv7();
+    await db.insert(schema.notification).values({
+      id: notificationId,
+      organizationId: workspace.organizationId,
+      userId: recipient.user.id,
+      actorId: workspace.admin.userId,
+      actorName: 'Admin',
+      type: 'comment_added',
+      entityType: 'comment',
+      entityId: comment.id,
+      title: 'Historical issue comment',
+      url: `/issues/${issue.id}`,
+      deliveredChannels: ['inbox'],
+    });
+    await runNotificationConversationBackfill(db, {
+      organizationIds: [workspace.organizationId],
+    });
+    const page = await listInboxConversations(recipient.principal);
+    const conversation = page.conversations.find((row) => row.subjectId === notificationId);
+    expect(
+      page.conversations.map((row) => ({ id: row.subjectId, type: row.subjectType })),
+    ).toContainEqual({ id: notificationId, type: 'legacy_notification' });
+    const conversationId = conversation?.id ?? '';
+    const history = await listInboxConversationEvents(recipient.principal, conversationId);
+    expect(history.events[0]?.title).toBe('Historical issue comment');
+    await expect(getInboxConversation(workspace.admin, conversationId)).rejects.toThrow();
+    await db
+      .delete(schema.teamMember)
+      .where(
+        and(
+          eq(schema.teamMember.teamId, workspace.teamId),
+          eq(schema.teamMember.userId, recipient.user.id),
+        ),
+      );
+    await expect(
+      listInboxConversationEvents(recipient.principal, conversationId),
+    ).rejects.toThrow();
+    expect((await listInboxConversations(recipient.principal)).conversations).toHaveLength(0);
+  });
+
   it('groups events, filters mentions before pagination, and returns ordered history', async () => {
     const { recipient, doc } = await fixture();
     await emit(doc.id, recipient.user.id, 1, 'mention');

--- a/packages/services/src/notifications/conversation-access.ts
+++ b/packages/services/src/notifications/conversation-access.ts
@@ -123,6 +123,26 @@ export async function lockNotificationSubjectAccess(
       subjectId: event.entityId,
     });
   }
+  if (input.subjectType === 'comment' && subjectId !== undefined) {
+    const [comment] = await tx
+      .select({ issueId: schema.comment.issueId })
+      .from(schema.comment)
+      .where(
+        and(
+          eq(schema.comment.id, subjectId),
+          eq(schema.comment.organizationId, input.organizationId),
+        ),
+      )
+      .for('share');
+    return (
+      comment !== undefined &&
+      (await lockNotificationSubjectAccess(tx, {
+        ...input,
+        subjectType: 'issue',
+        subjectId: comment.issueId,
+      }))
+    );
+  }
   if (input.subjectType === 'doc_comment' && subjectId !== undefined) {
     const [comment] = await tx
       .select({ docId: schema.docComment.docId })

--- a/packages/services/src/notifications/conversation-backfill.ts
+++ b/packages/services/src/notifications/conversation-backfill.ts
@@ -2,7 +2,10 @@ import type { Database, Transaction } from '@orbit/db';
 import { PULL_REQUEST_NOTIFICATION_TYPES } from '@orbit/shared';
 import { randomUUIDv7 } from '@orbit/shared/utils';
 import { sql } from 'drizzle-orm';
-import { lockNotificationSubjectAccess } from './conversation-access.ts';
+import {
+  lockNotificationSubjectAccess,
+  notificationSubjectAccessMap,
+} from './conversation-access.ts';
 import {
   type NotificationConversationIdentity,
   resolveNotificationConversation,
@@ -2878,31 +2881,41 @@ export async function verifyNotificationConversationBackfill(
       sql`select id from organization where id = ${organizationId}`,
     );
     if (existing.length === 0) throw new Error(`Organization ${organizationId} does not exist.`);
-    const drift = await database.transaction(async (tx) => {
-      const drift = await verifyOrganizationBackfill(tx, organizationId, now);
-      const conversations = await tx.execute<{
-        subjectType: string;
-        subjectId: string;
-        userId: string;
-        hidden: boolean;
-      }>(sql`
-        select subject_type as "subjectType", subject_id as "subjectId", user_id as "userId", access_hidden_at is not null as hidden
-        from notification_conversation where organization_id = ${organizationId} order by subject_type, subject_id, user_id
+    const drift = await database.transaction(async (tx) =>
+      verifyOrganizationBackfill(tx, organizationId, now),
+    );
+    const conversations = await database.execute<{
+      id: string;
+      subjectType: string;
+      subjectId: string;
+      userId: string;
+      hidden: boolean;
+    }>(sql`
+        select id, subject_type as "subjectType", subject_id as "subjectId", user_id as "userId", access_hidden_at is not null as hidden
+        from notification_conversation where organization_id = ${organizationId} order by user_id, id
       `);
-      let accessStateDrift = 0;
-      for (const row of conversations) {
-        const allowed = await lockNotificationSubjectAccess(tx, {
-          organizationId,
-          userId: row.userId,
-          subjectType: row.subjectType,
-          subjectId: row.subjectId,
-        });
-        if (allowed === row.hidden) accessStateDrift += 1;
-      }
-      return { ...drift, accessStateDrift };
-    });
-    organizations.push({ organizationId, drift });
-    totals = addBackfillDrift(totals, drift);
+    let accessStateDrift = 0;
+    for (let offset = 0; offset < conversations.length; ) {
+      const userId = conversations[offset]?.userId;
+      if (userId === undefined) break;
+      const batch = conversations.slice(offset, offset + 50).filter((row) => row.userId === userId);
+      accessStateDrift += await database.transaction(async (tx) => {
+        await tx.execute(sql`set local lock_timeout = '2s'`);
+        await tx.execute(sql`set local statement_timeout = '10s'`);
+        const access = await notificationSubjectAccessMap(tx, organizationId, userId, batch);
+        const current = await tx.execute<{ id: string; hidden: boolean }>(sql`
+          select id, access_hidden_at is not null as hidden
+          from notification_conversation
+          where organization_id = ${organizationId} and user_id = ${userId}
+            and id in (${sqlList(batch.map((row) => row.id))})
+        `);
+        return current.filter((row) => access.get(row.id) === row.hidden).length;
+      });
+      offset += batch.length;
+    }
+    const verified = { ...drift, accessStateDrift };
+    organizations.push({ organizationId, drift: verified });
+    totals = addBackfillDrift(totals, verified);
   }
   return { ok: driftIsZero(totals), organizations, totals };
 }

--- a/packages/services/tests/notifications/conversation-backfill.test.ts
+++ b/packages/services/tests/notifications/conversation-backfill.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { db } from '@orbit/db';
+import { db, pool, schema } from '@orbit/db';
 import {
   integration,
   notification,
@@ -14,6 +14,7 @@ import {
 } from '@orbit/db/schema';
 import { randomUUIDv7 } from '@orbit/shared/utils';
 import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/postgres-js';
 import {
   type ConversationBackfillBatchResult,
   type ConversationBackfillPhase,
@@ -75,6 +76,69 @@ function delivery(
 }
 
 describe('conversation backfill planning', () => {
+  it('verifies historical access without one query sequence per conversation', async () => {
+    const suffix = randomUUIDv7();
+    const organizationId = `org_verify_${suffix}`;
+    const userId = `usr_verify_${suffix}`;
+    await db.insert(organization).values({ id: organizationId, name: 'Verifier', slug: suffix });
+    await db
+      .insert(user)
+      .values({ id: userId, name: 'Verifier', handle: suffix, email: `${suffix}@orbit.local` });
+    try {
+      await db.insert(notification).values(
+        Array.from({ length: 55 }, (_, index) => ({
+          id: `ntf_verify_${suffix}_${index}`,
+          organizationId,
+          userId,
+          type: 'comment_created',
+          reason: 'commented' as const,
+          actorId: userId,
+          actorName: 'Verifier',
+          entityType: 'issue',
+          entityId: `missing_${index}`,
+          title: 'Historical comment',
+          body: '',
+          url: `/issues/missing_${index}`,
+          deliveredChannels: ['inbox'],
+          createdAt: january,
+        })),
+      );
+      await runNotificationConversationBackfill(db, { organizationIds: [organizationId] });
+      let queries = 0;
+      const observed = drizzle(pool, {
+        schema,
+        logger: {
+          logQuery() {
+            queries += 1;
+          },
+        },
+      });
+      const result = await verifyNotificationConversationBackfill(observed, {
+        organizationIds: [organizationId],
+      });
+      expect(result.ok).toBe(true);
+      expect(queries).toBeLessThan(50);
+      const [conversation] = await db
+        .select({ id: notificationConversation.id })
+        .from(notificationConversation)
+        .where(eq(notificationConversation.organizationId, organizationId))
+        .limit(1);
+      if (conversation === undefined) throw new Error('Missing backfilled conversation');
+      await db
+        .update(notificationConversation)
+        .set({ accessHiddenAt: null })
+        .where(eq(notificationConversation.id, conversation.id));
+      const drift = await verifyNotificationConversationBackfill(observed, {
+        organizationIds: [organizationId],
+      });
+      expect(drift.ok).toBe(false);
+      expect(drift.totals.accessStateDrift).toBe(1);
+    } finally {
+      await db.delete(organization).where(eq(organization.id, organizationId));
+      await db.delete(user).where(eq(user.id, userId));
+    }
+  });
+
   it('bounds concurrent source work and verifies all historical rows after completion', async () => {
     const suffix = randomUUIDv7();
     const organizationId = `org_parallel_${suffix}`;


### PR DESCRIPTION
## Summary
- Verify access in batches of at most 50 conversations per recipient using the existing batch policy checker.
- Release policy and row locks between batches, with bounded lock and statement timeouts.
- Read current hidden state after acquiring access locks and preserve all structural drift checks.

## Production finding
The previous verifier held a transaction for more than 20 minutes while performing per-conversation network round trips. Production updates waited on its shared row locks. The read-only verification process was stopped, its transaction rolled back, and blocked sessions returned to zero. The completed backfill was not modified.

## Verification
- Regression reproduced the excessive query count before the fix.
- 15 backfill tests passed; the query-budget regression covers multiple batches and still detects incorrect hidden state.
- 8 authorization tests passed, including revoked document access and cross-workspace handling.
- Full repository verification is running; production retry uses the fixed short-batch CLI with providers still paused.
- No schema migration or provider resend is introduced.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR bounds notification conversation access verification to short, recipient-scoped transactions and adds issue-based authorization for historical comment notifications.
- Verifies at most 50 conversations per recipient in each transaction.
- Applies bounded lock and statement timeouts and re-reads hidden state after access locks are acquired.
- Resolves comment access through the comment’s organization-scoped issue.
- Adds regression coverage for query bounds, drift detection, historical comment access, and revoked team membership.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/services/src/notifications/conversation-backfill.ts | Replaces long per-organization access verification with bounded per-recipient batches and current-state comparison inside short transactions. |
| packages/services/src/notifications/conversation-access.ts | Adds organization-scoped comment lookup and delegates authorization to the associated issue’s existing access policy. |
| packages/core/tests/notifications/conversation-service.test.ts | Covers historical issue-comment history while authorized and denial after team access is revoked. |
| packages/services/tests/notifications/conversation-backfill.test.ts | Covers multi-batch query bounds and verifies that incorrect hidden state is still detected. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant V as Backfill verifier
  participant DB as Database
  participant P as Access policy
  V->>DB: Load organization conversations ordered by user and id
  loop Each recipient batch (max 50)
    V->>DB: Begin short transaction
    V->>DB: Set lock and statement timeouts
    V->>P: Resolve batched subject access
    P->>DB: Acquire policy and subject locks
    V->>DB: Re-read current hidden state
    V->>V: Count access-state drift
    V->>DB: Commit and release locks
  end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(notifications): authorize historical..."](https://github.com/noveum/orbit/commit/4efb9485351e3b39980b690312b4b39e6aeac318) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61636344)</sub>

<!-- /greptile_comment -->