### PR TITLE
fix(auth): support login on protected Vercel preview URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ REDIS_URL=redis://localhost:6380
 BETTER_AUTH_SECRET=dev-secret-change-me-in-production-0123456789abcdef
 BETTER_AUTH_URL=http://localhost:3000
 ORBIT_AUTH_ALLOWED_HOSTS=
+OAUTH_PROXY_SECRET=
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 # Optional override for the MCP endpoint; defaults to the app's /mcp route.
 # NEXT_PUBLIC_MCP_URL=

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ REDIS_URL=redis://localhost:6380
 
 BETTER_AUTH_SECRET=dev-secret-change-me-in-production-0123456789abcdef
 BETTER_AUTH_URL=http://localhost:3000
+ORBIT_AUTH_ALLOWED_HOSTS=
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 # Optional override for the MCP endpoint; defaults to the app's /mcp route.
 # NEXT_PUBLIC_MCP_URL=

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -285,7 +285,7 @@ export function LoginForm({
       const result = await authClient.signIn.social({
         provider,
         callbackURL: callbackUrl,
-        errorCallbackURL: '/login',
+        errorCallbackURL: new URL('/login', window.location.origin).toString(),
       });
       if (result.error) throw new Error(result.error.message ?? 'That provider is unavailable.');
     });

--- a/apps/web/src/lib/auth/client.ts
+++ b/apps/web/src/lib/auth/client.ts
@@ -3,10 +3,8 @@
 import { passkeyClient } from '@better-auth/passkey/client';
 import { emailOTPClient, organizationClient } from 'better-auth/client/plugins';
 import { createAuthClient } from 'better-auth/react';
-import { publicAppUrl } from '@/lib/env.ts';
 
 export const authClient = createAuthClient({
-  baseURL: publicAppUrl(),
   plugins: [passkeyClient(), emailOTPClient(), organizationClient()],
 });
 

--- a/apps/web/src/lib/auth/deployment.ts
+++ b/apps/web/src/lib/auth/deployment.ts
@@ -4,7 +4,10 @@ import { z } from 'zod';
 const deploymentSchema = z.object({
   BETTER_AUTH_URL: z.url().default('http://localhost:3000'),
   ORBIT_AUTH_ALLOWED_HOSTS: z.string().default(''),
-  OAUTH_PROXY_SECRET: z.string().min(32).optional(),
+  OAUTH_PROXY_SECRET: z.preprocess(
+    (value) => (value === '' ? undefined : value),
+    z.string().min(32).optional(),
+  ),
   VERCEL_URL: z.string().optional(),
   VERCEL_BRANCH_URL: z.string().optional(),
 });
@@ -21,7 +24,9 @@ export function deploymentAuthOptions(
     ...env.ORBIT_AUTH_ALLOWED_HOSTS.split(',')
       .map((host) => host.trim())
       .filter(Boolean),
-    ...[env.VERCEL_URL, env.VERCEL_BRANCH_URL].filter((host) => host !== undefined),
+    ...[env.VERCEL_URL, env.VERCEL_BRANCH_URL]
+      .map((host) => host?.trim())
+      .filter((host) => host !== undefined && host.length > 0),
   ].map((host) => hostSchema.parse(host));
   const plugins: [] | [ReturnType<typeof oAuthProxy>] = env.OAUTH_PROXY_SECRET
     ? [oAuthProxy({ productionURL: canonical.origin, secret: env.OAUTH_PROXY_SECRET })]
@@ -33,7 +38,6 @@ export function deploymentAuthOptions(
         ? canonical.origin
         : {
             allowedHosts: [...new Set(allowedHosts)],
-            fallback: canonical.origin,
           },
     plugins,
   };

--- a/apps/web/src/lib/auth/deployment.ts
+++ b/apps/web/src/lib/auth/deployment.ts
@@ -1,0 +1,40 @@
+import { oAuthProxy } from 'better-auth/plugins';
+import { z } from 'zod';
+
+const deploymentSchema = z.object({
+  BETTER_AUTH_URL: z.url().default('http://localhost:3000'),
+  ORBIT_AUTH_ALLOWED_HOSTS: z.string().default(''),
+  OAUTH_PROXY_SECRET: z.string().min(32).optional(),
+  VERCEL_URL: z.string().optional(),
+  VERCEL_BRANCH_URL: z.string().optional(),
+});
+
+const hostSchema = z.string().regex(/^[a-zA-Z0-9*.-]+(?::\d+)?$/);
+
+export function deploymentAuthOptions(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+) {
+  const env = deploymentSchema.parse(environment);
+  const canonical = new URL(env.BETTER_AUTH_URL);
+  const allowedHosts = [
+    canonical.host,
+    ...env.ORBIT_AUTH_ALLOWED_HOSTS.split(',')
+      .map((host) => host.trim())
+      .filter(Boolean),
+    ...[env.VERCEL_URL, env.VERCEL_BRANCH_URL].filter((host) => host !== undefined),
+  ].map((host) => hostSchema.parse(host));
+  const plugins: [] | [ReturnType<typeof oAuthProxy>] = env.OAUTH_PROXY_SECRET
+    ? [oAuthProxy({ productionURL: canonical.origin, secret: env.OAUTH_PROXY_SECRET })]
+    : [];
+
+  return {
+    baseURL:
+      allowedHosts.length === 1
+        ? canonical.origin
+        : {
+            allowedHosts: [...new Set(allowedHosts)],
+            fallback: canonical.origin,
+          },
+    plugins,
+  };
+}

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -18,8 +18,8 @@ import { nextCookies } from 'better-auth/next-js';
 import { emailOTP, mcp, organization } from 'better-auth/plugins';
 import { z } from 'zod';
 import { isDevLoginRequest } from '@/lib/api/dev-login.ts';
+import { deploymentAuthOptions } from '@/lib/auth/deployment.ts';
 import { mcpServerUrl, serverEnv } from '@/lib/env.ts';
-import { deploymentAuthOptions } from './deployment.ts';
 import { uniqueHandleFor } from './handle.ts';
 import { hashPassword, verifyPassword } from './password.ts';
 

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -19,6 +19,7 @@ import { emailOTP, mcp, organization } from 'better-auth/plugins';
 import { z } from 'zod';
 import { isDevLoginRequest } from '@/lib/api/dev-login.ts';
 import { mcpServerUrl, serverEnv } from '@/lib/env.ts';
+import { deploymentAuthOptions } from './deployment.ts';
 import { uniqueHandleFor } from './handle.ts';
 import { hashPassword, verifyPassword } from './password.ts';
 
@@ -179,9 +180,11 @@ function signInCodeIdempotencyKey(email: string, otp: string): string {
   return `sign-in-code:${digest}`;
 }
 
+const deployment = deploymentAuthOptions();
+
 export const auth = betterAuth({
   appName: 'Orbit',
-  baseURL: serverEnv().BETTER_AUTH_URL,
+  baseURL: deployment.baseURL,
   secret: serverEnv().BETTER_AUTH_SECRET,
   database: drizzleAdapter(db, { provider: 'pg', schema }),
   emailAndPassword: emailAndPassword(),
@@ -247,6 +250,7 @@ export const auth = betterAuth({
     },
   },
   plugins: [
+    ...deployment.plugins,
     mcpTokenRateLimitProbe(),
     passkey({ rpName: 'Orbit' }),
     emailOTP({

--- a/apps/web/tests/components/auth/login-form.test.tsx
+++ b/apps/web/tests/components/auth/login-form.test.tsx
@@ -6,6 +6,7 @@ import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
 const requestPasswordReset = mock();
 const sendVerificationOtp = mock();
 const signInEmailOtp = mock();
+const signInSocial = mock();
 const toast = mock();
 const originalLocation = window.location;
 const assign = mock();
@@ -14,7 +15,7 @@ await restoreModulesAfterThisFile(['@/components/ui/toast.tsx']);
 
 Object.defineProperty(window, 'location', {
   configurable: true,
-  value: { ...window.location, assign },
+  value: { ...window.location, origin: 'https://orbit-abc123-magicapi.vercel.app', assign },
 });
 
 mock.module('@/lib/auth/client.ts', () => ({
@@ -24,6 +25,7 @@ mock.module('@/lib/auth/client.ts', () => ({
       sendVerificationOtp: (...args: unknown[]) => sendVerificationOtp(...args),
     },
     signIn: {
+      social: (...args: unknown[]) => signInSocial(...args),
       emailOtp: (...args: unknown[]) => signInEmailOtp(...args),
     },
   },
@@ -39,6 +41,7 @@ beforeEach(() => {
   requestPasswordReset.mockReset();
   sendVerificationOtp.mockReset();
   signInEmailOtp.mockReset();
+  signInSocial.mockReset();
   toast.mockReset();
   assign.mockReset();
 });
@@ -54,6 +57,18 @@ function renderForm(passwordEnabled: boolean, openSignUp = false) {
 const SIGN_UP_NOTE = 'New here? Signing in creates your account, then you set up a workspace.';
 
 describe('LoginForm', () => {
+  it('returns social login failures to the current preview', async () => {
+    signInSocial.mockResolvedValue({ error: null });
+    render(<LoginForm providers={['google']} passwordEnabled={false} />);
+    await userEvent.setup().click(screen.getByText('Continue with Google'));
+    expect(signInSocial).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'google',
+        errorCallbackURL: 'https://orbit-abc123-magicapi.vercel.app/login',
+      }),
+    );
+  });
+
   it('renders no password field while password auth is off', () => {
     renderForm(false);
     expect(screen.queryByLabelText('Password')).toBeNull();

--- a/apps/web/tests/lib/auth/deployment.test.ts
+++ b/apps/web/tests/lib/auth/deployment.test.ts
@@ -42,12 +42,23 @@ function socialSignIn(origin: string, provider: string, callbackURL = '/inbox') 
     new nativeFetchGlobals.Request(`${origin}/api/auth/sign-in/social`, {
       method: 'POST',
       headers: { 'content-type': 'application/json', origin, cookie: 'existing=1' },
-      body: JSON.stringify({ provider, callbackURL }),
+      body: JSON.stringify({ provider, callbackURL, errorCallbackURL: `${origin}/login` }),
     }),
   );
 }
 
 describe('deployment authentication', () => {
+  it('returns provider cancellation to the preview login page', async () => {
+    const response = await socialSignIn(preview, 'google');
+    const authorization = new URL((await response.json()).url);
+    const callback = new URL(`${canonical}/api/auth/callback/google`);
+    callback.searchParams.set('state', authorization.searchParams.get('state') ?? '');
+    callback.searchParams.set('error', 'access_denied');
+    const cancelled = await createAuth().handler(new nativeFetchGlobals.Request(callback));
+    expect(cancelled.status).toBe(302);
+    expect(cancelled.headers.get('location')).toBe(`${preview}/login?error=access_denied`);
+  });
+
   it('creates a session on the preview after the production callback and rejects replay', async () => {
     const previewAuth = createAuth();
     const productionAuth = createAuth('production-session-secret-different-from-preview');

--- a/apps/web/tests/lib/auth/deployment.test.ts
+++ b/apps/web/tests/lib/auth/deployment.test.ts
@@ -1,0 +1,168 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { betterAuth } from 'better-auth';
+import { memoryAdapter } from 'better-auth/adapters/memory';
+import { symmetricDecrypt } from 'better-auth/crypto';
+import { deploymentAuthOptions } from '@/lib/auth/deployment';
+import { nativeFetchGlobals } from '../../../tests-preload';
+
+const canonical = 'https://orbit.example.com';
+const preview = 'https://orbit-abc123-magicapi.vercel.app';
+const browserFetchGlobals = {
+  Headers: globalThis.Headers,
+  Request: globalThis.Request,
+  Response: globalThis.Response,
+};
+
+beforeAll(() => {
+  Object.assign(globalThis, nativeFetchGlobals);
+});
+afterAll(() => {
+  Object.assign(globalThis, browserFetchGlobals);
+});
+
+function createAuth(secret = 'preview-session-secret-at-least-32-characters') {
+  return betterAuth({
+    ...deploymentAuthOptions({
+      BETTER_AUTH_URL: canonical,
+      ORBIT_AUTH_ALLOWED_HOSTS: 'orbit-*-magicapi.vercel.app',
+      OAUTH_PROXY_SECRET: 'dedicated-proxy-secret-at-least-32-characters',
+    }),
+    database: memoryAdapter({ user: [], account: [], session: [], verification: [] }),
+    advanced: { disableOriginCheck: false, disableCSRFCheck: false },
+    secret,
+    socialProviders: {
+      google: { clientId: 'test-google-client', clientSecret: 'test-google-secret' },
+      github: { clientId: 'test-github-client', clientSecret: 'test-github-secret' },
+    },
+  });
+}
+
+function socialSignIn(origin: string, provider: string, callbackURL = '/inbox') {
+  return createAuth().handler(
+    new nativeFetchGlobals.Request(`${origin}/api/auth/sign-in/social`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin, cookie: 'existing=1' },
+      body: JSON.stringify({ provider, callbackURL }),
+    }),
+  );
+}
+
+describe('deployment authentication', () => {
+  it('creates a session on the preview after the production callback and rejects replay', async () => {
+    const previewAuth = createAuth();
+    const productionAuth = createAuth('production-session-secret-different-from-preview');
+    const productionContext = await productionAuth.$context;
+    const provider = productionContext.socialProviders.find((item) => item.id === 'google');
+    if (!provider) throw new Error('Missing Google provider');
+    provider.validateAuthorizationCode = () => Promise.resolve({ accessToken: 'test-token' });
+    provider.getUserInfo = () =>
+      Promise.resolve({
+        user: {
+          id: 'provider-user',
+          name: 'Preview Tester',
+          email: 'tester@example.com',
+          emailVerified: true,
+        },
+        data: {},
+      });
+    const signIn = await previewAuth.handler(
+      new nativeFetchGlobals.Request(`${preview}/api/auth/sign-in/social`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', origin: preview },
+        body: JSON.stringify({ provider: 'google', callbackURL: `${preview}/inbox` }),
+      }),
+    );
+    const authorization = new URL((await signIn.json()).url);
+    const callback = new URL(`${canonical}/api/auth/callback/google`);
+    callback.searchParams.set('code', 'test-code');
+    callback.searchParams.set('state', authorization.searchParams.get('state') ?? '');
+    const exchange = await productionAuth.handler(new nativeFetchGlobals.Request(callback));
+    expect(exchange.status).toBe(302);
+    const location = exchange.headers.get('location') ?? '';
+    expect(new URL(location).origin).toBe(preview);
+    const login = await previewAuth.handler(new nativeFetchGlobals.Request(location));
+    expect(login.status).toBe(302);
+    expect(login.headers.get('location')).toBe(`${preview}/inbox`);
+    const cookies = login.headers.getSetCookie();
+    expect(cookies.some((cookie) => cookie.includes('session_token='))).toBe(true);
+    expect(cookies.join(';')).not.toContain('Domain=');
+    const session = await previewAuth.api.getSession({
+      headers: new Headers({ cookie: cookies.map((cookie) => cookie.split(';')[0]).join('; ') }),
+    });
+    expect(session?.user.email).toBe('tester@example.com');
+    expect(
+      await productionContext.internalAdapter.findUserByEmail('tester@example.com'),
+    ).toBeNull();
+    const replay = await previewAuth.handler(new nativeFetchGlobals.Request(location));
+    expect(replay.headers.get('location')).toContain('state_mismatch');
+  });
+
+  it('includes the exact deployment and branch aliases', () => {
+    const options = deploymentAuthOptions({
+      BETTER_AUTH_URL: canonical,
+      VERCEL_URL: 'orbit-abc123-magicapi.vercel.app',
+      VERCEL_BRANCH_URL: 'orbit-git-feature-magicapi.vercel.app',
+    });
+    expect(options.baseURL).toMatchObject({
+      allowedHosts: [
+        'orbit.example.com',
+        'orbit-abc123-magicapi.vercel.app',
+        'orbit-git-feature-magicapi.vercel.app',
+      ],
+    });
+    expect(options.plugins).toEqual([]);
+  });
+
+  it('rejects malformed host configuration and short proxy secrets', () => {
+    expect(() =>
+      deploymentAuthOptions({ ORBIT_AUTH_ALLOWED_HOSTS: 'https://example.com/path' }),
+    ).toThrow();
+    expect(() => deploymentAuthOptions({ OAUTH_PROXY_SECRET: 'short' })).toThrow();
+  });
+
+  it.each(['google', 'github'])(
+    'routes preview %s authorization through the stable callback',
+    async (provider) => {
+      const response = await socialSignIn(preview, provider);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const url = new URL(body.url);
+      expect(url.searchParams.get('redirect_uri')).toBe(
+        `${canonical}/api/auth/callback/${provider}`,
+      );
+      expect(url.searchParams.get('state')).toBeTruthy();
+      const state = JSON.parse(
+        await symmetricDecrypt({
+          key: 'dedicated-proxy-secret-at-least-32-characters',
+          data: url.searchParams.get('state') ?? '',
+        }),
+      );
+      const payload = JSON.parse(
+        await symmetricDecrypt({
+          key: 'dedicated-proxy-secret-at-least-32-characters',
+          data: state.stateCookie,
+        }),
+      );
+      expect(new URL(payload.callbackURL).origin).toBe(preview);
+    },
+  );
+
+  it('preserves normal production login', async () => {
+    const response = await socialSignIn(canonical, 'google');
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(new URL(body.url).searchParams.get('redirect_uri')).toBe(
+      `${canonical}/api/auth/callback/google`,
+    );
+  });
+
+  it('rejects another Vercel project', async () => {
+    const response = await socialSignIn('https://other-magicapi.vercel.app', 'google');
+    expect(response.status).toBe(403);
+  });
+
+  it('rejects an external post-login redirect', async () => {
+    const response = await socialSignIn(preview, 'google', 'https://attacker.example/inbox');
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/web/tests/lib/auth/deployment.test.ts
+++ b/apps/web/tests/lib/auth/deployment.test.ts
@@ -87,7 +87,10 @@ describe('deployment authentication', () => {
     expect(cookies.some((cookie) => cookie.includes('session_token='))).toBe(true);
     expect(cookies.join(';')).not.toContain('Domain=');
     const session = await previewAuth.api.getSession({
-      headers: new Headers({ cookie: cookies.map((cookie) => cookie.split(';')[0]).join('; ') }),
+      headers: new Headers({
+        host: new URL(preview).host,
+        cookie: cookies.map((cookie) => cookie.split(';')[0]).join('; '),
+      }),
     });
     expect(session?.user.email).toBe('tester@example.com');
     expect(
@@ -118,6 +121,16 @@ describe('deployment authentication', () => {
       deploymentAuthOptions({ ORBIT_AUTH_ALLOWED_HOSTS: 'https://example.com/path' }),
     ).toThrow();
     expect(() => deploymentAuthOptions({ OAUTH_PROXY_SECRET: 'short' })).toThrow();
+  });
+
+  it('ignores empty optional deployment values in local configuration', () => {
+    const options = deploymentAuthOptions({
+      VERCEL_URL: '',
+      VERCEL_BRANCH_URL: ' ',
+      OAUTH_PROXY_SECRET: '',
+    });
+    expect(options.baseURL).toBe('http://localhost:3000');
+    expect(options.plugins).toEqual([]);
   });
 
   it.each(['google', 'github'])(
@@ -157,8 +170,7 @@ describe('deployment authentication', () => {
   });
 
   it('rejects another Vercel project', async () => {
-    const response = await socialSignIn('https://other-magicapi.vercel.app', 'google');
-    expect(response.status).toBe(403);
+    await expect(socialSignIn('https://other-magicapi.vercel.app', 'google')).rejects.toThrow();
   });
 
   it('rejects an external post-login redirect', async () => {

--- a/apps/web/tests/lib/auth/server.test.ts
+++ b/apps/web/tests/lib/auth/server.test.ts
@@ -16,7 +16,8 @@ describe('password authentication', () => {
 
   it('stores sign in codes as hashes', () => {
     const plugin = auth.options.plugins?.find((candidate) => candidate.id === 'email-otp');
-    expect(plugin?.options).toMatchObject({ storeOTP: 'hashed' });
+    if (!(plugin && 'options' in plugin)) throw new Error('Email OTP plugin is missing');
+    expect(plugin.options).toMatchObject({ storeOTP: 'hashed' });
   });
 
   it('exposes the MCP OAuth provider for one-click clients', () => {

--- a/docs/preview-authentication.md
+++ b/docs/preview-authentication.md
@@ -1,0 +1,35 @@
+# Preview authentication
+
+Keep `BETTER_AUTH_URL` set to the stable OAuth callback origin in production and
+previews. For the hosted Orbit project this is `https://orbit.noveum.ai`.
+
+Set `ORBIT_AUTH_ALLOWED_HOSTS=orbit-*-magicapi.vercel.app` in both Vercel
+environments. The auth server also accepts the canonical hostname and the exact
+`VERCEL_URL` and `VERCEL_BRANCH_URL` provided by Vercel. Browser authentication
+uses the current origin, so password and email OTP sessions stay on the preview.
+
+Set a dedicated random `OAUTH_PROXY_SECRET` of at least 32 characters to the same
+value in production and previews. Do not put its value in source control. This
+enables Better Auth's OAuth proxy in both environments without requiring their
+main session secrets or databases to match.
+
+Register only the stable callback URLs with the OAuth providers:
+
+- `https://orbit.noveum.ai/api/auth/callback/google`
+- `https://orbit.noveum.ai/api/auth/callback/github`
+
+Deploy the proxy code to production before testing social login on previews.
+Google and GitHub return to production, which exchanges the authorization code
+and sends an encrypted, short-lived profile to the initiating preview. The
+preview consumes its original state and creates the user and session in its own
+database. The session cookie belongs to that preview hostname.
+
+Keep Vercel Authentication enabled for deployment URLs. Team members must pass
+that gate before starting Orbit login. This does not replace Orbit login or its
+email-domain restrictions. Do not configure a wildcard cookie domain on
+`vercel.app` or allow all Vercel customers as auth origins.
+
+Existing immutable deployments do not acquire this code or new environment
+variables. Redeploy their branches after the production proxy is available.
+Passkeys remain bound to their registration hostname; use Google, GitHub, or
+email OTP when testing a newly generated preview hostname.


### PR DESCRIPTION
Keep authentication sessions on each Vercel preview and route Google and GitHub callbacks through the stable production OAuth proxy.