### PR TITLE
fix(notifications): suppress stale CI alerts and improve Slack summaries

### DIFF
--- a/docs/features/inbox.md
+++ b/docs/features/inbox.md
@@ -28,6 +28,11 @@ GitHub check notifications describe current PR-head transitions. Old-head
 failures remain history without changing current status. Several failing jobs
 on one commit do not create several failure notifications.
 
+Before sending a queued CI failure to Slack or email, the worker checks that the
+PR is still open, still on that commit, and still failing. Superseded failures
+stay in the audit history but are not delivered. Resuming a paused queue must
+not replay failure alerts for every earlier commit.
+
 ## Reading and triage
 
 Activity, Status, Unread, Mentions and Pull requests filter on the server before
@@ -48,13 +53,22 @@ disabled. Personal DMs and admin-managed channel mappings are separate routes.
 A PR connected to several issues does not multiply messages to the same channel.
 
 Each Slack update includes an Orbit link and, when available, a separate GitHub
-or source link. Long comments use a bounded excerpt. Untrusted comment text does
-not automatically trigger Slack channel or user mentions.
+or source link. CI alerts identify the commit and up to three failed checks,
+including timeout or cancellation when GitHub supplies that conclusion. The
+source button opens the failed check when its URL is available. It does not
+invent an error diagnosis from build logs that Orbit has not fetched.
+
+Comment previews use readable plain text, at most two nonempty lines and about
+400 escaped characters, instead of raw Markdown or HTML. Full content remains
+available through the links. Untrusted comment text does not automatically
+trigger Slack channel or user mentions. Roots no longer repeat a thread-guidance
+footer, and replies never broadcast back to the channel.
 
 ![A local preview of the Slack root, reply and document message](../assets/screenshots/notification-slack-formatter-preview.png)
 
-This preview renders the actual formatter's blocks with sample data. It is not
-a message sent to Slack; the Slack client's final layout can differ.
+This earlier preview renders formatter blocks with sample data, not production
+messages. The current layout uses shorter previews and omits the guidance
+footer shown above. The Slack client's final layout can differ.
 
 Notification email uses Resend and a verified address. Neither Slack nor email
 is recorded as delivered until the provider confirms a message identity.
@@ -74,6 +88,16 @@ destination for the original message. There is no documented Slack send
 idempotency guarantee. A reconnect to another Slack team/app cannot reuse an old
 destination or thread. Notification email freezes its first attempted request
 and reuses its idempotency key only within the permitted retention window.
+
+An obsolete CI alert is also marked `unavailable`, with
+`github_check_failure_superseded`, without starting a provider request. Already
+delivered messages are not deleted or rewritten by this check.
+
+Historical notifications without canonical source identity can still appear as
+separate conversations. In particular, older issue-comment records need a
+separate parent-issue regrouping repair. Similar titles alone are not proof of
+duplicate events. Such a repair must preserve read state, recipients, source
+identities and delivery confirmations; do not reset or resend provider records.
 
 ## Deployment and migration
 

--- a/packages/services/src/github/apply.ts
+++ b/packages/services/src/github/apply.ts
@@ -483,7 +483,7 @@ async function githubCheckFailureNotifications(
       entityId: pull.id,
       userIds,
       title: `Checks failed on ${pull.title}`,
-      body: `${context.repo.repositoryName}#${pull.number}`,
+      body: `${context.repo.repositoryName}#${pull.number}\nCommit ${pull.headSha.slice(0, 7)}`,
       url: `/pulls/${pull.id}`,
       externalUrl: externalUrl.length > 0 ? externalUrl : pull.url,
       source: {

--- a/packages/services/src/github/apply.ts
+++ b/packages/services/src/github/apply.ts
@@ -458,7 +458,6 @@ async function githubCheckFailureNotifications(
     normalized?.kind === 'context'
       ? normalized.providerUpdatedAt
       : context.event.activity.occurredAt;
-  const externalUrl = normalized?.kind === 'context' ? normalized.url : '';
   return await Promise.all(
     pulls.map(async (pull): Promise<NotificationEvent> => {
       const linkedIssueIds = linkedIssueIdsByPull.get(pull.id) ?? [];
@@ -490,7 +489,7 @@ async function githubCheckFailureNotifications(
         title: `Checks failed on ${pull.title}`,
         body: details.body,
         url: `/pulls/${pull.id}`,
-        externalUrl: externalUrl.length > 0 ? externalUrl : details.externalUrl,
+        externalUrl: details.externalUrl,
         source: {
           sourceEventKey: `github-pr:${context.repo.repositoryId}:${pull.number}:${pull.headSha}:checks-failed`,
           subjectType: 'github_pull_request',

--- a/packages/services/src/github/apply.ts
+++ b/packages/services/src/github/apply.ts
@@ -33,6 +33,7 @@ import { declaredIssueIdentifiers, randomUUIDv7 } from '@orbit/shared/utils';
 import { and, asc, eq, getTableColumns, inArray, lte, or, sql } from 'drizzle-orm';
 import type { NotificationEvent } from '../notifications/index.ts';
 import type { GithubPullRequestHistoryEntry } from './app.ts';
+import { githubFailureDetails } from './failure-details.ts';
 import {
   canAdvance,
   type NormalizedGithubCheckContext,
@@ -458,50 +459,55 @@ async function githubCheckFailureNotifications(
       ? normalized.providerUpdatedAt
       : context.event.activity.occurredAt;
   const externalUrl = normalized?.kind === 'context' ? normalized.url : '';
-  return pulls.map((pull) => {
-    const linkedIssueIds = linkedIssueIdsByPull.get(pull.id) ?? [];
-    const linkedUserIds = linkedIssueIds.flatMap((issueId) => context.audiences.get(issueId) ?? []);
-    const unlinkedCandidate = unlinkedCandidates.get(pull.id) ?? null;
-    const userIds = checkFailureUserIds(
-      linkedUserIds,
-      unlinkedCandidate,
-      linkedIssueIds.length === 0 ? authorizedUnlinked : authorizedLinkedAuthors,
-    );
-    const teamIds = unique([
-      ...context.defaultTeamIds,
-      ...linkedIssueIds.flatMap((issueId) => {
-        const linked = issueById.get(issueId);
-        return linked === undefined ? [] : [linked.teamId];
-      }),
-    ]);
-    return {
-      organizationId: context.repo.organizationId,
-      type: 'pr_checks_failed',
-      reason: 'subscribed',
-      actor: context.actor,
-      entityType: 'github_pull_request',
-      entityId: pull.id,
-      userIds,
-      title: `Checks failed on ${pull.title}`,
-      body: `${context.repo.repositoryName}#${pull.number}\nCommit ${pull.headSha.slice(0, 7)}`,
-      url: `/pulls/${pull.id}`,
-      externalUrl: externalUrl.length > 0 ? externalUrl : pull.url,
-      source: {
-        sourceEventKey: `github-pr:${context.repo.repositoryId}:${pull.number}:${pull.headSha}:checks-failed`,
-        subjectType: 'github_pull_request',
-        subjectKey: `github-pr:${context.repo.repositoryId}:${pull.number}`,
-        occurredAt: eventDate(providerOccurredAt, context.now),
-        teamIds,
-        payload: {
-          action: context.event.action,
-          headSha: pull.headSha,
-          repository: context.event.repository,
-          pullRequestId: pull.id,
-          pullRequestNumber: pull.number,
+  return await Promise.all(
+    pulls.map(async (pull): Promise<NotificationEvent> => {
+      const linkedIssueIds = linkedIssueIdsByPull.get(pull.id) ?? [];
+      const linkedUserIds = linkedIssueIds.flatMap(
+        (issueId) => context.audiences.get(issueId) ?? [],
+      );
+      const unlinkedCandidate = unlinkedCandidates.get(pull.id) ?? null;
+      const userIds = checkFailureUserIds(
+        linkedUserIds,
+        unlinkedCandidate,
+        linkedIssueIds.length === 0 ? authorizedUnlinked : authorizedLinkedAuthors,
+      );
+      const teamIds = unique([
+        ...context.defaultTeamIds,
+        ...linkedIssueIds.flatMap((issueId) => {
+          const linked = issueById.get(issueId);
+          return linked === undefined ? [] : [linked.teamId];
+        }),
+      ]);
+      const details = await githubFailureDetails(database, pull);
+      return {
+        organizationId: context.repo.organizationId,
+        type: 'pr_checks_failed',
+        reason: 'subscribed',
+        actor: context.actor,
+        entityType: 'github_pull_request',
+        entityId: pull.id,
+        userIds,
+        title: `Checks failed on ${pull.title}`,
+        body: details.body,
+        url: `/pulls/${pull.id}`,
+        externalUrl: externalUrl.length > 0 ? externalUrl : details.externalUrl,
+        source: {
+          sourceEventKey: `github-pr:${context.repo.repositoryId}:${pull.number}:${pull.headSha}:checks-failed`,
+          subjectType: 'github_pull_request',
+          subjectKey: `github-pr:${context.repo.repositoryId}:${pull.number}`,
+          occurredAt: eventDate(providerOccurredAt, context.now),
+          teamIds,
+          payload: {
+            action: context.event.action,
+            headSha: pull.headSha,
+            repository: context.event.repository,
+            pullRequestId: pull.id,
+            pullRequestNumber: pull.number,
+          },
         },
-      },
-    };
-  });
+      };
+    }),
+  );
 }
 
 function checkFailureUserIds(

--- a/packages/services/src/github/failure-details.ts
+++ b/packages/services/src/github/failure-details.ts
@@ -42,7 +42,12 @@ export async function githubFailureDetails(
   const names = failures.slice(0, 3).map(({ payload }) => {
     const context = payload['context'];
     const name =
-      typeof context === 'string' ? context.replace(/\s+/g, ' ').slice(0, 80) : 'CI check';
+      typeof context === 'string'
+        ? context
+            .replace(/\s+/g, ' ')
+            .slice(0, 80)
+            .replace(/[\uD800-\uDBFF]$/u, '')
+        : 'CI check';
     const conclusion = payload['conclusion'];
     if (conclusion === 'timed_out') return `${name} (timed out)`;
     if (conclusion === 'cancelled') return `${name} (cancelled)`;
@@ -58,7 +63,7 @@ export async function githubFailureDetails(
   if (typeof candidate === 'string') {
     try {
       const parsed = new URL(candidate);
-      if (parsed.protocol === 'https:' || parsed.protocol === 'http:') externalUrl = parsed.href;
+      if (parsed.protocol === 'https:') externalUrl = parsed.href;
     } catch {
       externalUrl = pull.url;
     }

--- a/packages/services/src/github/failure-details.ts
+++ b/packages/services/src/github/failure-details.ts
@@ -1,0 +1,70 @@
+import { type Database, schema, type Transaction } from '@orbit/db';
+import { and, asc, eq } from 'drizzle-orm';
+
+export async function githubFailureDetails(
+  database: Database | Transaction,
+  pull: Pick<
+    typeof schema.githubPullRequest.$inferSelect,
+    | 'id'
+    | 'organizationId'
+    | 'repositorySyncId'
+    | 'repositoryName'
+    | 'number'
+    | 'headSha'
+    | 'headEpoch'
+    | 'url'
+  >,
+) {
+  const projection = schema.githubPullRequestCheckContext;
+  const activity = schema.githubCheckActivity;
+  const failures = await database
+    .select({ payload: activity.payload })
+    .from(projection)
+    .innerJoin(
+      activity,
+      and(
+        eq(activity.id, projection.latestActivityId),
+        eq(activity.organizationId, projection.organizationId),
+      ),
+    )
+    .where(
+      and(
+        eq(projection.organizationId, pull.organizationId),
+        eq(projection.repositorySyncId, pull.repositorySyncId),
+        eq(projection.pullRequestId, pull.id),
+        eq(projection.headSha, pull.headSha),
+        eq(projection.capturedHeadEpoch, pull.headEpoch),
+        eq(projection.projectedState, 'failure'),
+      ),
+    )
+    .orderBy(asc(projection.contextKey))
+    .limit(4);
+  const names = failures.slice(0, 3).map(({ payload }) => {
+    const context = payload['context'];
+    const name =
+      typeof context === 'string' ? context.replace(/\s+/g, ' ').slice(0, 80) : 'CI check';
+    const conclusion = payload['conclusion'];
+    if (conclusion === 'timed_out') return `${name} (timed out)`;
+    if (conclusion === 'cancelled') return `${name} (cancelled)`;
+    if (conclusion === 'action_required') return `${name} (action required)`;
+    return name;
+  });
+  const failed =
+    names.length === 0
+      ? 'See GitHub for check details'
+      : `Failed: ${names.join(', ')}${failures.length > 3 ? ', and more' : ''}`;
+  let externalUrl = pull.url;
+  const candidate = failures[0]?.payload['url'];
+  if (typeof candidate === 'string') {
+    try {
+      const parsed = new URL(candidate);
+      if (parsed.protocol === 'https:' || parsed.protocol === 'http:') externalUrl = parsed.href;
+    } catch {
+      externalUrl = pull.url;
+    }
+  }
+  return {
+    body: `${pull.repositoryName}#${pull.number} · Commit ${pull.headSha.slice(0, 7)}\n${failed}`,
+    externalUrl,
+  };
+}

--- a/packages/services/src/github/failure-details.ts
+++ b/packages/services/src/github/failure-details.ts
@@ -63,12 +63,13 @@ export async function githubFailureDetails(
   if (typeof candidate === 'string') {
     try {
       const parsed = new URL(candidate);
-      if (parsed.protocol === 'https:') externalUrl = parsed.href;
+      if (parsed.protocol === 'https:' && parsed.href.length <= 2048) externalUrl = parsed.href;
     } catch {
       externalUrl = pull.url;
     }
   }
   return {
+    bodyFormat: 'plain_text' as const,
     body: `${pull.repositoryName}#${pull.number} · Commit ${pull.headSha.slice(0, 7)}\n${failed}`,
     externalUrl,
   };

--- a/packages/services/src/github/notifications.ts
+++ b/packages/services/src/github/notifications.ts
@@ -13,6 +13,7 @@ import { unique } from '@orbit/shared';
 import { isInOrganization, isInTeam, type Principal, policyRole } from '@orbit/shared/policy';
 import { and, asc, eq, inArray } from 'drizzle-orm';
 import { type NotificationEvent, notifyMany } from '../notifications/index.ts';
+import { githubFailureDetails } from './failure-details.ts';
 import type { GithubCheckFailureTransition } from './reconciliation.ts';
 
 type GithubNotificationDatabase = Database | Transaction;
@@ -257,6 +258,7 @@ export async function githubCheckFailureTransitionEvents(
     );
     let teamIds = linked.map((entry) => entry.teamId);
     if (linked.length === 0 && repository.teamId !== null) teamIds = [repository.teamId];
+    const details = await githubFailureDetails(database, pull);
     events.push({
       organizationId: transition.organizationId,
       type: 'pr_checks_failed' as const,
@@ -266,9 +268,9 @@ export async function githubCheckFailureTransitionEvents(
       entityId: pull.id,
       userIds,
       title: `Checks failed on ${pull.title}`,
-      body: `${repository.repositoryName}#${pull.number}\nCommit ${pull.headSha.slice(0, 7)}`,
+      body: details.body,
       url: `/pulls/${pull.id}`,
-      externalUrl: pull.url,
+      externalUrl: details.externalUrl,
       source: {
         sourceEventKey: `github-pr:${repository.repositoryId}:${pull.number}:${pull.headSha}:checks-failed`,
         subjectType: 'github_pull_request',

--- a/packages/services/src/github/notifications.ts
+++ b/packages/services/src/github/notifications.ts
@@ -266,7 +266,7 @@ export async function githubCheckFailureTransitionEvents(
       entityId: pull.id,
       userIds,
       title: `Checks failed on ${pull.title}`,
-      body: `${repository.repositoryName}#${pull.number}`,
+      body: `${repository.repositoryName}#${pull.number}\nCommit ${pull.headSha.slice(0, 7)}`,
       url: `/pulls/${pull.id}`,
       externalUrl: pull.url,
       source: {

--- a/packages/services/src/notifications/provider-outbox.ts
+++ b/packages/services/src/notifications/provider-outbox.ts
@@ -416,6 +416,30 @@ async function subjectAllowed(tx: Transaction, delivery: Delivery, subject: Prov
   });
 }
 
+async function subjectStillRelevant(tx: Transaction, delivery: Delivery, subject: ProviderSubject) {
+  const type = subject.recipientEvent?.type ?? delivery.providerPayload?.['notificationType'];
+  if (type !== 'pr_checks_failed') return true;
+  const pullRequestId = subject.source?.payload?.['pullRequestId'];
+  const headSha = subject.source?.payload?.['headSha'];
+  if (typeof pullRequestId !== 'string' || typeof headSha !== 'string' || headSha.length === 0)
+    return false;
+  const [pull] = await tx
+    .select({ id: schema.githubPullRequest.id })
+    .from(schema.githubPullRequest)
+    .where(
+      and(
+        eq(schema.githubPullRequest.organizationId, delivery.organizationId ?? ''),
+        eq(schema.githubPullRequest.id, pullRequestId),
+        eq(schema.githubPullRequest.headSha, headSha),
+        eq(schema.githubPullRequest.checkStatus, 'failure'),
+        eq(schema.githubPullRequest.state, 'open'),
+        eq(schema.githubPullRequest.merged, false),
+      ),
+    )
+    .for('share');
+  return pull !== undefined;
+}
+
 async function slackConnection(
   tx: Transaction,
   delivery: Delivery,
@@ -642,6 +666,17 @@ async function recordProviderStart(
   return started;
 }
 
+function providerPreflightError(
+  allowed: boolean,
+  relevant: boolean,
+  destinationError: string | null,
+  recipientError: string | null,
+) {
+  if (!allowed) return 'subject_access_lost';
+  if (!relevant) return 'github_check_failure_superseded';
+  return destinationError ?? recipientError;
+}
+
 async function preflight(
   database: ProviderDatabase,
   claim: Claim,
@@ -651,6 +686,7 @@ async function preflight(
     const delivery = claim.delivery;
     const subject = await loadProviderSubject(tx, delivery);
     const allowed = await subjectAllowed(tx, delivery, subject);
+    const relevant = await subjectStillRelevant(tx, delivery, subject);
     const destination =
       delivery.channel === 'email'
         ? { token: null, channelId: null, error: null, draining: false }
@@ -670,7 +706,7 @@ async function preflight(
       !threadClaimIsCurrent(thread, delivery)
     )
       return null;
-    const error = allowed ? (destination.error ?? recipient.error) : 'subject_access_lost';
+    const error = providerPreflightError(allowed, relevant, destination.error, recipient.error);
     if (error !== null) {
       await markPreflightUnavailable(tx, current, error, destination.draining, now);
       return null;

--- a/packages/services/src/notifications/provider-outbox.ts
+++ b/packages/services/src/notifications/provider-outbox.ts
@@ -8,6 +8,7 @@ import {
 } from '@orbit/shared';
 import { randomUUIDv7 } from '@orbit/shared/utils';
 import { and, asc, count, eq, inArray, isNull, lte, min, or, sql } from 'drizzle-orm';
+import { githubFailureDetails } from '../github/failure-details.ts';
 import { decryptSlackBotToken } from '../slack/credentials.ts';
 import { SlackApiError, SlackClient } from '../slack/index.ts';
 import {
@@ -416,15 +417,15 @@ async function subjectAllowed(tx: Transaction, delivery: Delivery, subject: Prov
   });
 }
 
-async function subjectStillRelevant(tx: Transaction, delivery: Delivery, subject: ProviderSubject) {
+async function subjectRelevance(tx: Transaction, delivery: Delivery, subject: ProviderSubject) {
   const type = subject.recipientEvent?.type ?? delivery.providerPayload?.['notificationType'];
-  if (type !== 'pr_checks_failed') return true;
+  if (type !== 'pr_checks_failed') return { relevant: true, details: null };
   const pullRequestId = subject.source?.payload?.['pullRequestId'];
   const headSha = subject.source?.payload?.['headSha'];
   if (typeof pullRequestId !== 'string' || typeof headSha !== 'string' || headSha.length === 0)
-    return false;
+    return { relevant: false, details: null };
   const [pull] = await tx
-    .select({ id: schema.githubPullRequest.id })
+    .select()
     .from(schema.githubPullRequest)
     .where(
       and(
@@ -437,7 +438,23 @@ async function subjectStillRelevant(tx: Transaction, delivery: Delivery, subject
       ),
     )
     .for('share');
-  return pull !== undefined;
+  return pull === undefined
+    ? { relevant: false, details: null }
+    : { relevant: true, details: await githubFailureDetails(tx, pull) };
+}
+
+function providerContent(
+  delivery: Delivery,
+  subject: ProviderSubject,
+  details: Awaited<ReturnType<typeof githubFailureDetails>> | null,
+) {
+  const event = subject.recipientEvent;
+  const payload = event ?? delivery.providerPayload;
+  if (details === null) return { event, payload };
+  return {
+    event: event === undefined ? undefined : { ...event, ...details },
+    payload: { ...payload, ...details },
+  };
 }
 
 async function slackConnection(
@@ -686,12 +703,13 @@ async function preflight(
     const delivery = claim.delivery;
     const subject = await loadProviderSubject(tx, delivery);
     const allowed = await subjectAllowed(tx, delivery, subject);
-    const relevant = await subjectStillRelevant(tx, delivery, subject);
+    const relevance = await subjectRelevance(tx, delivery, subject);
+    const content = providerContent(delivery, subject, relevance.details);
     const destination =
       delivery.channel === 'email'
         ? { token: null, channelId: null, error: null, draining: false }
         : await slackDestination(tx, delivery, subject);
-    const recipient = await recipientPreflight(tx, delivery, subject.recipientEvent);
+    const recipient = await recipientPreflight(tx, delivery, content.event);
     const thread = claim.thread === null ? null : await lockThread(tx, delivery);
     const [current] = await tx
       .select()
@@ -706,12 +724,17 @@ async function preflight(
       !threadClaimIsCurrent(thread, delivery)
     )
       return null;
-    const error = providerPreflightError(allowed, relevant, destination.error, recipient.error);
+    const error = providerPreflightError(
+      allowed,
+      relevance.relevant,
+      destination.error,
+      recipient.error,
+    );
     if (error !== null) {
       await markPreflightUnavailable(tx, current, error, destination.draining, now);
       return null;
     }
-    const payload = subject.recipientEvent ?? current.providerPayload;
+    const payload = content.payload;
     if (current.channel !== 'email') {
       const validated = notificationProviderPayloadSchema.parse(payload);
       absoluteNotificationUrl(validated.externalUrl ?? validated.url);

--- a/packages/services/src/slack/notification-threads.ts
+++ b/packages/services/src/slack/notification-threads.ts
@@ -3,7 +3,7 @@ import { renderPlainText } from '../markdown/index.ts';
 import { escapeSlackText, type PostMessageInput } from './index.ts';
 
 function messageExcerpt(value: string): string {
-  const lines = renderPlainText(value.slice(0, 4000))
+  const lines = renderPlainText(value.slice(0, 4000).replace(/[\uD800-\uDBFF]$/u, ''))
     .split(/\n+/)
     .filter((line) => line.trim().length > 0);
   const preview = [lines[0] ?? '', lines.slice(1).join(' ')].filter(Boolean).join('\n');

--- a/packages/services/src/slack/notification-threads.ts
+++ b/packages/services/src/slack/notification-threads.ts
@@ -2,8 +2,9 @@ import { notificationProviderPayloadSchema } from '@orbit/shared';
 import { renderPlainText } from '../markdown/index.ts';
 import { escapeSlackText, type PostMessageInput } from './index.ts';
 
-function messageExcerpt(value: string): string {
-  const lines = renderPlainText(value.slice(0, 4000).replace(/[\uD800-\uDBFF]$/u, ''))
+function messageExcerpt(value: string, format: 'markdown' | 'plain_text'): string {
+  const bounded = value.slice(0, 4000).replace(/[\uD800-\uDBFF]$/u, '');
+  const lines = (format === 'plain_text' ? bounded : renderPlainText(bounded))
     .split(/\n+/)
     .filter((line) => line.trim().length > 0);
   const preview = [lines[0] ?? '', lines.slice(1).join(' ')].filter(Boolean).join('\n');
@@ -50,7 +51,7 @@ export function notificationSlackMessage(input: {
   const payload = notificationProviderPayloadSchema.parse(input.payload);
   const links = messageLinks(payload.url, payload.externalUrl);
   const title = escapeSlackText(payload.title);
-  const body = messageExcerpt(payload.body);
+  const body = messageExcerpt(payload.body, payload.bodyFormat);
   const text = [title, body, ...links.map((link) => `${link.label}: ${link.url}`)]
     .filter((part) => part.length > 0)
     .join('\n');

--- a/packages/services/src/slack/notification-threads.ts
+++ b/packages/services/src/slack/notification-threads.ts
@@ -1,13 +1,19 @@
 import { notificationProviderPayloadSchema } from '@orbit/shared';
+import { renderPlainText } from '../markdown/index.ts';
 import { escapeSlackText, type PostMessageInput } from './index.ts';
 
 function messageExcerpt(value: string): string {
-  const escaped = escapeSlackText(value);
-  if (escaped.length <= 1200) return escaped;
+  const lines = renderPlainText(value.slice(0, 4000))
+    .split(/\n+/)
+    .filter((line) => line.trim().length > 0);
+  const preview = [lines[0] ?? '', lines.slice(1).join(' ')].filter(Boolean).join('\n');
+  const omitted = value.length > 4000;
+  const escaped = escapeSlackText(preview);
+  if (escaped.length <= 400) return `${escaped}${omitted ? '…' : ''}`;
   let excerpt = '';
-  for (const character of value) {
+  for (const character of preview) {
     const next = escapeSlackText(character);
-    if (excerpt.length + next.length > 1199) break;
+    if (excerpt.length + next.length > 399) break;
     excerpt += next;
   }
   return `${excerpt}…`;
@@ -68,19 +74,6 @@ export function notificationSlackMessage(input: {
           url: link.url,
         })),
       },
-      ...(input.rootTs === null
-        ? [
-            {
-              type: 'context',
-              elements: [
-                {
-                  type: 'plain_text',
-                  text: 'Later updates to this conversation appear in this thread.',
-                },
-              ],
-            },
-          ]
-        : []),
     ],
     ...(input.rootTs === null ? {} : { threadTs: input.rootTs }),
     replyBroadcast: false,

--- a/packages/services/tests/github/apply.test.ts
+++ b/packages/services/tests/github/apply.test.ts
@@ -316,6 +316,7 @@ describe('applyGithubEvent', () => {
           expect(event.title.length).toBeLessThanOrEqual(255);
           expect(event.title).toStartWith('Checks failed on ');
           expect(event.body).toContain(`Commit ${HEAD_SHA.slice(0, 7)}`);
+          expect(event.body).toContain('Failed: verify');
           expect(event.title).not.toMatch(/[\uD800-\uDBFF]…$/u);
           expect(event.externalUrl).toBe('https://github.com/acme/web/actions/runs/1');
           expect(event.url).toBe(result.notificationEvents[0]?.url ?? '');

--- a/packages/services/tests/github/apply.test.ts
+++ b/packages/services/tests/github/apply.test.ts
@@ -205,6 +205,7 @@ function checkRunEvent(input: {
   readonly id: number;
   readonly name: string;
   readonly conclusion: string;
+  readonly url?: string;
   readonly headSha?: string;
   readonly appId?: number;
   readonly completedAt?: string;
@@ -220,7 +221,7 @@ function checkRunEvent(input: {
         app: { id: input.appId ?? 10 },
         status: 'completed',
         conclusion: input.conclusion,
-        html_url: `https://github.com/acme/web/actions/runs/${input.id}`,
+        html_url: input.url ?? `https://github.com/acme/web/actions/runs/${input.id}`,
         head_sha: input.headSha ?? HEAD_SHA,
         pull_requests: (input.pullRequestNumbers ?? [7]).map((number) => ({ number })),
         check_suite: { head_branch: 'eng-3-dashboard' },
@@ -295,6 +296,67 @@ async function currentStateName(tx: TestTransaction, issueId: string): Promise<s
 }
 
 describe('applyGithubEvent', () => {
+  it('bounds failure summaries and excludes recovered checks and old head generations', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await applyGithubEvent(tx, prEvent({}));
+      for (const [index, name] of ['alpha', 'beta', 'gamma', 'omega', 'recovered'].entries()) {
+        await applyCheckEvent(
+          tx,
+          fixture.organizationId,
+          checkRunEvent({
+            id: index + 1,
+            name,
+            conclusion: name === 'recovered' ? 'success' : 'failure',
+            completedAt: '2026-08-13T05:00:00.000Z',
+          }),
+        );
+      }
+      const [pull] = await tx
+        .select()
+        .from(githubPullRequest)
+        .where(eq(githubPullRequest.organizationId, fixture.organizationId));
+      if (pull === undefined) throw new Error('Missing pull request');
+      const details = await githubFailureDetails(tx, pull);
+      const shown = details.body.match(/\b(alpha|beta|gamma|omega)\b/g) ?? [];
+      expect(shown).toHaveLength(3);
+      expect(new Set(shown).size).toBe(3);
+      expect(details.body).toContain('and more');
+      expect(details.body).not.toContain('recovered');
+      expect(details.externalUrl).toMatch(
+        /^https:\/\/github\.com\/acme\/web\/actions\/runs\/[1-4]$/,
+      );
+      const laterGeneration = await githubFailureDetails(tx, {
+        ...pull,
+        headEpoch: pull.headEpoch + 1,
+      });
+      expect(laterGeneration.body).not.toContain('Failed:');
+      expect(laterGeneration.externalUrl).toBe(pull.url);
+    });
+  });
+
+  it('uses a secure fallback instead of the triggering check HTTP URL', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await applyGithubEvent(tx, prEvent({}));
+      const result = await applyCheckEvent(
+        tx,
+        fixture.organizationId,
+        checkRunEvent({
+          id: 1,
+          name: 'verify',
+          conclusion: 'failure',
+          completedAt: '2026-08-13T05:00:00.000Z',
+          url: 'http://checks.example.com/run/1',
+        }),
+      );
+      expect(result.notificationEvents).toHaveLength(1);
+      const outcome = await notifyMany(tx, result.notificationEvents, { slackEnabled: false });
+      expect(outcome.notifications.length).toBeGreaterThan(0);
+      expect(outcome.notifications[0]?.externalUrl).toBe('https://github.com/acme/web/pull/7');
+    });
+  });
+
   it('keeps failed-check links secure and check names Unicode-safe', async () => {
     await withRollback(async (tx) => {
       const fixture = await seed(tx);
@@ -314,7 +376,12 @@ describe('applyGithubEvent', () => {
         .from(githubPullRequest)
         .where(eq(githubPullRequest.organizationId, fixture.organizationId));
       if (pull === undefined) throw new Error('Missing pull request');
-      for (const url of ['http://checks.example.com/run/1', 'javascript:alert(1)', 'not a URL']) {
+      for (const url of [
+        'http://checks.example.com/run/1',
+        'javascript:alert(1)',
+        'not a URL',
+        `https://checks.example.com/${'x'.repeat(2048)}`,
+      ]) {
         await tx
           .update(githubCheckActivity)
           .set({

--- a/packages/services/tests/github/apply.test.ts
+++ b/packages/services/tests/github/apply.test.ts
@@ -26,6 +26,7 @@ import {
 import { randomUUIDv7 } from '@orbit/shared/utils';
 import { and, eq } from 'drizzle-orm';
 import { applyGithubEvent, upsertGithubPullRequestHistory } from '../../src/github/apply.ts';
+import { githubFailureDetails } from '../../src/github/failure-details.ts';
 import { notifyMany } from '../../src/notifications/index.ts';
 import { type TestTransaction, withRollback } from '../../src/test-database.ts';
 
@@ -294,6 +295,39 @@ async function currentStateName(tx: TestTransaction, issueId: string): Promise<s
 }
 
 describe('applyGithubEvent', () => {
+  it('keeps failed-check links secure and check names Unicode-safe', async () => {
+    await withRollback(async (tx) => {
+      const fixture = await seed(tx);
+      await applyGithubEvent(tx, prEvent({}));
+      await applyCheckEvent(
+        tx,
+        fixture.organizationId,
+        checkRunEvent({
+          id: 1,
+          name: 'verify',
+          conclusion: 'failure',
+          completedAt: '2026-08-13T05:00:00.000Z',
+        }),
+      );
+      const [pull] = await tx
+        .select()
+        .from(githubPullRequest)
+        .where(eq(githubPullRequest.organizationId, fixture.organizationId));
+      if (pull === undefined) throw new Error('Missing pull request');
+      for (const url of ['http://checks.example.com/run/1', 'javascript:alert(1)', 'not a URL']) {
+        await tx
+          .update(githubCheckActivity)
+          .set({
+            payload: { context: `${'x'.repeat(79)}🙂`, conclusion: 'failure', url },
+          })
+          .where(eq(githubCheckActivity.organizationId, fixture.organizationId));
+        const details = await githubFailureDetails(tx, pull);
+        expect(details.externalUrl).toBe(pull.url);
+        expect(details.body).not.toMatch(/[\uD800-\uDBFF]$/u);
+      }
+    });
+  });
+
   for (const title of ['L'.repeat(256), `${'L'.repeat(236)}😀${'z'.repeat(18)}`]) {
     it('ingests a maximum-length pull title without rejecting its prefixed check notification', async () => {
       await withRollback(async (tx) => {

--- a/packages/services/tests/github/apply.test.ts
+++ b/packages/services/tests/github/apply.test.ts
@@ -315,6 +315,7 @@ describe('applyGithubEvent', () => {
         for (const event of outcome.notifications) {
           expect(event.title.length).toBeLessThanOrEqual(255);
           expect(event.title).toStartWith('Checks failed on ');
+          expect(event.body).toContain(`Commit ${HEAD_SHA.slice(0, 7)}`);
           expect(event.title).not.toMatch(/[\uD800-\uDBFF]…$/u);
           expect(event.externalUrl).toBe('https://github.com/acme/web/actions/runs/1');
           expect(event.url).toBe(result.notificationEvents[0]?.url ?? '');

--- a/packages/services/tests/github/reconciliation.test.ts
+++ b/packages/services/tests/github/reconciliation.test.ts
@@ -398,6 +398,7 @@ describe('reconcileNextGithubCheckHead', () => {
       expect(recipients).toHaveLength(1);
       expect(recipients[0]?.userId).toBe(fixture.userId);
       expect(recipients[0]?.body).toContain(`Commit ${HEAD_SHA.slice(0, 7)}`);
+      expect(recipients[0]?.body).toContain('Failed: verify');
     });
   });
 

--- a/packages/services/tests/github/reconciliation.test.ts
+++ b/packages/services/tests/github/reconciliation.test.ts
@@ -397,6 +397,7 @@ describe('reconcileNextGithubCheckHead', () => {
         .where(eq(notification.organizationId, fixture.organizationId));
       expect(recipients).toHaveLength(1);
       expect(recipients[0]?.userId).toBe(fixture.userId);
+      expect(recipients[0]?.body).toContain(`Commit ${HEAD_SHA.slice(0, 7)}`);
     });
   });
 

--- a/packages/services/tests/notifications/provider-outbox.test.ts
+++ b/packages/services/tests/notifications/provider-outbox.test.ts
@@ -198,9 +198,12 @@ describe('durable notification provider delivery', () => {
             { slackEnabled: true },
           );
           let calls = 0;
-          const fetch = fakeFetch((url) => {
+          const requests: string[] = [];
+          const fetch = fakeFetch((url, init) => {
             calls += 1;
-            if (url.includes('resend.com')) return Response.json({ id: 'mail-test' });
+            requests.push(String(init?.body));
+            if (new URL(url).hostname === 'api.resend.com')
+              return Response.json({ id: 'mail-test' });
             return Response.json({ ok: true, channel: 'C-test', ts: '1.000' });
           });
           await deliverNotificationProviders(tx, worker(fixture, fetch, [channel]));
@@ -215,9 +218,41 @@ describe('durable notification provider delivery', () => {
               ),
             );
           expect(delivery?.status).toBe(scenario === 'current' ? 'delivered' : 'unavailable');
+          if (scenario === 'current') expect(requests[0]).toContain('Commit old-hea');
           if (scenario !== 'current') {
             expect(delivery?.lastError).toBe('github_check_failure_superseded');
             expect(delivery?.sendStartedAt).toBeNull();
+          }
+          if (scenario === 'superseded') {
+            await notifyMany(
+              tx,
+              [
+                {
+                  organizationId: fixture.organizationId,
+                  userIds: [fixture.userId],
+                  type: 'pr_checks_failed',
+                  reason: 'subscribed',
+                  entityType: 'github_pull_request',
+                  entityId: pullId,
+                  title: 'Checks failed on the current commit',
+                  body: 'example/repository#42',
+                  url: `/pulls/${pullId}`,
+                  actor: { type: 'integration', id: 'github', name: 'GitHub' },
+                  source: {
+                    sourceEventKey: 'github-pr:123:42:new-head:checks-failed',
+                    subjectType: 'github_pull_request',
+                    subjectKey: 'github-pr:123:42',
+                    occurredAt: new Date(),
+                    payload: { pullRequestId: pullId, headSha: 'new-head' },
+                  },
+                },
+              ],
+              { slackEnabled: true },
+            );
+            expect(await deliverNotificationProviders(tx, worker(fixture, fetch, [channel]))).toBe(
+              1,
+            );
+            expect(calls).toBe(1);
           }
         });
       });

--- a/packages/services/tests/notifications/provider-outbox.test.ts
+++ b/packages/services/tests/notifications/provider-outbox.test.ts
@@ -146,6 +146,84 @@ async function waitForBlockedWorker(tx: TestTransaction) {
 }
 
 describe('durable notification provider delivery', () => {
+  for (const scenario of ['superseded', 'recovered', 'closed', 'current'] as const) {
+    for (const channel of ['slack', 'slack_dm', 'email'] as const) {
+      it(`checks CI failure freshness before sending a ${scenario} pull request notification via ${channel}`, async () => {
+        await withRollback(async (tx) => {
+          const fixture = await seedProviders(tx, 0);
+          const repositoryId = randomUUIDv7();
+          const pullId = randomUUIDv7();
+          await tx.insert(schema.githubRepositorySync).values({
+            id: repositoryId,
+            organizationId: fixture.organizationId,
+            integrationId: fixture.integrationId,
+            repositoryId: '123',
+            repositoryName: 'example/repository',
+          });
+          await tx.insert(schema.githubPullRequest).values({
+            id: pullId,
+            organizationId: fixture.organizationId,
+            repositorySyncId: repositoryId,
+            repositoryId: '123',
+            repositoryName: 'example/repository',
+            number: 42,
+            url: 'https://github.com/example/repository/pull/42',
+            headSha: scenario === 'superseded' ? 'new-head' : 'old-head',
+            checkStatus: scenario === 'recovered' ? 'success' : 'failure',
+            state: scenario === 'closed' ? 'closed' : 'open',
+          });
+          await notifyMany(
+            tx,
+            [
+              {
+                organizationId: fixture.organizationId,
+                userIds: [fixture.userId],
+                type: 'pr_checks_failed',
+                reason: 'subscribed',
+                entityType: 'github_pull_request',
+                entityId: pullId,
+                title: 'Checks failed on example',
+                body: 'example/repository#42',
+                url: `/pulls/${pullId}`,
+                actor: { type: 'integration', id: 'github', name: 'GitHub' },
+                source: {
+                  sourceEventKey: 'github-pr:123:42:old-head:checks-failed',
+                  subjectType: 'github_pull_request',
+                  subjectKey: 'github-pr:123:42',
+                  occurredAt: new Date(),
+                  payload: { pullRequestId: pullId, headSha: 'old-head' },
+                },
+              },
+            ],
+            { slackEnabled: true },
+          );
+          let calls = 0;
+          const fetch = fakeFetch((url) => {
+            calls += 1;
+            if (url.includes('resend.com')) return Response.json({ id: 'mail-test' });
+            return Response.json({ ok: true, channel: 'C-test', ts: '1.000' });
+          });
+          await deliverNotificationProviders(tx, worker(fixture, fetch, [channel]));
+          expect(calls).toBe(scenario === 'current' ? 1 : 0);
+          const [delivery] = await tx
+            .select()
+            .from(schema.notificationDelivery)
+            .where(
+              and(
+                eq(schema.notificationDelivery.organizationId, fixture.organizationId),
+                eq(schema.notificationDelivery.channel, channel),
+              ),
+            );
+          expect(delivery?.status).toBe(scenario === 'current' ? 'delivered' : 'unavailable');
+          if (scenario !== 'current') {
+            expect(delivery?.lastError).toBe('github_check_failure_superseded');
+            expect(delivery?.sendStartedAt).toBeNull();
+          }
+        });
+      });
+    }
+  }
+
   for (const phase of ['preflight', 'finalization'] as const) {
     it(`rejects a lease that expires while ${phase} waits for a database lock`, async () => {
       const fixture = await db.transaction((tx) => seedProviders(tx));

--- a/packages/services/tests/slack/notification-threads.test.ts
+++ b/packages/services/tests/slack/notification-threads.test.ts
@@ -85,7 +85,11 @@ describe('notification Slack messages', () => {
   });
 
   it('truncates without splitting escaped entities or Unicode code points', () => {
-    for (const body of [`${'x'.repeat(1198)}& more`, `${'x'.repeat(1199)}🙂`]) {
+    for (const body of [
+      `${'x'.repeat(1198)}& more`,
+      `${'x'.repeat(1199)}🙂`,
+      `${' '.repeat(3999)}🙂`,
+    ]) {
       const message = notificationSlackMessage({
         channel: 'C-test',
         rootTs: null,
@@ -95,6 +99,7 @@ describe('notification Slack messages', () => {
       expect(section.text.text).toEndWith('…');
       expect(section.text.text).not.toMatch(/&(?:a|am|amp)?…$/);
       expect(section.text.text).not.toMatch(/[\uD800-\uDBFF]…$/u);
+      expect(section.text.text).not.toContain('\uFFFD');
       expect(section.text.text.length).toBeLessThanOrEqual(1204);
     }
   });

--- a/packages/services/tests/slack/notification-threads.test.ts
+++ b/packages/services/tests/slack/notification-threads.test.ts
@@ -21,6 +21,25 @@ afterAll(() => {
 });
 
 describe('notification Slack messages', () => {
+  it('keeps comment previews short and readable without raw Markdown or HTML', () => {
+    const message = notificationSlackMessage({
+      channel: 'C-test',
+      rootTs: '1.000',
+      payload: {
+        title: 'New comment from Sam',
+        body: `**Type check** failed.\n\n<details><summary>Details</summary>Missing an export.</details>\n\n${'More context '.repeat(100)}`,
+        url: '/inbox',
+      },
+    });
+    const section = z.object({ text: z.object({ text: z.string() }) }).parse(message.blocks?.[0]);
+    expect(section.text.text).toContain('Type check failed.');
+    expect(section.text.text).not.toContain('<details>');
+    expect(section.text.text).not.toContain('&lt;details&gt;');
+    expect(section.text.text).not.toContain('**Type check**');
+    expect(section.text.text.length).toBeLessThanOrEqual(450);
+    expect(section.text.text).toEndWith('…');
+  });
+
   it('disables automatic mention parsing for ordinary workspace mention text', () => {
     const message = notificationSlackMessage({
       channel: 'C-test',
@@ -80,13 +99,13 @@ describe('notification Slack messages', () => {
     }
   });
 
-  it('bounds sections and provides root-only thread guidance without broadcasting replies', () => {
+  it('bounds sections without repetitive footers or broadcasting replies', () => {
     const payload = { title: '&'.repeat(255), body: '<'.repeat(100_000), url: '/inbox' };
     const root = notificationSlackMessage({ channel: 'C-test', rootTs: null, payload });
     const reply = notificationSlackMessage({ channel: 'C-test', rootTs: '1.000', payload });
     const section = z.object({ text: z.object({ text: z.string() }) }).parse(root.blocks?.[0]);
     expect(section.text.text.length).toBeLessThanOrEqual(3000);
-    expect(root.blocks).toHaveLength(3);
+    expect(root.blocks).toHaveLength(2);
     expect(root.threadTs).toBeUndefined();
     expect(reply.blocks).toHaveLength(2);
     expect(reply.threadTs).toBe('1.000');

--- a/packages/services/tests/slack/notification-threads.test.ts
+++ b/packages/services/tests/slack/notification-threads.test.ts
@@ -21,6 +21,20 @@ afterAll(() => {
 });
 
 describe('notification Slack messages', () => {
+  it('preserves literal CI check names rather than interpreting them as comment markup', () => {
+    const message = notificationSlackMessage({
+      channel: 'C-test',
+      rootTs: null,
+      payload: {
+        title: 'Checks failed',
+        body: 'repo#1 · Commit abc1234\nFailed: build <linux>',
+        bodyFormat: 'plain_text',
+        url: '/inbox',
+      },
+    });
+    expect(message.text).toContain('build &lt;linux&gt;');
+  });
+
   it('keeps comment previews short and readable without raw Markdown or HTML', () => {
     const message = notificationSlackMessage({
       channel: 'C-test',

--- a/packages/shared/src/validators/notification-provider.ts
+++ b/packages/shared/src/validators/notification-provider.ts
@@ -16,6 +16,7 @@ export const notificationTitleSchema = z
 export const notificationProviderPayloadSchema = z.object({
   title: notificationTitleSchema,
   body: z.string().max(100_000).default(''),
+  bodyFormat: z.enum(['markdown', 'plain_text']).default('markdown'),
   url: z.string().min(1).max(2048),
   externalUrl: z.string().max(2048).nullable().optional(),
 });


### PR DESCRIPTION
## Summary

- Recheck PR state, current commit and failed-check status immediately before Slack channel, Slack DM or email delivery. Superseded alerts become unavailable without a provider request; delivery audit history is preserved.
- Include commit identity and up to three actual failed check names, with timeout/cancellation context and a direct check URL when available.
- Render short readable comment previews instead of raw HTML/Markdown, retain navigation buttons, and remove repeated thread-guidance footers. Replies remain threaded without channel broadcasts.
- Document the behavior and remaining historical inbox regrouping work.

## Production investigation

The reported nine same-looking Slack messages came from nine distinct commits for one PR. Each had exactly one delivery attempt; all were drained within five seconds after the provider pause ended. No duplicate delivered source/destination groups were found. The missing send-time freshness check allowed obsolete failures to be sent, and identical message bodies hid the commit differences. GitHub and the production PR mirror agree on the newer successful head.

Older issue-comment inbox records also remain individually grouped despite known parent issues. Regrouping those historical conversations is a separate data repair, not included here. Existing delivered Slack messages are not deleted or rewritten.

## Verification

- Reproduced stale, recovered and closed PR sends before the fix.
- Regression coverage across Slack channels, DMs and email, including valid current failures.
- Reproduced missing failure details and noisy previews before their fixes.
- 114 affected tests pass with 472 assertions across provider delivery, GitHub ingestion/reconciliation and Slack formatting. Final preview suite also passes independently.
- Lint, comment policy and all package typechecks pass.
- Full CI and review must pass before production deployment. No new schema migration.





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61666014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/noveum-ai/-/pull-requests/noveum/orbit/447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Revalidates the PR head, open/merged state, and current failure status before provider delivery.
- Adds commit identity, bounded failed-check summaries, and validated direct check links.
- Converts comment bodies into short plain-text Slack previews and removes repeated thread guidance.
- Extends regression coverage and documents delivery behavior and historical regrouping limitations.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant W as Provider worker
  participant DB as Orbit database
  participant G as GitHub PR mirror
  participant P as Slack or email provider
  W->>DB: Claim queued delivery
  W->>DB: Recheck access and CI relevance
  DB-->>W: Current PR head, state, and failures
  alt Alert is superseded
    W->>DB: Mark delivery unavailable
  else Alert is current
    W->>W: Refresh summary and provider payload
    W->>P: Send notification
    P-->>W: Provider result
    W->>DB: Record final delivery state
  end
```
</details>

<!-- /greptile_comment -->