### PR TITLE
fix(mcp): restore OAuth discovery with a dynamic baseURL

### DIFF
--- a/apps/web/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/apps/web/src/app/.well-known/oauth-authorization-server/route.ts
@@ -5,8 +5,8 @@ import { METADATA_CORS_HEADERS, metadataPreflight } from '../metadata-headers.ts
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function GET(): Promise<Response> {
-  const metadata = await auth.api.getMcpOAuthConfig();
+export async function GET(request: Request): Promise<Response> {
+  const metadata = await auth.api.getMcpOAuthConfig({ headers: request.headers });
   const patched = {
     ...metadata,
     authorization_endpoint: absoluteUrl(MCP_AUTHORIZE_START_PATH),

--- a/apps/web/src/lib/auth/deployment.ts
+++ b/apps/web/src/lib/auth/deployment.ts
@@ -38,6 +38,7 @@ export function deploymentAuthOptions(
         ? canonical.origin
         : {
             allowedHosts: [...new Set(allowedHosts)],
+            fallback: canonical.origin,
           },
     plugins,
   };

--- a/apps/web/tests/app/well-known/oauth-authorization-server.test.ts
+++ b/apps/web/tests/app/well-known/oauth-authorization-server.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+
+const ROUTE = 'src/app/.well-known/oauth-authorization-server/route.ts';
+
+describe('the oauth authorization server metadata', () => {
+  it('resolves OAuth metadata from the incoming request host', async () => {
+    const source = await readFile(ROUTE, 'utf8');
+    expect(source).toContain('GET(request: Request)');
+    expect(source).toContain('auth.api.getMcpOAuthConfig({ headers: request.headers })');
+  });
+});

--- a/apps/web/tests/lib/auth/deployment.test.ts
+++ b/apps/web/tests/lib/auth/deployment.test.ts
@@ -150,17 +150,17 @@ describe('deployment authentication', () => {
     });
 
     const withoutRequest = await auth.api.getMcpOAuthConfig();
-    expect(withoutRequest.issuer).toBe(canonical);
+    expect(withoutRequest?.issuer).toBe(canonical);
 
     const previewHost = await auth.api.getMcpOAuthConfig({
       headers: new Headers({ host: new URL(preview).host }),
     });
-    expect(previewHost.issuer).toBe(preview);
+    expect(previewHost?.issuer).toBe(preview);
 
     const unknownHost = await auth.api.getMcpOAuthConfig({
       headers: new Headers({ host: 'attacker.example' }),
     });
-    expect(unknownHost.issuer).toBe(canonical);
+    expect(unknownHost?.issuer).toBe(canonical);
   });
 
   it('ignores empty optional deployment values in local configuration', () => {

--- a/apps/web/tests/lib/auth/deployment.test.ts
+++ b/apps/web/tests/lib/auth/deployment.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { betterAuth } from 'better-auth';
 import { memoryAdapter } from 'better-auth/adapters/memory';
 import { symmetricDecrypt } from 'better-auth/crypto';
+import { mcp } from 'better-auth/plugins';
 import { deploymentAuthOptions } from '@/lib/auth/deployment';
 import { nativeFetchGlobals } from '../../../tests-preload';
 
@@ -123,6 +124,7 @@ describe('deployment authentication', () => {
         'orbit-abc123-magicapi.vercel.app',
         'orbit-git-feature-magicapi.vercel.app',
       ],
+      fallback: canonical,
     });
     expect(options.plugins).toEqual([]);
   });
@@ -132,6 +134,33 @@ describe('deployment authentication', () => {
       deploymentAuthOptions({ ORBIT_AUTH_ALLOWED_HOSTS: 'https://example.com/path' }),
     ).toThrow();
     expect(() => deploymentAuthOptions({ OAUTH_PROXY_SECRET: 'short' })).toThrow();
+  });
+
+  it('resolves MCP OAuth metadata on the canonical origin without a request', async () => {
+    const deployment = deploymentAuthOptions({
+      BETTER_AUTH_URL: canonical,
+      VERCEL_URL: 'orbit-abc123-magicapi.vercel.app',
+      ORBIT_AUTH_ALLOWED_HOSTS: 'orbit-*-magicapi.vercel.app',
+    });
+    const auth = betterAuth({
+      ...deployment,
+      database: memoryAdapter({ user: [], account: [], session: [], verification: [] }),
+      secret: 'preview-session-secret-at-least-32-characters',
+      plugins: [...deployment.plugins, mcp({ loginPage: '/login', resource: `${canonical}/mcp` })],
+    });
+
+    const withoutRequest = await auth.api.getMcpOAuthConfig();
+    expect(withoutRequest.issuer).toBe(canonical);
+
+    const previewHost = await auth.api.getMcpOAuthConfig({
+      headers: new Headers({ host: new URL(preview).host }),
+    });
+    expect(previewHost.issuer).toBe(preview);
+
+    const unknownHost = await auth.api.getMcpOAuthConfig({
+      headers: new Headers({ host: 'attacker.example' }),
+    });
+    expect(unknownHost.issuer).toBe(canonical);
   });
 
   it('ignores empty optional deployment values in local configuration', () => {
@@ -181,7 +210,9 @@ describe('deployment authentication', () => {
   });
 
   it('rejects another Vercel project', async () => {
-    await expect(socialSignIn('https://other-magicapi.vercel.app', 'google')).rejects.toThrow();
+    const response = await socialSignIn('https://other-magicapi.vercel.app', 'google');
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ code: 'INVALID_ORIGIN' });
   });
 
   it('rejects an external post-login redirect', async () => {

--- a/docs/preview-authentication.md
+++ b/docs/preview-authentication.md
@@ -7,6 +7,8 @@ Set `ORBIT_AUTH_ALLOWED_HOSTS=orbit-*-magicapi.vercel.app` in both Vercel
 environments. The auth server also accepts the canonical hostname and the exact
 `VERCEL_URL` and `VERCEL_BRANCH_URL` provided by Vercel. Browser authentication
 uses the current origin, so password and email OTP sessions stay on the preview.
+A request whose host is missing or not allowed uses `BETTER_AUTH_URL` as the
+origin. It never uses an unrecognised host.
 
 Set a dedicated random `OAUTH_PROXY_SECRET` of at least 32 characters to the same
 value in production and previews. Do not put its value in source control. This


### PR DESCRIPTION
Closes #466
## Why
MCP clients cannot start OAuth against production because `/.well-known/oauth-authorization-server` returns 500. That started when preview login made `baseURL` a dynamic object on Vercel, and the metadata route was the only `auth.api` call that passed no request.

## What changed
- Pass the incoming request headers into `getMcpOAuthConfig` so the issuer resolves from the request host.
- Set `fallback` on the dynamic `baseURL` to `BETTER_AUTH_URL`, so headerless calls and unrecognised hosts use the canonical origin instead of throwing.
- Cover headerless metadata, an allowed preview host, and an unknown host. Foreign Vercel origins still fail with 403 `INVALID_ORIGIN`.

## How verified
Focused: `bun --env-file=../../.env test tests/lib/auth/deployment.test.ts tests/app/well-known --timeout 20000` in `apps/web` (19 pass).
Pre-push: lint and workspace typecheck.
Not verified here: a production deploy of this branch, or a live Claude MCP login against `orbit.noveum.ai`.

## Out of scope
Did not change the dev sign-in `createVerificationOTP` call site. The fallback covers it.

Closes #466


Made with [Cursor](https://cursor.com)