### PR TITLE
feat(standup): offer member cards and dropdown layouts

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,2 +1,5 @@
 reviews:
   high_level_summary: false
+  pre_merge_checks:
+    docstrings:
+      mode: off

--- a/apps/web/e2e/standup-visibility.spec.ts
+++ b/apps/web/e2e/standup-visibility.spec.ts
@@ -89,3 +89,51 @@ test('Standup shows a member tasks from other teams and filters by participant',
     true,
   );
 });
+
+test('Standup remembers member layouts and supports shortcuts in both', async ({ page }) => {
+  await page.goto(`${BASE}/login`);
+  await page.getByTestId('dev-sign-in-alex@orbit.example').click();
+  await page.waitForURL(`${BASE}/my-issues`);
+  await page.goto(`${BASE}/standup`);
+  const cards = page.getByTestId('standup-tiles');
+  await expect(cards).toBeVisible();
+  await expect(cards.getByText('Alex (You)', { exact: true })).toBeVisible();
+  const isMac = await page.evaluate(() => /Mac/i.test(navigator.platform));
+  const next = isMac ? 'Tab' : 'j';
+  const previous = isMac ? 'Shift+Tab' : 'k';
+  for (const layout of ['cards', 'dropdown']) {
+    if (layout === 'dropdown') {
+      await page.getByRole('button', { name: 'Display options' }).click();
+      await page.getByRole('menuitemradio', { name: 'Dropdown', exact: true }).click();
+      await expect(cards).toBeHidden();
+    }
+    const before = new URL(page.url()).searchParams.get('person');
+    await page.keyboard.down('Alt');
+    await page.keyboard.press(next);
+    await expect.poll(() => new URL(page.url()).searchParams.get('person')).not.toBe(before);
+    await expect(cards.getByRole('button', { pressed: true })).toHaveAttribute('aria-label', /.+/);
+    const first = await cards.getByRole('button', { pressed: true }).getAttribute('aria-label');
+    await page.keyboard.press(next);
+    await expect(cards.getByRole('button', { pressed: true })).not.toHaveAttribute(
+      'aria-label',
+      first ?? '',
+    );
+    await page.keyboard.press(previous);
+    await expect(cards.getByRole('button', { pressed: true })).toHaveAttribute(
+      'aria-label',
+      first ?? '',
+    );
+    await page.keyboard.up('Alt');
+    if (layout === 'cards') await expect(cards).toBeVisible();
+    else await expect(cards).toBeHidden();
+  }
+  const selectedUrl = page.url();
+  await page.reload();
+  await expect(page.getByRole('button', { name: /^Members:/ })).toBeVisible();
+  await expect(cards).toBeHidden();
+  await page.getByRole('button', { name: 'Display options' }).click();
+  await expect(page.getByRole('menuitemradio', { name: 'Dropdown', exact: true })).toBeChecked();
+  await page.getByRole('menuitemradio', { name: 'Cards', exact: true }).click();
+  await expect(cards).toBeVisible();
+  await expect(page).toHaveURL(selectedUrl);
+});

--- a/apps/web/e2e/standup-visibility.spec.ts
+++ b/apps/web/e2e/standup-visibility.spec.ts
@@ -45,7 +45,6 @@ test('Standup shows a member tasks from other teams and filters by participant',
   );
   const person = external.assigneeId;
   if (person === null) throw new Error('Expected an assignee.');
-  await page.getByTestId('standup-members').click();
   await expect(page.getByTestId(`standup-tile-count-${person}`)).toHaveText(
     String(summary.groupTotals[person]),
   );
@@ -72,7 +71,6 @@ test('Standup shows a member tasks from other teams and filters by participant',
       return rendered.length > 0 && rendered.every((id) => id !== null && selectedCards.has(id));
     })
     .toBe(true);
-  await page.getByTestId('standup-members').click();
   await page.getByTestId('standup-tile-everyone').click();
   for (const theme of ['light', 'dark']) {
     await page.evaluate((theme) => {

--- a/apps/web/src/features/filters/display-menu.tsx
+++ b/apps/web/src/features/filters/display-menu.tsx
@@ -16,6 +16,7 @@ import {
   ISSUE_ORDERING_LABELS,
 } from '@orbit/shared/filters';
 import { SlidersHorizontal } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import {
   DropdownMenu,
@@ -35,6 +36,7 @@ export interface DisplayMenuProps {
   readonly modified: boolean;
   readonly onChange: (next: ViewConfig) => void;
   readonly compact?: boolean;
+  readonly extraOptions?: ReactNode;
 }
 
 function toggleProperty(
@@ -52,6 +54,7 @@ export function DisplayMenu({
   modified,
   onChange,
   compact = false,
+  extraOptions,
 }: DisplayMenuProps) {
   const setDisplay = (patch: Partial<ViewConfig['display']>) => {
     onChange({ ...config, display: { ...config.display, ...patch } });
@@ -84,6 +87,7 @@ export function DisplayMenu({
         className="max-h-[var(--radix-dropdown-menu-content-available-height)] w-64 overflow-y-auto"
         data-testid="display-menu"
       >
+        {extraOptions}
         <DropdownMenuLabel>Grouping</DropdownMenuLabel>
         <DropdownMenuRadioGroup
           value={config.groupBy}

--- a/apps/web/src/features/filters/filter-bar.tsx
+++ b/apps/web/src/features/filters/filter-bar.tsx
@@ -3,7 +3,7 @@
 import type { FilterCondition, FilterGroup, FilterProperty } from '@orbit/shared/filters';
 import { conditionsOf, dropLastCondition, removeCondition } from '@orbit/shared/filters';
 import { Bookmark, ListFilter, Save, X } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { type ReactNode, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
 import { HOTKEY_PRIORITY, useHotkey } from '@/lib/keyboard/index.ts';
@@ -32,6 +32,8 @@ export interface FilterBarProps {
   readonly savedView?: View | null;
   readonly dirty?: boolean;
   readonly showSaveView?: boolean;
+  readonly displayOptions?: ReactNode;
+  readonly displayModified?: boolean;
 }
 
 export function FilterBar({
@@ -46,6 +48,8 @@ export function FilterBar({
   savedView = null,
   dirty = false,
   showSaveView = true,
+  displayOptions,
+  displayModified = false,
 }: FilterBarProps) {
   const workspace = useWorkspace();
   const savedScope: ViewScope = scope ?? { teamId, projectId: null };
@@ -190,7 +194,8 @@ export function FilterBar({
         <DisplayMenu
           config={config}
           capability={controls.capability}
-          modified={controls.displayModified}
+          modified={controls.displayModified || displayModified}
+          extraOptions={displayOptions}
           onChange={onChange}
         />
       </div>

--- a/apps/web/src/features/standup/member-layout.tsx
+++ b/apps/web/src/features/standup/member-layout.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { z } from 'zod';
+import {
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu.tsx';
+
+const memberLayoutSchema = z.enum(['cards', 'dropdown']);
+export type MemberLayout = z.infer<typeof memberLayoutSchema>;
+
+export function useMemberLayout(userId: string | null) {
+  const key = userId === null ? null : `orbit.standup.member-layout.${userId}`;
+  const [layout, setLayout] = useState<MemberLayout>('cards');
+
+  useEffect(() => {
+    if (key === null) {
+      setLayout('cards');
+      return;
+    }
+    try {
+      const stored = memberLayoutSchema.safeParse(window.localStorage.getItem(key));
+      setLayout(stored.success ? stored.data : 'cards');
+    } catch {
+      setLayout('cards');
+    }
+  }, [key]);
+
+  const update = useCallback(
+    (next: MemberLayout) => {
+      setLayout(next);
+      if (key === null) return;
+      try {
+        window.localStorage.setItem(key, next);
+      } catch {
+        return;
+      }
+    },
+    [key],
+  );
+
+  return [layout, update] as const;
+}
+
+export function MemberLayoutOptions({
+  layout,
+  onChange,
+}: {
+  readonly layout: MemberLayout;
+  readonly onChange: (layout: MemberLayout) => void;
+}) {
+  return (
+    <>
+      <DropdownMenuLabel>Members</DropdownMenuLabel>
+      <DropdownMenuRadioGroup
+        value={layout}
+        onValueChange={(value) => onChange(memberLayoutSchema.parse(value))}
+      >
+        <DropdownMenuRadioItem value="cards">Cards</DropdownMenuRadioItem>
+        <DropdownMenuRadioItem value="dropdown">Dropdown</DropdownMenuRadioItem>
+      </DropdownMenuRadioGroup>
+      <DropdownMenuSeparator />
+    </>
+  );
+}

--- a/apps/web/src/features/standup/member-picker.tsx
+++ b/apps/web/src/features/standup/member-picker.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import { ChevronDown, Users } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-import { Button } from '@/components/ui/button.tsx';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover.tsx';
 import { isEditableTarget } from '@/lib/keyboard/binding.ts';
 import { PersonTiles, type PersonTilesProps, UNASSIGNED } from './person-tiles.tsx';
 
@@ -24,21 +21,13 @@ function memberSwitchDirection(event: KeyboardEvent, isMac: boolean): number {
 }
 
 export function MemberPicker(props: PersonTilesProps) {
-  const [open, setOpen] = useState(false);
   const [isMac, setIsMac] = useState(false);
+  const current = useRef(props.selectedId);
+  current.current = props.selectedId;
 
   useEffect(() => {
     setIsMac(/Mac/i.test(navigator.platform));
   }, []);
-  const switching = useRef(false);
-  const preserveFocus = useRef(false);
-  const current = useRef(props.selectedId);
-  current.current = props.selectedId;
-  const content = useRef<HTMLDivElement>(null);
-  const label =
-    props.selectedId === UNASSIGNED
-      ? 'Unassigned'
-      : (props.members.find((member) => member.id === props.selectedId)?.name ?? 'All Members');
 
   useEffect(() => {
     const showUnassigned =
@@ -50,11 +39,6 @@ export function MemberPicker(props: PersonTilesProps) {
       ...props.members.map((member) => member.id),
       ...(showUnassigned ? [UNASSIGNED] : []),
     ];
-    function close() {
-      if (!switching.current) return;
-      switching.current = false;
-      setOpen(false);
-    }
     function keydown(event: KeyboardEvent) {
       const direction = memberSwitchDirection(event, isMac);
       if (direction === 0 || !event.altKey || event.ctrlKey || event.metaKey || event.isComposing)
@@ -63,81 +47,27 @@ export function MemberPicker(props: PersonTilesProps) {
       if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
       event.preventDefault();
       event.stopPropagation();
-      switching.current = true;
-      preserveFocus.current = true;
       const index = choices.indexOf(current.current);
       const next = choices[(index + direction + choices.length) % choices.length] ?? null;
       current.current = next;
       props.onSelect(next);
-      setOpen(true);
-    }
-    function keyup(event: KeyboardEvent) {
-      if (event.key === 'Alt' || !event.altKey) close();
     }
     window.addEventListener('keydown', keydown, true);
-    window.addEventListener('keyup', keyup, true);
-    window.addEventListener('blur', close);
-    return () => {
-      window.removeEventListener('keydown', keydown, true);
-      window.removeEventListener('keyup', keyup, true);
-      window.removeEventListener('blur', close);
-    };
+    return () => window.removeEventListener('keydown', keydown, true);
   }, [isMac, props.members, props.onSelect, props.counts, props.selectedId]);
 
-  useEffect(() => {
-    if (open)
-      content.current
-        ?.querySelector(`[data-testid="standup-tile-${props.selectedId ?? 'everyone'}"]`)
-        ?.scrollIntoView?.({ block: 'nearest' });
-  }, [open, props.selectedId]);
-
   return (
-    <Popover
-      open={open}
-      onOpenChange={(next) => {
-        switching.current = false;
-        setOpen(next);
-      }}
+    <fieldset
+      data-testid="standup-members"
+      aria-label="Standup members"
+      className="min-w-0 max-w-full"
+      title={
+        isMac
+          ? 'Next member: Option+Tab. Previous member: Option+Shift+Tab'
+          : 'Next member: Alt+J. Previous member: Alt+K'
+      }
     >
-      <PopoverTrigger asChild>
-        <Button
-          size="sm"
-          variant="secondary"
-          data-testid="standup-members"
-          aria-label={`Members: ${label}`}
-          title={
-            isMac
-              ? 'Next member: Option+Tab. Previous member: Option+Shift+Tab'
-              : 'Next member: Alt+J. Previous member: Alt+K'
-          }
-        >
-          <Users className="size-3.5" aria-hidden="true" />
-          <span className="max-w-40 truncate">{label}</span>
-          <ChevronDown className="size-3.5" aria-hidden="true" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        ref={content}
-        align="end"
-        aria-label="Members"
-        className="max-h-80 overflow-y-auto"
-        onOpenAutoFocus={(event) => {
-          if (switching.current) event.preventDefault();
-        }}
-        onCloseAutoFocus={(event) => {
-          if (preserveFocus.current) event.preventDefault();
-          preserveFocus.current = false;
-        }}
-      >
-        <PersonTiles
-          {...props}
-          onSelect={(id) => {
-            props.onSelect(id);
-            switching.current = false;
-            setOpen(false);
-          }}
-        />
-      </PopoverContent>
-    </Popover>
+      <PersonTiles {...props} />
+    </fieldset>
   );
 }

--- a/apps/web/src/features/standup/member-picker.tsx
+++ b/apps/web/src/features/standup/member-picker.tsx
@@ -7,8 +7,29 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { isEditableTarget } from '@/lib/keyboard/binding.ts';
 import { PersonTiles, type PersonTilesProps, UNASSIGNED } from './person-tiles.tsx';
 
+function memberSwitchDirection(event: KeyboardEvent, isMac: boolean): number {
+  if (isMac) {
+    if (event.key !== 'Tab') return 0;
+    return event.shiftKey ? -1 : 1;
+  }
+  if (event.shiftKey) return 0;
+  switch (event.key.toLowerCase()) {
+    case 'j':
+      return 1;
+    case 'k':
+      return -1;
+    default:
+      return 0;
+  }
+}
+
 export function MemberPicker(props: PersonTilesProps) {
   const [open, setOpen] = useState(false);
+  const [isMac, setIsMac] = useState(false);
+
+  useEffect(() => {
+    setIsMac(/Mac/i.test(navigator.platform));
+  }, []);
   const switching = useRef(false);
   const preserveFocus = useRef(false);
   const current = useRef(props.selectedId);
@@ -35,13 +56,8 @@ export function MemberPicker(props: PersonTilesProps) {
       setOpen(false);
     }
     function keydown(event: KeyboardEvent) {
-      if (
-        event.key !== 'Tab' ||
-        !event.altKey ||
-        event.ctrlKey ||
-        event.metaKey ||
-        event.isComposing
-      )
+      const direction = memberSwitchDirection(event, isMac);
+      if (direction === 0 || !event.altKey || event.ctrlKey || event.metaKey || event.isComposing)
         return;
       if (isEditableTarget(event.target)) return;
       if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
@@ -50,8 +66,7 @@ export function MemberPicker(props: PersonTilesProps) {
       switching.current = true;
       preserveFocus.current = true;
       const index = choices.indexOf(current.current);
-      const next =
-        choices[(index + (event.shiftKey ? -1 : 1) + choices.length) % choices.length] ?? null;
+      const next = choices[(index + direction + choices.length) % choices.length] ?? null;
       current.current = next;
       props.onSelect(next);
       setOpen(true);
@@ -67,7 +82,7 @@ export function MemberPicker(props: PersonTilesProps) {
       window.removeEventListener('keyup', keyup, true);
       window.removeEventListener('blur', close);
     };
-  }, [props.members, props.onSelect, props.counts, props.selectedId]);
+  }, [isMac, props.members, props.onSelect, props.counts, props.selectedId]);
 
   useEffect(() => {
     if (open)
@@ -90,7 +105,11 @@ export function MemberPicker(props: PersonTilesProps) {
           variant="secondary"
           data-testid="standup-members"
           aria-label={`Members: ${label}`}
-          title="Switch members with Option+Tab or Option+Shift+Tab"
+          title={
+            isMac
+              ? 'Next member: Option+Tab. Previous member: Option+Shift+Tab'
+              : 'Next member: Alt+J. Previous member: Alt+K'
+          }
         >
           <Users className="size-3.5" aria-hidden="true" />
           <span className="max-w-40 truncate">{label}</span>

--- a/apps/web/src/features/standup/member-picker.tsx
+++ b/apps/web/src/features/standup/member-picker.tsx
@@ -95,8 +95,7 @@ export function MemberPicker(props: PersonTilesProps) {
     : 'Next member: Alt+J. Previous member: Alt+K';
   const selected = props.members.find((member) => member.id === props.selectedId);
   const label =
-    selected?.name.trim().split(/\s+/)[0] ??
-    (props.selectedId === UNASSIGNED ? 'Unassigned' : 'All Members');
+    selected?.name.trim() ?? (props.selectedId === UNASSIGNED ? 'Unassigned' : 'All Members');
 
   if (!dropdown)
     return (

--- a/apps/web/src/features/standup/member-picker.tsx
+++ b/apps/web/src/features/standup/member-picker.tsx
@@ -1,6 +1,9 @@
 'use client';
 
+import { ChevronDown, Users } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button.tsx';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover.tsx';
 import { isEditableTarget } from '@/lib/keyboard/binding.ts';
 import { PersonTiles, type PersonTilesProps, UNASSIGNED } from './person-tiles.tsx';
 
@@ -21,6 +24,11 @@ function memberSwitchDirection(event: KeyboardEvent, isMac: boolean): number {
 }
 
 export function MemberPicker(props: PersonTilesProps) {
+  const dropdown = props.layout === 'dropdown';
+  const [open, setOpen] = useState(false);
+  const switching = useRef(false);
+  const preserveFocus = useRef(false);
+  const content = useRef<HTMLDivElement>(null);
   const [isMac, setIsMac] = useState(false);
   const current = useRef(props.selectedId);
   current.current = props.selectedId;
@@ -39,6 +47,14 @@ export function MemberPicker(props: PersonTilesProps) {
       ...props.members.map((member) => member.id),
       ...(showUnassigned ? [UNASSIGNED] : []),
     ];
+    function close() {
+      if (!switching.current) return;
+      switching.current = false;
+      setOpen(false);
+    }
+    function keyup(event: KeyboardEvent) {
+      if (event.key === 'Alt' || !event.altKey) close();
+    }
     function keydown(event: KeyboardEvent) {
       const direction = memberSwitchDirection(event, isMac);
       if (direction === 0 || !event.altKey || event.ctrlKey || event.metaKey || event.isComposing)
@@ -51,23 +67,92 @@ export function MemberPicker(props: PersonTilesProps) {
       const next = choices[(index + direction + choices.length) % choices.length] ?? null;
       current.current = next;
       props.onSelect(next);
+      if (dropdown) {
+        switching.current = true;
+        preserveFocus.current = true;
+        setOpen(true);
+      }
     }
     window.addEventListener('keydown', keydown, true);
-    return () => window.removeEventListener('keydown', keydown, true);
-  }, [isMac, props.members, props.onSelect, props.counts, props.selectedId]);
+    window.addEventListener('keyup', keyup, true);
+    window.addEventListener('blur', close);
+    return () => {
+      window.removeEventListener('keydown', keydown, true);
+      window.removeEventListener('keyup', keyup, true);
+      window.removeEventListener('blur', close);
+    };
+  }, [dropdown, isMac, props.members, props.onSelect, props.counts, props.selectedId]);
+
+  useEffect(() => {
+    if (open)
+      content.current
+        ?.querySelector(`[data-testid="standup-tile-${props.selectedId ?? 'everyone'}"]`)
+        ?.scrollIntoView?.({ block: 'nearest' });
+  }, [open, props.selectedId]);
+
+  const shortcut = isMac
+    ? 'Next member: Option+Tab. Previous member: Option+Shift+Tab'
+    : 'Next member: Alt+J. Previous member: Alt+K';
+  const selected = props.members.find((member) => member.id === props.selectedId);
+  const label =
+    selected?.name.trim().split(/\s+/)[0] ??
+    (props.selectedId === UNASSIGNED ? 'Unassigned' : 'All Members');
+
+  if (!dropdown)
+    return (
+      <fieldset
+        data-testid="standup-members"
+        aria-label="Standup members"
+        className="w-full min-w-0 max-w-full sm:w-auto"
+        title={shortcut}
+      >
+        <PersonTiles {...props} />
+      </fieldset>
+    );
 
   return (
-    <fieldset
-      data-testid="standup-members"
-      aria-label="Standup members"
-      className="min-w-0 max-w-full"
-      title={
-        isMac
-          ? 'Next member: Option+Tab. Previous member: Option+Shift+Tab'
-          : 'Next member: Alt+J. Previous member: Alt+K'
-      }
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        switching.current = false;
+        setOpen(next);
+      }}
     >
-      <PersonTiles {...props} />
-    </fieldset>
+      <PopoverTrigger asChild>
+        <Button
+          size="sm"
+          variant="secondary"
+          data-testid="standup-members"
+          aria-label={`Members: ${selected?.name ?? label}`}
+          title={shortcut}
+        >
+          <Users className="size-3.5" aria-hidden="true" />
+          <span className="max-w-40 truncate">{label}</span>
+          <ChevronDown className="size-3.5" aria-hidden="true" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        ref={content}
+        align="end"
+        aria-label="Members"
+        className="max-h-80 overflow-y-auto"
+        onOpenAutoFocus={(event) => {
+          if (switching.current) event.preventDefault();
+        }}
+        onCloseAutoFocus={(event) => {
+          if (preserveFocus.current) event.preventDefault();
+          preserveFocus.current = false;
+        }}
+      >
+        <PersonTiles
+          {...props}
+          onSelect={(id) => {
+            props.onSelect(id);
+            switching.current = false;
+            setOpen(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/apps/web/src/features/standup/person-tiles.tsx
+++ b/apps/web/src/features/standup/person-tiles.tsx
@@ -86,8 +86,8 @@ export function PersonTiles({
             )}
           >
             <Avatar name={member.name} src={member.image} size="xs" />
-            <span className="max-w-28 truncate">
-              {member.name.trim().split(/\s+/)[0]}
+            <span className={layout === 'cards' ? 'max-w-28 truncate' : 'max-w-48 truncate'}>
+              {layout === 'cards' ? member.name.trim().split(/\s+/)[0] : member.name.trim()}
               {member.id === currentUserId ? ' (You)' : ''}
             </span>
             {member.isAgent ? <span className="text-faint">AI</span> : null}

--- a/apps/web/src/features/standup/person-tiles.tsx
+++ b/apps/web/src/features/standup/person-tiles.tsx
@@ -18,7 +18,7 @@ export interface PersonTilesProps {
 }
 
 const tile =
-  'flex h-7 w-full shrink-0 items-center gap-1.5 rounded-md px-2 text-2xs transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)]';
+  'flex h-7 shrink-0 items-center gap-1.5 rounded-md border px-2 text-2xs transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)]';
 
 const UNKNOWN_COUNT = '?';
 
@@ -42,7 +42,10 @@ export function PersonTiles({
   const unassigned = countOf(UNASSIGNED);
 
   return (
-    <div data-testid="standup-tiles" className="flex min-w-0 flex-col gap-0.5">
+    <div
+      data-testid="standup-tiles"
+      className="flex min-w-0 flex-wrap items-center justify-end gap-1.5"
+    >
       <button
         type="button"
         data-testid="standup-tile-everyone"
@@ -63,12 +66,13 @@ export function PersonTiles({
             data-testid={`standup-tile-${member.id}`}
             aria-pressed={selected}
             title={member.name}
+            aria-label={member.id === currentUserId ? `${member.name} (You)` : member.name}
             onClick={() => onSelect(selected ? null : member.id)}
             className={cn(tile, tileTone(selected, count))}
           >
             <Avatar name={member.name} src={member.image} size="xs" />
-            <span className="max-w-48 truncate">
-              {member.name}
+            <span className="max-w-28 truncate">
+              {member.name.trim().split(/\s+/)[0]}
               {member.id === currentUserId ? ' (You)' : ''}
             </span>
             {member.isAgent ? <span className="text-faint">AI</span> : null}
@@ -105,7 +109,7 @@ function TileCount({ tileId, count }: TileCountProps) {
       data-numeric
       data-testid={`standup-tile-count-${tileId}`}
       title={count === null ? 'Workload counts are unavailable' : undefined}
-      className="ml-auto text-faint"
+      className="text-faint"
     >
       {count ?? UNKNOWN_COUNT}
     </span>

--- a/apps/web/src/features/standup/person-tiles.tsx
+++ b/apps/web/src/features/standup/person-tiles.tsx
@@ -6,10 +6,12 @@ import { Avatar } from '@/components/ui/avatar.tsx';
 import { cn } from '@/lib/cn.ts';
 import { cardHover } from '@/lib/interaction.ts';
 import type { Member } from '@/lib/query/schemas.ts';
+import type { MemberLayout } from './member-layout.tsx';
 
 export const UNASSIGNED = UNSET_FILTER_VALUE;
 
 export interface PersonTilesProps {
+  readonly layout?: MemberLayout;
   readonly members: readonly Member[];
   readonly currentUserId?: string | null;
   readonly selectedId: string | null;
@@ -32,6 +34,7 @@ function tileTone(selected: boolean, count: number | null): string {
 }
 
 export function PersonTiles({
+  layout = 'cards',
   members,
   selectedId,
   counts,
@@ -44,14 +47,22 @@ export function PersonTiles({
   return (
     <div
       data-testid="standup-tiles"
-      className="flex min-w-0 flex-wrap items-center justify-end gap-1.5"
+      className={
+        layout === 'cards'
+          ? 'flex min-w-0 flex-wrap items-center justify-end gap-1.5'
+          : 'flex min-w-0 flex-col gap-0.5'
+      }
     >
       <button
         type="button"
         data-testid="standup-tile-everyone"
         aria-pressed={selectedId === null}
         onClick={() => onSelect(null)}
-        className={cn(tile, selectedId === null ? selectedTile : idleTile)}
+        className={cn(
+          tile,
+          layout === 'dropdown' && 'w-full border-transparent',
+          selectedId === null ? selectedTile : idleTile,
+        )}
       >
         <Users className="size-3.5" aria-hidden="true" />
         All Members
@@ -68,7 +79,11 @@ export function PersonTiles({
             title={member.name}
             aria-label={member.id === currentUserId ? `${member.name} (You)` : member.name}
             onClick={() => onSelect(selected ? null : member.id)}
-            className={cn(tile, tileTone(selected, count))}
+            className={cn(
+              tile,
+              layout === 'dropdown' && 'w-full border-transparent',
+              tileTone(selected, count),
+            )}
           >
             <Avatar name={member.name} src={member.image} size="xs" />
             <span className="max-w-28 truncate">
@@ -87,7 +102,11 @@ export function PersonTiles({
           aria-pressed={selectedId === UNASSIGNED}
           title="Issues nobody owns"
           onClick={() => onSelect(selectedId === UNASSIGNED ? null : UNASSIGNED)}
-          className={cn(tile, tileTone(selectedId === UNASSIGNED, unassigned))}
+          className={cn(
+            tile,
+            layout === 'dropdown' && 'w-full border-transparent',
+            tileTone(selectedId === UNASSIGNED, unassigned),
+          )}
         >
           <UserMinus className="size-3.5" aria-hidden="true" />
           Unassigned

--- a/apps/web/src/features/standup/person-tiles.tsx
+++ b/apps/web/src/features/standup/person-tiles.tsx
@@ -20,7 +20,7 @@ export interface PersonTilesProps {
 }
 
 const tile =
-  'flex h-7 shrink-0 items-center gap-1.5 rounded-md border px-2 text-2xs transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)]';
+  'flex h-7 shrink-0 items-center gap-1.5 rounded-md px-2 text-2xs transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)]';
 
 const UNKNOWN_COUNT = '?';
 
@@ -60,7 +60,7 @@ export function PersonTiles({
         onClick={() => onSelect(null)}
         className={cn(
           tile,
-          layout === 'dropdown' && 'w-full border-transparent',
+          layout === 'cards' ? 'border' : 'w-full',
           selectedId === null ? selectedTile : idleTile,
         )}
       >
@@ -81,7 +81,7 @@ export function PersonTiles({
             onClick={() => onSelect(selected ? null : member.id)}
             className={cn(
               tile,
-              layout === 'dropdown' && 'w-full border-transparent',
+              layout === 'cards' ? 'border' : 'w-full',
               tileTone(selected, count),
             )}
           >
@@ -104,7 +104,7 @@ export function PersonTiles({
           onClick={() => onSelect(selectedId === UNASSIGNED ? null : UNASSIGNED)}
           className={cn(
             tile,
-            layout === 'dropdown' && 'w-full border-transparent',
+            layout === 'cards' ? 'border' : 'w-full',
             tileTone(selectedId === UNASSIGNED, unassigned),
           )}
         >

--- a/apps/web/src/features/standup/standup-board.tsx
+++ b/apps/web/src/features/standup/standup-board.tsx
@@ -33,6 +33,7 @@ import { useWorkspace } from '@/features/issues/workspace-provider.tsx';
 import { summarySearch } from '@/lib/query/issue-search.ts';
 import type { Issue } from '@/lib/query/schemas.ts';
 import { useAllIssues, useIssueSummary } from '@/lib/query/use-issues.ts';
+import { MemberLayoutOptions, useMemberLayout } from './member-layout.tsx';
 import { MemberPicker } from './member-picker.tsx';
 import { UNASSIGNED } from './person-tiles.tsx';
 
@@ -57,6 +58,7 @@ export function standupBoardOptions(role: OrgRole, groupBy: GroupByField, orderB
 
 export function StandupBoard() {
   const workspace = useWorkspace();
+  const [memberLayout, setMemberLayout] = useMemberLayout(workspace.userId);
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { config, setConfig } = useViewConfig(null, 'board', 'standup', CARRIED_PARAMS);
@@ -207,14 +209,16 @@ export function StandupBoard() {
               </DropdownMenuRadioGroup>
             </DropdownMenuContent>
           </DropdownMenu>
-          <MemberPicker
-            members={members}
-            currentUserId={workspace.userId}
-            selectedId={selectedId}
-            counts={counts}
-            onSelect={selectPerson}
-          />
         </div>
+        <MemberPicker
+          key={memberLayout}
+          layout={memberLayout}
+          members={members}
+          currentUserId={workspace.userId}
+          selectedId={selectedId}
+          counts={counts}
+          onSelect={selectPerson}
+        />
       </div>
 
       <FilterBar
@@ -226,6 +230,8 @@ export function StandupBoard() {
         controls={controls}
         facets={model.facets}
         showSaveView={false}
+        displayModified={memberLayout !== 'cards'}
+        displayOptions={<MemberLayoutOptions layout={memberLayout} onChange={setMemberLayout} />}
       />
 
       <StandupBody

--- a/apps/web/tests/features/standup/member-layout.test.tsx
+++ b/apps/web/tests/features/standup/member-layout.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { act, renderHook } from '@testing-library/react';
+import { useMemberLayout } from '../../../src/features/standup/member-layout.tsx';
+
+const userId = 'member-layout-test';
+const otherUserId = 'member-layout-other';
+const key = `orbit.standup.member-layout.${userId}`;
+
+afterEach(() => {
+  window.localStorage.removeItem(key);
+  window.localStorage.removeItem(`orbit.standup.member-layout.${otherUserId}`);
+});
+
+describe('useMemberLayout', () => {
+  it('defaults to cards with no saved preference or an invalid value', () => {
+    const first = renderHook(() => useMemberLayout(userId));
+    expect(first.result.current[0]).toBe('cards');
+    first.unmount();
+    window.localStorage.setItem(key, 'unknown');
+    const second = renderHook(() => useMemberLayout(userId));
+    expect(second.result.current[0]).toBe('cards');
+  });
+
+  it('remembers the selected layout across mounts', () => {
+    const first = renderHook(() => useMemberLayout(userId));
+    act(() => first.result.current[1]('dropdown'));
+    expect(window.localStorage.getItem(key)).toBe('dropdown');
+    first.unmount();
+    const second = renderHook(() => useMemberLayout(userId));
+    expect(second.result.current[0]).toBe('dropdown');
+  });
+
+  it('keeps each account preference separate', () => {
+    window.localStorage.setItem(key, 'dropdown');
+    const { result, rerender } = renderHook(({ id }) => useMemberLayout(id), {
+      initialProps: { id: userId },
+    });
+    expect(result.current[0]).toBe('dropdown');
+    rerender({ id: otherUserId });
+    expect(result.current[0]).toBe('cards');
+    rerender({ id: userId });
+    expect(result.current[0]).toBe('dropdown');
+  });
+});

--- a/apps/web/tests/features/standup/person-tiles.test.tsx
+++ b/apps/web/tests/features/standup/person-tiles.test.tsx
@@ -51,7 +51,7 @@ describe('PersonTiles', () => {
 
   it('shows first names while keeping full names accessible and available on hover', () => {
     mount(null);
-    const ada = screen.getByRole('button', { name: 'Ada Lovelace', exact: true });
+    const ada = screen.getByRole('button', { name: 'Ada Lovelace' });
     expect(within(ada).getByText('Ada', { exact: true })).toBeVisible();
     expect(within(ada).queryByText('Ada Lovelace', { exact: true })).toBeNull();
     expect(ada).toHaveAttribute('title', 'Ada Lovelace');
@@ -69,9 +69,9 @@ describe('PersonTiles', () => {
         onSelect={() => undefined}
       />,
     );
-    expect(screen.getByRole('button', { name: 'Ada Lovelace (You)', exact: true })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Ada Lovelace (You)' })).toBeVisible();
     expect(screen.getByText('Ada (You)', { exact: true })).toBeVisible();
-    expect(screen.getByRole('button', { name: 'Ada Byron', exact: true })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Ada Byron' })).toBeVisible();
     expect(screen.getByText('Lin', { exact: true })).toBeVisible();
   });
 

--- a/apps/web/tests/features/standup/person-tiles.test.tsx
+++ b/apps/web/tests/features/standup/person-tiles.test.tsx
@@ -75,6 +75,20 @@ describe('PersonTiles', () => {
     expect(screen.getByText('Lin', { exact: true })).toBeVisible();
   });
 
+  it('shows full names in the dropdown to distinguish duplicate first names', () => {
+    render(
+      <PersonTiles
+        layout="dropdown"
+        members={[member('user_ada', 'Ada Lovelace'), member('user_other_ada', 'Ada Byron')]}
+        selectedId={null}
+        counts={counts}
+        onSelect={() => undefined}
+      />,
+    );
+    expect(screen.getByText('Ada Lovelace', { exact: true })).toBeVisible();
+    expect(screen.getByText('Ada Byron', { exact: true })).toBeVisible();
+  });
+
   it('starts on Everyone when nobody is picked', () => {
     mount(null);
 

--- a/apps/web/tests/features/standup/person-tiles.test.tsx
+++ b/apps/web/tests/features/standup/person-tiles.test.tsx
@@ -49,6 +49,32 @@ describe('PersonTiles', () => {
     ]);
   });
 
+  it('shows first names while keeping full names accessible and available on hover', () => {
+    mount(null);
+    const ada = screen.getByRole('button', { name: 'Ada Lovelace', exact: true });
+    expect(within(ada).getByText('Ada', { exact: true })).toBeVisible();
+    expect(within(ada).queryByText('Ada Lovelace', { exact: true })).toBeNull();
+    expect(ada).toHaveAttribute('title', 'Ada Lovelace');
+    expect(within(screen.getByTestId('standup-tile-user_bo')).getByText('Bo')).toBeVisible();
+    expect(within(screen.getByTestId('standup-tile-user_cy')).getByText('Cy')).toBeVisible();
+  });
+
+  it('keeps duplicate first names distinct and marks the current user', () => {
+    render(
+      <PersonTiles
+        members={[...members, member('user_other_ada', 'Ada Byron'), member('user_lin', 'Lin')]}
+        currentUserId="user_ada"
+        selectedId={null}
+        counts={counts}
+        onSelect={() => undefined}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Ada Lovelace (You)', exact: true })).toBeVisible();
+    expect(screen.getByText('Ada (You)', { exact: true })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Ada Byron', exact: true })).toBeVisible();
+    expect(screen.getByText('Lin', { exact: true })).toBeVisible();
+  });
+
   it('starts on Everyone when nobody is picked', () => {
     mount(null);
 

--- a/apps/web/tests/features/standup/standup-board.test.tsx
+++ b/apps/web/tests/features/standup/standup-board.test.tsx
@@ -275,7 +275,6 @@ describe('StandupBoard', () => {
     mountBoard();
 
     await screen.findByTestId('standup-kanban');
-    await userEvent.setup().click(screen.getByTestId('standup-members'));
 
     expect(served.listUrls.length).toBe(1);
     for (const url of [...served.listUrls, ...served.facetUrls, ...served.rosterUrls]) {
@@ -291,7 +290,6 @@ describe('StandupBoard', () => {
     mountBoard();
 
     await screen.findByTestId('standup-kanban');
-    await userEvent.setup().click(screen.getByTestId('standup-members'));
 
     expect(cardShown('ENG-1')).toBe(true);
     expect(cardShown('ENG-2')).toBe(true);
@@ -306,7 +304,6 @@ describe('StandupBoard', () => {
     mountBoard();
 
     await screen.findByTestId('standup-kanban');
-    await userEvent.setup().click(screen.getByTestId('standup-members'));
 
     expect(cardHref('ENG-1')).toBe('/issue/ENG-1');
     expect(cardHref('ENG-2')).toBeNull();
@@ -319,9 +316,7 @@ describe('StandupBoard', () => {
     mountBoard();
 
     await screen.findByTestId('standup-kanban');
-    await userEvent.setup().click(screen.getByTestId('standup-members'));
     await user.click(screen.getByTestId(`standup-tile-${bo.id}`));
-    await user.click(screen.getByTestId('standup-members'));
 
     await waitFor(() => {
       expect(served.listUrls.some((url) => participantIdIn(url) === bo.id)).toBe(true);
@@ -340,11 +335,9 @@ describe('StandupBoard', () => {
     mountBoard();
 
     await screen.findByTestId('standup-kanban');
-    await userEvent.setup().click(screen.getByTestId('standup-members'));
     expect(tileCount(ada.id)).toBe('5');
 
     await user.click(screen.getByTestId(`standup-tile-${bo.id}`));
-    await user.click(screen.getByTestId('standup-members'));
 
     await waitFor(() => {
       expect(screen.getByTestId(`standup-tile-${bo.id}`)).toHaveAttribute('aria-pressed', 'true');
@@ -359,7 +352,6 @@ describe('StandupBoard', () => {
     mountBoard();
 
     await screen.findByTestId('standup-kanban');
-    await userEvent.setup().click(screen.getByTestId('standup-members'));
 
     await waitFor(() => {
       expect(tileCount(ada.id)).toBe('?');
@@ -384,7 +376,6 @@ describe('StandupBoard', () => {
     mountBoard();
 
     await screen.findByTestId('standup-kanban');
-    await userEvent.setup().click(screen.getByTestId('standup-members'));
 
     expect(served.rosterUrls.length).toBeGreaterThan(0);
     expect(served.rosterUrls.every((url) => url.includes('filter='))).toBe(true);
@@ -398,7 +389,6 @@ describe('StandupBoard', () => {
     mountBoard();
 
     await screen.findByTestId('standup-kanban');
-    await userEvent.setup().click(screen.getByTestId('standup-members'));
     expect(tileCount('none')).toBe('1');
 
     await user.click(screen.getByTestId('standup-tile-none'));
@@ -419,16 +409,13 @@ describe('StandupBoard', () => {
     mountBoard();
 
     await screen.findByTestId('standup-kanban');
-    await userEvent.setup().click(screen.getByTestId('standup-members'));
     await user.click(screen.getByTestId(`standup-tile-${bo.id}`));
-    await user.click(screen.getByTestId('standup-members'));
 
     await waitFor(() => {
       expect(window.location.search).toContain(`person=${bo.id}`);
     });
 
     await user.click(screen.getByTestId(`standup-tile-${bo.id}`));
-    await user.click(screen.getByTestId('standup-members'));
 
     await waitFor(() => {
       expect(window.location.search).not.toContain('person=');
@@ -442,7 +429,6 @@ describe('StandupBoard', () => {
     mountBoard();
 
     await screen.findByTestId('standup-kanban');
-    await userEvent.setup().click(screen.getByTestId('standup-members'));
 
     expect(served.listUrls.every((url) => participantIdIn(url) === bo.id)).toBe(true);
     expect(screen.getByTestId(`standup-tile-${bo.id}`).getAttribute('aria-pressed')).toBe('true');
@@ -460,7 +446,6 @@ describe('StandupBoard', () => {
     mountBoard();
 
     await screen.findByTestId('standup-kanban');
-    await userEvent.setup().click(screen.getByTestId('standup-members'));
 
     expect(served.listUrls.every((url) => participantIdIn(url) === null)).toBe(true);
     expect(screen.getByTestId('standup-tile-everyone').getAttribute('aria-pressed')).toBe('true');
@@ -472,7 +457,6 @@ describe('StandupBoard', () => {
     mountBoard();
 
     await screen.findByTestId('standup-kanban');
-    await userEvent.setup().click(screen.getByTestId('standup-members'));
 
     expect(screen.getByTestId('filter-bar')).toBeTruthy();
     expect(screen.getByTestId('add-filter')).toBeTruthy();
@@ -498,14 +482,16 @@ describe('StandupBoard', () => {
   });
 });
 
-describe('standup compact controls', () => {
-  it('opens only the member button until clicked and switches immediately while Option is held', async () => {
+describe('standup member cards', () => {
+  it('shows all member cards and switches immediately while Option is held', async () => {
     setPlatform('MacIntel');
     workspace = buildWorkspace();
     serve();
     mountBoard();
     await screen.findByTestId('standup-kanban');
-    expect(screen.queryByTestId('standup-tile-user_ada')).toBeNull();
+    expect(screen.getByTestId('standup-tile-user_ada')).toBeVisible();
+    expect(screen.getByTestId('standup-tile-user_bo')).toBeVisible();
+    expect(screen.queryByRole('button', { name: /^Members:/ })).toBeNull();
     expect(screen.getByTestId('standup-members').title).toBe(
       'Next member: Option+Tab. Previous member: Option+Shift+Tab',
     );
@@ -519,7 +505,7 @@ describe('standup compact controls', () => {
     fireEvent.keyUp(window, { key: 'Tab', altKey: true });
     expect(screen.queryByTestId('standup-tile-user_ada')).not.toBeNull();
     fireEvent.keyUp(window, { key: 'Alt' });
-    await waitFor(() => expect(screen.queryByTestId('standup-tile-user_ada')).toBeNull());
+    expect(screen.getByTestId('standup-tile-user_ada')).toBeVisible();
   });
   for (const platform of ['Win32', 'Linux x86_64']) {
     it(`switches members with Alt+J/K on ${platform} and leaves Alt+Tab alone`, async () => {
@@ -533,7 +519,7 @@ describe('standup compact controls', () => {
       );
       expect(fireEvent.keyDown(window, { key: 'Tab', altKey: true })).toBe(true);
       expect(fireEvent.keyDown(window, { key: 'Tab', altKey: true, shiftKey: true })).toBe(true);
-      expect(screen.queryByTestId('standup-tiles')).toBeNull();
+      expect(window.location.search).not.toContain('person=user_ada');
       for (const modifiers of [
         {},
         { altKey: true, ctrlKey: true },
@@ -542,7 +528,7 @@ describe('standup compact controls', () => {
         { altKey: true, isComposing: true },
       ]) {
         expect(fireEvent.keyDown(window, { key: 'j', ...modifiers })).toBe(true);
-        expect(screen.queryByTestId('standup-tiles')).toBeNull();
+        expect(window.location.search).not.toContain('person=user_ada');
       }
       fireEvent.keyDown(window, { key: 'j', altKey: true });
       await screen.findByTestId('standup-tile-user_ada');
@@ -558,15 +544,15 @@ describe('standup compact controls', () => {
       fireEvent.keyUp(window, { key: 'k', altKey: true });
       expect(screen.queryByTestId('standup-tiles')).not.toBeNull();
       fireEvent.keyUp(window, { key: 'Alt' });
-      await waitFor(() => expect(screen.queryByTestId('standup-tiles')).toBeNull());
+      expect(screen.getByTestId('standup-tiles')).toBeVisible();
       const input = document.createElement('input');
       document.body.append(input);
       fireEvent.keyDown(input, { key: 'j', altKey: true });
-      expect(screen.queryByTestId('standup-tiles')).toBeNull();
+      expect(window.location.search).toContain('person=none');
       input.remove();
     });
   }
-  it('wraps backwards and closes on loss of focus', async () => {
+  it('wraps backwards and keeps the cards visible on loss of focus', async () => {
     setPlatform('MacIntel');
     workspace = buildWorkspace();
     serve();
@@ -576,7 +562,7 @@ describe('standup compact controls', () => {
     expect(window.location.search).toContain('person=none');
     await screen.findByTestId('standup-tile-none');
     fireEvent.blur(window);
-    await waitFor(() => expect(screen.queryByTestId('standup-tile-none')).toBeNull());
+    expect(screen.getByTestId('standup-tile-none')).toHaveAttribute('aria-pressed', 'true');
   });
   it('sends combined AI and work type scopes to lists, facets and roster counts', async () => {
     workspace = buildWorkspace();
@@ -633,17 +619,17 @@ describe('standup filter interactions', () => {
     const button = screen.getByRole('button', { name: 'AI only' });
     button.focus();
     fireEvent.keyDown(window, { key: 'Tab' });
-    expect(screen.queryByTestId('standup-tiles')).toBeNull();
+    expect(window.location.search).not.toContain('person=user_ada');
     fireEvent.keyDown(window, { key: 'Tab', altKey: true });
     await screen.findByTestId('standup-tiles');
     fireEvent.keyUp(window, { key: 'Alt' });
-    await waitFor(() => expect(screen.queryByTestId('standup-tiles')).toBeNull());
+    expect(screen.getByTestId('standup-tiles')).toBeVisible();
     expect(document.activeElement).toBe(button);
     const input = document.createElement('input');
     document.body.append(input);
     input.focus();
     fireEvent.keyDown(input, { key: 'Tab', altKey: true });
-    expect(screen.queryByTestId('standup-tiles')).toBeNull();
+    expect(window.location.search).toContain('person=user_ada');
     input.remove();
   });
 });

--- a/apps/web/tests/features/standup/standup-board.test.tsx
+++ b/apps/web/tests/features/standup/standup-board.test.tsx
@@ -12,6 +12,12 @@ import { restoreModulesAfterThisFile } from '../../../tests-support.ts';
 
 await restoreModulesAfterThisFile(['@/features/issues/workspace-provider.tsx']);
 
+const originalPlatform = Object.getOwnPropertyDescriptor(navigator, 'platform');
+
+function setPlatform(value: string) {
+  Object.defineProperty(navigator, 'platform', { configurable: true, value });
+}
+
 let search = '';
 
 mock.module('next/navigation', () => ({
@@ -255,6 +261,8 @@ const PRIORITY_FILTER = JSON.stringify({
 });
 
 afterEach(() => {
+  if (originalPlatform) Object.defineProperty(navigator, 'platform', originalPlatform);
+  else Reflect.deleteProperty(navigator, 'platform');
   globalThis.fetch = originalFetch;
   search = '';
   window.history.replaceState(null, '', '/standup');
@@ -492,11 +500,15 @@ describe('StandupBoard', () => {
 
 describe('standup compact controls', () => {
   it('opens only the member button until clicked and switches immediately while Option is held', async () => {
+    setPlatform('MacIntel');
     workspace = buildWorkspace();
     serve();
     mountBoard();
     await screen.findByTestId('standup-kanban');
     expect(screen.queryByTestId('standup-tile-user_ada')).toBeNull();
+    expect(screen.getByTestId('standup-members').title).toBe(
+      'Next member: Option+Tab. Previous member: Option+Shift+Tab',
+    );
     fireEvent.keyDown(window, { key: 'Tab', altKey: true });
     await screen.findByTestId('standup-tile-user_ada');
     expect(window.location.search).toContain('person=user_ada');
@@ -509,7 +521,53 @@ describe('standup compact controls', () => {
     fireEvent.keyUp(window, { key: 'Alt' });
     await waitFor(() => expect(screen.queryByTestId('standup-tile-user_ada')).toBeNull());
   });
+  for (const platform of ['Win32', 'Linux x86_64']) {
+    it(`switches members with Alt+J/K on ${platform} and leaves Alt+Tab alone`, async () => {
+      setPlatform(platform);
+      workspace = buildWorkspace();
+      serve();
+      mountBoard();
+      await screen.findByTestId('standup-kanban');
+      expect(screen.getByTestId('standup-members').title).toBe(
+        'Next member: Alt+J. Previous member: Alt+K',
+      );
+      expect(fireEvent.keyDown(window, { key: 'Tab', altKey: true })).toBe(true);
+      expect(fireEvent.keyDown(window, { key: 'Tab', altKey: true, shiftKey: true })).toBe(true);
+      expect(screen.queryByTestId('standup-tiles')).toBeNull();
+      for (const modifiers of [
+        {},
+        { altKey: true, ctrlKey: true },
+        { altKey: true, metaKey: true },
+        { altKey: true, shiftKey: true },
+        { altKey: true, isComposing: true },
+      ]) {
+        expect(fireEvent.keyDown(window, { key: 'j', ...modifiers })).toBe(true);
+        expect(screen.queryByTestId('standup-tiles')).toBeNull();
+      }
+      fireEvent.keyDown(window, { key: 'j', altKey: true });
+      await screen.findByTestId('standup-tile-user_ada');
+      expect(window.location.search).toContain('person=user_ada');
+      fireEvent.keyDown(window, { key: 'j', altKey: true });
+      expect(window.location.search).toContain('person=user_bo');
+      fireEvent.keyDown(window, { key: 'k', altKey: true });
+      expect(window.location.search).toContain('person=user_ada');
+      fireEvent.keyDown(window, { key: 'k', altKey: true });
+      expect(window.location.search).not.toContain('person=');
+      fireEvent.keyDown(window, { key: 'k', altKey: true });
+      expect(window.location.search).toContain('person=none');
+      fireEvent.keyUp(window, { key: 'k', altKey: true });
+      expect(screen.queryByTestId('standup-tiles')).not.toBeNull();
+      fireEvent.keyUp(window, { key: 'Alt' });
+      await waitFor(() => expect(screen.queryByTestId('standup-tiles')).toBeNull());
+      const input = document.createElement('input');
+      document.body.append(input);
+      fireEvent.keyDown(input, { key: 'j', altKey: true });
+      expect(screen.queryByTestId('standup-tiles')).toBeNull();
+      input.remove();
+    });
+  }
   it('wraps backwards and closes on loss of focus', async () => {
+    setPlatform('MacIntel');
     workspace = buildWorkspace();
     serve();
     mountBoard();
@@ -567,6 +625,7 @@ describe('standup filter interactions', () => {
   });
 
   it('leaves ordinary Tab and editable fields alone and preserves focus during switching', async () => {
+    setPlatform('MacIntel');
     workspace = buildWorkspace();
     serve();
     mountBoard();

--- a/apps/web/tests/features/standup/standup-board.test.tsx
+++ b/apps/web/tests/features/standup/standup-board.test.tsx
@@ -228,9 +228,9 @@ function serve(options: { failList?: boolean; failRoster?: boolean } = {}): Serv
   return { listUrls, facetUrls, rosterUrls };
 }
 
-function mountBoard(): void {
+function mountBoard() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  render(
+  return render(
     <QueryClientProvider client={client}>
       <ToastProvider>
         <HotkeyProvider>
@@ -265,6 +265,7 @@ afterEach(() => {
   else Reflect.deleteProperty(navigator, 'platform');
   globalThis.fetch = originalFetch;
   search = '';
+  window.localStorage.removeItem('orbit.standup.member-layout.user_ada');
   window.history.replaceState(null, '', '/standup');
 });
 
@@ -552,6 +553,71 @@ describe('standup member cards', () => {
       input.remove();
     });
   }
+  for (const platform of ['MacIntel', 'Win32', 'Linux x86_64']) {
+    it(`uses the same shortcuts in the dropdown on ${platform}`, async () => {
+      setPlatform(platform);
+      workspace = buildWorkspace();
+      serve();
+      mountBoard();
+      await screen.findByTestId('standup-kanban');
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: 'Display options' }));
+      expect(screen.getByRole('menuitemradio', { name: 'Cards' })).toHaveAttribute(
+        'aria-checked',
+        'true',
+      );
+      await user.click(screen.getByRole('menuitemradio', { name: 'Dropdown' }));
+      const button = screen.getByRole('button', { name: 'Members: All Members' });
+      button.focus();
+      expect(screen.queryByTestId('standup-tiles')).toBeNull();
+      const key = platform === 'MacIntel' ? 'Tab' : 'j';
+      fireEvent.keyDown(window, { key, altKey: true });
+      expect(screen.getByTestId('standup-tile-user_ada')).toHaveAttribute('aria-pressed', 'true');
+      fireEvent.keyDown(window, { key, altKey: true });
+      expect(screen.getByTestId('standup-tile-user_bo')).toHaveAttribute('aria-pressed', 'true');
+      fireEvent.keyDown(window, {
+        key: platform === 'MacIntel' ? 'Tab' : 'k',
+        altKey: true,
+        shiftKey: platform === 'MacIntel',
+      });
+      expect(screen.getByTestId('standup-tile-user_ada')).toHaveAttribute('aria-pressed', 'true');
+      fireEvent.keyUp(window, { key: 'Alt' });
+      await waitFor(() => expect(screen.queryByTestId('standup-tiles')).toBeNull());
+      expect(document.activeElement).toBe(button);
+      expect(window.location.search).toContain('person=user_ada');
+      await user.click(button);
+      await user.click(screen.getByTestId('standup-tile-user_bo'));
+      await waitFor(() => expect(screen.queryByTestId('standup-tiles')).toBeNull());
+      expect(window.location.search).toContain('person=user_bo');
+    });
+  }
+
+  it('remembers the member layout and preserves the selection when changing it', async () => {
+    workspace = buildWorkspace();
+    serve();
+    const mounted = mountBoard();
+    await screen.findByTestId('standup-kanban');
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('standup-tile-user_bo'));
+    await user.click(screen.getByRole('button', { name: 'Display options' }));
+    await user.click(screen.getByRole('menuitemradio', { name: 'Dropdown' }));
+    expect(screen.getByRole('button', { name: 'Members: Bo Chen' })).toBeVisible();
+    expect(window.location.search).toContain('person=user_bo');
+    expect(window.localStorage.getItem('orbit.standup.member-layout.user_ada')).toBe('dropdown');
+    mounted.unmount();
+    mountBoard();
+    await screen.findByTestId('standup-kanban');
+    expect(screen.queryByTestId('standup-tiles')).toBeNull();
+    await user.click(screen.getByRole('button', { name: 'Display options' }));
+    expect(screen.getByRole('menuitemradio', { name: 'Dropdown' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    await user.click(screen.getByRole('menuitemradio', { name: 'Cards' }));
+    expect(screen.getByTestId('standup-tile-user_bo')).toBeVisible();
+    expect(window.localStorage.getItem('orbit.standup.member-layout.user_ada')).toBe('cards');
+  });
+
   it('wraps backwards and keeps the cards visible on loss of focus', async () => {
     setPlatform('MacIntel');
     workspace = buildWorkspace();

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -146,7 +146,7 @@ work in an input, because you always need a way out.
 | Option + Tab | Alt + J | Next member |
 | Option + Shift + Tab | Alt + K | Previous member |
 
-Member cards are shown by default with first names; hover a card for the full name. Choose **Display > Members > Cards** or **Dropdown** to change the layout. Your choice is remembered for your account in this browser. Changing layouts keeps the selected member and board filters.
+Member cards are shown by default with first names; hover a card for the full name. Open **Display options** and choose **Cards** or **Dropdown** under the **Members** section to change the layout. Your choice is remembered for your account in this browser. Changing layouts keeps the selected member and board filters.
 
 The shortcuts work in both layouts and immediately filter the board. Switching wraps through All Members, the team members, and Unassigned when available. In dropdown mode, hold Option or Alt to keep the picker open and release it to close; cards remain visible in card mode. Hover the member group or dropdown button for your platform's shortcuts. Alt+Tab is left to the window switcher on Windows/Linux.
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -146,7 +146,7 @@ work in an input, because you always need a way out.
 | Option + Tab | Alt + J | Next member |
 | Option + Shift + Tab | Alt + K | Previous member |
 
-Hold Option on macOS or Alt on Windows/Linux to keep the member dropdown open while switching. Release the modifier to close it and keep the current selection. Switching wraps through All Members, the team members, and Unassigned when available. The member button's tooltip shows the shortcuts for your platform. Alt+Tab is left to the window switcher on Windows/Linux.
+All member cards remain visible and show first names; hover a card for the full name. Each shortcut immediately selects the next or previous card and filters the board. Switching wraps through All Members, the team members, and Unassigned when available. Releasing Option or Alt keeps the current selection. Hover the member group for your platform's shortcuts. Alt+Tab is left to the window switcher on Windows/Linux.
 
 ## Adding one
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -141,12 +141,12 @@ work in an input, because you always need a way out.
 
 ## Standup member switching
 
-| Shortcut | Action |
-| --- | --- |
-| Option + Tab | Next member |
-| Option + Shift + Tab | Previous member |
+| macOS | Windows / Linux | Action |
+| --- | --- | --- |
+| Option + Tab | Alt + J | Next member |
+| Option + Shift + Tab | Alt + K | Previous member |
 
-Hold Option to keep the member dropdown open while switching. Release Option to close it and keep the current selection. On keyboards that label the modifier Alt, use Alt. The operating system may reserve Alt+Tab; the member dropdown remains available by mouse and ordinary keyboard navigation.
+Hold Option on macOS or Alt on Windows/Linux to keep the member dropdown open while switching. Release the modifier to close it and keep the current selection. Switching wraps through All Members, the team members, and Unassigned when available. The member button's tooltip shows the shortcuts for your platform. Alt+Tab is left to the window switcher on Windows/Linux.
 
 ## Adding one
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -146,7 +146,7 @@ work in an input, because you always need a way out.
 | Option + Tab | Alt + J | Next member |
 | Option + Shift + Tab | Alt + K | Previous member |
 
-Member cards are shown by default with first names; hover a card for the full name. Open **Display options** and choose **Cards** or **Dropdown** under the **Members** section to change the layout. Your choice is remembered for your account in this browser. Changing layouts keeps the selected member and board filters.
+Member cards are shown by default with first names; hover a card for the full name. The dropdown shows full names to distinguish members with the same first name. Open **Display options** and choose **Cards** or **Dropdown** under the **Members** section to change the layout. Your choice is remembered for your account in this browser. Changing layouts keeps the selected member and board filters.
 
 The shortcuts work in both layouts and immediately filter the board. Switching wraps through All Members, the team members, and Unassigned when available. In dropdown mode, hold Option or Alt to keep the picker open and release it to close; cards remain visible in card mode. Hover the member group or dropdown button for your platform's shortcuts. Alt+Tab is left to the window switcher on Windows/Linux.
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -146,7 +146,9 @@ work in an input, because you always need a way out.
 | Option + Tab | Alt + J | Next member |
 | Option + Shift + Tab | Alt + K | Previous member |
 
-All member cards remain visible and show first names; hover a card for the full name. Each shortcut immediately selects the next or previous card and filters the board. Switching wraps through All Members, the team members, and Unassigned when available. Releasing Option or Alt keeps the current selection. Hover the member group for your platform's shortcuts. Alt+Tab is left to the window switcher on Windows/Linux.
+Member cards are shown by default with first names; hover a card for the full name. Choose **Display > Members > Cards** or **Dropdown** to change the layout. Your choice is remembered for your account in this browser. Changing layouts keeps the selected member and board filters.
+
+The shortcuts work in both layouts and immediately filter the board. Switching wraps through All Members, the team members, and Unassigned when available. In dropdown mode, hold Option or Alt to keep the picker open and release it to close; cards remain visible in card mode. Hover the member group or dropdown button for your platform's shortcuts. Alt+Tab is left to the window switcher on Windows/Linux.
 
 ## Adding one
 


### PR DESCRIPTION
Show first-name member cards by default, offer a remembered dropdown layout in Display options, and support platform-specific member shortcuts in both layouts.